### PR TITLE
feat(split): gc useless data after partition split

### DIFF
--- a/src/base/pegasus_const.cpp
+++ b/src/base/pegasus_const.cpp
@@ -88,4 +88,7 @@ const std::string ROCKSDB_ENV_SLOW_QUERY_THRESHOLD("replica.slow_query_threshold
 /// time threshold of each rocksdb iteration
 const std::string
     ROCKSDB_ITERATION_THRESHOLD_TIME_MS("replica.rocksdb_iteration_threshold_time_ms");
+
+/// true means compaction and scan will check partition_hash, otherwise false
+const std::string SPLIT_VALIDATE_PARTITION_HASH("replica.split.validate_partition_hash");
 } // namespace pegasus

--- a/src/base/pegasus_const.cpp
+++ b/src/base/pegasus_const.cpp
@@ -89,6 +89,6 @@ const std::string ROCKSDB_ENV_SLOW_QUERY_THRESHOLD("replica.slow_query_threshold
 const std::string
     ROCKSDB_ITERATION_THRESHOLD_TIME_MS("replica.rocksdb_iteration_threshold_time_ms");
 
-/// true means compaction and scan will check partition_hash, otherwise false
+/// true means compaction and scan will validate partition_hash, otherwise false
 const std::string SPLIT_VALIDATE_PARTITION_HASH("replica.split.validate_partition_hash");
 } // namespace pegasus

--- a/src/base/pegasus_const.h
+++ b/src/base/pegasus_const.h
@@ -62,4 +62,6 @@ extern const std::string PEGASUS_CLUSTER_SECTION_NAME;
 extern const std::string ROCKSDB_ENV_SLOW_QUERY_THRESHOLD;
 
 extern const std::string ROCKSDB_ITERATION_THRESHOLD_TIME_MS;
+
+extern const std::string SPLIT_VALIDATE_PARTITION_HASH;
 } // namespace pegasus

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -131,7 +131,7 @@
   # Options:
   #   - falcon
   #   - prometheus
-  perf_counter_sink = prometheus
+  perf_counter_sink =
   # The HTTP port exposed to Prometheus for pulling metrics from pegasus server.
   prometheus_port = @PROMETHEUS_PORT@
 

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2296,6 +2296,7 @@ void pegasus_server_impl::update_app_envs(const std::map<std::string, std::strin
     update_checkpoint_reserve(envs);
     update_slow_query_threshold(envs);
     update_rocksdb_iteration_threshold(envs);
+    update_validate_partition_hash(envs);
     _manual_compact_svc.start_manual_compact_if_needed(envs);
 }
 
@@ -2312,6 +2313,7 @@ void pegasus_server_impl::update_app_envs_before_open_db(
     update_checkpoint_reserve(envs);
     update_slow_query_threshold(envs);
     update_rocksdb_iteration_threshold(envs);
+    update_validate_partition_hash(envs);
     _manual_compact_svc.start_manual_compact_if_needed(envs);
 }
 
@@ -2437,6 +2439,25 @@ void pegasus_server_impl::update_rocksdb_iteration_threshold(
                        _rng_rd_opts.rocksdb_iteration_threshold_time_ms,
                        threshold_ms);
         _rng_rd_opts.rocksdb_iteration_threshold_time_ms = threshold_ms;
+    }
+}
+
+void pegasus_server_impl::update_validate_partition_hash(
+    const std::map<std::string, std::string> &envs)
+{
+    bool new_value = false;
+    auto iter = envs.find(SPLIT_VALIDATE_PARTITION_HASH);
+    if (iter != envs.end()) {
+        if (!dsn::buf2bool(iter->second, new_value)) {
+            derror_replica("{}={} is invalid.", iter->first, iter->second);
+            return;
+        }
+    }
+    if (new_value != _check_partition_hash) {
+        ddebug_replica(
+            "update '_check_partition_hash' from {} to {}", _check_partition_hash, new_value);
+        _check_partition_hash = new_value;
+        _key_ttl_compaction_filter_factory->SetCheckPartitionHash(_check_partition_hash);
     }
 }
 

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2453,11 +2453,11 @@ void pegasus_server_impl::update_validate_partition_hash(
             return;
         }
     }
-    if (new_value != _check_partition_hash) {
+    if (new_value != _validate_partition_hash) {
         ddebug_replica(
-            "update '_check_partition_hash' from {} to {}", _check_partition_hash, new_value);
-        _check_partition_hash = new_value;
-        _key_ttl_compaction_filter_factory->SetCheckPartitionHash(_check_partition_hash);
+            "update '_validate_partition_hash' from {} to {}", _validate_partition_hash, new_value);
+        _validate_partition_hash = new_value;
+        _key_ttl_compaction_filter_factory->SetValidatePartitionHash(_validate_partition_hash);
     }
 }
 

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1458,6 +1458,8 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
 
     // only enable filter after correct pegasus_data_version set
     _key_ttl_compaction_filter_factory->SetPegasusDataVersion(_pegasus_data_version);
+    _key_ttl_compaction_filter_factory->SetPartitionIndex(_gpid.get_partition_index());
+    _key_ttl_compaction_filter_factory->SetPartitionVersion(_gpid.get_partition_index() - 1);
     _key_ttl_compaction_filter_factory->EnableFilter();
 
     parse_checkpoints();
@@ -2750,8 +2752,7 @@ void pegasus_server_impl::set_partition_version(int32_t partition_version)
     int32_t old_partition_version = _partition_version.exchange(partition_version);
     ddebug_replica(
         "update partition version from {} to {}", old_partition_version, partition_version);
-
-    // TODO(heyuchen): set filter _partition_version in further pr
+    _key_ttl_compaction_filter_factory->SetPartitionVersion(partition_version);
 }
 
 ::dsn::error_code pegasus_server_impl::flush_all_family_columns(bool wait)

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -404,7 +404,7 @@ private:
     pegasus_manual_compact_service _manual_compact_svc;
 
     std::atomic<int32_t> _partition_version;
-    bool _check_partition_hash{false};
+    bool _validate_partition_hash{false};
 
     dsn::replication::ingestion_status::type _ingestion_status{
         dsn::replication::ingestion_status::IS_INVALID};

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -262,6 +262,8 @@ private:
 
     void update_rocksdb_iteration_threshold(const std::map<std::string, std::string> &envs);
 
+    void update_validate_partition_hash(const std::map<std::string, std::string> &envs);
+
     // return true if parse compression types 'config' success, otherwise return false.
     // 'compression_per_level' will not be changed if parse failed.
     bool parse_compression_types(const std::string &config,
@@ -402,6 +404,7 @@ private:
     pegasus_manual_compact_service _manual_compact_svc;
 
     std::atomic<int32_t> _partition_version;
+    bool _check_partition_hash{false};
 
     dsn::replication::ingestion_status::type _ingestion_status{
         dsn::replication::ingestion_status::IS_INVALID};


### PR DESCRIPTION
If app's `validate_partition_hash=true`, it will check partition_hash when execute rocksdb compaction, to gc old data during partition split.