### PR TITLE
fix: replace use of insecure sprintf

### DIFF
--- a/src/client_lib/pegasus_client_factory_impl.cpp
+++ b/src/client_lib/pegasus_client_factory_impl.cpp
@@ -23,7 +23,7 @@ bool pegasus_client_factory_impl::initialize(const char *config_file)
             // use config file to run
             char exe[] = "client";
             char config[1024];
-            sprintf(config, "%s", config_file);
+            snprintf(config, 1024, "%s", config_file);
             char *argv[] = {exe, config};
             dsn_run(2, argv, false);
         }

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -181,8 +181,8 @@ info_collector::app_stat_counters *info_collector::get_app_counters(const std::s
     char counter_desc[1024];
 #define INIT_COUNTER(name)                                                                         \
     do {                                                                                           \
-        sprintf(counter_name, "app.stat." #name "#%s", app_name.c_str());                          \
-        sprintf(counter_desc, "statistic the " #name " of app %s", app_name.c_str());              \
+        snprintf(counter_name, 1024, "app.stat." #name "#%s", app_name.c_str());                   \
+        snprintf(counter_desc, 1024, "statistic the " #name " of app %s", app_name.c_str());       \
         counters->name.init_app_counter(                                                           \
             "app.pegasus", counter_name, COUNTER_TYPE_NUMBER, counter_desc);                       \
     } while (0)

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -32,7 +32,7 @@ DEFINE_TASK_CODE(LPC_PEGASUS_SERVER_DELAY, TASK_PRIORITY_COMMON, ::dsn::THREAD_P
 static std::string chkpt_get_dir_name(int64_t decree)
 {
     char buffer[256];
-    sprintf(buffer, "checkpoint.%" PRId64 "", decree);
+    snprintf(buffer, 256, "checkpoint.%" PRId64 "", decree);
     return std::string(buffer);
 }
 

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -840,9 +840,9 @@ get_app_stat(shell_context *sc, const std::string &app_name, std::vector<row_dat
     std::vector<std::string> arguments;
     char tmp[256];
     if (app_name.empty()) {
-        sprintf(tmp, ".*@.*");
+        snprintf(tmp, 256, ".*@.*");
     } else {
-        sprintf(tmp, ".*@%d\\..*", app_info->app_id);
+        snprintf(tmp, 256, ".*@%d\\..*", app_info->app_id);
     }
     arguments.emplace_back(tmp);
     std::vector<std::pair<bool, std::string>> results =

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -2387,7 +2387,7 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
         char hash_key_count_str[100];
         hash_key_count_str[0] = '\0';
         if (diff_hash_key) {
-            sprintf(hash_key_count_str, " (%ld hash keys)", cur_total_hash_key_count);
+            snprintf(hash_key_count_str, 100, " (%ld hash keys)", cur_total_hash_key_count);
         }
         if (!stopped_by_wait_seconds && error_occurred.load()) {
             fprintf(stderr,


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Use of `sprintf()` is dangerous and may cause buffer overflows.

### What is changed and how it works?
Replace `sprintf()` with `snprintf()`, limiting bytes written to the buffer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code


Code changes

- Has exported function/method change
- Has exported variable/fields change
- Has interface methods change
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
