### PR TITLE
refactor: use rocksdb_wrapper::get to reimplement check_and_mutate

### DIFF
--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -422,41 +422,31 @@ public:
 
         ::dsn::blob check_key;
         pegasus_generate_key(check_key, update.hash_key, update.check_sort_key);
-        rocksdb::Slice check_raw_key(check_key.data(), check_key.length());
-        std::string check_raw_value;
-        rocksdb::Status check_status = _db->Get(_rd_opts, check_raw_key, &check_raw_value);
-        if (check_status.ok()) {
-            // read check value succeed
-            if (check_if_record_expired(
-                    _pegasus_data_version, utils::epoch_now(), check_raw_value)) {
-                // check value ttl timeout
-                _pfc_recent_expire_count->increment();
-                check_status = rocksdb::Status::NotFound();
-            }
-        } else if (!check_status.IsNotFound()) {
+
+        db_get_context get_context;
+        dsn::string_view check_raw_key(check_key.data(), check_key.length());
+        int err = _rocksdb_wrapper->get(check_raw_key, &get_context);
+        if (err != 0) {
             // read check value failed
-            derror_rocksdb("GetCheckValue for CheckAndMutate",
-                           check_status.ToString(),
-                           "decree: {}, hash_key: {}, check_sort_key: {}",
+            derror_rocksdb("Error to GetCheckValue for CheckAndMutate decree: {}, hash_key: {}, "
+                           "check_sort_key: {}",
                            decree,
                            utils::c_escape_string(update.hash_key),
                            utils::c_escape_string(update.check_sort_key));
-            resp.error = check_status.code();
+            resp.error = err;
             return resp.error;
         }
-        dassert_f(check_status.ok() || check_status.IsNotFound(),
-                  "status = %s",
-                  check_status.ToString().c_str());
 
         ::dsn::blob check_value;
-        if (check_status.ok()) {
+        bool value_exist = !get_context.expired && get_context.found;
+        if (value_exist) {
             pegasus_extract_user_data(
-                _pegasus_data_version, std::move(check_raw_value), check_value);
+                _pegasus_data_version, std::move(get_context.raw_value), check_value);
         }
 
         if (update.return_check_value) {
             resp.check_value_returned = true;
-            if (check_status.ok()) {
+            if (value_exist) {
                 resp.check_value_exist = true;
                 resp.check_value = check_value;
             }
@@ -466,7 +456,7 @@ public:
         bool passed = validate_check(decree,
                                      update.check_type,
                                      update.check_operand,
-                                     check_status.ok(),
+                                     value_exist,
                                      check_value,
                                      invalid_argument);
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
use rocksdb_wrapper::get to reimplement `check_and_mutate`.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

There are a lot of function tests in `test_check_and_mutate.cpp`.

- Manual test (add detailed scripts or steps below)
```
>>> use temp
OK
>>> exist a b 
False

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> check_and_mutate a -c b -t exist -r
Load mutations, like
  set <sort_key> <value> [ttl]
  del <sort_key>
Print "ok" to finish loading, "abort" to abort this command
>>> set b1 c1
LOAD: set sortkey "b1", value "c1", ttl 0
>>> set b2 c2
LOAD: set sortkey "b2", value "c2", ttl 0
>>> ok
INFO: load mutations done.

hash_key: "a"
check_sort_key: "b"
check_type: exist
return_check_value: true
mutations:
  mutation[0].type: SET
  mutation[0].sort_key: "b1"
  mutation[0].value: "c1"
  mutation[0].expire_seconds: 0
  mutation[1].type: SET
  mutation[1].sort_key: "b2"
  mutation[1].value: "c2"
  mutation[1].expire_seconds: 0

Mutate failed, because check not passed.

Check value not exist.

app_id          : 2
partition_index : 4
decree          : 13
server          : 10.232.55.210:34802
>>> get a b1
Not found

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> get a b2
Not found

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> set a b c
OK

app_id          : 2
partition_index : 4
decree          : 14
server          : 10.232.55.210:34802
>>> check_and_mutate a -c b -t exist -r
Load mutations, like
  set <sort_key> <value> [ttl]
  del <sort_key>
Print "ok" to finish loading, "abort" to abort this command
>>> set b1 c1
LOAD: set sortkey "b1", value "c1", ttl 0
>>> set b2 c2
LOAD: set sortkey "b2", value "c2", ttl 0
>>> ok
INFO: load mutations done.

hash_key: "a"
check_sort_key: "b"
check_type: exist
return_check_value: true
mutations:
  mutation[0].type: SET
  mutation[0].sort_key: "b1"
  mutation[0].value: "c1"
  mutation[0].expire_seconds: 0
  mutation[1].type: SET
  mutation[1].sort_key: "b2"
  mutation[1].value: "c2"
  mutation[1].expire_seconds: 0

Mutate succeed.

Check value: "c"

app_id          : 2
partition_index : 4
decree          : 16
server          : 10.232.55.210:34802
>>> get a b1
"c1"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> get a b2
"c2"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> set a b c 1
OK

app_id          : 2
partition_index : 4
decree          : 19
server          : 10.232.55.210:34802
>>> check_and_mutate a -c b -t exist -r
Load mutations, like
  set <sort_key> <value> [ttl]
  del <sort_key>
Print "ok" to finish loading, "abort" to abort this command
>>> set b3 c3
LOAD: set sortkey "b3", value "c3", ttl 0
>>> ok
INFO: load mutations done.

hash_key: "a"
check_sort_key: "b"
check_type: exist
return_check_value: true
mutations:
  mutation[0].type: SET
  mutation[0].sort_key: "b3"
  mutation[0].value: "c3"
  mutation[0].expire_seconds: 0

Mutate failed, because check not passed.

Check value not exist.

app_id          : 2
partition_index : 4
decree          : 20
server          : 10.232.55.210:34802
>>> exist a b3
False

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> check_and_mutate a -c b -t not_exist -r
Load mutations, like
  set <sort_key> <value> [ttl]
  del <sort_key>
Print "ok" to finish loading, "abort" to abort this command
>>> set b3 c3
LOAD: set sortkey "b3", value "c3", ttl 0
>>> ok
INFO: load mutations done.

hash_key: "a"
check_sort_key: "b"
check_type: not_exist
return_check_value: true
mutations:
  mutation[0].type: SET
  mutation[0].sort_key: "b3"
  mutation[0].value: "c3"
  mutation[0].expire_seconds: 0

Mutate succeed.

Check value not exist.

app_id          : 2
partition_index : 4
decree          : 39
server          : 10.232.55.210:34802
>>> get a b3
"c3"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
```