### PR TITLE
feat(bulk_load): add remote_file_root for start_bulk_load_request

### DIFF
--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -266,7 +266,6 @@
   cold_backup_root = %{cluster.name}
   max_concurrent_uploading_file_count = 10
 
-  bulk_load_provider_root = bulk_load_root
   max_concurrent_bulk_load_downloading_count = 5
 
 [pegasus.server]

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -117,7 +117,6 @@
   duplication_disabled = true
   cluster_name = onebox
   cold_backup_checkpoint_reserve_minutes = 10
-  bulk_load_provider_root = bulk_load_root
 
 [meta_server.apps.@APP_NAME@]
   app_name = @APP_NAME@

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -460,7 +460,8 @@ static command_executor commands[] = {
     {
         "start_bulk_load",
         "start app bulk load",
-        "<-a --app_name str> <-c --cluster_name str> <-p --file_provider_type str>",
+        "<-a --app_name str> <-c --cluster_name str> <-p --file_provider_type str> <-r "
+        "--root_path>",
         start_bulk_load,
     },
     {

--- a/src/test/function_test/test_bulk_load.cpp
+++ b/src/test/function_test/test_bulk_load.cpp
@@ -103,7 +103,7 @@ public:
 
     error_code start_bulk_load()
     {
-        auto err_resp = ddl_client->start_bulk_load(APP_NAME, CLUSTER, PROVIDER);
+        auto err_resp = ddl_client->start_bulk_load(APP_NAME, CLUSTER, PROVIDER, LOCAL_ROOT);
         return err_resp.get_value().err;
     }
 


### PR DESCRIPTION
rdsn [686](https://github.com/XiaoMi/rdsn/pull/686) support user-defined remote file provider root path, this pr update shell command and tests, and remove useless `bulk_load_provider_root` in config file.