### PR TITLE
fix(shell): update help to claim that policy in restore_app is optional

### DIFF
--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -418,9 +418,10 @@ static command_executor commands[] = {
     {
         "restore_app",
         "restore app from backup media",
-        "<-c|--old_cluster_name str> <-p|--old_policy_name str> <-a|--old_app_name str> "
+        "<-c|--old_cluster_name str> <-a|--old_app_name str> "
         "<-i|--old_app_id id> <-t|--timestamp/backup_id timestamp> "
-        "<-b|--backup_provider_type str> [-n|--new_app_name str] [-s|--skip_bad_partition]",
+        "<-b|--backup_provider_type str> "
+        "[-p|--old_policy_name str] [-n|--new_app_name str] [-s|--skip_bad_partition]",
         restore,
     },
     {


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
>>> restore_app 
USAGE:  restore_app             <-c|--old_cluster_name str> <-p|--old_policy_name str>
                                <-a|--old_app_name str> <-i|--old_app_id id>
                                <-t|--timestamp/backup_id timestamp> <-b|--backup_provider_type str>
                                [-n|--new_app_name str] [-s|--skip_bad_partition]
```

`<-p|--old_policy_name str>` is required at least in the help info of `restore_app` command.
Users are prone to make mistakes to add this argument when they restore a table.

What it is now:

```
>>> restore_app 
invalid parameter
USAGE: 	restore_app             <-c|--old_cluster_name str> <-a|--old_app_name str>
	                        <-i|--old_app_id id> <-t|--timestamp/backup_id timestamp>
	                        <-b|--backup_provider_type str> [-p|--old_policy_name str]
	                        [-n|--new_app_name str] [-s|--skip_bad_partition]
```

`--old_policy_name` is not required anymore.


### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

