### PR TITLE
refactor: use rocksdb_wrapper to reimplement check_and_mutate

### DIFF
--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -452,13 +452,13 @@ public:
                 ::dsn::blob key;
                 pegasus_generate_key(key, update.hash_key, m.sort_key);
                 if (m.operation == ::dsn::apps::mutate_operation::MO_PUT) {
-                    resp.error = db_write_batch_put(
+                    resp.error = _rocksdb_wrapper->write_batch_put(
                         decree, key, m.value, static_cast<uint32_t>(m.set_expire_ts_seconds));
                 } else {
                     dassert_f(m.operation == ::dsn::apps::mutate_operation::MO_DELETE,
                               "m.operation = %d",
                               m.operation);
-                    resp.error = db_write_batch_delete(decree, key);
+                    resp.error = _rocksdb_wrapper->write_batch_delete(decree, key);
                 }
 
                 // in case of failure, cancel mutations
@@ -467,17 +467,17 @@ public:
             }
         } else {
             // check not passed, write empty record to update rocksdb's last flushed decree
-            resp.error = db_write_batch_put(decree, dsn::string_view(), dsn::string_view(), 0);
+            resp.error = _rocksdb_wrapper->write_batch_put(
+                decree, dsn::string_view(), dsn::string_view(), 0);
         }
 
+        auto cleanup = dsn::defer([this]() { _rocksdb_wrapper->clear_up_write_batch(); });
         if (resp.error) {
-            clear_up_batch_states(decree, resp.error);
             return resp.error;
         }
 
-        resp.error = db_write(decree);
+        resp.error = _rocksdb_wrapper->write(decree);
         if (resp.error) {
-            clear_up_batch_states(decree, resp.error);
             return resp.error;
         }
 
@@ -486,8 +486,6 @@ public:
             resp.error =
                 invalid_argument ? rocksdb::Status::kInvalidArgument : rocksdb::Status::kTryAgain;
         }
-
-        clear_up_batch_states(decree, resp.error);
         return 0;
     }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
use rocksdb_wrapper to reimplement check_and_mutate

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

There are a lot of function tests in `test_check_and_mutate.cpp`.

- Manual test (add detailed scripts or steps below)

```
>>> use temp
OK
>>> exist a b 
False

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34803
>>> check_and_mutate a -c b -t exist -r
Load mutations, like
  set <sort_key> <value> [ttl]
  del <sort_key>
Print "ok" to finish loading, "abort" to abort this command
>>> set b1 c1
LOAD: set sortkey "b1", value "c1", ttl 0
>>> set b2 c2
LOAD: set sortkey "b2", value "c2", ttl 0
>>> ok
INFO: load mutations done.

hash_key: "a"
check_sort_key: "b"
check_type: exist
return_check_value: true
mutations:
  mutation[0].type: SET
  mutation[0].sort_key: "b1"
  mutation[0].value: "c1"
  mutation[0].expire_seconds: 0
  mutation[1].type: SET
  mutation[1].sort_key: "b2"
  mutation[1].value: "c2"
  mutation[1].expire_seconds: 0

Mutate failed, because check not passed.

Check value not exist.

app_id          : 2
partition_index : 4
decree          : 9
server          : 10.232.55.210:34803
>>> get a b1
Not found

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34803
>>> get a b2
Not found

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34803
>>> set a b c
OK

app_id          : 2
partition_index : 4
decree          : 14
server          : 10.232.55.210:34803
>>> check_and_mutate a -c b -t exist -r
Load mutations, like
  set <sort_key> <value> [ttl]
  del <sort_key>
Print "ok" to finish loading, "abort" to abort this command
>>> set b1 c1
LOAD: set sortkey "b1", value "c1", ttl 0
>>> set b2 c2
LOAD: set sortkey "b2", value "c2", ttl 0
>>> ok
INFO: load mutations done.

hash_key: "a"
check_sort_key: "b"
check_type: exist
return_check_value: true
mutations:
  mutation[0].type: SET
  mutation[0].sort_key: "b1"
  mutation[0].value: "c1"
  mutation[0].expire_seconds: 0
  mutation[1].type: SET
  mutation[1].sort_key: "b2"
  mutation[1].value: "c2"
  mutation[1].expire_seconds: 0

Mutate succeed.

Check value: "c"

app_id          : 2
partition_index : 4
decree          : 18
server          : 10.232.55.210:34803
>>> get a b1
"c1"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34803
>>> get a b2
"c2"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34803
>>>  set a b c 1
OK

app_id          : 2
partition_index : 4
decree          : 21
server          : 10.232.55.210:34803
>>> check_and_mutate a -c b -t exist -r
Load mutations, like
  set <sort_key> <value> [ttl]
  del <sort_key>
Print "ok" to finish loading, "abort" to abort this command
>>>  set b3 c3
LOAD: set sortkey "b3", value "c3", ttl 0
>>> ok
INFO: load mutations done.

hash_key: "a"
check_sort_key: "b"
check_type: exist
return_check_value: true
mutations:
  mutation[0].type: SET
  mutation[0].sort_key: "b3"
  mutation[0].value: "c3"
  mutation[0].expire_seconds: 0

Mutate failed, because check not passed.

Check value not exist.

app_id          : 2
partition_index : 4
decree          : 24
server          : 10.232.55.210:34803
>>> exist a b3
False

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34803
>>> check_and_mutate a -c b -t not_exist -r
Load mutations, like
  set <sort_key> <value> [ttl]
  del <sort_key>
Print "ok" to finish loading, "abort" to abort this command
>>> set b3 c3
LOAD: set sortkey "b3", value "c3", ttl 0
>>> ok
INFO: load mutations done.

hash_key: "a"
check_sort_key: "b"
check_type: not_exist
return_check_value: true
mutations:
  mutation[0].type: SET
  mutation[0].sort_key: "b3"
  mutation[0].value: "c3"
  mutation[0].expire_seconds: 0

Mutate succeed.

Check value not exist.

app_id          : 2
partition_index : 4
decree          : 28
server          : 10.232.55.210:34803
>>> get a b3
"c3"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34803

```