### PR TITLE
refactor: reimplement pegasus_server_write::on_batched_write_requests

### DIFF
--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -52,7 +52,7 @@ int pegasus_server_write::on_batched_write_requests(dsn::message_ex **requests,
 
     auto iter = _single_put_methods.find(requests[0]->rpc_code());
     if (iter != _single_put_methods.end()) {
-        dassert_f(count == 1, "count = {}", count);
+        dcheck_eq(count, 1);
         return iter->second(this, requests[0]);
     } else {
         return on_batched_writes(requests, count);

--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -140,62 +140,41 @@ void pegasus_server_write::init_non_batch_write_handlers()
 {
     _non_batch_write_handlers = {
         {dsn::apps::RPC_RRDB_RRDB_MULTI_PUT,
-         [this](dsn::message_ex *request) -> int { return multi_put(request); }},
+         [this](dsn::message_ex *request) -> int {
+             auto rpc = multi_put_rpc::auto_reply(request);
+             return _write_svc->multi_put(_write_ctx, rpc.request(), rpc.response());
+         }},
         {dsn::apps::RPC_RRDB_RRDB_MULTI_REMOVE,
-         [this](dsn::message_ex *request) -> int { return multi_remove(request); }},
+         [this](dsn::message_ex *request) -> int {
+             auto rpc = multi_remove_rpc::auto_reply(request);
+             return _write_svc->multi_remove(_decree, rpc.request(), rpc.response());
+         }},
         {dsn::apps::RPC_RRDB_RRDB_INCR,
-         [this](dsn::message_ex *request) -> int { return incr(request); }},
+         [this](dsn::message_ex *request) -> int {
+             auto rpc = incr_rpc::auto_reply(request);
+             return _write_svc->incr(_decree, rpc.request(), rpc.response());
+         }},
         {dsn::apps::RPC_RRDB_RRDB_DUPLICATE,
-         [this](dsn::message_ex *request) -> int { return duplicate(request); }},
+         [this](dsn::message_ex *request) -> int {
+             auto rpc = duplicate_rpc::auto_reply(request);
+             return _write_svc->duplicate(_decree, rpc.request(), rpc.response());
+         }},
         {dsn::apps::RPC_RRDB_RRDB_CHECK_AND_SET,
-         [this](dsn::message_ex *request) -> int { return check_and_set(request); }},
+         [this](dsn::message_ex *request) -> int {
+             auto rpc = check_and_set_rpc::auto_reply(request);
+             return _write_svc->check_and_set(_decree, rpc.request(), rpc.response());
+         }},
         {dsn::apps::RPC_RRDB_RRDB_CHECK_AND_MUTATE,
-         [this](dsn::message_ex *request) -> int { return check_and_mutate(request); }},
+         [this](dsn::message_ex *request) -> int {
+             auto rpc = check_and_mutate_rpc::auto_reply(request);
+             return _write_svc->check_and_mutate(_decree, rpc.request(), rpc.response());
+         }},
         {dsn::apps::RPC_RRDB_RRDB_BULK_LOAD,
-         [this](dsn::message_ex *request) -> int { return ingestion_files(request); }},
+         [this](dsn::message_ex *request) -> int {
+             auto rpc = ingestion_rpc::auto_reply(request);
+             return _write_svc->ingestion_files(_decree, rpc.request(), rpc.response());
+         }},
     };
-}
-
-int pegasus_server_write::multi_put(dsn::message_ex *request)
-{
-    auto rpc = multi_put_rpc::auto_reply(request);
-    return _write_svc->multi_put(_write_ctx, rpc.request(), rpc.response());
-}
-
-int pegasus_server_write::multi_remove(dsn::message_ex *request)
-{
-    auto rpc = multi_remove_rpc::auto_reply(request);
-    return _write_svc->multi_remove(_decree, rpc.request(), rpc.response());
-}
-
-int pegasus_server_write::incr(dsn::message_ex *request)
-{
-    auto rpc = incr_rpc::auto_reply(request);
-    return _write_svc->incr(_decree, rpc.request(), rpc.response());
-}
-
-int pegasus_server_write::duplicate(dsn::message_ex *request)
-{
-    auto rpc = duplicate_rpc::auto_reply(request);
-    return _write_svc->duplicate(_decree, rpc.request(), rpc.response());
-}
-
-int pegasus_server_write::check_and_set(dsn::message_ex *request)
-{
-    auto rpc = check_and_set_rpc::auto_reply(request);
-    return _write_svc->check_and_set(_decree, rpc.request(), rpc.response());
-}
-
-int pegasus_server_write::check_and_mutate(dsn::message_ex *request)
-{
-    auto rpc = check_and_mutate_rpc::auto_reply(request);
-    return _write_svc->check_and_mutate(_decree, rpc.request(), rpc.response());
-}
-
-int pegasus_server_write::ingestion_files(dsn::message_ex *request)
-{
-    auto rpc = ingestion_rpc::auto_reply(request);
-    return _write_svc->ingestion_files(_decree, rpc.request(), rpc.response());
 }
 } // namespace server
 } // namespace pegasus

--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -33,7 +33,7 @@ namespace server {
 pegasus_server_write::pegasus_server_write(pegasus_server_impl *server, bool verbose_log)
     : replica_base(server), _write_svc(new pegasus_write_service(server)), _verbose_log(verbose_log)
 {
-    init_non_batch_write_handler();
+    init_non_batch_write_handlers();
 }
 
 int pegasus_server_write::on_batched_write_requests(dsn::message_ex **requests,
@@ -136,7 +136,7 @@ void pegasus_server_write::request_key_check(int64_t decree,
     }
 }
 
-void pegasus_server_write::init_non_batch_write_handler()
+void pegasus_server_write::init_non_batch_write_handlers()
 {
     _non_batch_write_handlers = {
         {dsn::apps::RPC_RRDB_RRDB_MULTI_PUT,

--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -53,7 +53,7 @@ int pegasus_server_write::on_batched_write_requests(dsn::message_ex **requests,
 
     auto iter = _non_batch_write_handlers.find(requests[0]->rpc_code());
     if (iter != _non_batch_write_handlers.end()) {
-        dcheck_eq(count, 1);
+        dassert_f(count == 1, "count = {}", count);
         return iter->second(requests[0]);
     }
     return on_batched_writes(requests, count);

--- a/src/server/pegasus_server_write.h
+++ b/src/server/pegasus_server_write.h
@@ -80,6 +80,7 @@ private:
     int check_and_set(dsn::message_ex *request);
     int check_and_mutate(dsn::message_ex *request);
     int ingestion_files(dsn::message_ex *request);
+    void init_non_batch_write_handler();
 
     friend class pegasus_server_write_test;
     friend class pegasus_write_service_test;
@@ -95,9 +96,8 @@ private:
 
     const bool _verbose_log;
 
-    typedef std::map<dsn::task_code, std::function<int(pegasus_server_write *, dsn::message_ex *)>>
-        single_put_rpc_map;
-    static single_put_rpc_map _single_put_methods;
+    typedef std::map<dsn::task_code, std::function<int(dsn::message_ex *)>> non_batch_writes_map;
+    non_batch_writes_map _non_batch_write_handlers;
 };
 
 } // namespace server

--- a/src/server/pegasus_server_write.h
+++ b/src/server/pegasus_server_write.h
@@ -78,7 +78,7 @@ private:
     int check_and_set(dsn::message_ex *request);
     int check_and_mutate(dsn::message_ex *request);
     int ingestion_files(dsn::message_ex *request);
-    void init_non_batch_write_handler();
+    void init_non_batch_write_handlers();
 
     friend class pegasus_server_write_test;
     friend class pegasus_write_service_test;

--- a/src/server/pegasus_server_write.h
+++ b/src/server/pegasus_server_write.h
@@ -71,6 +71,8 @@ private:
     void request_key_check(int64_t decree, dsn::message_ex *m, const dsn::blob &key);
 
 private:
+    /// TODO(zlw): using member functions of pegasus_write_service to refactor these functions
+    /// below, in order to remove class pegasus_write_service in the later
     int multi_put(dsn::message_ex *request);
     int multi_remove(dsn::message_ex *request);
     int incr(dsn::message_ex *request);

--- a/src/server/pegasus_server_write.h
+++ b/src/server/pegasus_server_write.h
@@ -71,8 +71,6 @@ private:
     void request_key_check(int64_t decree, dsn::message_ex *m, const dsn::blob &key);
 
 private:
-    /// TODO(zlw): using member functions of pegasus_write_service to refactor these functions
-    /// below, in order to remove class pegasus_write_service in the later
     int multi_put(dsn::message_ex *request);
     int multi_remove(dsn::message_ex *request);
     int incr(dsn::message_ex *request);

--- a/src/server/pegasus_server_write.h
+++ b/src/server/pegasus_server_write.h
@@ -71,13 +71,6 @@ private:
     void request_key_check(int64_t decree, dsn::message_ex *m, const dsn::blob &key);
 
 private:
-    int multi_put(dsn::message_ex *request);
-    int multi_remove(dsn::message_ex *request);
-    int incr(dsn::message_ex *request);
-    int duplicate(dsn::message_ex *request);
-    int check_and_set(dsn::message_ex *request);
-    int check_and_mutate(dsn::message_ex *request);
-    int ingestion_files(dsn::message_ex *request);
     void init_non_batch_write_handlers();
 
     friend class pegasus_server_write_test;

--- a/src/server/pegasus_server_write.h
+++ b/src/server/pegasus_server_write.h
@@ -71,6 +71,14 @@ private:
     void request_key_check(int64_t decree, dsn::message_ex *m, const dsn::blob &key);
 
 private:
+    int multi_put(dsn::message_ex *request);
+    int multi_remove(dsn::message_ex *request);
+    int incr(dsn::message_ex *request);
+    int duplicate(dsn::message_ex *request);
+    int check_and_set(dsn::message_ex *request);
+    int check_and_mutate(dsn::message_ex *request);
+    int ingestion_files(dsn::message_ex *request);
+
     friend class pegasus_server_write_test;
     friend class pegasus_write_service_test;
     friend class pegasus_write_service_impl_test;
@@ -84,6 +92,10 @@ private:
     int64_t _decree;
 
     const bool _verbose_log;
+
+    typedef std::map<dsn::task_code, std::function<int(pegasus_server_write *, dsn::message_ex *)>>
+        single_put_rpc_map;
+    static single_put_rpc_map _single_put_methods;
 };
 
 } // namespace server


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
reimplement pegasus_server_write::on_batched_write_requests

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test
```
>>> ls
[general_info]
app_id  status     app_name  app_type  partition_count  replica_count  is_stateful  create_time          drop_time  drop_expire  envs_count  
1       AVAILABLE  stat      pegasus   4                3              true         2021-01-13_11:14:51  -          -            0           
2       AVAILABLE  temp      pegasus   8                3              true         2021-01-13_11:14:51  -          -            0           

[summary]
total_app_count  : 2

>>> use temp
OK
>>> multi_set a b1 c1 b2 c2
OK

app_id          : 2
partition_index : 4
decree          : 1
server          : 10.232.55.210:34802
>>> get a b1
"c1"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> get a b2
"c2"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> multi_del a b1 b2
2 key-value pairs deleted.

app_id          : 2
partition_index : 4
decree          : 3
server          : 10.232.55.210:34802
>>> get a b1
Not found

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> get a b2
Not found

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> set a b 1
OK

app_id          : 2
partition_index : 4
decree          : 5
server          : 10.232.55.210:34802
>>> incr a b 
2

app_id          : 2
partition_index : 4
decree          : 6
server          : 10.232.55.210:34802
>>> get a b
"2"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> check_and_set a -c b -t exist -s b3 -v c3 -r
hash_key: "a"
check_sort_key: "b"
check_type: exist
set_sort_key: "b3"
set_value: "c3"
set_value_ttl_seconds: 0
return_check_value: true

Set succeed.

Check value: "2"

app_id          : 2
partition_index : 4
decree          : 16
server          : 10.232.55.210:34802
>>> get a b3 c3
USAGE: 	get                     <hash_key> <sort_key>
>>> get a b3
"c3"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> check_and_mutate a -c b -t exist -r
Load mutations, like
  set <sort_key> <value> [ttl]
  del <sort_key>
Print "ok" to finish loading, "abort" to abort this command
>>> set b4 c4
LOAD: set sortkey "b4", value "c4", ttl 0
>>> set b5 c5
LOAD: set sortkey "b5", value "c5", ttl 0
>>> ok
INFO: load mutations done.

hash_key: "a"
check_sort_key: "b"
check_type: exist
return_check_value: true
mutations:
  mutation[0].type: SET
  mutation[0].sort_key: "b4"
  mutation[0].value: "c4"
  mutation[0].expire_seconds: 0
  mutation[1].type: SET
  mutation[1].sort_key: "b5"
  mutation[1].value: "c5"
  mutation[1].expire_seconds: 0

Mutate succeed.

Check value: "2"

app_id          : 2
partition_index : 4
decree          : 21
server          : 10.232.55.210:34802
>>> get a b4
"c4"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802
>>> get a b5
"c5"

app_id          : 2
partition_index : 4
server          : 10.232.55.210:34802

```