### PR TITLE
refactor: add pegasus_value_service and pegasus_value_schema

### DIFF
--- a/src/base/pegasus_value_schema.h
+++ b/src/base/pegasus_value_schema.h
@@ -234,4 +234,29 @@ private:
     std::vector<rocksdb::Slice> _write_slices;
 };
 
+enum pegasus_data_version
+{
+    /// TBD(zlw):
+};
+
+struct generage_value_params
+{
+    // TBD(zlw):
+};
+
+class pegasus_value_schema
+{
+public:
+    virtual ~pegasus_value_schema() = default;
+
+    /// In order to keep high performance, this interface can use tricky code to avoid memory copy.
+    /// So the parameter type of value is std::string &&
+    virtual dsn::blob extract_user_data(std::string &&value) = 0;
+    virtual uint64_t extract_timetag(dsn::string_view value) = 0;
+    virtual uint32_t extract_expire_ts(dsn::string_view raw_value) = 0;
+
+    virtual pegasus_data_version get_data_version() = 0;
+    virtual void update_expire_ts(std::string &value, uint32_t new_expire_ts) = 0;
+    virtual rocksdb::SliceParts generate_value(generage_value_params params) = 0;
+};
 } // namespace pegasus

--- a/src/base/pegasus_value_schema.h
+++ b/src/base/pegasus_value_schema.h
@@ -236,27 +236,12 @@ private:
 
 enum pegasus_data_version
 {
-    /// TBD(zlw):
-};
-
-struct generage_value_params
-{
-    // TBD(zlw):
+    // TBD(zlw)
 };
 
 class pegasus_value_schema
 {
 public:
     virtual ~pegasus_value_schema() = default;
-
-    /// In order to keep high performance, this interface can use tricky code to avoid memory copy.
-    /// So the parameter type of value is std::string &&
-    virtual dsn::blob extract_user_data(std::string &&value) = 0;
-    virtual uint64_t extract_timetag(dsn::string_view value) = 0;
-    virtual uint32_t extract_expire_ts(dsn::string_view raw_value) = 0;
-
-    virtual pegasus_data_version get_data_version() = 0;
-    virtual void update_expire_ts(std::string &value, uint32_t new_expire_ts) = 0;
-    virtual rocksdb::SliceParts generate_value(generage_value_params params) = 0;
 };
 } // namespace pegasus

--- a/src/base/pegasus_value_schema.h
+++ b/src/base/pegasus_value_schema.h
@@ -242,6 +242,6 @@ enum pegasus_data_version
 class pegasus_value_schema
 {
 public:
-    virtual ~pegasus_value_schema() = default;
+    virtual ~pegasus_value_schema() = 0;
 };
 } // namespace pegasus

--- a/src/base/pegasus_value_service.cpp
+++ b/src/base/pegasus_value_service.cpp
@@ -20,6 +20,7 @@
 #include "pegasus_value_service.h"
 
 namespace pegasus {
+pegasus_value_schema::~pegasus_value_schema() = default;
 
 pegasus_value_schema *pegasus_value_service::get_value_schema(uint32_t meta_store_data_version,
                                                               dsn::string_view value) const
@@ -45,6 +46,10 @@ void pegasus_value_service::register_schema(pegasus_value_schema *schema)
     // TBD(zlw)
 }
 
+/**
+ * If someone wants to add a new data version, he only need to implement the new value schema,
+ * and register it here. No more other modifications.
+ */
 void register_value_schemas()
 {
     // TBD(zlw)

--- a/src/base/pegasus_value_service.cpp
+++ b/src/base/pegasus_value_service.cpp
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "pegasus_value_service.h"
+
+namespace pegasus {
+
+pegasus_value_schema *pegasus_value_service::get_value_schema(uint32_t meta_store_data_version,
+                                                              dsn::string_view value) const
+{
+    // TBD(zlw)
+}
+
+pegasus_value_schema *pegasus_value_service::get_value_schema(uint32_t version) const
+{
+    // TBD(zlw)
+}
+
+pegasus_value_schema *pegasus_value_service::get_latest_value_schema() const
+{
+    // TBD(zlw)
+}
+
+void pegasus_value_service::register_schema(pegasus_value_schema *schema)
+{
+    // TBD(zlw)
+}
+
+void register_value_schemas()
+{
+    // TBD(zlw)
+}
+
+struct value_schemas_registerer
+{
+    value_schemas_registerer() { register_value_schemas(); }
+};
+static value_schemas_registerer value_schemas_reg;
+
+} // namespace pegasus

--- a/src/base/pegasus_value_service.cpp
+++ b/src/base/pegasus_value_service.cpp
@@ -25,16 +25,19 @@ pegasus_value_schema *pegasus_value_service::get_value_schema(uint32_t meta_stor
                                                               dsn::string_view value) const
 {
     // TBD(zlw)
+    return nullptr;
 }
 
 pegasus_value_schema *pegasus_value_service::get_value_schema(uint32_t version) const
 {
     // TBD(zlw)
+    return nullptr;
 }
 
 pegasus_value_schema *pegasus_value_service::get_latest_value_schema() const
 {
     // TBD(zlw)
+    return nullptr;
 }
 
 void pegasus_value_service::register_schema(pegasus_value_schema *schema)

--- a/src/base/pegasus_value_service.h
+++ b/src/base/pegasus_value_service.h
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "pegasus_value_schema.h"
+
+#include <dsn/utility/singleton.h>
+#include <dsn/utility/string_view.h>
+
+namespace pegasus {
+class pegasus_value_service : public dsn::utils::singleton<pegasus_value_service>
+{
+public:
+    void register_schema(pegasus_value_schema *schema);
+    pegasus_value_schema *get_value_schema(uint32_t meta_store_data_version,
+                                           dsn::string_view value) const;
+    pegasus_value_schema *get_value_schema(uint32_t version) const;
+    pegasus_value_schema *get_latest_value_schema() const;
+
+private:
+    pegasus_value_service() = default;
+    friend class dsn::utils::singleton<pegasus_value_service>;
+
+    std::map<pegasus_data_version, pegasus_value_schema *> _schemas;
+};
+} // namespace pegasus


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
In order to refactor the implementation code in `pegasus_value_schema.h`, I add pegasus_value_service and pegasus_value_schema in this pull request. 

The global design is here:
![2021-03-19 14-47-49 的屏幕截图](https://user-images.githubusercontent.com/22141103/111741843-1eff1a80-88c2-11eb-9057-9b44b42aa998.png)


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
I will add unit tests in later pull requests.

