### PR TITLE
feat: add perf counter to record the rejected duplicate rpc count

### DIFF
--- a/src/server/pegasus_mutation_duplicator.h
+++ b/src/server/pegasus_mutation_duplicator.h
@@ -69,6 +69,7 @@ private:
 
     dsn::perf_counter_wrapper _shipped_ops;
     dsn::perf_counter_wrapper _failed_shipping_ops;
+    dsn::perf_counter_wrapper _rejected_shipping_ops;
 };
 
 // Decodes the binary `request_data` into write request in thrift struct, and


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
add perf counter to record the rejected duplicate rpc count

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1. start two clusters: c4tst-dup1 and c4tst-dup2
2. create app test_dup on both clusters: create test_dup
3. add duplicate on c4tst-dup1: add_dup test_dup c4tst-dup2
4. on c4tst-dup2: set_app_envs replica.write_throttling_by_size 1*delay*100,2*reject*100
5. on c4tst-dup1, set value repeatly: set a b c 
6. to see the perf counter: 

![image](https://user-images.githubusercontent.com/22141103/103992977-db0bdd00-51cf-11eb-8add-c3b478ea4c03.png)