### PR TITLE
refactor: use rocksdb_wrapper to reimplement empty_put

### DIFF
--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -104,15 +104,13 @@ public:
 
     int empty_put(int64_t decree)
     {
-        int err = db_write_batch_put(decree, dsn::string_view(), dsn::string_view(), 0);
+        int err = _rocksdb_wrapper->write_batch_put(decree, dsn::string_view(), dsn::string_view(), 0);
+        auto cleanup = dsn::defer([this]() { _rocksdb_wrapper->clear_up_write_batch(); });
         if (err) {
-            clear_up_batch_states(decree, err);
             return err;
         }
 
-        err = db_write(decree);
-
-        clear_up_batch_states(decree, err);
+        err = _rocksdb_wrapper->write(decree);
         return err;
     }
 

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -104,7 +104,8 @@ public:
 
     int empty_put(int64_t decree)
     {
-        int err = _rocksdb_wrapper->write_batch_put(decree, dsn::string_view(), dsn::string_view(), 0);
+        int err =
+            _rocksdb_wrapper->write_batch_put(decree, dsn::string_view(), dsn::string_view(), 0);
         auto cleanup = dsn::defer([this]() { _rocksdb_wrapper->clear_up_write_batch(); });
         if (err) {
             return err;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
use rocksdb_wrapper to reimplement `empty_put`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
 There are some unit tests in `pegasus_write_service_test.cpp` to test `empty_put`

- Manual test (add detailed scripts or steps below)
Use incr to trigger empty_put

```
>>> use temp
OK
>>> set a b c
OK

app_id          : 2
partition_index : 4
decree          : 1
server          : 10.232.55.210:34802
>>> incr a b 1
ERROR: invalid argument

app_id          : 2
partition_index : 4
decree          : 2
server          : 10.232.55.210:34802
>>> incr a b 1
ERROR: invalid argument

app_id          : 2
partition_index : 4
decree          : 3
server          : 10.232.55.210:34802
>>> incr a b 5
ERROR: invalid argument

app_id          : 2
partition_index : 4
decree          : 5
server          : 10.232.55.210:34802
```