### PR TITLE
fix: shell app_stat removes unexpected columns

### DIFF
--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -591,8 +591,6 @@ bool app_stat(command_executor *e, shell_context *sc, arguments args)
             tp.append_data(row.recent_abnormal_count);
             tp.append_data(row.recent_write_throttling_delay_count);
             tp.append_data(row.recent_write_throttling_reject_count);
-            tp.append_data(row.recent_read_throttling_delay_count);
-            tp.append_data(row.recent_read_throttling_reject_count);
         }
         if (!only_qps) {
             tp.append_data(row.storage_mb);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

```
>>> app_stat
F2021-04-07 16:11:32.546 (1617783092546521940 16004)  mimic.io-thrd.16004: output_utils.cpp:150:append_string_data(): assertion expression: last_index <= _max_col_width.size()
F2021-04-07 16:11:32.546 (1617783092546549469 16004)  mimic.io-thrd.16004: output_utils.cpp:150:append_string_data(): column data exceed
```

https://github.com/apache/incubator-pegasus/pull/705 This PR appends two columns to `app_stat`. But they don't have a column title. So when they are appended, the shell coredumped.

### What is changed and how does it work?

This PR removes the incorrect two columns.

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Manually call `app_stat`, everything works.
