### PR TITLE
refactor: move write_batch_delete into rocksdb_wrapper

### DIFF
--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -29,6 +29,7 @@
 namespace dsn {
 namespace replication {
 
+
 /// static definition of mutation_duplicator::creator.
 /*static*/ std::function<std::unique_ptr<mutation_duplicator>(
     replica_base *, string_view, string_view)>

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -29,7 +29,6 @@
 namespace dsn {
 namespace replication {
 
-
 /// static definition of mutation_duplicator::creator.
 /*static*/ std::function<std::unique_ptr<mutation_duplicator>(
     replica_base *, string_view, string_view)>

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -169,21 +169,19 @@ public:
             return empty_put(decree);
         }
 
+        auto cleanup = dsn::defer([this]() { _rocksdb_wrapper->clear_up_write_batch(); });
         for (auto &sort_key : update.sort_keys) {
             resp.error =
-                db_write_batch_delete(decree, composite_raw_key(update.hash_key, sort_key));
+                _rocksdb_wrapper->write_batch_delete(decree, composite_raw_key(update.hash_key, sort_key));
             if (resp.error) {
-                clear_up_batch_states(decree, resp.error);
                 return resp.error;
             }
         }
 
-        resp.error = db_write(decree);
+        resp.error = _rocksdb_wrapper->write(decree);
         if (resp.error == 0) {
             resp.count = update.sort_keys.size();
         }
-
-        clear_up_batch_states(decree, resp.error);
         return resp.error;
     }
 

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -171,8 +171,8 @@ public:
 
         auto cleanup = dsn::defer([this]() { _rocksdb_wrapper->clear_up_write_batch(); });
         for (auto &sort_key : update.sort_keys) {
-            resp.error =
-                _rocksdb_wrapper->write_batch_delete(decree, composite_raw_key(update.hash_key, sort_key));
+            resp.error = _rocksdb_wrapper->write_batch_delete(
+                decree, composite_raw_key(update.hash_key, sort_key));
             if (resp.error) {
                 return resp.error;
             }

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -169,7 +169,7 @@ int rocksdb_wrapper::write_batch_delete(int64_t decree, dsn::string_view raw_key
     if (dsn_unlikely(!s.ok())) {
         dsn::blob hash_key, sort_key;
         pegasus_restore_key(dsn::blob(raw_key.data(), 0, raw_key.size()), hash_key, sort_key);
-        derror_rocksdb("WriteBatchDelete",
+        derror_rocksdb("write_batch_delete",
                        s.ToString(),
                        "decree: {}, hash_key: {}, sort_key: {}",
                        decree,

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -163,18 +163,18 @@ int rocksdb_wrapper::write(int64_t decree)
 int rocksdb_wrapper::write_batch_delete(int64_t decree, dsn::string_view raw_key)
 {
     FAIL_POINT_INJECT_F("db_write_batch_delete",
-            [](dsn::string_view) -> int { return FAIL_DB_WRITE_BATCH_DELETE; });
+                        [](dsn::string_view) -> int { return FAIL_DB_WRITE_BATCH_DELETE; });
 
     rocksdb::Status s = _write_batch->Delete(utils::to_rocksdb_slice(raw_key));
     if (dsn_unlikely(!s.ok())) {
         dsn::blob hash_key, sort_key;
         pegasus_restore_key(dsn::blob(raw_key.data(), 0, raw_key.size()), hash_key, sort_key);
         derror_rocksdb("WriteBatchDelete",
-                s.ToString(),
-                "decree: {}, hash_key: {}, sort_key: {}",
-                decree,
-                utils::c_escape_string(hash_key),
-                utils::c_escape_string(sort_key));
+                       s.ToString(),
+                       "decree: {}, hash_key: {}, sort_key: {}",
+                       decree,
+                       utils::c_escape_string(hash_key),
+                       utils::c_escape_string(sort_key));
     }
     return s.code();
 }

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -160,6 +160,25 @@ int rocksdb_wrapper::write(int64_t decree)
     return status.code();
 }
 
+int rocksdb_wrapper::write_batch_delete(int64_t decree, dsn::string_view raw_key)
+{
+    FAIL_POINT_INJECT_F("db_write_batch_delete",
+            [](dsn::string_view) -> int { return FAIL_DB_WRITE_BATCH_DELETE; });
+
+    rocksdb::Status s = _write_batch->Delete(utils::to_rocksdb_slice(raw_key));
+    if (dsn_unlikely(!s.ok())) {
+        dsn::blob hash_key, sort_key;
+        pegasus_restore_key(dsn::blob(raw_key.data(), 0, raw_key.size()), hash_key, sort_key);
+        derror_rocksdb("WriteBatchDelete",
+                s.ToString(),
+                "decree: {}, hash_key: {}, sort_key: {}",
+                decree,
+                utils::c_escape_string(hash_key),
+                utils::c_escape_string(sort_key));
+    }
+    return s.code();
+}
+
 void rocksdb_wrapper::clear_up_write_batch() { _write_batch->Clear(); }
 
 void rocksdb_wrapper::set_default_ttl(uint32_t ttl)

--- a/src/server/rocksdb_wrapper.h
+++ b/src/server/rocksdb_wrapper.h
@@ -62,6 +62,7 @@ public:
                             dsn::string_view value,
                             uint32_t expire_sec);
     int write(int64_t decree);
+    int write_batch_delete(int64_t decree, dsn::string_view raw_key);
     void clear_up_write_batch();
 
     void set_default_ttl(uint32_t ttl);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
move write_batch_delete into rocksdb_wrapper, and use it to reimplement `multi_remove`


- Manual test (add detailed scripts or steps below)
```
>>> use temp
OK
>>> multi_set hash sort1 value1 sort2 value2 sort3 value3 sort4 value4
OK

app_id          : 2
partition_index : 4
decree          : 9
server          : 10.232.55.210:34802
>>> multi_get hash
"hash" : "sort1" => "value1"
"hash" : "sort2" => "value2"
"hash" : "sort3" => "value3"
"hash" : "sort4" => "value4"

4 key-value pairs got, fetch completed.

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> multi_del hash sort1
1 key-value pairs deleted.

app_id          : 2
partition_index : 4
decree          : 10
server          : 10.232.55.210:34802
>>> multi_get hash
"hash" : "sort2" => "value2"
"hash" : "sort3" => "value3"
"hash" : "sort4" => "value4"

3 key-value pairs got, fetch completed.

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> multi_del hash sort2 sort3
2 key-value pairs deleted.

app_id          : 2
partition_index : 4
decree          : 11
server          : 10.232.55.210:34802
>>> multi_get hash
"hash" : "sort4" => "value4"

1 key-value pairs got, fetch completed.

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> multi_del hash sort4
1 key-value pairs deleted.

app_id          : 2
partition_index : 4
decree          : 13
server          : 10.232.55.210:34802
>>> multi_get hash

0 key-value pairs got, fetch completed.

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
```