### PR TITLE
refactor: use rocksdb_wrapper::get to reimplement check_and_set

### DIFF
--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -311,7 +311,7 @@ public:
         bool value_exist = !get_context.expired && get_context.found;
         if (value_exist) {
             pegasus_extract_user_data(
-                    _pegasus_data_version, std::move(get_context.raw_value), check_value);
+                _pegasus_data_version, std::move(get_context.raw_value), check_value);
         }
 
         if (update.return_check_value) {

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -292,41 +292,31 @@ public:
 
         ::dsn::blob check_key;
         pegasus_generate_key(check_key, update.hash_key, update.check_sort_key);
-        rocksdb::Slice check_raw_key(check_key.data(), check_key.length());
-        std::string check_raw_value;
-        rocksdb::Status check_status = _db->Get(_rd_opts, check_raw_key, &check_raw_value);
-        if (check_status.ok()) {
-            // read check value succeed
-            if (check_if_record_expired(
-                    _pegasus_data_version, utils::epoch_now(), check_raw_value)) {
-                // check value ttl timeout
-                _pfc_recent_expire_count->increment();
-                check_status = rocksdb::Status::NotFound();
-            }
-        } else if (!check_status.IsNotFound()) {
+
+        db_get_context get_context;
+        dsn::string_view check_raw_key(check_key.data(), check_key.length());
+        int err = _rocksdb_wrapper->get(check_raw_key, &get_context);
+        if (err != 0) {
             // read check value failed
-            derror_rocksdb("GetCheckValue for CheckAndSet",
-                           check_status.ToString(),
-                           "decree: {}, hash_key: {}, check_sort_key: {}",
+            derror_rocksdb("Error to GetCheckValue for CheckAndSet decree: {}, hash_key: {}, "
+                           "check_sort_key: {}",
                            decree,
                            utils::c_escape_string(update.hash_key),
                            utils::c_escape_string(update.check_sort_key));
-            resp.error = check_status.code();
+            resp.error = err;
             return resp.error;
         }
-        dassert_f(check_status.ok() || check_status.IsNotFound(),
-                  "status = %s",
-                  check_status.ToString().c_str());
 
         ::dsn::blob check_value;
-        if (check_status.ok()) {
+        bool value_exist = !get_context.expired && get_context.found;
+        if (value_exist) {
             pegasus_extract_user_data(
-                _pegasus_data_version, std::move(check_raw_value), check_value);
+                    _pegasus_data_version, std::move(get_context.raw_value), check_value);
         }
 
         if (update.return_check_value) {
             resp.check_value_returned = true;
-            if (check_status.ok()) {
+            if (value_exist) {
                 resp.check_value_exist = true;
                 resp.check_value = check_value;
             }
@@ -336,7 +326,7 @@ public:
         bool passed = validate_check(decree,
                                      update.check_type,
                                      update.check_operand,
-                                     check_status.ok(),
+                                     value_exist,
                                      check_value,
                                      invalid_argument);
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
use rocksdb_wrapper::get to reimplement `check_and_set`.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

There are a lot of function tests in `test_check_and_test.cpp`.

- Manual test (add detailed scripts or steps below)
```
>>> use temp
OK
>>> check_and_set a -c b -t exist -s b1 -v c1 -r
hash_key: "a"
check_sort_key: "b"
check_type: exist
set_sort_key: "b1"
set_value: "c1"
set_value_ttl_seconds: 0
return_check_value: true

Set failed, because check not passed.

Check value not exist.

app_id          : 2
partition_index : 4
decree          : 16
server          : 10.232.55.210:34802
>>> set a b c
OK

app_id          : 2
partition_index : 4
decree          : 17
server          : 10.232.55.210:34802
>>> get a b
"c"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> check_and_set a -c b -t exist -s b1 -v c1 -r
hash_key: "a"
check_sort_key: "b"
check_type: exist
set_sort_key: "b1"
set_value: "c1"
set_value_ttl_seconds: 0
return_check_value: true

Set succeed.

Check value: "c"

app_id          : 2
partition_index : 4
decree          : 18
server          : 10.232.55.210:34802
>>> get a b1
"c1"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> set a b c 1
OK

app_id          : 2
partition_index : 4
decree          : 26
server          : 10.232.55.210:34802
>>> check_and_set a -c b -t exist -s b2 -v c2 -r
hash_key: "a"
check_sort_key: "b"
check_type: exist
set_sort_key: "b2"
set_value: "c2"
set_value_ttl_seconds: 0
return_check_value: true

Set failed, because check not passed.

Check value not exist.

app_id          : 2
partition_index : 4
decree          : 27
server          : 10.232.55.210:34802
>>> get a b2
Not found

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> check_and_set a -c b -t not_exist -s b2 -v c2 -r
hash_key: "a"
check_sort_key: "b"
check_type: not_exist
set_sort_key: "b2"
set_value: "c2"
set_value_ttl_seconds: 0
return_check_value: true

Set succeed.

Check value not exist.

app_id          : 2
partition_index : 4
decree          : 41
server          : 10.232.55.210:34802
>>> get a b2
"c2"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802

```