### PR TITLE
improve performance of count_data

### DIFF
--- a/src/base/rrdb_types.cpp
+++ b/src/base/rrdb_types.cpp
@@ -3342,8 +3342,8 @@ check_and_mutate_request::check_and_mutate_request(check_and_mutate_request &&ot
     return_check_value = std::move(other99.return_check_value);
     __isset = std::move(other99.__isset);
 }
-check_and_mutate_request &check_and_mutate_request::
-operator=(const check_and_mutate_request &other100)
+check_and_mutate_request &
+check_and_mutate_request::operator=(const check_and_mutate_request &other100)
 {
     hash_key = other100.hash_key;
     check_sort_key = other100.check_sort_key;
@@ -3589,8 +3589,8 @@ check_and_mutate_response::check_and_mutate_response(check_and_mutate_response &
     server = std::move(other103.server);
     __isset = std::move(other103.__isset);
 }
-check_and_mutate_response &check_and_mutate_response::
-operator=(const check_and_mutate_response &other104)
+check_and_mutate_response &
+check_and_mutate_response::operator=(const check_and_mutate_response &other104)
 {
     error = other104.error;
     check_value_returned = other104.check_value_returned;
@@ -3603,8 +3603,8 @@ operator=(const check_and_mutate_response &other104)
     __isset = other104.__isset;
     return *this;
 }
-check_and_mutate_response &check_and_mutate_response::
-operator=(check_and_mutate_response &&other105)
+check_and_mutate_response &
+check_and_mutate_response::operator=(check_and_mutate_response &&other105)
 {
     error = std::move(other105.error);
     check_value_returned = std::move(other105.check_value_returned);
@@ -3677,6 +3677,12 @@ void get_scanner_request::__set_validate_partition_hash(const bool val)
 {
     this->validate_partition_hash = val;
     __isset.validate_partition_hash = true;
+}
+
+void get_scanner_request::__set_count_only(const bool val)
+{
+    this->count_only = val;
+    __isset.count_only = true;
 }
 
 uint32_t get_scanner_request::read(::apache::thrift::protocol::TProtocol *iprot)
@@ -3790,6 +3796,14 @@ uint32_t get_scanner_request::read(::apache::thrift::protocol::TProtocol *iprot)
                 xfer += iprot->skip(ftype);
             }
             break;
+        case 12:
+            if (ftype == ::apache::thrift::protocol::T_BOOL) {
+                xfer += iprot->readBool(this->count_only);
+                this->__isset.count_only = true;
+            } else {
+                xfer += iprot->skip(ftype);
+            }
+            break;
         default:
             xfer += iprot->skip(ftype);
             break;
@@ -3856,6 +3870,11 @@ uint32_t get_scanner_request::write(::apache::thrift::protocol::TProtocol *oprot
         xfer += oprot->writeBool(this->validate_partition_hash);
         xfer += oprot->writeFieldEnd();
     }
+    if (this->__isset.count_only) {
+        xfer += oprot->writeFieldBegin("count_only", ::apache::thrift::protocol::T_BOOL, 12);
+        xfer += oprot->writeBool(this->count_only);
+        xfer += oprot->writeFieldEnd();
+    }
     xfer += oprot->writeFieldStop();
     xfer += oprot->writeStructEnd();
     return xfer;
@@ -3875,6 +3894,7 @@ void swap(get_scanner_request &a, get_scanner_request &b)
     swap(a.sort_key_filter_type, b.sort_key_filter_type);
     swap(a.sort_key_filter_pattern, b.sort_key_filter_pattern);
     swap(a.validate_partition_hash, b.validate_partition_hash);
+    swap(a.count_only, b.count_only);
     swap(a.__isset, b.__isset);
 }
 
@@ -3891,6 +3911,7 @@ get_scanner_request::get_scanner_request(const get_scanner_request &other108)
     sort_key_filter_type = other108.sort_key_filter_type;
     sort_key_filter_pattern = other108.sort_key_filter_pattern;
     validate_partition_hash = other108.validate_partition_hash;
+    count_only = other108.count_only;
     __isset = other108.__isset;
 }
 get_scanner_request::get_scanner_request(get_scanner_request &&other109)
@@ -3906,6 +3927,7 @@ get_scanner_request::get_scanner_request(get_scanner_request &&other109)
     sort_key_filter_type = std::move(other109.sort_key_filter_type);
     sort_key_filter_pattern = std::move(other109.sort_key_filter_pattern);
     validate_partition_hash = std::move(other109.validate_partition_hash);
+    count_only = std::move(other109.count_only);
     __isset = std::move(other109.__isset);
 }
 get_scanner_request &get_scanner_request::operator=(const get_scanner_request &other110)
@@ -3921,6 +3943,7 @@ get_scanner_request &get_scanner_request::operator=(const get_scanner_request &o
     sort_key_filter_type = other110.sort_key_filter_type;
     sort_key_filter_pattern = other110.sort_key_filter_pattern;
     validate_partition_hash = other110.validate_partition_hash;
+    count_only = other110.count_only;
     __isset = other110.__isset;
     return *this;
 }
@@ -3937,6 +3960,7 @@ get_scanner_request &get_scanner_request::operator=(get_scanner_request &&other1
     sort_key_filter_type = std::move(other111.sort_key_filter_type);
     sort_key_filter_pattern = std::move(other111.sort_key_filter_pattern);
     validate_partition_hash = std::move(other111.validate_partition_hash);
+    count_only = std::move(other111.count_only);
     __isset = std::move(other111.__isset);
     return *this;
 }
@@ -3967,6 +3991,9 @@ void get_scanner_request::printTo(std::ostream &out) const
         << "validate_partition_hash=";
     (__isset.validate_partition_hash ? (out << to_string(validate_partition_hash))
                                      : (out << "<null>"));
+    out << ", "
+        << "count_only=";
+    (__isset.count_only ? (out << to_string(count_only)) : (out << "<null>"));
     out << ")";
 }
 
@@ -4620,5 +4647,6 @@ void duplicate_response::printTo(std::ostream &out) const
     (__isset.error_hint ? (out << to_string(error_hint)) : (out << "<null>"));
     out << ")";
 }
-}
-} // namespace
+
+} // namespace apps
+} // namespace dsn

--- a/src/base/rrdb_types.cpp
+++ b/src/base/rrdb_types.cpp
@@ -3342,8 +3342,8 @@ check_and_mutate_request::check_and_mutate_request(check_and_mutate_request &&ot
     return_check_value = std::move(other99.return_check_value);
     __isset = std::move(other99.__isset);
 }
-check_and_mutate_request &
-check_and_mutate_request::operator=(const check_and_mutate_request &other100)
+check_and_mutate_request &check_and_mutate_request::
+operator=(const check_and_mutate_request &other100)
 {
     hash_key = other100.hash_key;
     check_sort_key = other100.check_sort_key;
@@ -3589,8 +3589,8 @@ check_and_mutate_response::check_and_mutate_response(check_and_mutate_response &
     server = std::move(other103.server);
     __isset = std::move(other103.__isset);
 }
-check_and_mutate_response &
-check_and_mutate_response::operator=(const check_and_mutate_response &other104)
+check_and_mutate_response &check_and_mutate_response::
+operator=(const check_and_mutate_response &other104)
 {
     error = other104.error;
     check_value_returned = other104.check_value_returned;
@@ -3603,8 +3603,8 @@ check_and_mutate_response::operator=(const check_and_mutate_response &other104)
     __isset = other104.__isset;
     return *this;
 }
-check_and_mutate_response &
-check_and_mutate_response::operator=(check_and_mutate_response &&other105)
+check_and_mutate_response &check_and_mutate_response::
+operator=(check_and_mutate_response &&other105)
 {
     error = std::move(other105.error);
     check_value_returned = std::move(other105.check_value_returned);

--- a/src/client_lib/pegasus_scanner_impl.cpp
+++ b/src/client_lib/pegasus_scanner_impl.cpp
@@ -215,6 +215,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_start_scan()
         _options.sort_key_filter_pattern.data(), 0, _options.sort_key_filter_pattern.size());
     req.no_value = _options.no_value;
     req.__set_validate_partition_hash(_validate_partition_hash);
+    req.__set_count_only(_options.count_only);
 
     dassert(!_rpc_started, "");
     _rpc_started = true;

--- a/src/idl/rrdb.thrift
+++ b/src/idl/rrdb.thrift
@@ -253,6 +253,7 @@ struct get_scanner_request
     9:filter_type  sort_key_filter_type;
     10:dsn.blob    sort_key_filter_pattern;
     11:optional bool    validate_partition_hash;
+    12:optional bool    count_only;
 }
 
 struct scan_request

--- a/src/include/pegasus/client.h
+++ b/src/include/pegasus/client.h
@@ -251,6 +251,7 @@ public:
         filter_type sort_key_filter_type;
         std::string sort_key_filter_pattern;
         bool no_value; // only fetch hash_key and sort_key, but not fetch value
+        bool count_only;
         scan_options()
             : timeout_ms(5000),
               batch_size(100),
@@ -258,7 +259,8 @@ public:
               stop_inclusive(false),
               hash_key_filter_type(FT_NO_FILTER),
               sort_key_filter_type(FT_NO_FILTER),
-              no_value(false)
+              no_value(false),
+              count_only(false)
         {
         }
         scan_options(const scan_options &o)
@@ -270,7 +272,8 @@ public:
               hash_key_filter_pattern(o.hash_key_filter_pattern),
               sort_key_filter_type(o.sort_key_filter_type),
               sort_key_filter_pattern(o.sort_key_filter_pattern),
-              no_value(o.no_value)
+              no_value(o.no_value),
+              count_only(o.count_only)
         {
         }
     };

--- a/src/include/rrdb/rrdb_types.h
+++ b/src/include/rrdb/rrdb_types.h
@@ -1559,7 +1559,8 @@ typedef struct _get_scanner_request__isset
           hash_key_filter_pattern(false),
           sort_key_filter_type(false),
           sort_key_filter_pattern(false),
-          validate_partition_hash(false)
+          validate_partition_hash(false),
+          count_only(false)
     {
     }
     bool start_key : 1;
@@ -1573,6 +1574,7 @@ typedef struct _get_scanner_request__isset
     bool sort_key_filter_type : 1;
     bool sort_key_filter_pattern : 1;
     bool validate_partition_hash : 1;
+    bool count_only : 1;
 } _get_scanner_request__isset;
 
 class get_scanner_request
@@ -1589,7 +1591,8 @@ public:
           no_value(0),
           hash_key_filter_type((filter_type::type)0),
           sort_key_filter_type((filter_type::type)0),
-          validate_partition_hash(0)
+          validate_partition_hash(0),
+          count_only(0)
     {
     }
 
@@ -1605,6 +1608,7 @@ public:
     filter_type::type sort_key_filter_type;
     ::dsn::blob sort_key_filter_pattern;
     bool validate_partition_hash;
+    bool count_only;
 
     _get_scanner_request__isset __isset;
 
@@ -1629,6 +1633,8 @@ public:
     void __set_sort_key_filter_pattern(const ::dsn::blob &val);
 
     void __set_validate_partition_hash(const bool val);
+
+    void __set_count_only(const bool val);
 
     bool operator==(const get_scanner_request &rhs) const
     {
@@ -1656,6 +1662,10 @@ public:
             return false;
         else if (__isset.validate_partition_hash &&
                  !(validate_partition_hash == rhs.validate_partition_hash))
+            return false;
+        if (__isset.count_only != rhs.__isset.count_only)
+            return false;
+        else if (__isset.count_only && !(count_only == rhs.count_only))
             return false;
         return true;
     }
@@ -1949,7 +1959,8 @@ inline std::ostream &operator<<(std::ostream &out, const duplicate_response &obj
     obj.printTo(out);
     return out;
 }
-}
-} // namespace
+
+} // namespace apps
+} // namespace dsn
 
 #endif

--- a/src/server/pegasus_scan_context.h
+++ b/src/server/pegasus_scan_context.h
@@ -42,7 +42,8 @@ struct pegasus_scan_context
                          const std::string &&sort_key_filter_pattern_,
                          int32_t batch_size_,
                          bool no_value_,
-                         bool validate_partition_hash_)
+                         bool validate_partition_hash_,
+                         bool count_only_)
         : _stop_holder(std::move(stop_)),
           _hash_key_filter_pattern_holder(std::move(hash_key_filter_pattern_)),
           _sort_key_filter_pattern_holder(std::move(sort_key_filter_pattern_)),
@@ -57,7 +58,8 @@ struct pegasus_scan_context
               _sort_key_filter_pattern_holder.data(), 0, _sort_key_filter_pattern_holder.length()),
           batch_size(batch_size_),
           no_value(no_value_),
-          validate_partition_hash(validate_partition_hash_)
+          validate_partition_hash(validate_partition_hash_),
+          count_only(count_only_)
     {
     }
 
@@ -77,6 +79,7 @@ public:
     int32_t batch_size;
     bool no_value;
     bool validate_partition_hash;
+    bool count_only;
 };
 
 class pegasus_context_cache

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1031,7 +1031,6 @@ void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
 
         limiter->add_count();
 
-
         auto state = append_key_value_for_scan(
             resp.kvs,
             it->key(),

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -221,7 +221,8 @@ private:
                               const ::dsn::blob &sort_key_filter_pattern,
                               uint32_t epoch_now,
                               bool no_value,
-                              bool request_validate_hash);
+                              bool request_validate_hash,
+                              bool count_only);
 
     range_iteration_state
     append_key_value_for_multi_get(std::vector<::dsn::apps::key_value> &kvs,
@@ -231,6 +232,10 @@ private:
                                    const ::dsn::blob &sort_key_filter_pattern,
                                    uint32_t epoch_now,
                                    bool no_value);
+
+    void create_kv_for_count_only(std::vector<::dsn::apps::key_value> &kvs,
+                                  rocksdb::Iterator *it,
+                                  int64_t count);
 
     // return true if the filter type is supported
     bool is_filter_type_supported(::dsn::apps::filter_type::type filter_type)

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -303,7 +303,8 @@ static command_executor commands[] = {
         "[-y|--sort_key_filter_pattern str] "
         "[-v|--value_filter_type anywhere|prefix|postfix|exact] "
         "[-z|--value_filter_pattern str][-d|--diff_hash_key] "
-        "[-a|--stat_size] [-n|--top_count num] [-r|--run_seconds num]",
+        "[-a|--stat_size] [-n|--top_count num] [-r|--run_seconds num] "
+        "[-f|--count_only]",
         data_operations,
     },
     {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
When we precisely count data for a large table, it will cost minutes or hours.

### What is changed and how does it work?
Actually,we just need the count of data.So we just need transfer the count of data from server to client,  but not the detailed data.
In our test, it will 10x faster than before.

##### Tests <!-- At least one of them must be included. -->
- Unit test
- Manual test (add detailed scripts or steps below)
1. create a table with millions of data.
2. use "count_data -c -f"

##### Related changes
- Need to update the documentation
- Need to be included in the release note
