### PR TITLE
fix(scripts): skip packaging irrelevant libs

### DIFF
--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -9,7 +9,7 @@ name: pull_request
 on:
   # run on each pull request
   pull_request:
-    types: [ synchronize, reopened, labeled ]
+    types: [ synchronize, opened ]
     branches:
       - master
       - 'v[0-9]+.*' # release branch

--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -55,6 +55,12 @@ jobs:
         run: unzip /root/thirdparties-bin.zip -d ./rdsn/thirdparty
       - name: Compilation
         run: ./run.sh build -c --skip_thirdparty
+      -
+        name: Packaging Server
+        run: ./run.sh pack_server
+      -
+        name: Packaging Tools
+        run: ./run.sh pack_tools
       - name: Unit Testing
         run: |
           source ./config_hdfs.sh

--- a/scripts/pack_common.sh
+++ b/scripts/pack_common.sh
@@ -100,11 +100,21 @@ function check_bit()
     fi
 }
 
-function pack_system_lib()
-{
+function need_system_lib() {
+    # return if system libname is not empty, if false, it means this library is not a dependency
+    libname=$(ldd ./DSN_ROOT/bin/pegasus_"$1"/pegasus_"$1" 2>/dev/null | grep "lib${2}\.so")
+    [ -n "${libname}" ]
+}
+
+function pack_system_lib() {
     local package_path=$1
     local package_type=$2
     local lib_name=$3
+
+    if ! need_system_lib "${package_type}" "${lib_name}"; then
+        echo "ERROR: ${lib_name} is not a required dependency, skip packaging this lib"
+        return;
+    fi
 
     SYS_LIB_PATH=$(get_system_lib "${package_type}" "${lib_name}")
     if [ -z "${SYS_LIB_PATH}" ]; then


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Some environments may build pegasus with less dependencies than we expected. For example, we assume that ubuntu18.04 must require icui18n icuuc icudata, but with image [pegasus-kv/thirdparties-bin:ubuntu1804](https://github.com/orgs/pegasus-kv/packages/container/thirdparties-bin/1553681) I found it always builds without linking these libs. So when we package pegasus, the script will fail if it can't find them in the system path (apt-get doesn't find this package). This is annoying and needs endless fixes.

### What is changed and how it works?

I add a check before packaging a lib, if it's not required, the script prints an error log and goes on.

### Manual Test

```
'./scripts/sendmail.sh' -> 'pegasus-server-2.1.SNAPSHOT-eca50e0-glibc2.27-release/bin/sendmail.sh'
'./src/server/config.ini' -> 'pegasus-server-2.1.SNAPSHOT-eca50e0-glibc2.27-release/bin/config.ini'
'./src/server/config.min.ini' -> 'pegasus-server-2.1.SNAPSHOT-eca50e0-glibc2.27-release/bin/config.min.ini'
'./config_hdfs.sh' -> 'pegasus-server-2.1.SNAPSHOT-eca50e0-glibc2.27-release/bin/config_hdfs.sh'
'/usr/lib/x86_64-linux-gnu/libstdc++.so.6' -> 'pegasus-server-2.1.SNAPSHOT-eca50e0-glibc2.27-release/bin/libstdc++.so.6'
'/usr/lib/x86_64-linux-gnu/libsnappy.so.1' -> 'pegasus-server-2.1.SNAPSHOT-eca50e0-glibc2.27-release/bin/libsnappy.so.1'
'/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1' -> 'pegasus-server-2.1.SNAPSHOT-eca50e0-glibc2.27-release/bin/libcrypto.so.1.1'
'/usr/lib/x86_64-linux-gnu/libssl.so.1.1' -> 'pegasus-server-2.1.SNAPSHOT-eca50e0-glibc2.27-release/bin/libssl.so.1.1'
'/usr/lib/x86_64-linux-gnu/libzstd.so.1' -> 'pegasus-server-2.1.SNAPSHOT-eca50e0-glibc2.27-release/bin/libzstd.so.1'
'/usr/lib/x86_64-linux-gnu/liblz4.so.1' -> 'pegasus-server-2.1.SNAPSHOT-eca50e0-glibc2.27-release/bin/liblz4.so.1'
Couldn't find env  or no valid keytab file was specified,
          hadoop-related files were not packed.
ERROR: icui18n is not a required dependency, skip packaging this lib
ERROR: icuuc is not a required dependency, skip packaging this lib
ERROR: icudata is not a required dependency, skip packaging this lib
Modifying  ...
sed: no input files
sed: no input files
sed: no input files
Done
```