### PR TITLE
fix: bugfix on incr

### DIFF
--- a/src/server/test/pegasus_write_service_impl_test.cpp
+++ b/src/server/test/pegasus_write_service_impl_test.cpp
@@ -217,5 +217,31 @@ TEST_F(incr_test, invalid_incr)
     ASSERT_EQ(resp.new_value, 100);
 }
 
+TEST_F(incr_test, fail_on_get)
+{
+    dsn::fail::setup();
+    dsn::fail::cfg("db_get", "100%1*return()");
+    // when db_get failed, incr should return an error.
+
+    req.increment = 10;
+    _write_impl->incr(1, req, resp);
+    ASSERT_EQ(resp.error, FAIL_DB_GET);
+
+    dsn::fail::teardown();
+}
+
+TEST_F(incr_test, fail_on_put)
+{
+    dsn::fail::setup();
+    dsn::fail::cfg("db_write_batch_put", "100%1*return()");
+    // when rocksdb put failed, incr should return an error.
+
+    req.increment = 10;
+    _write_impl->incr(1, req, resp);
+    ASSERT_EQ(resp.error, FAIL_DB_WRITE_BATCH_PUT);
+
+    dsn::fail::teardown();
+}
+
 } // namespace server
 } // namespace pegasus


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/apache/incubator-pegasus/pull/598 introduced a bug, which makes incr continue to proceed even the rocksdb::get failed.

### What is changed and how it works?

This PR fixes this bug and adds some unit tests using fail-point library to mock rocksdb get failure.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
