### PR TITLE
refactor: use rocksdb_wrapper to reimplement batch operations

### DIFF
--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -35,6 +35,12 @@
 namespace pegasus {
 namespace server {
 
+/// internal error codes used for fail injection
+constexpr int FAIL_DB_WRITE_BATCH_PUT = -101;
+constexpr int FAIL_DB_WRITE_BATCH_DELETE = -102;
+constexpr int FAIL_DB_WRITE = -103;
+constexpr int FAIL_DB_GET = -104;
+
 struct db_get_context
 {
     // value read from DB.

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -27,7 +27,6 @@
 #include "meta_store.h"
 #include "rocksdb_wrapper.h"
 
-#include <dsn/utility/fail_point.h>
 #include <dsn/utility/filesystem.h>
 #include <dsn/utility/string_conv.h>
 #include <gtest/gtest_prod.h>
@@ -35,12 +34,6 @@
 
 namespace pegasus {
 namespace server {
-
-/// internal error codes used for fail injection
-static constexpr int FAIL_DB_WRITE_BATCH_PUT = -101;
-static constexpr int FAIL_DB_WRITE_BATCH_DELETE = -102;
-static constexpr int FAIL_DB_WRITE = -103;
-extern const int FAIL_DB_GET;
 
 struct db_get_context
 {
@@ -90,15 +83,8 @@ public:
         : replica_base(server),
           _primary_address(server->_primary_address),
           _pegasus_data_version(server->_pegasus_data_version),
-          _db(server->_db),
-          _data_cf(server->_data_cf),
-          _meta_cf(server->_meta_cf),
-          _rd_opts(server->_data_cf_rd_opts),
-          _default_ttl(0),
           _pfc_recent_expire_count(server->_pfc_recent_expire_count)
     {
-        // disable write ahead logging as replication handles logging instead now
-        _wt_opts.disableWAL = true;
         _rocksdb_wrapper = dsn::make_unique<rocksdb_wrapper>(server);
     }
 
@@ -523,7 +509,7 @@ public:
                   const dsn::apps::update_request &update,
                   dsn::apps::update_response &resp)
     {
-        resp.error = db_write_batch_put_ctx(
+        resp.error = _rocksdb_wrapper->write_batch_put_ctx(
             ctx, update.key, update.value, static_cast<uint32_t>(update.expire_ts_seconds));
         _update_responses.emplace_back(&resp);
         return resp.error;
@@ -531,171 +517,23 @@ public:
 
     int batch_remove(int64_t decree, const dsn::blob &key, dsn::apps::update_response &resp)
     {
-        resp.error = db_write_batch_delete(decree, key);
+        resp.error = _rocksdb_wrapper->write_batch_delete(decree, key);
         _update_responses.emplace_back(&resp);
         return resp.error;
     }
 
     int batch_commit(int64_t decree)
     {
-        int err = db_write(decree);
+        int err = _rocksdb_wrapper->write(decree);
         clear_up_batch_states(decree, err);
         return err;
     }
 
     void batch_abort(int64_t decree, int err) { clear_up_batch_states(decree, err); }
 
-    void set_default_ttl(uint32_t ttl)
-    {
-        // TODO(zlw): remove these lines after the refactor is done
-        if (_default_ttl != ttl) {
-            _default_ttl = ttl;
-            ddebug_replica("update _default_ttl to {}.", ttl);
-        }
-
-        _rocksdb_wrapper->set_default_ttl(ttl);
-    }
+    void set_default_ttl(uint32_t ttl) { _rocksdb_wrapper->set_default_ttl(ttl); }
 
 private:
-    int db_write_batch_put(int64_t decree,
-                           dsn::string_view raw_key,
-                           dsn::string_view value,
-                           uint32_t expire_sec)
-    {
-        return db_write_batch_put_ctx(db_write_context::empty(decree), raw_key, value, expire_sec);
-    }
-
-    int db_write_batch_put_ctx(const db_write_context &ctx,
-                               dsn::string_view raw_key,
-                               dsn::string_view value,
-                               uint32_t expire_sec)
-    {
-        FAIL_POINT_INJECT_F("db_write_batch_put",
-                            [](dsn::string_view) -> int { return FAIL_DB_WRITE_BATCH_PUT; });
-
-        uint64_t new_timetag = ctx.remote_timetag;
-        if (!ctx.is_duplicated_write()) { // local write
-            new_timetag = generate_timetag(ctx.timestamp, get_cluster_id_if_exists(), false);
-        }
-
-        if (ctx.verify_timetag &&         // needs read-before-write
-            _pegasus_data_version >= 1 && // data version 0 doesn't support timetag.
-            !raw_key.empty()) {           // not an empty write
-
-            db_get_context get_ctx;
-            int err = db_get(raw_key, &get_ctx);
-            if (dsn_unlikely(err != 0)) {
-                return err;
-            }
-            // if record exists and is not expired.
-            if (get_ctx.found && !get_ctx.expired) {
-                uint64_t local_timetag =
-                    pegasus_extract_timetag(_pegasus_data_version, get_ctx.raw_value);
-
-                if (local_timetag >= new_timetag) {
-                    // ignore this stale update with lower timetag,
-                    // and write an empty record instead
-                    raw_key = value = dsn::string_view();
-                }
-            }
-        }
-
-        rocksdb::Slice skey = utils::to_rocksdb_slice(raw_key);
-        rocksdb::SliceParts skey_parts(&skey, 1);
-        rocksdb::SliceParts svalue = _value_generator.generate_value(
-            _pegasus_data_version, value, db_expire_ts(expire_sec), new_timetag);
-        rocksdb::Status s = _batch.Put(skey_parts, svalue);
-        if (dsn_unlikely(!s.ok())) {
-            ::dsn::blob hash_key, sort_key;
-            pegasus_restore_key(::dsn::blob(raw_key.data(), 0, raw_key.size()), hash_key, sort_key);
-            derror_rocksdb("WriteBatchPut",
-                           s.ToString(),
-                           "decree: {}, hash_key: {}, sort_key: {}, expire_ts: {}",
-                           ctx.decree,
-                           utils::c_escape_string(hash_key),
-                           utils::c_escape_string(sort_key),
-                           expire_sec);
-        }
-        return s.code();
-    }
-
-    int db_write_batch_delete(int64_t decree, dsn::string_view raw_key)
-    {
-        FAIL_POINT_INJECT_F("db_write_batch_delete",
-                            [](dsn::string_view) -> int { return FAIL_DB_WRITE_BATCH_DELETE; });
-
-        rocksdb::Status s = _batch.Delete(utils::to_rocksdb_slice(raw_key));
-        if (dsn_unlikely(!s.ok())) {
-            ::dsn::blob hash_key, sort_key;
-            pegasus_restore_key(::dsn::blob(raw_key.data(), 0, raw_key.size()), hash_key, sort_key);
-            derror_rocksdb("WriteBatchDelete",
-                           s.ToString(),
-                           "decree: {}, hash_key: {}, sort_key: {}",
-                           decree,
-                           utils::c_escape_string(hash_key),
-                           utils::c_escape_string(sort_key));
-        }
-        return s.code();
-    }
-
-    // Apply the write batch into rocksdb.
-    int db_write(int64_t decree)
-    {
-        dassert(_batch.Count() != 0, "");
-
-        FAIL_POINT_INJECT_F("db_write", [](dsn::string_view) -> int { return FAIL_DB_WRITE; });
-
-        rocksdb::Status status =
-            _batch.Put(_meta_cf, meta_store::LAST_FLUSHED_DECREE, std::to_string(decree));
-        if (dsn_unlikely(!status.ok())) {
-            derror_rocksdb("Write",
-                           status.ToString(),
-                           "put decree of meta cf into batch error, decree: {}",
-                           decree);
-            return status.code();
-        }
-
-        status = _db->Write(_wt_opts, &_batch);
-        if (dsn_unlikely(!status.ok())) {
-            derror_rocksdb("Write", status.ToString(), "write rocksdb error, decree: {}", decree);
-        }
-        return status.code();
-    }
-
-    /// Calls RocksDB Get and store the result into `db_get_context`.
-    /// \returns 0 if Get succeeded. On failure, a non-zero rocksdb status code is returned.
-    /// \result ctx.expired=true if record expired. Still 0 is returned.
-    /// \result ctx.found=false if record is not found. Still 0 is returned.
-    int db_get(dsn::string_view raw_key,
-               /*out*/ db_get_context *ctx)
-    {
-        FAIL_POINT_INJECT_F("db_get", [](dsn::string_view) -> int { return FAIL_DB_GET; });
-
-        rocksdb::Status s = _db->Get(_rd_opts, utils::to_rocksdb_slice(raw_key), &(ctx->raw_value));
-        if (dsn_likely(s.ok())) {
-            // success
-            ctx->found = true;
-            ctx->expire_ts = pegasus_extract_expire_ts(_pegasus_data_version, ctx->raw_value);
-            if (check_if_ts_expired(utils::epoch_now(), ctx->expire_ts)) {
-                ctx->expired = true;
-            }
-            return 0;
-        }
-        if (s.IsNotFound()) {
-            // NotFound is an acceptable error
-            ctx->found = false;
-            return 0;
-        }
-        ::dsn::blob hash_key, sort_key;
-        pegasus_restore_key(::dsn::blob(raw_key.data(), 0, raw_key.size()), hash_key, sort_key);
-        derror_rocksdb("Get",
-                       s.ToString(),
-                       "hash_key: {}, sort_key: {}",
-                       utils::c_escape_string(hash_key),
-                       utils::c_escape_string(sort_key));
-        return s.code();
-    }
-
     void clear_up_batch_states(int64_t decree, int err)
     {
         if (!_update_responses.empty()) {
@@ -711,7 +549,7 @@ private:
             _update_responses.clear();
         }
 
-        _batch.Clear();
+        _rocksdb_wrapper->clear_up_write_batch();
     }
 
     static dsn::blob composite_raw_key(dsn::string_view hash_key, dsn::string_view sort_key)
@@ -828,16 +666,6 @@ private:
         return false;
     }
 
-    uint32_t db_expire_ts(uint32_t expire_ts)
-    {
-        // use '_default_ttl' when ttl is not set for this write operation.
-        if (_default_ttl != 0 && expire_ts == 0) {
-            return utils::epoch_now() + _default_ttl;
-        }
-
-        return expire_ts;
-    }
-
 private:
     friend class pegasus_write_service_test;
     friend class pegasus_server_write_test;
@@ -849,15 +677,7 @@ private:
     const std::string _primary_address;
     const uint32_t _pegasus_data_version;
 
-    rocksdb::WriteBatch _batch;
-    rocksdb::DB *_db;
-    rocksdb::ColumnFamilyHandle *_data_cf;
-    rocksdb::ColumnFamilyHandle *_meta_cf;
-    rocksdb::WriteOptions _wt_opts;
-    rocksdb::ReadOptions &_rd_opts;
-    volatile uint32_t _default_ttl;
     ::dsn::perf_counter_wrapper &_pfc_recent_expire_count;
-    pegasus_value_generator _value_generator;
 
     std::unique_ptr<rocksdb_wrapper> _rocksdb_wrapper;
 

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -36,10 +36,10 @@ namespace pegasus {
 namespace server {
 
 /// internal error codes used for fail injection
-constexpr int FAIL_DB_WRITE_BATCH_PUT = -101;
-constexpr int FAIL_DB_WRITE_BATCH_DELETE = -102;
-constexpr int FAIL_DB_WRITE = -103;
-constexpr int FAIL_DB_GET = -104;
+static constexpr int FAIL_DB_WRITE_BATCH_PUT = -101;
+static constexpr int FAIL_DB_WRITE_BATCH_DELETE = -102;
+static constexpr int FAIL_DB_WRITE = -103;
+static constexpr int FAIL_DB_GET = -104;
 
 struct db_get_context
 {

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -19,6 +19,7 @@
 
 #include "rocksdb_wrapper.h"
 
+#include <dsn/utility/fail_point.h>
 #include <rocksdb/db.h>
 #include "pegasus_write_service_impl.h"
 #include "base/pegasus_value_schema.h"
@@ -26,7 +27,11 @@
 namespace pegasus {
 namespace server {
 
-const int FAIL_DB_GET = -104;
+/// internal error codes used for fail injection
+static const int FAIL_DB_WRITE_BATCH_PUT = -101;
+static const int FAIL_DB_WRITE_BATCH_DELETE = -102;
+static const int FAIL_DB_WRITE = -103;
+static const int FAIL_DB_GET = -104;
 
 rocksdb_wrapper::rocksdb_wrapper(pegasus_server_impl *server)
     : replica_base(server),

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -28,10 +28,10 @@ namespace pegasus {
 namespace server {
 
 /// internal error codes used for fail injection
-static const int FAIL_DB_WRITE_BATCH_PUT = -101;
-static const int FAIL_DB_WRITE_BATCH_DELETE = -102;
-static const int FAIL_DB_WRITE = -103;
-static const int FAIL_DB_GET = -104;
+const int FAIL_DB_WRITE_BATCH_PUT = -101;
+const int FAIL_DB_WRITE_BATCH_DELETE = -102;
+const int FAIL_DB_WRITE = -103;
+const int FAIL_DB_GET = -104;
 
 rocksdb_wrapper::rocksdb_wrapper(pegasus_server_impl *server)
     : replica_base(server),

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -27,12 +27,6 @@
 namespace pegasus {
 namespace server {
 
-/// internal error codes used for fail injection
-const int FAIL_DB_WRITE_BATCH_PUT = -101;
-const int FAIL_DB_WRITE_BATCH_DELETE = -102;
-const int FAIL_DB_WRITE = -103;
-const int FAIL_DB_GET = -104;
-
 rocksdb_wrapper::rocksdb_wrapper(pegasus_server_impl *server)
     : replica_base(server),
       _db(server->_db),

--- a/src/server/rocksdb_wrapper.h
+++ b/src/server/rocksdb_wrapper.h
@@ -84,6 +84,7 @@ private:
 
     friend class rocksdb_wrapper_test;
     friend class pegasus_write_service_test;
+    friend class pegasus_server_write_test;
     FRIEND_TEST(rocksdb_wrapper_test, put_verify_timetag);
     FRIEND_TEST(rocksdb_wrapper_test, verify_timetag_compatible_with_version_0);
     FRIEND_TEST(rocksdb_wrapper_test, get);

--- a/src/server/rocksdb_wrapper.h
+++ b/src/server/rocksdb_wrapper.h
@@ -82,6 +82,7 @@ private:
     volatile uint32_t _default_ttl;
 
     friend class rocksdb_wrapper_test;
+    friend class pegasus_write_service_test;
     FRIEND_TEST(rocksdb_wrapper_test, put_verify_timetag);
     FRIEND_TEST(rocksdb_wrapper_test, verify_timetag_compatible_with_version_0);
     FRIEND_TEST(rocksdb_wrapper_test, get);

--- a/src/server/test/pegasus_server_write_test.cpp
+++ b/src/server/test/pegasus_server_write_test.cpp
@@ -92,7 +92,8 @@ public:
                 ASSERT_TRUE(_server_write->_write_svc->_batch_qps_perfcounters.empty());
                 ASSERT_TRUE(_server_write->_write_svc->_batch_latency_perfcounters.empty());
                 ASSERT_EQ(_server_write->_write_svc->_batch_start_time, 0);
-                ASSERT_EQ(_server_write->_write_svc->_impl->_batch.Count(), 0);
+                ASSERT_EQ(_server_write->_write_svc->_impl->_rocksdb_wrapper->_write_batch->Count(),
+                          0);
                 ASSERT_EQ(_server_write->_write_svc->_impl->_update_responses.size(), 0);
 
                 ASSERT_EQ(put_rpc::mail_box().size(), put_rpc_cnt);

--- a/src/server/test/pegasus_write_service_impl_test.cpp
+++ b/src/server/test/pegasus_write_service_impl_test.cpp
@@ -17,16 +17,16 @@
  * under the License.
  */
 
+#include <dsn/utility/fail_point.h>
 #include "pegasus_server_test_base.h"
 #include "server/pegasus_server_write.h"
 #include "server/pegasus_write_service_impl.h"
 #include "message_utils.h"
 
-#include <dsn/utility/defer.h>
-
 namespace pegasus {
 namespace server {
 extern const int FAIL_DB_GET;
+extern const int FAIL_DB_WRITE_BATCH_PUT;
 
 class pegasus_write_service_impl_test : public pegasus_server_test_base
 {
@@ -42,33 +42,6 @@ public:
         _server_write = dsn::make_unique<pegasus_server_write>(_server.get(), true);
         _write_impl = _server_write->_write_svc->_impl.get();
         _rocksdb_wrapper = _write_impl->_rocksdb_wrapper.get();
-    }
-
-    uint64_t read_timestamp_from(dsn::string_view raw_key)
-    {
-        std::string raw_value;
-        rocksdb::Status s = _write_impl->_db->Get(
-            _write_impl->_rd_opts, utils::to_rocksdb_slice(raw_key), &raw_value);
-
-        uint64_t local_timetag =
-            pegasus_extract_timetag(_write_impl->_pegasus_data_version, raw_value);
-        return extract_timestamp_from_timetag(local_timetag);
-    }
-
-    // start with duplicating.
-    void set_app_duplicating()
-    {
-        _server->stop(false);
-        dsn::replication::destroy_replica(_replica);
-
-        dsn::app_info app_info;
-        app_info.app_type = "pegasus";
-        app_info.duplicating = true;
-        _replica =
-            dsn::replication::create_test_replica(_replica_stub, _gpid, app_info, "./", false);
-        _server = dsn::make_unique<pegasus_server_impl>(_replica);
-
-        SetUp();
     }
 
     int db_get(dsn::string_view raw_key, db_get_context *get_ctx)
@@ -87,92 +60,6 @@ public:
         ASSERT_EQ(_write_impl->batch_commit(0), 0);
     }
 };
-
-TEST_F(pegasus_write_service_impl_test, put_verify_timetag)
-{
-    set_app_duplicating();
-
-    dsn::blob raw_key;
-    pegasus::pegasus_generate_key(
-        raw_key, dsn::string_view("hash_key"), dsn::string_view("sort_key"));
-    std::string value = "value";
-    int64_t decree = 10;
-
-    /// insert timestamp 10
-    uint64_t timestamp = 10;
-    auto ctx = db_write_context::create(decree, timestamp);
-    ASSERT_EQ(0, _write_impl->db_write_batch_put_ctx(ctx, raw_key, value, 0));
-    ASSERT_EQ(0, _write_impl->db_write(ctx.decree));
-    _write_impl->clear_up_batch_states(decree, 0);
-    ASSERT_EQ(read_timestamp_from(raw_key), timestamp);
-
-    /// insert timestamp 15, which overwrites the previous record
-    timestamp = 15;
-    ctx = db_write_context::create(decree, timestamp);
-    ASSERT_EQ(0, _write_impl->db_write_batch_put_ctx(ctx, raw_key, value, 0));
-    ASSERT_EQ(0, _write_impl->db_write(ctx.decree));
-    _write_impl->clear_up_batch_states(decree, 0);
-    ASSERT_EQ(read_timestamp_from(raw_key), timestamp);
-
-    /// insert timestamp 15 from remote, which will overwrite the previous record,
-    /// since its cluster id is larger (current cluster_id=1)
-    timestamp = 15;
-    ctx.remote_timetag = pegasus::generate_timetag(timestamp, 2, false);
-    ctx.verify_timetag = true;
-    ASSERT_EQ(0, _write_impl->db_write_batch_put_ctx(ctx, raw_key, value + "_new", 0));
-    ASSERT_EQ(0, _write_impl->db_write(ctx.decree));
-    _write_impl->clear_up_batch_states(decree, 0);
-    ASSERT_EQ(read_timestamp_from(raw_key), timestamp);
-    std::string raw_value;
-    dsn::blob user_value;
-    rocksdb::Status s =
-        _write_impl->_db->Get(_write_impl->_rd_opts, utils::to_rocksdb_slice(raw_key), &raw_value);
-    pegasus_extract_user_data(_write_impl->_pegasus_data_version, std::move(raw_value), user_value);
-    ASSERT_EQ(user_value.to_string(), "value_new");
-
-    // write retry
-    ASSERT_EQ(0, _write_impl->db_write_batch_put_ctx(ctx, raw_key, value + "_new", 0));
-    ASSERT_EQ(0, _write_impl->db_write(ctx.decree));
-    _write_impl->clear_up_batch_states(decree, 0);
-
-    /// insert timestamp 16 from local, which will overwrite the remote record,
-    /// since its timestamp is larger
-    timestamp = 16;
-    ctx = db_write_context::create(decree, timestamp);
-    ASSERT_EQ(0, _write_impl->db_write_batch_put_ctx(ctx, raw_key, value, 0));
-    ASSERT_EQ(0, _write_impl->db_write(ctx.decree));
-    _write_impl->clear_up_batch_states(decree, 0);
-    ASSERT_EQ(read_timestamp_from(raw_key), timestamp);
-
-    // write retry
-    ASSERT_EQ(0, _write_impl->db_write_batch_put_ctx(ctx, raw_key, value, 0));
-    ASSERT_EQ(0, _write_impl->db_write(ctx.decree));
-    _write_impl->clear_up_batch_states(decree, 0);
-}
-
-// verify timetag on data version v0
-TEST_F(pegasus_write_service_impl_test, verify_timetag_compatible_with_version_0)
-{
-    dsn::fail::setup();
-    dsn::fail::cfg("db_get", "100%1*return()");
-    // if db_write_batch_put_ctx invokes db_get, this test must fail.
-
-    const_cast<uint32_t &>(_write_impl->_pegasus_data_version) = 0; // old version
-
-    dsn::blob raw_key;
-    pegasus::pegasus_generate_key(
-        raw_key, dsn::string_view("hash_key"), dsn::string_view("sort_key"));
-    std::string value = "value";
-    int64_t decree = 10;
-    uint64_t timestamp = 10;
-
-    auto ctx = db_write_context::create_duplicate(decree, timestamp, true);
-    ASSERT_EQ(0, _write_impl->db_write_batch_put_ctx(ctx, raw_key, value, 0));
-    ASSERT_EQ(0, _write_impl->db_write(ctx.decree));
-    _write_impl->clear_up_batch_states(decree, 0);
-
-    dsn::fail::teardown();
-}
 
 class incr_test : public pegasus_write_service_impl_test
 {

--- a/src/server/test/pegasus_write_service_impl_test.cpp
+++ b/src/server/test/pegasus_write_service_impl_test.cpp
@@ -25,8 +25,6 @@
 
 namespace pegasus {
 namespace server {
-extern const int FAIL_DB_GET;
-extern const int FAIL_DB_WRITE_BATCH_PUT;
 
 class pegasus_write_service_impl_test : public pegasus_server_test_base
 {

--- a/src/server/test/pegasus_write_service_test.cpp
+++ b/src/server/test/pegasus_write_service_test.cpp
@@ -26,9 +26,6 @@
 
 namespace pegasus {
 namespace server {
-extern const int FAIL_DB_WRITE_BATCH_PUT;
-extern const int FAIL_DB_WRITE_BATCH_DELETE;
-extern const int FAIL_DB_WRITE;
 
 class pegasus_write_service_test : public pegasus_server_test_base
 {

--- a/src/server/test/pegasus_write_service_test.cpp
+++ b/src/server/test/pegasus_write_service_test.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <dsn/utility/fail_point.h>
 #include "base/pegasus_key_schema.h"
 #include "pegasus_server_test_base.h"
 #include "server/pegasus_server_write.h"
@@ -25,6 +26,9 @@
 
 namespace pegasus {
 namespace server {
+extern const int FAIL_DB_WRITE_BATCH_PUT;
+extern const int FAIL_DB_WRITE_BATCH_DELETE;
+extern const int FAIL_DB_WRITE;
 
 class pegasus_write_service_test : public pegasus_server_test_base
 {
@@ -195,7 +199,7 @@ public:
         ASSERT_EQ(response.partition_index, _gpid.get_partition_index());
         ASSERT_EQ(response.decree, decree);
         ASSERT_EQ(response.server, _write_svc->_impl->_primary_address);
-        ASSERT_EQ(_write_svc->_impl->_batch.Count(), 0);
+        ASSERT_EQ(_write_svc->_impl->_rocksdb_wrapper->_write_batch->Count(), 0);
         ASSERT_EQ(_write_svc->_impl->_update_responses.size(), 0);
     }
 };


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
use rocksdb_wrapper to reimplement batch operations

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
```
>>> use temp
OK
>>> set a c b
OK

app_id          : 2
partition_index : 4
decree          : 4
server          : 10.232.55.210:34802
>>> get a c 
"b"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> del a c 
OK

app_id          : 2
partition_index : 4
decree          : 31
server          : 10.232.55.210:34802
>>> get a c 
Not found

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
```