### PR TITLE
fix: clean the specified key

### DIFF
--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -62,10 +62,6 @@ public:
     KeyWithTTLCompactionFilter(uint32_t pegasus_data_version, uint32_t default_ttl, bool enabled)
         : _pegasus_data_version(pegasus_data_version), _default_ttl(default_ttl), _enabled(enabled)
     {
-        _pfc_cleaned_key_count.init_app_counter("app.pegasus",
-                                                "cleaned_key_count",
-                                                COUNTER_TYPE_NUMBER,
-                                                "statistic the cleaned count of key");
     }
 
     bool Filter(int /*level*/,
@@ -95,7 +91,6 @@ public:
         }
 
         if (need_clean_key(key, expire_ts, now_ts)) {
-            _pfc_cleaned_key_count->increment();
             return true;
         }
         return false;
@@ -108,8 +103,6 @@ private:
     uint32_t _default_ttl;
     bool _enabled; // only process filtering when _enabled == true
     mutable pegasus_value_generator _gen;
-
-    dsn::perf_counter_wrapper _pfc_cleaned_key_count;
 };
 
 class KeyWithTTLCompactionFilterFactory : public rocksdb::CompactionFilterFactory

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -47,7 +47,7 @@ inline bool need_clean_key(const rocksdb::Slice &key, uint32_t expire_ts, uint32
             0 == hash_key.compare(0, key_prefix.length(), key_prefix)) {
             static int count = 0;
             if (count++ % 1000 == 0) {
-                ddebug_f("{} keys are cleaned");
+                ddebug_f("{} keys are cleaned", count);
             }
             return true;
         }

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -37,7 +37,7 @@ inline bool need_clean_key(const rocksdb::Slice &key, uint32_t expire_ts, uint32
     std::vector<std::string> cleaned_hash_key_prefix = {"raw_tts_audio:", "stored_tts_url_info:"};
 
     uint32_t oneday_sec = 24 * 60 * 60;
-    if (expire_ts < now_ts + 3 * oneday_sec) {
+    if (expire_ts <= 0 || expire_ts < now_ts + 3 * oneday_sec) {
         return false;
     }
 

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -37,6 +37,7 @@ inline bool need_clean_key(const rocksdb::Slice &key, uint32_t expire_ts, uint32
     std::vector<std::string> cleaned_hash_key_prefix = {"raw_tts_audio:", "stored_tts_url_info:"};
 
     uint32_t oneday_sec = 24 * 60 * 60;
+    // includes expire_tx == 0
     if (expire_ts < now_ts + 3 * oneday_sec) {
         return false;
     }

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -24,8 +24,6 @@
 #include <rocksdb/compaction_filter.h>
 #include <rocksdb/merge_operator.h>
 #include <base/pegasus_key_schema.h>
-#include <dsn/utility/flags.h>
-#include <dsn/perf_counter/perf_counter_wrapper.h>
 
 #include "base/pegasus_utils.h"
 #include "base/pegasus_value_schema.h"
@@ -47,6 +45,10 @@ inline bool need_clean_key(const rocksdb::Slice &key, uint32_t expire_ts, uint32
     for (const auto &key_prefix : cleaned_hash_key_prefix) {
         if (hash_key.length() >= key_prefix.length() &&
             0 == hash_key.compare(0, key_prefix.length(), key_prefix)) {
+            static int count = 0;
+            if (count++ / 1000 == 0) {
+                ddebug_f("{} keys are cleaned");
+            }
             return true;
         }
     }

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -90,10 +90,7 @@ public:
             return true;
         }
 
-        if (need_clean_key(key, expire_ts, now_ts)) {
-            return true;
-        }
-        return false;
+        return need_clean_key(key, expire_ts, now_ts);
     }
 
     const char *Name() const override { return "KeyWithTTLCompactionFilter"; }

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -46,7 +46,7 @@ inline bool need_clean_key(const rocksdb::Slice &key, uint32_t expire_ts, uint32
         if (hash_key.length() >= key_prefix.length() &&
             0 == hash_key.compare(0, key_prefix.length(), key_prefix)) {
             static int count = 0;
-            if (count++ / 1000 == 0) {
+            if (count++ % 1000 == 0) {
                 ddebug_f("{} keys are cleaned");
             }
             return true;

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -32,7 +32,7 @@ namespace pegasus {
 namespace server {
 inline bool need_clean_key(const rocksdb::Slice &key, uint32_t expire_ts, uint32_t now_ts)
 {
-    std::vector<std::string> cleaned_hash_key_prefix = {"raw_tts_audio:", "stored_tts_url_info:"};
+    static const std::vector<std::string> cleaned_hash_key_prefix = {"raw_tts_audio:", "stored_tts_url_info:"};
 
     uint32_t oneday_sec = 24 * 60 * 60;
     // includes expire_tx == 0

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -37,7 +37,7 @@ inline bool need_clean_key(const rocksdb::Slice &key, uint32_t expire_ts, uint32
     std::vector<std::string> cleaned_hash_key_prefix = {"raw_tts_audio:", "stored_tts_url_info:"};
 
     uint32_t oneday_sec = 24 * 60 * 60;
-    if (expire_ts == 0 || expire_ts < now_ts + 3 * oneday_sec) {
+    if (expire_ts < now_ts + 3 * oneday_sec) {
         return false;
     }
 

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -37,7 +37,7 @@ inline bool need_clean_key(const rocksdb::Slice &key, uint32_t expire_ts, uint32
     std::vector<std::string> cleaned_hash_key_prefix = {"raw_tts_audio:", "stored_tts_url_info:"};
 
     uint32_t oneday_sec = 24 * 60 * 60;
-    if (expire_ts <= 0 || expire_ts < now_ts + 3 * oneday_sec) {
+    if (expire_ts == 0 || expire_ts < now_ts + 3 * oneday_sec) {
         return false;
     }
 

--- a/src/server/test/key_ttl_compaction_filter_test.cpp
+++ b/src/server/test/key_ttl_compaction_filter_test.cpp
@@ -31,7 +31,7 @@ TEST(key_ttl_compaction_filter_test, need_clean_key)
     {
         std::string hash_key;
         int32_t expire_sec_from_now;
-        bool clear_ttl = false;
+        bool clear_ttl;
         bool need_clean;
     } tests[] = {{"raw_tts_audio:", 100, false, false},
                  {"raw_tts_audio:xxx", 100, false, false},

--- a/src/server/test/key_ttl_compaction_filter_test.cpp
+++ b/src/server/test/key_ttl_compaction_filter_test.cpp
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "server/key_ttl_compaction_filter.h"
+
+namespace pegasus {
+namespace server {
+
+TEST(key_ttl_compaction_filter_test, need_clean_key)
+{
+    int32_t oneday_sec = 24 * 60 * 60;
+
+    struct
+    {
+        std::string hash_key;
+        int32_t expire_sec_from_now;
+        bool need_clean;
+    } tests[] = {{"raw_tts_audio:", 100, false},
+                 {"raw_tts_audio:xxx", 100, false},
+                 {"raw_tts_audio:xxx", 3 * oneday_sec - 1, false},
+                 {"raw_tts_audio:xxx", 3 * oneday_sec, true},
+                 {"raw_tts_audio", 4 * oneday_sec, false},
+                 {"stored_tts_url_info:", 100, false},
+                 {"stored_tts_url_info:xxx", 100, false},
+                 {"stored_tts_url_info:xxx", 3 * oneday_sec - 1, false},
+                 {"stored_tts_url_info:xxx", 3 * oneday_sec, true},
+                 {"stored_tts_url_info", 4 * oneday_sec, false},
+                 {"donot_clean_key", 100, false},
+                 {"donot_clean_key", 4 * oneday_sec, false}};
+
+    for (auto const &test : tests) {
+        uint32_t now_ts = utils::epoch_now();
+
+        dsn::blob raw_key;
+        pegasus_generate_key(raw_key, test.hash_key, std::string("sort"));
+        bool need_clean = need_clean_key(
+            utils::to_rocksdb_slice(raw_key), test.expire_sec_from_now + now_ts, now_ts);
+        ASSERT_EQ(need_clean, test.need_clean);
+    }
+}
+
+} // namespace server
+} // namespace pegasus

--- a/src/server/test/key_ttl_compaction_filter_test.cpp
+++ b/src/server/test/key_ttl_compaction_filter_test.cpp
@@ -31,27 +31,35 @@ TEST(key_ttl_compaction_filter_test, need_clean_key)
     {
         std::string hash_key;
         int32_t expire_sec_from_now;
+        bool clear_ttl = false;
         bool need_clean;
-    } tests[] = {{"raw_tts_audio:", 100, false},
-                 {"raw_tts_audio:xxx", 100, false},
-                 {"raw_tts_audio:xxx", 3 * oneday_sec - 1, false},
-                 {"raw_tts_audio:xxx", 3 * oneday_sec, true},
-                 {"raw_tts_audio", 4 * oneday_sec, false},
-                 {"stored_tts_url_info:", 100, false},
-                 {"stored_tts_url_info:xxx", 100, false},
-                 {"stored_tts_url_info:xxx", 3 * oneday_sec - 1, false},
-                 {"stored_tts_url_info:xxx", 3 * oneday_sec, true},
-                 {"stored_tts_url_info", 4 * oneday_sec, false},
-                 {"donot_clean_key", 100, false},
-                 {"donot_clean_key", 4 * oneday_sec, false}};
+    } tests[] = {{"raw_tts_audio:", 100, false, false},
+                 {"raw_tts_audio:xxx", 100, false, false},
+                 {"raw_tts_audio:xxx", 3 * oneday_sec - 1, false, false},
+                 {"raw_tts_audio:xxx", 3 * oneday_sec, false, true},
+                 {"raw_tts_audio:no_ttl", 3 * oneday_sec, true, false},
+                 {"raw_tts_audio", 4 * oneday_sec, false, false},
+                 {"stored_tts_url_info:", 100, false, false},
+                 {"stored_tts_url_info:xxx", 100, false, false},
+                 {"stored_tts_url_info:xxx", 3 * oneday_sec - 1, false, false},
+                 {"stored_tts_url_info:xxx", 3 * oneday_sec, false, true},
+                 {"stored_tts_url_info:no_ttl", 3 * oneday_sec, true, false},
+                 {"stored_tts_url_info", 4 * oneday_sec, false, false},
+                 {"donot_clean_key", 100, false, false},
+                 {"donot_clean_key", 4 * oneday_sec, false, false},
+                 {"donot_clean_key_no_ttl", 4 * oneday_sec, true, false}};
 
     for (auto const &test : tests) {
         uint32_t now_ts = utils::epoch_now();
 
         dsn::blob raw_key;
         pegasus_generate_key(raw_key, test.hash_key, std::string("sort"));
+        uint32_t expire_ts = test.expire_sec_from_now + now_ts;
+        if (test.clear_ttl) {
+            expire_ts = 0;
+        }
         bool need_clean = need_clean_key(
-            utils::to_rocksdb_slice(raw_key), test.expire_sec_from_now + now_ts, now_ts);
+            utils::to_rocksdb_slice(raw_key), expire_ts, now_ts);
         ASSERT_EQ(need_clean, test.need_clean);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
clean the specified key with ttl > 3

### Manaul Test

#### 1. First set value into one app
```
>>> use test111
OK
>>> set raw_tts_audio: sort 18000 
OK

app_id          : 481
partition_index : 0
decree          : 2
server          : 10.132.15.54:45801
>>> set raw_tts_audio:18000 sort 18000
OK

app_id          : 481
partition_index : 2
decree          : 2
server          : 10.162.54.12:45801
>>> set raw_tts_audio:259199 sort value 259199
OK

app_id          : 481
partition_index : 1
decree          : 2
server          : 10.162.53.12:45801
>>> set raw_tts_audio:345600 sort value 345600
OK

app_id          : 481
partition_index : 0
decree          : 3
server          : 10.132.15.54:45801
>>> set raw_tts_audio345600 sort value 345600
OK

app_id          : 481
partition_index : 3
decree          : 3
server          : 10.132.15.54:45801
>>> set raw_tts_audio sort value 345600
OK

app_id          : 481
partition_index : 1
decree          : 3
server          : 10.162.53.12:45801
>>> set stored_tts_url_info:345600 sort value 345600
OK

app_id          : 481
partition_index : 3
decree          : 4
server          : 10.132.15.54:45801
>>> set donot_clean_key345600 sort value 345600
OK

app_id          : 481
partition_index : 0
decree          : 4
server          : 10.132.15.54:45801
>>> set donot_clean_key18000 sort value 18000
OK

app_id          : 481
partition_index : 3
decree          : 5
server          : 10.132.15.54:45801
>>> set no_ttl sort value
OK

app_id          : 481
partition_index : 1
decree          : 4
server          : 10.162.53.12:45801

```

#### 2. Do manual compact
```
./scripts/pegasus_manual_compact.sh -c ${meta_list} -t once -a test111
``` 

#### 3.get the keys which are set before, to see whether it is exist or not
```
>>> use test111
OK
>>> get raw_tts_audio: sort
"18000"

app_id          : 481
partition_index : 0
server          : 10.132.15.54:45801
>>> get raw_tts_audio:18000 sort
"18000"

app_id          : 481
partition_index : 2
server          : 10.162.54.12:45801
>>> get raw_tts_audio:259199 sort
"value"

app_id          : 481
partition_index : 1
server          : 10.162.53.12:45801
>>> get raw_tts_audio:345600 sort
Not found

app_id          : 481
partition_index : 0
server          : 10.132.15.54:45801
>>> get raw_tts_audio345600 sort
"value"

app_id          : 481
partition_index : 3
server          : 10.132.15.54:45801
>>> get raw_tts_audio sort
"value"

app_id          : 481
partition_index : 1
server          : 10.162.53.12:45801
>>> get raw_tts_audio345600 sort
"value"

app_id          : 481
partition_index : 3
server          : 10.132.15.54:45801
>>> get stored_tts_url_info:345600 sort
Not found

app_id          : 481
partition_index : 3
server          : 10.132.15.54:45801
>>> get donot_clean_key345600 sort
"value"

app_id          : 481
partition_index : 0
server          : 10.132.15.54:45801
>>> get donot_clean_key18000 sort
"value"

app_id          : 481
partition_index : 3
server          : 10.132.15.54:45801
>>> get no_ttl sort 
"value"

app_id          : 481
partition_index : 1
server          : 10.162.53.12:45801
```

All the keys need to delete are not exist now. And the keys can't delete are all exist.