### PR TITLE
fix(rocksdb): fix bug for starting server while reading meta from metacf

### DIFF
--- a/src/server/meta_store.h
+++ b/src/server/meta_store.h
@@ -40,9 +40,9 @@ public:
     void set_data_version(uint32_t version) const;
     void set_last_manual_compact_finish_time(uint64_t last_manual_compact_finish_time) const;
 
-    bool is_get_value_from_manifest() const
+    bool is_get_value_from_meta_cf() const
     {
-        return _get_meta_store_type == meta_store_type::kManifestOnly;
+        return _get_meta_store_type == meta_store_type::kMetaCFOnly;
     }
 
 private:

--- a/src/server/meta_store.h
+++ b/src/server/meta_store.h
@@ -40,6 +40,11 @@ public:
     void set_data_version(uint32_t version) const;
     void set_last_manual_compact_finish_time(uint64_t last_manual_compact_finish_time) const;
 
+    bool is_get_value_from_manifest() const
+    {
+        return _get_meta_store_type == meta_store_type::kManifestOnly;
+    }
+
 private:
     ::dsn::error_code
     get_value_from_meta_cf(bool read_flushed_data, const std::string &key, uint64_t *value) const;

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1366,8 +1366,9 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
     // Create _meta_store which provide Pegasus meta data read and write.
     _meta_store = dsn::make_unique<meta_store>(this, _db, _meta_cf);
 
+    // When db_exist, read meta data firstly
     uint64_t last_manual_compact_finish_time = 0;
-    if (db_exist || (!db_exist && _meta_store->is_get_value_from_manifest())) {
+    if (db_exist) {
         _last_committed_decree = _meta_store->get_last_flushed_decree();
         _pegasus_data_version = _meta_store->get_data_version();
         last_manual_compact_finish_time = _meta_store->get_last_manual_compact_finish_time();
@@ -1383,7 +1384,7 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
         _meta_store->set_data_version(_pegasus_data_version);
         _meta_store->set_last_flushed_decree(_last_committed_decree);
         _meta_store->set_last_manual_compact_finish_time(last_manual_compact_finish_time);
-        flush_all_family_columns(!_meta_store->is_get_value_from_manifest());
+        flush_all_family_columns(_meta_store->is_get_value_from_meta_cf());
     }
 
     // only enable filter after correct pegasus_data_version set


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
For pegasus 2.0.0 release, creating table will be failed while `get_meta_store_type = metacf`, it means getting pegasus meta data from meta column family, not from manifest file.

The previous implementation will always try to get meta data in `start()` after open a rocksdb instance, we use `last_flushed_decree` as an example, the code is like:
https://github.com/apache/incubator-pegasus/blob/5d969e89cb42934800e326a2771844bffb2d3f40/src/server/meta_store.cpp#L38-L52

If server get last_flushed_decree from manifest file, `_db->GetLastFlushedDecree()` will always return the value. If server gets last_flushed_decree from column family, if get value failed, it will assert on line 45. When creating a new table, meta column family has no value, it won't get any value.

To fix this problem, I add condition in `start()` function.
- If db exists, we should read meta data firstly, no matter from manifest or meta cf
- If db not exists, use default value of meta data


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test
    - start onebox with read meta from manifest, set data, restart onebox with read meta from cf
    - start onebox with read meta from cf, set data, restart onebox with read meta from manifest
