### PR TITLE
chore: move github pullrequests to commits mail-list

### DIFF
--- a/.asf.yml
+++ b/.asf.yml
@@ -39,3 +39,7 @@ github:
     merge:   false
     # disable rebase button:
     rebase:  false
+
+notifications:
+  commits: commits@pegasus.apache.org
+  pullrequests: commits@pegasus.apache.org


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

The notification of pull-requests is currently automatically sent to dev@pegasus.apache.org. They are with less priority but usually with large amounts. So I in this PR move them to commits@pegasus.apache.org. For the convenience of mail filtering.

### What is changed and how it works?

See this doc:
https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code
