### PR TITLE
fix(http): change the way to start http server

### DIFF
--- a/src/server/info_collector_app.cpp
+++ b/src/server/info_collector_app.cpp
@@ -16,8 +16,9 @@ namespace pegasus {
 namespace server {
 
 info_collector_app::info_collector_app(const dsn::service_app_info *info)
-    : service_app(info), _updater_started(false), _http_server(new ::dsn::http_server())
+    : service_app(info), _updater_started(false)
 {
+    dsn::start_http_server();
 }
 
 info_collector_app::~info_collector_app() {}

--- a/src/server/info_collector_app.h
+++ b/src/server/info_collector_app.h
@@ -25,7 +25,6 @@ private:
     info_collector _collector;
     available_detector _detector;
     bool _updater_started;
-    std::unique_ptr<::dsn::http_server> _http_server;
 };
 }
 } // namespace


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
In pervious, the info collector use the way of `new ::dsn::http_server()` to start http server. But it will produce a compile error, since the pr(https://github.com/XiaoMi/rdsn/pull/610) in rdsn change the way to start http server.

