### PR TITLE
feat(hotkey): add an interface of hotkey capture

### DIFF
--- a/src/server/capacity_unit_calculator.cpp
+++ b/src/server/capacity_unit_calculator.cpp
@@ -138,11 +138,11 @@ void capacity_unit_calculator::add_multi_get_cu(int32_t status,
 
     if (status == rocksdb::Status::kNotFound) {
         add_read_cu(1);
-        _read_hotkey_collector->capture_raw_key(hash_key, key_count);
+        _read_hotkey_collector->capture_hash_key(hash_key, key_count);
         return;
     }
     add_read_cu(data_size);
-    _read_hotkey_collector->capture_raw_key(hash_key, key_count);
+    _read_hotkey_collector->capture_hash_key(hash_key, key_count);
 }
 
 void capacity_unit_calculator::add_scan_cu(int32_t status,

--- a/src/server/capacity_unit_calculator.h
+++ b/src/server/capacity_unit_calculator.h
@@ -12,11 +12,6 @@ namespace pegasus {
 namespace server {
 
 class hotkey_collector;
-enum class key_type
-{
-    RAW_KEY = 0,
-    HASH_KEY
-};
 
 class capacity_unit_calculator : public dsn::replication::replica_base
 {
@@ -64,9 +59,6 @@ protected:
 #endif
 
 private:
-    void count_read_data(const dsn::blob &key, key_type type, int64_t size);
-    void count_write_data(const dsn::blob &key, key_type type, int64_t size);
-
     uint64_t _read_capacity_unit_size;
     uint64_t _write_capacity_unit_size;
     uint32_t _log_read_cu_size;

--- a/src/server/capacity_unit_calculator.h
+++ b/src/server/capacity_unit_calculator.h
@@ -75,6 +75,24 @@ private:
     ::dsn::perf_counter_wrapper _pfc_check_and_set_bytes;
     ::dsn::perf_counter_wrapper _pfc_check_and_mutate_bytes;
 
+    /*
+        hotkey capturing weight rules:
+            add_get_cu: whether find the key or not, weight = 1(read_collector),
+            add_multi_get_cu: weight = returned sortkey count(read_collector),
+            add_scan_cu : not capture now,
+            add_sortkey_count_cu: weight = 1(read_collector),
+            add_ttl_cu: weight = 1(read_collector),
+            add_put_cu: weight = 1(write_collector),
+            add_remove_cu: weight = 1(write_collector),
+            add_multi_put_cu: weight = returned sortkey count(write_collector),
+            add_multi_remove_cu: weight = returned sortkey count(write_collector),
+            add_incr_cu: if find the key, weight = 1(write_collector),
+                         else weight = 1(read_collector)
+            add_check_and_set_cu: if find the key, weight = 1(write_collector),
+                         else weight = 1(read_collector)
+            add_check_and_mutate_cu: if find the key, weight = mutate_list size
+                                     else weight = 1
+    */
     std::shared_ptr<hotkey_collector> _read_hotkey_collector;
     std::shared_ptr<hotkey_collector> _write_hotkey_collector;
 };

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -795,7 +795,7 @@ void pegasus_server_impl::on_sortkey_count(sortkey_count_rpc rpc)
         resp.count = -1;
     }
 
-    _cu_calculator->add_sortkey_count_cu(resp.error);
+    _cu_calculator->add_sortkey_count_cu(resp.error, hash_key);
     _pfc_scan_latency->set(dsn_now_ns() - start_time);
 }
 
@@ -857,7 +857,7 @@ void pegasus_server_impl::on_ttl(ttl_rpc rpc)
         }
     }
 
-    _cu_calculator->add_ttl_cu(resp.error);
+    _cu_calculator->add_ttl_cu(resp.error, key);
 }
 
 void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
@@ -1486,7 +1486,8 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
     });
 
     // initialize cu calculator and write service after server being initialized.
-    _cu_calculator = dsn::make_unique<capacity_unit_calculator>(this);
+    _cu_calculator = dsn::make_unique<capacity_unit_calculator>(
+        this, _read_hotkey_collector, _write_hotkey_collector);
     _server_write = dsn::make_unique<pegasus_server_write>(this, _verbose_log);
 
     return ::dsn::ERR_OK;

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -173,7 +173,7 @@ int pegasus_write_service::incr(int64_t decree,
     int err = _impl->incr(decree, update, resp);
 
     if (_server->is_primary()) {
-        _cu_calculator->add_incr_cu(resp.error);
+        _cu_calculator->add_incr_cu(resp.error, update.key);
     }
 
     _pfc_incr_latency->set(dsn_now_ns() - start_time);

--- a/src/server/test/capacity_unit_calculator_test.cpp
+++ b/src/server/test/capacity_unit_calculator_test.cpp
@@ -202,7 +202,7 @@ TEST_F(capacity_unit_calculator_test, scan)
 TEST_F(capacity_unit_calculator_test, sortkey_count)
 {
     for (int i = 0; i < MAX_ROCKSDB_STATUS_CODE; i++) {
-        _cal->add_sortkey_count_cu(i, dsn::blob());
+        _cal->add_sortkey_count_cu(i, key);
         if (i == rocksdb::Status::kOk || i == rocksdb::Status::kNotFound) {
             ASSERT_EQ(_cal->read_cu, 1);
         } else {
@@ -216,7 +216,7 @@ TEST_F(capacity_unit_calculator_test, sortkey_count)
 TEST_F(capacity_unit_calculator_test, ttl)
 {
     for (int i = 0; i < MAX_ROCKSDB_STATUS_CODE; i++) {
-        _cal->add_ttl_cu(i, dsn::blob());
+        _cal->add_ttl_cu(i, key);
         if (i == rocksdb::Status::kOk || i == rocksdb::Status::kNotFound) {
             ASSERT_EQ(_cal->read_cu, 1);
         } else {
@@ -302,7 +302,7 @@ TEST_F(capacity_unit_calculator_test, multi_remove)
 TEST_F(capacity_unit_calculator_test, incr)
 {
     for (int i = 0; i < MAX_ROCKSDB_STATUS_CODE; i++) {
-        _cal->add_incr_cu(i, dsn::blob());
+        _cal->add_incr_cu(i, key);
         if (i == rocksdb::Status::kOk) {
             ASSERT_EQ(_cal->read_cu, 1);
             ASSERT_EQ(_cal->write_cu, 1);

--- a/src/server/test/capacity_unit_calculator_test.cpp
+++ b/src/server/test/capacity_unit_calculator_test.cpp
@@ -6,6 +6,7 @@
 #include "server/capacity_unit_calculator.h"
 
 #include <dsn/dist/replication/replica_base.h>
+#include "server/hotkey_collector.h"
 
 namespace pegasus {
 namespace server {
@@ -26,7 +27,8 @@ public:
     }
 
     explicit mock_capacity_unit_calculator(dsn::replication::replica_base *r)
-        : capacity_unit_calculator(r)
+        : capacity_unit_calculator(
+              r, std::make_shared<hotkey_collector>(), std::make_shared<hotkey_collector>())
     {
     }
 
@@ -200,7 +202,7 @@ TEST_F(capacity_unit_calculator_test, scan)
 TEST_F(capacity_unit_calculator_test, sortkey_count)
 {
     for (int i = 0; i < MAX_ROCKSDB_STATUS_CODE; i++) {
-        _cal->add_sortkey_count_cu(i);
+        _cal->add_sortkey_count_cu(i, dsn::blob());
         if (i == rocksdb::Status::kOk || i == rocksdb::Status::kNotFound) {
             ASSERT_EQ(_cal->read_cu, 1);
         } else {
@@ -214,7 +216,7 @@ TEST_F(capacity_unit_calculator_test, sortkey_count)
 TEST_F(capacity_unit_calculator_test, ttl)
 {
     for (int i = 0; i < MAX_ROCKSDB_STATUS_CODE; i++) {
-        _cal->add_ttl_cu(i);
+        _cal->add_ttl_cu(i, dsn::blob());
         if (i == rocksdb::Status::kOk || i == rocksdb::Status::kNotFound) {
             ASSERT_EQ(_cal->read_cu, 1);
         } else {
@@ -300,7 +302,7 @@ TEST_F(capacity_unit_calculator_test, multi_remove)
 TEST_F(capacity_unit_calculator_test, incr)
 {
     for (int i = 0; i < MAX_ROCKSDB_STATUS_CODE; i++) {
-        _cal->add_incr_cu(i);
+        _cal->add_incr_cu(i, dsn::blob());
         if (i == rocksdb::Status::kOk) {
             ASSERT_EQ(_cal->read_cu, 1);
             ASSERT_EQ(_cal->write_cu, 1);


### PR DESCRIPTION
hotkey capturing is executed in `capacity_unit_calculator`.
Both `capture_raw_key` and `capture_hash_key` have two params: `key` `weight`
`key`: raw_key or hash_key
`weight`: In some scenarios, some keys will be counted several times, we can capture these keys just one time.


