### PR TITLE
chore: add config_hdfs.sh

### DIFF
--- a/config_hdfs.sh
+++ b/config_hdfs.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file should be sourced to set up LD_LIBRARY_PATH and CLASSPATH to
+# run Pegasus binaries which use libhdfs in the context of a dev environment.
+
+# Try to detect the system's JAVA_HOME
+# If javac exists, then the system has a Java SDK (JRE does not have javac).
+# Follow the symbolic links and use this to determine the system's JAVA_HOME.
+SYSTEM_JAVA_HOME="/usr/java/default"
+if [ -n "$(which javac)" ]; then
+  SYSTEM_JAVA_HOME=$(which javac | xargs readlink -f | sed "s:/bin/javac::")
+fi
+# Prefer the JAVA_HOME set in the environment, but use the system's JAVA_HOME otherwise.
+export JAVA_HOME="${JAVA_HOME:-${SYSTEM_JAVA_HOME}}"
+if [ ! -d "$JAVA_HOME" ]; then
+  echo "JAVA_HOME must be set to the location of your JDK!"
+  return 1
+fi
+# Link jvm library.
+JAVA_JVM_LIBRARY_DIR=$(dirname $(find "${JAVA_HOME}/" -name libjvm.so  | head -1))
+export LD_LIBRARY_PATH=${JAVA_JVM_LIBRARY_DIR}:$LD_LIBRARY_PATH
+
+# Set CLASSPATH to all the Hadoop jars needed to run Hadoop itself as well as
+# the right configuration directory containing core-site.xml or hdfs-site.xml.
+PEGASUS_HADOOP_HOME=`pwd`/rdsn/thirdparty/build/Source/hadoop
+# Prefer the HADOOP_HOME set in the environment, but use the pegasus's hadoop dir otherwise.
+export HADOOP_HOME="${HADOOP_HOME:-${PEGASUS_HADOOP_HOME}}"
+if [ ! -d "$HADOOP_HOME/etc/hadoop" ] || [ ! -d "$HADOOP_HOME/share/hadoop" ]; then
+  echo "HADOOP_HOME must be set to the location of your Hadoop jars and core-site.xml."
+  return 1
+fi
+export CLASSPATH=$CLASSPATH:$HADOOP_HOME/etc/hadoop/
+for f in $HADOOP_HOME/share/hadoop/common/lib/*.jar; do
+  export CLASSPATH=$CLASSPATH:$f
+done
+for f in $HADOOP_HOME/share/hadoop/common/*.jar; do
+  export CLASSPATH=$CLASSPATH:$f
+done
+for f in $HADOOP_HOME/share/hadoop/hdfs/lib/*.jar; do
+  export CLASSPATH=$CLASSPATH:$f
+done
+for f in $HADOOP_HOME/share/hadoop/hdfs/*.jar; do
+  export CLASSPATH=$CLASSPATH:$f
+done

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -32,8 +32,7 @@ if [ "$modified" ]; then
     exit 1
 fi
 
-export LD_LIBRARY_PATH=/usr/local/lib/jvm/openjdk11/lib/server:$LD_LIBRARY_PATH
-
+source "${root}"/config_hdfs.sh
 "${root}"/run.sh build -c --skip_thirdparty --disable_gperf && ./run.sh test --on_travis
 ret=$?
 if [ $ret ]; then


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Add config_hdfs.sh to help users set `LD_LIBRARY_PATH` and `CLASSPATH` when running
pegasus binaries which use libhdfs.

### What is changed and how it works?
- Add config_hdfs.sh

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
Build and run pegasus with libjvm.so directory not set in `LD_LIBRARY_PATH`

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
