### PR TITLE
build(ci): add asf.yml file and github action for semantic commits

### DIFF
--- a/.asf.yml
+++ b/.asf.yml
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+github:
+  description: "Apache Pegasus - A horizontally scalable, strongly consistent and high-performance key-value store"
+  homepage: https://pegasus.apache.org/
+  labels:
+    - pegasus
+    - key-value-store
+    - nosql
+    - distributed-database
+  features:
+    # Enable wiki for documentation
+    wiki: false
+    # Enable issues management
+    issues: true
+    # Enable projects for project management boards
+    projects: true
+  enabled_merge_buttons:
+    # enable squash button:
+    squash:  true
+    # disable merge button:
+    merge:   false
+    # disable rebase button:
+    rebase:  false

--- a/.github/workflows/ci-pull-request-title.yaml
+++ b/.github/workflows/ci-pull-request-title.yaml
@@ -1,0 +1,15 @@
+name: "Lint PR title"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v1.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

What is semantic pull request: https://github.com/zeke/semantic-pull-requests.

We used to manage it as a third-party [probot](https://probot.github.io/). It requires authorization from the code owner, which is now transferred to ASF. To not bother requesting from them, I manage this tool as a GitHub Action, which could be triggered every PR.

### What is changed and how it works?

I add a workflow under .github/workflows/ci-pull-request-title.yml. This config is copied from https://github.com/amannn/action-semantic-pull-request.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code
