### PR TITLE
refactor: use rocksdb_wrapper::write_batch_put_ctx to reimplement multi_put

### DIFF
--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -135,20 +135,19 @@ public:
             return empty_put(decree);
         }
 
+        auto cleanup = dsn::defer([this]() { _rocksdb_wrapper->clear_up_write_batch(); });
         for (auto &kv : update.kvs) {
-            resp.error = db_write_batch_put_ctx(ctx,
-                                                composite_raw_key(update.hash_key, kv.key),
-                                                kv.value,
-                                                static_cast<uint32_t>(update.expire_ts_seconds));
+            resp.error = _rocksdb_wrapper->write_batch_put_ctx(
+                ctx,
+                composite_raw_key(update.hash_key, kv.key),
+                kv.value,
+                static_cast<uint32_t>(update.expire_ts_seconds));
             if (resp.error) {
-                clear_up_batch_states(decree, resp.error);
                 return resp.error;
             }
         }
 
-        resp.error = db_write(decree);
-
-        clear_up_batch_states(decree, resp.error);
+        resp.error = _rocksdb_wrapper->write(decree);
         return resp.error;
     }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
use `rocksdb_wrapper::write_batch_put_ctx` to reimplement multi_put.

- Manual test (add detailed scripts or steps below)
```
>>> use temp
OK
>>> ls -d
[general_info]
app_id  status     app_name  app_type  partition_count  replica_count  is_stateful  create_time          drop_time  drop_expire  envs_count  
1       AVAILABLE  stat      pegasus   4                3              true         2020-12-31_14:40:35  -          -            0           
2       AVAILABLE  temp      pegasus   8                3              true         2020-12-31_14:40:35  -          -            0           

[healthy_info]
app_id  app_name  partition_count  fully_healthy  unhealthy  write_unhealthy  read_unhealthy  
1       stat      4                4              0          0                0               
2       temp      8                8              0          0                0               

[summary]
total_app_count            : 2
fully_healthy_app_count    : 2
unhealthy_app_count        : 0
write_unhealthy_app_count  : 0
read_unhealthy_app_count   : 0

>>> multi_set hash sort1 value1 sort2 value2 sort3 value3
OK

app_id          : 2
partition_index : 4
decree          : 5
server          : 10.232.55.210:34803
>>> multi_get hash sort1 sort2 sort3
"hash" : "sort1" => "value1"
"hash" : "sort2" => "value2"
"hash" : "sort3" => "value3"

3 key-value pairs got, fetch completed.

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34803
>>> 
```