### PR TITLE
fix: Load options from file when open an exist DB

### DIFF
--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -64,9 +64,10 @@ std::string meta_store::get_usage_scenario() const
     std::string usage_scenario = ROCKSDB_ENV_USAGE_SCENARIO_NORMAL;
     auto ec = get_string_value_from_meta_cf(false, ROCKSDB_ENV_USAGE_SCENARIO_KEY, &usage_scenario);
     dassert_replica(ec == ::dsn::ERR_OK || ec == ::dsn::ERR_OBJECT_NOT_FOUND,
-                    "rocksdb {} get {} from meta column family failed",
+                    "rocksdb {} get {} from meta column family failed: {}",
                     _db->GetName(),
-                    ROCKSDB_ENV_USAGE_SCENARIO_KEY);
+                    ROCKSDB_ENV_USAGE_SCENARIO_KEY,
+                    ec.to_string());
     return usage_scenario;
 }
 

--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -92,7 +92,6 @@ std::string meta_store::get_usage_scenario() const
     dassert_f(dsn::buf2uint64(data, *value),
               "rocksdb {} get \"{}\" from meta column family failed to parse into uint64",
               db->GetName(),
-              key,
               data);
     return ::dsn::ERR_OK;
 }

--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -58,8 +58,9 @@ uint64_t meta_store::get_decree_from_readonly_db(rocksdb::DB *db,
         db, meta_cf, true, LAST_FLUSHED_DECREE, &str_last_flushed_decree);
     dcheck_eq_replica(::dsn::ERR_OK, ec);
     dassert_f(dsn::buf2uint64(str_last_flushed_decree, last_flushed_decree),
-              "rocksdb {} get LAST_FLUSHED_DECREE from meta column family got error value {}",
+              "rocksdb {} get {} from meta column family got error value {}",
               db->GetName(),
+              LAST_FLUSHED_DECREE,
               str_last_flushed_decree);
     return last_flushed_decree;
 }

--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -90,7 +90,7 @@ std::string meta_store::get_usage_scenario() const
         return ec;
     }
     dassert_f(dsn::buf2uint64(data, *value),
-              "rocksdb {} get {} from meta column family got error value {}",
+              "rocksdb {} get \"{}\" from meta column family failed to parse into uint64",
               db->GetName(),
               key,
               data);

--- a/src/server/meta_store.h
+++ b/src/server/meta_store.h
@@ -30,21 +30,28 @@ public:
                                          rocksdb::ColumnFamilyHandle *meta_cf) const;
     uint32_t get_data_version() const;
     uint64_t get_last_manual_compact_finish_time() const;
+    std::string get_usage_scenario() const;
 
     void set_last_flushed_decree(uint64_t decree) const;
     void set_data_version(uint32_t version) const;
     void set_last_manual_compact_finish_time(uint64_t last_manual_compact_finish_time) const;
+    void set_usage_scenario(const std::string &usage_scenario) const;
 
 private:
     ::dsn::error_code
     get_value_from_meta_cf(bool read_flushed_data, const std::string &key, uint64_t *value) const;
-    ::dsn::error_code set_value_to_meta_cf(const std::string &key, uint64_t value) const;
-
-    static ::dsn::error_code get_value_from_meta_cf(rocksdb::DB *db,
-                                                    rocksdb::ColumnFamilyHandle *cf,
-                                                    bool read_flushed_data,
+    ::dsn::error_code get_string_value_from_meta_cf(bool read_flushed_data,
                                                     const std::string &key,
-                                                    uint64_t *value);
+                                                    std::string *value) const;
+    ::dsn::error_code set_value_to_meta_cf(const std::string &key, uint64_t value) const;
+    ::dsn::error_code set_string_value_to_meta_cf(const std::string &key,
+                                                  const std::string &value) const;
+
+    static ::dsn::error_code get_string_value_from_meta_cf(rocksdb::DB *db,
+                                                           rocksdb::ColumnFamilyHandle *cf,
+                                                           bool read_flushed_data,
+                                                           const std::string &key,
+                                                           std::string *value);
 
     friend class pegasus_write_service;
 

--- a/src/server/meta_store.h
+++ b/src/server/meta_store.h
@@ -47,6 +47,11 @@ private:
     ::dsn::error_code set_string_value_to_meta_cf(const std::string &key,
                                                   const std::string &value) const;
 
+    static ::dsn::error_code get_value_from_meta_cf(rocksdb::DB *db,
+                                                    rocksdb::ColumnFamilyHandle *cf,
+                                                    bool read_flushed_data,
+                                                    const std::string &key,
+                                                    uint64_t *value);
     static ::dsn::error_code get_string_value_from_meta_cf(rocksdb::DB *db,
                                                            rocksdb::ColumnFamilyHandle *cf,
                                                            bool read_flushed_data,

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1327,7 +1327,7 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
 
     ddebug("%s: start to open rocksDB's rdb(%s)", replica_name(), path.c_str());
 
-    // Here we create a 'tmp_data_cf_opts' because we don't want to modify '_data_cf_opts', which
+    // Here we create a `tmp_data_cf_opts` because we don't want to modify `_data_cf_opts`, which
     // will be used elsewhere.
     rocksdb::ColumnFamilyOptions tmp_data_cf_opts = _data_cf_opts;
     if (db_exist) {
@@ -1337,7 +1337,7 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
         rocksdb::DBOptions loaded_db_opt;
         std::vector<rocksdb::ColumnFamilyDescriptor> loaded_cf_descs;
         rocksdb::ColumnFamilyOptions loaded_data_cf_opts;
-        // Set 'ignore_unknown_options' true for forward compatibility.
+        // Set `ignore_unknown_options` true for forward compatibility.
         auto status = rocksdb::LoadLatestOptions(path,
                                                  rocksdb::Env::Default(),
                                                  &loaded_db_opt,
@@ -1362,7 +1362,7 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
         dassert_replica(!missing_meta_cf, "You must upgrade Pegasus server from 2.0");
         dassert_replica(!missing_data_cf, "Missing default column family");
         // Reset usage scenario related options according to loaded_data_cf_opts.
-        // We don't use 'loaded_data_cf_opts' directly because pointer-typed options will only be
+        // We don't use `loaded_data_cf_opts` directly because pointer-typed options will only be
         // initialized with default values when calling 'LoadLatestOptions', see
         // 'rocksdb/utilities/options_util.h'.
         reset_usage_scenario_options(loaded_data_cf_opts, &tmp_data_cf_opts);
@@ -1416,6 +1416,10 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
         _meta_store->set_last_manual_compact_finish_time(0);
         _meta_store->set_usage_scenario(ROCKSDB_ENV_USAGE_SCENARIO_NORMAL);
         flush_all_family_columns(true);
+        // Since ROCKSDB_ENV_USAGE_SCENARIO_NORMAL corresponds to the default options in
+        // `_data_cf_opts`(see set_usage_scenario()), initializing `_usage_scenario` to normal could
+        // avoid unnecessary `set_options` calls when open a new db.
+        _usage_scenario = ROCKSDB_ENV_USAGE_SCENARIO_NORMAL;
     }
 
     // only enable filter after correct pegasus_data_version set

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1354,7 +1354,7 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
                 missing_data_cf = false;
                 loaded_data_cf_opts = loaded_cf_descs[i].options;
             } else {
-                derror_replica("unkown column family name.");
+                derror_replica("unknown column family name.");
                 return ::dsn::ERR_LOCAL_APP_FAILURE;
             }
         }

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1398,6 +1398,7 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
     if (db_exist) {
         _last_committed_decree = _meta_store->get_last_flushed_decree();
         _pegasus_data_version = _meta_store->get_data_version();
+        _usage_scenario = _meta_store->get_usage_scenario();
         uint64_t last_manual_compact_finish_time =
             _meta_store->get_last_manual_compact_finish_time();
         if (_pegasus_data_version > PEGASUS_DATA_VERSION_MAX) {
@@ -1413,6 +1414,7 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
         _meta_store->set_data_version(PEGASUS_DATA_VERSION_MAX);
         _meta_store->set_last_flushed_decree(0);
         _meta_store->set_last_manual_compact_finish_time(0);
+        _meta_store->set_usage_scenario(ROCKSDB_ENV_USAGE_SCENARIO_NORMAL);
         flush_all_family_columns(true);
     }
 
@@ -2507,6 +2509,7 @@ bool pegasus_server_impl::set_usage_scenario(const std::string &usage_scenario)
         return false;
     }
     if (set_options(new_options)) {
+        _meta_store->set_usage_scenario(usage_scenario);
         _usage_scenario = usage_scenario;
         ddebug_replica(
             "set usage scenario from \"{}\" to \"{}\" succeed", old_usage_scenario, usage_scenario);

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -8,6 +8,7 @@
 #include <boost/lexical_cast.hpp>
 #include <rocksdb/convenience.h>
 #include <rocksdb/utilities/checkpoint.h>
+#include <rocksdb/utilities/options_util.h>
 #include <dsn/utility/chrono_literals.h>
 #include <dsn/utility/utils.h>
 #include <dsn/utility/filesystem.h>
@@ -1326,14 +1327,45 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
 
     ddebug("%s: start to open rocksDB's rdb(%s)", replica_name(), path.c_str());
 
+    // Here we create a 'tmp_data_cf_opts' because we don't want to modify '_data_cf_opts', which
+    // will be used elsewhere.
+    rocksdb::ColumnFamilyOptions tmp_data_cf_opts = _data_cf_opts;
     if (db_exist) {
-        // When DB exist, meta CF must be present.
         bool missing_meta_cf = true;
-        if (check_meta_cf(path, &missing_meta_cf) != ::dsn::ERR_OK) {
-            derror_replica("check meta column family failed");
+        bool missing_data_cf = true;
+        // Load latest options from option file stored in the db directory.
+        rocksdb::DBOptions loaded_db_opt;
+        std::vector<rocksdb::ColumnFamilyDescriptor> loaded_cf_descs;
+        rocksdb::ColumnFamilyOptions loaded_data_cf_opts;
+        // Set 'ignore_unknown_options' true for forward compatibility.
+        auto status = rocksdb::LoadLatestOptions(path,
+                                                 rocksdb::Env::Default(),
+                                                 &loaded_db_opt,
+                                                 &loaded_cf_descs,
+                                                 /*ignore_unknown_options*/ true);
+        if (!status.ok()) {
+            derror_replica("load latest option file failed.");
             return ::dsn::ERR_LOCAL_APP_FAILURE;
         }
+        for (int i = 0; i < loaded_cf_descs.size(); ++i) {
+            if (loaded_cf_descs[i].name == META_COLUMN_FAMILY_NAME) {
+                missing_meta_cf = false;
+            } else if (loaded_cf_descs[i].name == DATA_COLUMN_FAMILY_NAME) {
+                missing_data_cf = false;
+                loaded_data_cf_opts = loaded_cf_descs[i].options;
+            } else {
+                derror_replica("unkown column family name.");
+                return ::dsn::ERR_LOCAL_APP_FAILURE;
+            }
+        }
+        // When DB exist, meta CF and default CF must be present.
         dassert_replica(!missing_meta_cf, "You must upgrade Pegasus server from 2.0");
+        dassert_replica(!missing_data_cf, "Missing default column family");
+        // Reset usage scenario related options according to loaded_data_cf_opts.
+        // We don't use 'loaded_data_cf_opts' directly because pointer-typed options will only be
+        // initialized with default values when calling 'LoadLatestOptions', see
+        // 'rocksdb/utilities/options_util.h'.
+        reset_usage_scenario_options(loaded_data_cf_opts, &tmp_data_cf_opts);
     } else {
         // When create new DB, we have to create a new column family to store meta data (meta column
         // family).
@@ -1341,7 +1373,13 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
     }
 
     std::vector<rocksdb::ColumnFamilyDescriptor> column_families(
-        {{DATA_COLUMN_FAMILY_NAME, _data_cf_opts}, {META_COLUMN_FAMILY_NAME, _meta_cf_opts}});
+        {{DATA_COLUMN_FAMILY_NAME, tmp_data_cf_opts}, {META_COLUMN_FAMILY_NAME, _meta_cf_opts}});
+    auto s = rocksdb::CheckOptionsCompatibility(
+        path, rocksdb::Env::Default(), _db_opts, column_families, /*ignore_unknown_options*/ true);
+    if (!s.ok() && !s.IsNotFound()) {
+        derror_replica("rocksdb::CheckOptionsCompatibility failed, error = {}", s.ToString());
+        return ::dsn::ERR_LOCAL_APP_FAILURE;
+    }
     std::vector<rocksdb::ColumnFamilyHandle *> handles_opened;
     auto status = rocksdb::DB::Open(_db_opts, path, column_families, &handles_opened, &_db);
     if (!status.ok()) {
@@ -1406,9 +1444,6 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
                    last_durable_decree());
 
     _is_open = true;
-
-    // set default usage scenario after db opened.
-    set_usage_scenario(ROCKSDB_ENV_USAGE_SCENARIO_NORMAL);
 
     dinfo_replica("start the update rocksdb statistics timer task");
     _update_replica_rdb_stat =
@@ -2483,6 +2518,23 @@ bool pegasus_server_impl::set_usage_scenario(const std::string &usage_scenario)
     }
 }
 
+void pegasus_server_impl::reset_usage_scenario_options(
+    const rocksdb::ColumnFamilyOptions &base_opts, rocksdb::ColumnFamilyOptions *target_opts)
+{
+    // reset usage scenario related options, refer to options set in 'set_usage_scenario' function.
+    target_opts->level0_file_num_compaction_trigger = base_opts.level0_file_num_compaction_trigger;
+    target_opts->level0_slowdown_writes_trigger = base_opts.level0_slowdown_writes_trigger;
+    target_opts->level0_stop_writes_trigger = base_opts.level0_stop_writes_trigger;
+    target_opts->soft_pending_compaction_bytes_limit =
+        base_opts.soft_pending_compaction_bytes_limit;
+    target_opts->hard_pending_compaction_bytes_limit =
+        base_opts.hard_pending_compaction_bytes_limit;
+    target_opts->disable_auto_compactions = base_opts.disable_auto_compactions;
+    target_opts->max_compaction_bytes = base_opts.max_compaction_bytes;
+    target_opts->write_buffer_size = base_opts.write_buffer_size;
+    target_opts->max_write_buffer_number = base_opts.max_write_buffer_number;
+}
+
 bool pegasus_server_impl::set_options(
     const std::unordered_map<std::string, std::string> &new_options)
 {
@@ -2605,25 +2657,6 @@ void pegasus_server_impl::set_partition_version(int32_t partition_version)
         "update partition version from {} to {}", old_partition_version, partition_version);
 
     // TODO(heyuchen): set filter _partition_version in further pr
-}
-
-::dsn::error_code pegasus_server_impl::check_meta_cf(const std::string &path, bool *missing_meta_cf)
-{
-    *missing_meta_cf = true;
-    std::vector<std::string> column_families;
-    auto s = rocksdb::DB::ListColumnFamilies(rocksdb::DBOptions(), path, &column_families);
-    if (!s.ok()) {
-        derror_replica("rocksdb::DB::ListColumnFamilies failed, error = {}", s.ToString());
-        return ::dsn::ERR_LOCAL_APP_FAILURE;
-    }
-
-    for (const auto &column_family : column_families) {
-        if (column_family == META_COLUMN_FAMILY_NAME) {
-            *missing_meta_cf = false;
-            break;
-        }
-    }
-    return ::dsn::ERR_OK;
 }
 
 ::dsn::error_code pegasus_server_impl::flush_all_family_columns(bool wait)

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1358,9 +1358,9 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
                 return ::dsn::ERR_LOCAL_APP_FAILURE;
             }
         }
-        // When DB exist, meta CF and default CF must be present.
-        dassert_replica(!missing_meta_cf, "You must upgrade Pegasus server from 2.0");
-        dassert_replica(!missing_data_cf, "Missing default column family");
+        // When DB exists, meta CF and data CF must be present.
+        dassert_replica(!missing_meta_cf, "You must upgrade Pegasus server from 2.0"
+        dassert_replica(!missing_data_cf, "Missing data column family");
         // Reset usage scenario related options according to loaded_data_cf_opts.
         // We don't use `loaded_data_cf_opts` directly because pointer-typed options will only be
         // initialized with default values when calling 'LoadLatestOptions', see

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -166,6 +166,7 @@ private:
     friend class pegasus_compression_options_test;
     friend class pegasus_server_impl_test;
     FRIEND_TEST(pegasus_server_impl_test, default_data_version);
+    FRIEND_TEST(pegasus_server_impl_test, test_open_db_with_latest_options);
 
     friend class pegasus_manual_compact_service;
     friend class pegasus_write_service;
@@ -260,6 +261,9 @@ private:
     // return true if successfully changed
     bool set_usage_scenario(const std::string &usage_scenario);
 
+    void reset_usage_scenario_options(const rocksdb::ColumnFamilyOptions &base_opts,
+                                      rocksdb::ColumnFamilyOptions *target_opts);
+
     // return true if successfully set
     bool set_options(const std::unordered_map<std::string, std::string> &new_options);
 
@@ -304,8 +308,6 @@ private:
 
         return false;
     }
-
-    ::dsn::error_code check_meta_cf(const std::string &path, bool *missing_meta_cf);
 
     void release_db();
     void release_db(rocksdb::DB *db, const std::vector<rocksdb::ColumnFamilyHandle *> &handles);

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -167,6 +167,7 @@ private:
     friend class pegasus_server_impl_test;
     FRIEND_TEST(pegasus_server_impl_test, default_data_version);
     FRIEND_TEST(pegasus_server_impl_test, test_open_db_with_latest_options);
+    FRIEND_TEST(pegasus_server_impl_test, test_open_db_with_app_envs);
 
     friend class pegasus_manual_compact_service;
     friend class pegasus_write_service;

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -68,11 +68,15 @@ TEST_F(pegasus_server_impl_test, default_data_version)
 
 TEST_F(pegasus_server_impl_test, test_open_db_with_latest_options)
 {
+    // open a new db
+    ASSERT_EQ(ROCKSDB_ENV_USAGE_SCENARIO_NORMAL, _server->_usage_scenario);
+    // set bulk_load scenario for the db
     ASSERT_TRUE(_server->set_usage_scenario(ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD));
     ASSERT_EQ(ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD, _server->_usage_scenario);
     rocksdb::Options opts = _server->_db->GetOptions();
     ASSERT_EQ(1000000000, opts.level0_file_num_compaction_trigger);
     ASSERT_EQ(true, opts.disable_auto_compactions);
+    // reopen the db
     _server->stop(false);
     start();
     ASSERT_EQ(ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD, _server->_usage_scenario);

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -66,5 +66,18 @@ TEST_F(pegasus_server_impl_test, default_data_version)
     ASSERT_EQ(_server->_pegasus_data_version, 1);
 }
 
+TEST_F(pegasus_server_impl_test, test_open_db_with_latest_options)
+{
+    ASSERT_TRUE(_server->set_usage_scenario(ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD));
+    rocksdb::Options opts = _server->_db->GetOptions();
+    ASSERT_EQ(1000000000, opts.level0_file_num_compaction_trigger);
+    ASSERT_EQ(true, opts.disable_auto_compactions);
+    _server->stop(false);
+    start();
+    ASSERT_EQ(opts.level0_file_num_compaction_trigger,
+              _server->_db->GetOptions().level0_file_num_compaction_trigger);
+    ASSERT_EQ(opts.disable_auto_compactions, _server->_db->GetOptions().disable_auto_compactions);
+}
+
 } // namespace server
 } // namespace pegasus

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -94,9 +94,9 @@ TEST_F(pegasus_server_impl_test, test_open_db_with_latest_options)
 TEST_F(pegasus_server_impl_test, test_open_db_with_app_envs)
 {
     std::map<std::string, std::string> envs;
-    envs[ROCKSDB_ENV_USAGE_SCENARIO_KEY] = ROCKSDB_ENV_USAGE_SCENARIO_PREFER_WRITE;
+    envs[ROCKSDB_ENV_USAGE_SCENARIO_KEY] = ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD;
     start(envs);
-    ASSERT_EQ(ROCKSDB_ENV_USAGE_SCENARIO_PREFER_WRITE, _server->_usage_scenario);
+    ASSERT_EQ(ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD, _server->_usage_scenario);
 }
 
 } // namespace server

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -69,11 +69,13 @@ TEST_F(pegasus_server_impl_test, default_data_version)
 TEST_F(pegasus_server_impl_test, test_open_db_with_latest_options)
 {
     ASSERT_TRUE(_server->set_usage_scenario(ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD));
+    ASSERT_EQ(ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD, _server->_usage_scenario);
     rocksdb::Options opts = _server->_db->GetOptions();
     ASSERT_EQ(1000000000, opts.level0_file_num_compaction_trigger);
     ASSERT_EQ(true, opts.disable_auto_compactions);
     _server->stop(false);
     start();
+    ASSERT_EQ(ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD, _server->_usage_scenario);
     ASSERT_EQ(opts.level0_file_num_compaction_trigger,
               _server->_db->GetOptions().level0_file_num_compaction_trigger);
     ASSERT_EQ(opts.disable_auto_compactions, _server->_db->GetOptions().disable_auto_compactions);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

#571 

### What is changed and how it works?

RocksDB database automatically persisted its current set of options into a file since RocksDB 4.3[1], 
so when DB exists, we should open the rocksdb instance using the options file stored in the db directory.

This patch also adds usage scenario into meta column family to initialize `_usage_scenario`.

[1] https://github.com/facebook/rocksdb/wiki/RocksDB-Options-File

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Code changes

- Has exported function/method change

Side effects

- Increased code complexity

Related changes

- Need to cherry-pick to the release branch
- Need to be included in the release note
