### PR TITLE
fix: fix log bug in multi_get

### DIFF
--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -492,7 +492,7 @@ void pegasus_server_impl::on_multi_get(multi_get_rpc rpc)
                 if (r == 1) {
                     count++;
                     auto &kv = resp.kvs.back();
-                    int64_t kv_size = kv.key.length() + kv.value.length();
+                    uint64_t kv_size = kv.key.length() + kv.value.length();
                     size += kv_size;
                     limiter->add_size(kv_size);
                 } else if (r == 2) {
@@ -557,7 +557,7 @@ void pegasus_server_impl::on_multi_get(multi_get_rpc rpc)
                 if (r == 1) {
                     count++;
                     auto &kv = reverse_kvs.back();
-                    int64_t kv_size = kv.key.length() + kv.value.length();
+                    uint64_t kv_size = kv.key.length() + kv.value.length();
                     size += kv_size;
                     limiter->add_size(kv_size);
                 } else if (r == 2) {

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -492,7 +492,9 @@ void pegasus_server_impl::on_multi_get(multi_get_rpc rpc)
                 if (r == 1) {
                     count++;
                     auto &kv = resp.kvs.back();
-                    limiter->add_size(kv.key.length() + kv.value.length());
+                    int64_t kv_size = kv.key.length() + kv.value.length();
+                    size += kv_size;
+                    limiter->add_size(kv_size);
                 } else if (r == 2) {
                     expire_count++;
                 } else { // r == 3
@@ -555,7 +557,9 @@ void pegasus_server_impl::on_multi_get(multi_get_rpc rpc)
                 if (r == 1) {
                     count++;
                     auto &kv = reverse_kvs.back();
-                    limiter->add_size(kv.key.length() + kv.value.length());
+                    int64_t kv_size = kv.key.length() + kv.value.length();
+                    size += kv_size;
+                    limiter->add_size(kv_size);
                 } else if (r == 2) {
                     expire_count++;
                 } else { // r == 3


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
In fuction multi_get,  there is a statistical error in result size, which is used for logging. So this pr fix this bug.

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1. change to print the log when a multi_get request is coming.
2. send a multi_get request to onebox
```
>>> use temp
OK
>>> set a b c
OK

app_id          : 2
partition_index : 4
decree          : 1
server          : 10.232.55.210:34802
>>> multi_get a
"a" : "b" => "c"

1 key-value pairs got, fetch completed.

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
```
3. grep the abnormal log, the result_size is not 0.
```
➜  onebox git:(log-bug) ✗ grep -rn -I "abnormal" .
./replica3/data/log/log.1.txt:877:W2020-12-08 12:04:32.4495 (1607400272449200763 13bb) replica.local_app0.030013ae00010074: pegasus_server_impl.cpp:733:on_multi_get(): [2.4@10.232.55.210:34803] rocksdb abnormal multi_get from 10.232.55.210:1: hash_key = a, start_sort_key =  (inclusive), stop_sort_key =  (exclusive), sort_key_filter_type = FT_NO_FILTER, sort_key_filter_pattern = , max_kv_count = -1, max_kv_size = -1, reverse = false, result_count = 2, result_size = 4, iteration_count = 2, expire_count = 0, filter_count = 0, time_used = 155070 ns
```
