### PR TITLE
fix: fix compilation errors caused by rdsn pr#752

### DIFF
--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -64,6 +64,4 @@ jobs:
       - name: Compilation
         run: ./run.sh build -c --skip_thirdparty
       - name: Unit Testing
-        run: |
-          source ./config_hdfs.sh
-	  ./run.sh test --on_travis
+        run: ./run.sh test --on_travis

--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -64,4 +64,6 @@ jobs:
       - name: Compilation
         run: ./run.sh build -c --skip_thirdparty
       - name: Unit Testing
-        run: ./run.sh test --on_travis
+        run: |
+          source ./config_hdfs.sh
+	  ./run.sh test --on_travis

--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,7 @@ export REPORT_DIR="$ROOT/test_report"
 export DSN_ROOT=$ROOT/DSN_ROOT
 export DSN_THIRDPARTY_ROOT=$ROOT/rdsn/thirdparty/output
 export LD_LIBRARY_PATH=$DSN_ROOT/lib:$DSN_THIRDPARTY_ROOT/lib:$LD_LIBRARY_PATH
+source $ROOT/config_hdfs.sh
 
 function usage()
 {

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,6 @@ export REPORT_DIR="$ROOT/test_report"
 export DSN_ROOT=$ROOT/DSN_ROOT
 export DSN_THIRDPARTY_ROOT=$ROOT/rdsn/thirdparty/output
 export LD_LIBRARY_PATH=$DSN_ROOT/lib:$DSN_THIRDPARTY_ROOT/lib:$LD_LIBRARY_PATH
-source $ROOT/config_hdfs.sh
 
 function usage()
 {

--- a/src/base/test/CMakeLists.txt
+++ b/src/base/test/CMakeLists.txt
@@ -30,6 +30,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 set(MY_PROJ_LIBS
         dsn_runtime
         dsn_utils
+        dsn_aio
         pegasus_base
         gtest)
 

--- a/src/base/test/CMakeLists.txt
+++ b/src/base/test/CMakeLists.txt
@@ -28,9 +28,9 @@ set(MY_PROJ_SRC "")
 set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS
+        dsn_aio
         dsn_runtime
         dsn_utils
-        dsn_aio
         pegasus_base
         gtest)
 

--- a/src/client_lib/CMakeLists.txt
+++ b/src/client_lib/CMakeLists.txt
@@ -46,6 +46,7 @@ add_dependencies(pegasus_client_static combine_lib)
 set_target_properties(pegasus_client_static
     PROPERTIES
     IMPORTED_LOCATION ${pegasus_client_static_lib})
+target_link_libraries(pegasus_client_static INTERFACE dsn_aio)
 install(FILES ${pegasus_client_static_lib} DESTINATION "lib")
 
 # link the shared lib of pegasus client


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Although `dsn_aio` has been linked to `dsn_runtime`, pegasus also reported compilation errors:

```
/home/zyf/pegasus/DSN_ROOT/lib/libdsn_runtime.a(service_api_c.cpp.o): In function `dsn::utils::singleton<dsn::disk_engine>::instance()':
/home/zyf/pegasus/rdsn/include/dsn/utility/singleton.h:44: undefined reference to `dsn::disk_engine::disk_engine()'

../../client_lib/libpegasus_client_static.a(service_api_c.cpp.o): In function `dsn::utils::singleton<dsn::disk_engine>::instance()':
/home/zyf/pegasus/rdsn/include/dsn/utility/singleton.h:44: undefined reference
```

### What is changed and how it works?
 Linking  `dsn_aio` to some libraries manually.

Related changes
[752](https://github.com/XiaoMi/rdsn/pull/752)