### PR TITLE
refactor: use rocksdb_wrapper::write_batch_put to reimplement incr

### DIFF
--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -256,19 +256,17 @@ public:
             }
         }
 
-        resp.error =
-            db_write_batch_put(decree, update.key, std::to_string(new_value), new_expire_ts);
+        auto cleanup = dsn::defer([this]() { _rocksdb_wrapper->clear_up_write_batch(); });
+        resp.error = _rocksdb_wrapper->write_batch_put(
+            decree, update.key, std::to_string(new_value), new_expire_ts);
         if (resp.error) {
-            clear_up_batch_states(decree, resp.error);
             return resp.error;
         }
 
-        resp.error = db_write(decree);
+        resp.error = _rocksdb_wrapper->write(decree);
         if (resp.error == 0) {
             resp.new_value = new_value;
         }
-
-        clear_up_batch_states(decree, resp.error);
         return resp.error;
     }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
use rocksdb_wrapper::write_batch_put to reimplement incr

There are a lot of function tests in `test_incr.cpp.`

- Manual test (add detailed scripts or steps below)
```
>>> use temp
OK
>>> incr a b 0
0

app_id          : 2
partition_index : 4
decree          : 5
server          : 10.232.55.210:34802
>>> get a b 
"0"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> incr a b 1
1

app_id          : 2
partition_index : 4
decree          : 6
server          : 10.232.55.210:34802
>>> get a b 
"1"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> incr a b 5
6

app_id          : 2
partition_index : 4
decree          : 7
server          : 10.232.55.210:34802
>>> get a b 
"6"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802

```