### PR TITLE
chore: add disclaimer for not compliant with asf policy

### DIFF
--- a/DISCLAIMER-WIP
+++ b/DISCLAIMER-WIP
@@ -1,0 +1,19 @@
+Apache Pegasus is an effort undergoing incubation at The Apache Software Foundation (ASF), 
+sponsored by the Apache Incubator. Incubation is required of all newly accepted projects 
+until a further review indicates that the infrastructure, communications, and decision 
+making process have stabilized in a manner consistent with other successful ASF projects. 
+While incubation status is not necessarily a reflection of the completeness or stability 
+of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
+
+Some of the incubating project's releases may not be fully compliant with ASF policy. For 
+example, releases may have incomplete or un-reviewed licensing conditions. What follows is 
+a list of known issues the project is currently aware of (note that this list, by definition, 
+is likely to be incomplete): 
+
+ * Releases may have incomplete licensing conditions.
+ * Most of the top contributors have signed an ICLA and we are working on updating the headers.
+
+If you are planning to incorporate this work into your product/project, please be aware that
+you will need to conduct a thorough licensing review to determine the overall implications of 
+including this work. For the current status of this project through the Apache Incubator 
+visit: https://incubator.apache.org/projects/pegasus.html

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Apache Pegasus
+Copyright 2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Because headers in Pegasus are still copy-righted to XiaoMi, we are not compliant with ASF policy now.
Thus to be able to release the incoming version, we must disclaim that the ip-clearance is still working on.

http://www.apache.org/legal/release-policy.html

### What is changed and how it works?

I add a DISCLAIMER-WIP file under root dir.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code
