### PR TITLE
feat: remove the dependency of tls memory for redis_parser

### DIFF
--- a/src/redis_protocol/proxy_lib/redis_parser.cpp
+++ b/src/redis_protocol/proxy_lib/redis_parser.cpp
@@ -299,10 +299,8 @@ bool redis_parser::parse_stream()
             // string content + CR + LF
             if (_total_length >= _current_str.length + 2) {
                 if (_current_str.length > 0) {
-                    char *ptr =
-                        reinterpret_cast<char *>(dsn::tls_trans_malloc(_current_str.length));
-                    std::shared_ptr<char> str_data(ptr,
-                                                   [](char *ptr) { dsn::tls_trans_free(ptr); });
+                    std::shared_ptr<char> str_data(
+                        dsn::utils::make_shared_array<char>(_current_str.length));
                     eat_all(str_data.get(), _current_str.length);
                     _current_str.data.assign(std::move(str_data), 0, _current_str.length);
                 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
remove the dependency of tls memory for redis_parser, in order to move tls_memory in the later


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
There are a lot of unit tests in redis_proxy_test.cpp, which covers the code modified in this pull request