### PR TITLE
fix: Use default options to open db when latest option file has incompatible db options

### DIFF
--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1353,7 +1353,10 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
                                                  &loaded_cf_descs,
                                                  /*ignore_unknown_options=*/true);
         if (!status.ok()) {
-            if (status.ToString().find("pegasus") == std::string::npos) {
+            // Here we ignore an invalid argument error related to `pegasus_data_version` and
+            // `pegasus_data` options, which were used in old version rocksdbs (before 2.1.0).
+            if (status.code() != rocksdb::Status::kInvalidArgument ||
+                status.ToString().find("pegasus_data") == std::string::npos) {
                 derror_replica("load latest option file failed: {}.", status.ToString());
                 return ::dsn::ERR_LOCAL_APP_FAILURE;
             }

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1330,7 +1330,7 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
     // Here we create a `tmp_data_cf_opts` because we don't want to modify `_data_cf_opts`, which
     // will be used elsewhere.
     rocksdb::ColumnFamilyOptions tmp_data_cf_opts = _data_cf_opts;
-    bool has_uncompatible_db_options = false;
+    bool has_incompatible_db_options = false;
     if (db_exist) {
         // When DB exists, meta CF and data CF must be present.
         bool missing_meta_cf = true;
@@ -1357,13 +1357,13 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
                 derror_replica("load latest option file failed: {}.", status.ToString());
                 return ::dsn::ERR_LOCAL_APP_FAILURE;
             }
-            has_uncompatible_db_options = true;
-            dwarn_replica("The latest option file has uncompatible db options: {}, use default "
+            has_incompatible_db_options = true;
+            dwarn_replica("The latest option file has incompatible db options: {}, use default "
                           "options to open db.",
                           status.ToString());
         }
 
-        if (!has_uncompatible_db_options) {
+        if (!has_incompatible_db_options) {
             for (int i = 0; i < loaded_cf_descs.size(); ++i) {
                 if (loaded_cf_descs[i].name == DATA_COLUMN_FAMILY_NAME) {
                     loaded_data_cf_opts = loaded_cf_descs[i].options;
@@ -1385,7 +1385,7 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
         {{DATA_COLUMN_FAMILY_NAME, tmp_data_cf_opts}, {META_COLUMN_FAMILY_NAME, _meta_cf_opts}});
     auto s = rocksdb::CheckOptionsCompatibility(
         path, rocksdb::Env::Default(), _db_opts, column_families, /*ignore_unknown_options=*/true);
-    if (!s.ok() && !s.IsNotFound() && !has_uncompatible_db_options) {
+    if (!s.ok() && !s.IsNotFound() && !has_incompatible_db_options) {
         derror_replica("rocksdb::CheckOptionsCompatibility failed, error = {}", s.ToString());
         return ::dsn::ERR_LOCAL_APP_FAILURE;
     }

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -310,6 +310,9 @@ private:
         return false;
     }
 
+    ::dsn::error_code
+    check_column_families(const std::string &path, bool *missing_meta_cf, bool *miss_data_cf);
+
     void release_db();
     void release_db(rocksdb::DB *db, const std::vector<rocksdb::ColumnFamilyHandle *> &handles);
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
When we reopen an existing db, we will use latest option file to construct options. However,
if this file is an old version file which has incompatible options with official rocksdb, we would
get an error and fail to open db.
https://github.com/apache/incubator-pegasus/blob/ae7caa2599357f83cbbf79c4367a5d0a72f04288/src/server/pegasus_server_impl.cpp#L1341-L1349

### What is changed and how it works?
If the option file has known incompatible options `pegasus_data_version` and `pegasus_data`,
we skip loading options from file and use default options to open db.
A new version option file will be generated when we succeed to open db, after that we could use
existing option file to construct options. That means the first time we open an old version db, we
must use default options, and that may lead to unexpected flushes and compactions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1. deploy an old version cluster.
2. create some old version replicas.
3. upgrade replica servers to the new version with #587 and this patch.
4. test if new version servers could start apps sccessfully.

Code changes

- Has exported function/method change

Side effects

- Increased code complexity

Related changes

#587 
- Need to cherry-pick to the release branch
