### PR TITLE
fix: compilation error in pegasus_utils

### DIFF
--- a/src/base/pegasus_utils.h
+++ b/src/base/pegasus_utils.h
@@ -62,7 +62,7 @@ public:
             result.emplace_front(_queue.top());
             _queue.pop();
         }
-        return std::move(result);
+        return result;
     }
 
 protected:


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

```
/home/wutao1/git/pegasus/src/base/test/../pegasus_utils.h:65:32: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
   65 |         return std::move(result);
      |                                ^
/home/wutao1/git/pegasus/src/base/test/../pegasus_utils.h:65:32: note: remove ‘std::move’ call
```

### What is changed and how it works?

