### PR TITLE
fix: add incr_qps and duplicate_qps to total_write_qps

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -563,7 +563,7 @@ struct row_data
     double get_total_write_qps() const
     {
         return put_qps + remove_qps + multi_put_qps + multi_remove_qps + check_and_set_qps +
-               check_and_mutate_qps;
+               check_and_mutate_qps + incr_qps + duplicate_qps;
     }
 
     double get_total_read_bytes() const { return get_bytes + multi_get_bytes + scan_bytes; }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
add incr_qps and duplicate_qps to total_write_qps

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1. start onebox
2. do incr operation in app "temp" repeatly
3. the perf counter of write qps for _all_ is not zero
```
[collector*app.pegasus*app.stat.incr_qps#temp, NUMBER, 2.00]
[collector*app.pegasus*app.stat.write_qps#_all_, NUMBER, 2.00]
```