### PR TITLE
refactor: update default nfs copy rate when add_node_list and offline_node_list

### DIFF
--- a/scripts/pegasus_add_node_list.sh
+++ b/scripts/pegasus_add_node_list.sh
@@ -22,10 +22,10 @@
 PID=$$
 
 if [ $# -le 2 ]; then
-  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list>"
+  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list><nfs_copy_rate_megabytes>(default 200)"
   echo
   echo "For example:"
-  echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 1,2,3"
+  echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 1,2,3 200"
   echo
   exit 1
 fi
@@ -39,6 +39,12 @@ echo
 cluster=$1
 meta_list=$2
 replica_task_id_list=$3
+
+if [ -z $4 ]; then
+  nfs_copy_rate_megabytes=200
+else
+  nfs_copy_rate_megabytes=$4
+fi
 
 pwd="$( cd "$( dirname "$0"  )" && pwd )"
 shell_dir="$( cd $pwd/.. && pwd )"
@@ -71,7 +77,7 @@ do
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 done
 
-./scripts/pegasus_rebalance_cluster.sh $cluster $meta_list true
+./scripts/pegasus_rebalance_cluster.sh $cluster $meta_list true $nfs_copy_rate_megabytes
 
 echo "Finish time: `date`"
 add_node_finish_time=$((`date +%s`))

--- a/scripts/pegasus_add_node_list.sh
+++ b/scripts/pegasus_add_node_list.sh
@@ -22,7 +22,7 @@
 PID=$$
 
 if [ $# -le 2 ]; then
-  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list><nfs_copy_rate_megabytes>(default 200)"
+  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list> <nfs_copy_rate_megabytes>(default 200)"
   echo
   echo "For example:"
   echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 1,2,3 200"

--- a/scripts/pegasus_offline_node_list.sh
+++ b/scripts/pegasus_offline_node_list.sh
@@ -22,7 +22,7 @@
 PID=$$
 
 if [ $# -le 2 ]; then
-  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list><<nfs_copy_rate_megabytes>(default 100)>"
+  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list> <nfs_copy_rate_megabytes>(default 100)>"
   echo
   echo "For example:"
   echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 1,2,3 100"

--- a/scripts/pegasus_offline_node_list.sh
+++ b/scripts/pegasus_offline_node_list.sh
@@ -22,7 +22,7 @@
 PID=$$
 
 if [ $# -le 2 ]; then
-  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list>"
+  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list><<nfs_copy_rate_megabytes>(default 100)>"
   echo
   echo "For example:"
   echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 1,2,3"
@@ -40,6 +40,12 @@ cluster=$1
 meta_list=$2
 replica_task_id_list=$3
 
+if [ -z $4 ]; then
+  nfs_copy_rate_megabytes=100
+else
+  nfs_copy_rate_megabytes=$4
+fi
+
 pwd="$( cd "$( dirname "$0"  )" && pwd )"
 shell_dir="$( cd $pwd/.. && pwd )"
 cd $shell_dir
@@ -50,6 +56,14 @@ source ./scripts/pegasus_check_arguments.sh offline_node_list $cluster $meta_lis
 if [ $? -ne 0 ]; then
     echo "ERROR: the argument check failed"
     exit 1
+fi
+
+echo "Set nfs_copy_rate_megabytes $nfs_copy_rate_megabytes"
+echo "remote_command -t replica-server replica.nfs.max_copy_rate_megabytes $nfs_copy_rate_megabytes" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.offline_node_list.set_nfs_copy_rate_megabytes
+set_ok=`grep 'succeed: OK' /tmp/$UID.$PID.pegasus.add_offline_list.set_nfs_copy_rate_megabytes | wc -l`
+if [ $set_ok -le 0 ]; then
+  echo "ERROR: set nfs_copy_rate_megabytes failed"
+  exit 1
 fi
 
 echo "Set lb.assign_secondary_black_list..."

--- a/scripts/pegasus_offline_node_list.sh
+++ b/scripts/pegasus_offline_node_list.sh
@@ -25,7 +25,7 @@ if [ $# -le 2 ]; then
   echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list><<nfs_copy_rate_megabytes>(default 100)>"
   echo
   echo "For example:"
-  echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 1,2,3"
+  echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 1,2,3 100"
   echo
   exit 1
 fi
@@ -60,7 +60,7 @@ fi
 
 echo "Set nfs_copy_rate_megabytes $nfs_copy_rate_megabytes"
 echo "remote_command -t replica-server replica.nfs.max_copy_rate_megabytes $nfs_copy_rate_megabytes" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.offline_node_list.set_nfs_copy_rate_megabytes
-set_ok=`grep 'succeed: OK' /tmp/$UID.$PID.pegasus.add_offline_list.set_nfs_copy_rate_megabytes | wc -l`
+set_ok=`grep 'succeed: OK' /tmp/$UID.$PID.pegasus.offline_node_list.set_nfs_copy_rate_megabytes | wc -l`
 if [ $set_ok -le 0 ]; then
   echo "ERROR: set nfs_copy_rate_megabytes failed"
   exit 1

--- a/scripts/pegasus_rebalance_cluster.sh
+++ b/scripts/pegasus_rebalance_cluster.sh
@@ -22,7 +22,7 @@
 PID=$$
 
 if [ $# -le 1 ]; then
-  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <only-move-primary>(default false)<nfs_copy_rate_megabytes>(default 100)"
+  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <only-move-primary>(default false) <nfs_copy_rate_megabytes>(default 100)"
   echo 
   echo "for example:"
   echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 true 100"

--- a/scripts/pegasus_rebalance_cluster.sh
+++ b/scripts/pegasus_rebalance_cluster.sh
@@ -25,7 +25,7 @@ if [ $# -le 1 ]; then
   echo "USAGE: $0 <cluster-name> <cluster-meta-list> <only-move-primary>(default false)<nfs_copy_rate_megabytes>(default 100)"
   echo 
   echo "for example:"
-  echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 true"
+  echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 true 100"
   echo
   exit 1
 fi


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
default nfs copy rate is not appropriate when add/offline node

### What is changed and how it works?

- update  `pegasus_add_node_list.sh` support pass `replica.nfs.max_copy_rate_megabytes`(**default 200**) 
- update  `pegasus_offline_node_list.sh` support pass `replica.nfs.max_copy_rate_megabytes`(**default 100**) 

### Check List <!--REMOVE the items that are not applicable-->

- Manual test (add detailed scripts or steps below)


