### PR TITLE
feat(hotspot): add a cluster level perf_counter to display hotspot

### DIFF
--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -126,7 +126,7 @@
   partition_count = 4
 
 [pegasus.server]
-  perf_counter_enable_logging = false
+  perf_counter_enable_logging = true
   # Where the metrics are collected. If no value is given, no sink is used.
   # Options:
   #   - falcon

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -126,7 +126,7 @@
   partition_count = 4
 
 [pegasus.server]
-  perf_counter_enable_logging = true
+  perf_counter_enable_logging = false
   # Where the metrics are collected. If no value is given, no sink is used.
   # Options:
   #   - falcon

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -151,18 +151,16 @@ void hotspot_partition_calculator::data_analyse()
             "performed,in %s",
             _app_name.c_str());
 
-    for (uint32_t data_type = 0; data_type <= 1; data_type++) {
-        // data_type 0: READ_HOTSPOT_DATA; 1: WRITE_HOTSPOT_DATA
-        std::vector<int> hot_points;
-        stat_histories_analyse(data_type, hot_points);
-        update_hot_point(data_type, hot_points);
-    }
+    std::vector<int> hot_points;
+    stat_histories_analyse(READ_HOTSPOT_DATA, hot_points);
+    update_hot_point(WRITE_HOTSPOT_DATA, hot_points);
+
     if (!FLAGS_enable_detect_hotkey) {
         return;
     }
-    for (int data_type = 0; data_type <= 1; data_type++) {
-        detect_hotkey_in_hotpartition(data_type);
-    }
+
+    detect_hotkey_in_hotpartition(READ_HOTSPOT_DATA);
+    detect_hotkey_in_hotpartition(WRITE_HOTSPOT_DATA);
 }
 
 void hotspot_partition_calculator::detect_hotkey_in_hotpartition(int data_type)

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -153,6 +153,9 @@ void hotspot_partition_calculator::data_analyse()
 
     std::vector<int> hot_points;
     stat_histories_analyse(READ_HOTSPOT_DATA, hot_points);
+    update_hot_point(READ_HOTSPOT_DATA, hot_points);
+
+    stat_histories_analyse(WRITE_HOTSPOT_DATA, hot_points);
     update_hot_point(WRITE_HOTSPOT_DATA, hot_points);
 
     if (!FLAGS_enable_detect_hotkey) {

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -130,7 +130,7 @@ void hotspot_partition_calculator::stat_histories_analyse(uint32_t data_type,
 }
 
 void hotspot_partition_calculator::update_hot_point(uint32_t data_type,
-                                                    std::vector<int> &hot_points)
+                                                    const std::vector<int> &hot_points)
 {
     dcheck_eq(_hot_points.size(), hot_points.size());
     int size = hot_points.size();

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -151,12 +151,13 @@ void hotspot_partition_calculator::data_analyse()
             "performed,in %s",
             _app_name.c_str());
 
-    std::vector<int> hot_points;
-    stat_histories_analyse(READ_HOTSPOT_DATA, hot_points);
-    update_hot_point(READ_HOTSPOT_DATA, hot_points);
+    std::vector<int> read_hot_points;
+    stat_histories_analyse(READ_HOTSPOT_DATA, read_hot_points);
+    update_hot_point(READ_HOTSPOT_DATA, read_hot_points);
 
-    stat_histories_analyse(WRITE_HOTSPOT_DATA, hot_points);
-    update_hot_point(WRITE_HOTSPOT_DATA, hot_points);
+    std::vector<int> write_hot_points;
+    stat_histories_analyse(WRITE_HOTSPOT_DATA, write_hot_points);
+    update_hot_point(WRITE_HOTSPOT_DATA, write_hot_points);
 
     if (!FLAGS_enable_detect_hotkey) {
         return;

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -82,10 +82,18 @@ void hotspot_partition_calculator::init_perf_counter(int partition_count)
             _hot_points[i][data_type].init_app_counter(
                 "app.pegasus", counter_name.c_str(), COUNTER_TYPE_NUMBER, counter_desc.c_str());
         }
+
+        string total_desc =
+            _app_name + '.' +
+            (data_type == partition_qps_type::WRITE_HOTSPOT_DATA ? "write.total" : "read.total");
+        std::string counter_name = fmt::format("app.stat.hotspots.{}", total_desc);
+        std::string counter_desc = fmt::format("statistic the hotspots of app {}", total_desc);
+        _total_hotspot_cnt[data_type].init_app_counter(
+            "app.pegasus", counter_name.c_str(), COUNTER_TYPE_NUMBER, counter_desc.c_str());
     }
 }
 
-void hotspot_partition_calculator::stat_histories_analyse(int data_type,
+void hotspot_partition_calculator::stat_histories_analyse(uint32_t data_type,
                                                           std::vector<int> &hot_points)
 {
     double table_qps_sum = 0, standard_deviation = 0, table_qps_avg = 0;
@@ -121,13 +129,19 @@ void hotspot_partition_calculator::stat_histories_analyse(int data_type,
     }
 }
 
-void hotspot_partition_calculator::update_hot_point(int data_type, std::vector<int> &hot_points)
+void hotspot_partition_calculator::update_hot_point(uint32_t data_type,
+                                                    std::vector<int> &hot_points)
 {
     dcheck_eq(_hot_points.size(), hot_points.size());
     int size = hot_points.size();
+    uint32_t hotspot_count = 0;
     for (int i = 0; i < size; i++) {
         _hot_points[i][data_type].get()->set(hot_points[i]);
+        if (hot_points[i] >= FLAGS_hot_partition_threshold) {
+            hotspot_count++;
+        }
     }
+    _total_hotspot_cnt[data_type].get()->set(hotspot_count);
 }
 
 void hotspot_partition_calculator::data_analyse()
@@ -136,7 +150,8 @@ void hotspot_partition_calculator::data_analyse()
             "The number of partitions in this table has changed, and hotspot analysis cannot be "
             "performed,in %s",
             _app_name.c_str());
-    for (int data_type = 0; data_type <= 1; data_type++) {
+
+    for (uint32_t data_type = 0; data_type <= 1; data_type++) {
         // data_type 0: READ_HOTSPOT_DATA; 1: WRITE_HOTSPOT_DATA
         std::vector<int> hot_points;
         stat_histories_analyse(data_type, hot_points);

--- a/src/server/hotspot_partition_calculator.h
+++ b/src/server/hotspot_partition_calculator.h
@@ -61,7 +61,7 @@ private:
     // ref: https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule
     void stat_histories_analyse(uint32_t data_type, std::vector<int> &hot_points);
     // set hot_point to corresponding perf_counter
-    void update_hot_point(uint32_t data_type, std::vector<int> &hot_points);
+    void update_hot_point(uint32_t data_type, const std::vector<int> &hot_points);
     void detect_hotkey_in_hotpartition(int data_type);
 
     const std::string _app_name;

--- a/src/server/hotspot_partition_calculator.h
+++ b/src/server/hotspot_partition_calculator.h
@@ -68,8 +68,8 @@ private:
     void init_perf_counter(int perf_counter_count);
     // usually a partition with "hot-point value" >= 3 can be considered as a hotspot partition.
     hot_partition_counters _hot_points;
-    // hotspot_cnt c[type_of_read(0)/write(1)_stat] = number of hot partition count in one table per
-    // data_analyse
+    // hotspot_cnt c[type_of_read(0)/write(1)_stat] = number of hot partition count in one table
+    // per data_analyse
     std::array<dsn::perf_counter_wrapper, 2> _total_hotspot_cnt;
 
     // saving historical data can improve accuracy

--- a/src/server/hotspot_partition_calculator.h
+++ b/src/server/hotspot_partition_calculator.h
@@ -59,15 +59,19 @@ public:
 private:
     // empirical rule to calculate hot point of each partition
     // ref: https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule
-    void stat_histories_analyse(int data_type, std::vector<int> &hot_points);
+    void stat_histories_analyse(uint32_t data_type, std::vector<int> &hot_points);
     // set hot_point to corresponding perf_counter
-    void update_hot_point(int data_type, std::vector<int> &hot_points);
+    void update_hot_point(uint32_t data_type, std::vector<int> &hot_points);
     void detect_hotkey_in_hotpartition(int data_type);
 
     const std::string _app_name;
     void init_perf_counter(int perf_counter_count);
     // usually a partition with "hot-point value" >= 3 can be considered as a hotspot partition.
     hot_partition_counters _hot_points;
+    // hotspot_cnt c[type_of_read(0)/write(1)_stat] = number of hot partition count in one table per
+    // data_analyse
+    std::array<dsn::perf_counter_wrapper, 2> _total_hotspot_cnt;
+
     // saving historical data can improve accuracy
     stat_histories _partitions_stat_histories;
     std::shared_ptr<shell_context> _shell_context;


### PR DESCRIPTION
This PR adds a new perf_counter to show the count of hotspots in one table, it can help us intuitively find the hotspot in the cluster.
```
[collector*app.pegasus*app.stat.hotspots.temp.write.total, NUMBER, 2.00]
```
this perf_counter means in app `temp` has a hotspot in 2 partition
