### PR TITLE
feat: add read rate limiter perfcounter in info collector

### DIFF
--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -213,6 +213,8 @@ info_collector::app_stat_counters *info_collector::get_app_counters(const std::s
     INIT_COUNTER(recent_abnormal_count);
     INIT_COUNTER(recent_write_throttling_delay_count);
     INIT_COUNTER(recent_write_throttling_reject_count);
+    INIT_COUNTER(recent_read_throttling_delay_count);
+    INIT_COUNTER(recent_read_throttling_reject_count);
     INIT_COUNTER(storage_mb);
     INIT_COUNTER(storage_count);
     INIT_COUNTER(rdb_block_cache_hit_rate);

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -75,6 +75,10 @@ public:
                 row_stats.total_recent_write_throttling_delay_count);
             recent_write_throttling_reject_count->set(
                 row_stats.total_recent_write_throttling_reject_count);
+            recent_read_throttling_delay_count->set(
+                    row_stats.total_recent_read_throttling_delay_count);
+            recent_read_throttling_reject_count->set(
+                    row_stats.total_recent_read_throttling_reject_count);
             storage_mb->set(row_stats.total_storage_mb);
             storage_count->set(row_stats.total_storage_count);
             rdb_block_cache_hit_rate->set(
@@ -130,6 +134,8 @@ public:
         ::dsn::perf_counter_wrapper recent_abnormal_count;
         ::dsn::perf_counter_wrapper recent_write_throttling_delay_count;
         ::dsn::perf_counter_wrapper recent_write_throttling_reject_count;
+        ::dsn::perf_counter_wrapper recent_read_throttling_delay_count;
+        ::dsn::perf_counter_wrapper recent_read_throttling_reject_count;
         ::dsn::perf_counter_wrapper storage_mb;
         ::dsn::perf_counter_wrapper storage_count;
         ::dsn::perf_counter_wrapper rdb_block_cache_hit_rate;

--- a/src/server/table_stats.h
+++ b/src/server/table_stats.h
@@ -68,6 +68,8 @@ struct table_stats
         total_recent_abnormal_count += row.recent_abnormal_count;
         total_recent_write_throttling_delay_count += row.recent_write_throttling_delay_count;
         total_recent_write_throttling_reject_count += row.recent_write_throttling_reject_count;
+        total_recent_read_throttling_delay_count += row.recent_read_throttling_delay_count;
+        total_recent_read_throttling_reject_count += row.recent_read_throttling_reject_count;
         total_storage_mb += row.storage_mb;
         total_storage_count += row.storage_count;
         total_rdb_block_cache_hit_count += row.rdb_block_cache_hit_count;
@@ -114,6 +116,10 @@ struct table_stats
             row_stats.total_recent_write_throttling_delay_count;
         total_recent_write_throttling_reject_count +=
             row_stats.total_recent_write_throttling_reject_count;
+        total_recent_read_throttling_delay_count +=
+                row_stats.total_recent_read_throttling_delay_count;
+        total_recent_read_throttling_reject_count +=
+                row_stats.total_recent_read_throttling_reject_count;
         total_storage_mb += row_stats.total_storage_mb;
         total_storage_count += row_stats.total_storage_count;
         total_rdb_block_cache_hit_count += row_stats.total_rdb_block_cache_hit_count;
@@ -158,6 +164,8 @@ struct table_stats
     double total_recent_abnormal_count = 0;
     double total_recent_write_throttling_delay_count = 0;
     double total_recent_write_throttling_reject_count = 0;
+    double total_recent_read_throttling_delay_count = 0;
+    double total_recent_read_throttling_reject_count = 0;
     double total_storage_mb = 0;
     double total_storage_count = 0;
     double total_rdb_block_cache_hit_count = 0;

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -595,6 +595,8 @@ struct row_data
     double recent_abnormal_count = 0;
     double recent_write_throttling_delay_count = 0;
     double recent_write_throttling_reject_count = 0;
+    double recent_read_throttling_delay_count = 0;
+    double recent_read_throttling_reject_count = 0;
     double storage_mb = 0;
     double storage_count = 0;
     double rdb_block_cache_hit_count = 0;
@@ -660,6 +662,10 @@ update_app_pegasus_perf_counter(row_data &row, const std::string &counter_name, 
         row.recent_write_throttling_delay_count += value;
     else if (counter_name == "recent.write.throttling.reject.count")
         row.recent_write_throttling_reject_count += value;
+    else if (counter_name == "recent.read.throttling.delay.count")
+        row.recent_read_throttling_delay_count += value;
+    else if (counter_name == "recent.read.throttling.reject.count")
+        row.recent_read_throttling_reject_count += value;
     else if (counter_name == "disk.storage.sst(MB)")
         row.storage_mb += value;
     else if (counter_name == "disk.storage.sst.count")

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -505,6 +505,8 @@ bool app_stat(command_executor *e, shell_context *sc, arguments args)
         sum.recent_abnormal_count += row.recent_abnormal_count;
         sum.recent_write_throttling_delay_count += row.recent_write_throttling_delay_count;
         sum.recent_write_throttling_reject_count += row.recent_write_throttling_reject_count;
+        sum.recent_read_throttling_delay_count += row.recent_read_throttling_delay_count;
+        sum.recent_read_throttling_reject_count += row.recent_read_throttling_reject_count;
         sum.storage_mb += row.storage_mb;
         sum.storage_count += row.storage_count;
         sum.rdb_block_cache_hit_count += row.rdb_block_cache_hit_count;
@@ -589,6 +591,8 @@ bool app_stat(command_executor *e, shell_context *sc, arguments args)
             tp.append_data(row.recent_abnormal_count);
             tp.append_data(row.recent_write_throttling_delay_count);
             tp.append_data(row.recent_write_throttling_reject_count);
+            tp.append_data(row.recent_read_throttling_delay_count);
+            tp.append_data(row.recent_read_throttling_reject_count);
         }
         if (!only_qps) {
             tp.append_data(row.storage_mb);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
add read rate limiter perfcounter in info collector

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1. start onebox
2. set read limiter for table `stat` to a little value, such as '1*reject*100'
3. read table `stat` repeatly
4. the perf counter of read reject count is not zero:
```
2405:[collector*app.pegasus*app.stat.recent_read_throttling_reject_count#stat, NUMBER, 6.00]
```