### PR TITLE
feat: implement data version 2

### DIFF
--- a/src/base/pegasus_value_schema.h
+++ b/src/base/pegasus_value_schema.h
@@ -240,8 +240,9 @@ enum data_version
 {
     VERSION_0 = 0,
     VERSION_1 = 1,
+    VERSION_2 = 2,
     VERSION_COUNT,
-    VERSION_MAX = VERSION_1,
+    VERSION_MAX = VERSION_2,
     /// TBD(zlw)
 };
 

--- a/src/base/pegasus_value_schema.h
+++ b/src/base/pegasus_value_schema.h
@@ -243,7 +243,6 @@ enum data_version
     VERSION_2 = 2,
     VERSION_COUNT,
     VERSION_MAX = VERSION_2,
-    /// TBD(zlw)
 };
 
 struct value_params

--- a/src/base/test/value_manager_test.cpp
+++ b/src/base/test/value_manager_test.cpp
@@ -42,6 +42,7 @@ TEST(value_schema_manager, get_value_schema)
     } tests[] = {
         {pegasus::data_version::VERSION_0, true},
         {pegasus::data_version::VERSION_1, true},
+        {pegasus::data_version::VERSION_2, true},
         {pegasus::data_version::VERSION_MAX + 1, false},
     };
 

--- a/src/base/test/value_schema_test.cpp
+++ b/src/base/test/value_schema_test.cpp
@@ -77,6 +77,11 @@ TEST(value_schema, generate_and_extract)
         {1, std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint64_t>::max(), "pegasus"},
         {1, std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint64_t>::max(), ""},
         {1, 0, 0, "a"},
+
+        {2, 1000, 10001, ""},
+        {2, std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint64_t>::max(), "pegasus"},
+        {2, std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint64_t>::max(), ""},
+        {2, 0, 0, "a"},
     };
 
     for (const auto &t : tests) {
@@ -101,7 +106,9 @@ TEST(value_schema, update_expire_ts)
         uint32_t expire_ts;
         uint32_t update_expire_ts;
     } tests[] = {
-        {0, 1000, 10086}, {1, 1000, 10086},
+        {0, 1000, 10086},
+        {1, 1000, 10086},
+        {2, 1000, 10086},
     };
 
     for (const auto &t : tests) {

--- a/src/base/test/value_schema_test.cpp
+++ b/src/base/test/value_schema_test.cpp
@@ -106,9 +106,7 @@ TEST(value_schema, update_expire_ts)
         uint32_t expire_ts;
         uint32_t update_expire_ts;
     } tests[] = {
-        {0, 1000, 10086},
-        {1, 1000, 10086},
-        {2, 1000, 10086},
+        {0, 1000, 10086}, {1, 1000, 10086}, {2, 1000, 10086},
     };
 
     for (const auto &t : tests) {

--- a/src/base/value_schema_manager.cpp
+++ b/src/base/value_schema_manager.cpp
@@ -20,6 +20,7 @@
 #include "value_schema_manager.h"
 #include "value_schema_v0.h"
 #include "value_schema_v1.h"
+#include "value_schema_v2.h"
 
 namespace pegasus {
 value_schema_manager::value_schema_manager()
@@ -30,6 +31,7 @@ value_schema_manager::value_schema_manager()
      */
     register_schema(dsn::make_unique<value_schema_v0>());
     register_schema(dsn::make_unique<value_schema_v1>());
+    register_schema(dsn::make_unique<value_schema_v2>());
 }
 
 void value_schema_manager::register_schema(std::unique_ptr<value_schema> schema)

--- a/src/base/value_schema_v2.cpp
+++ b/src/base/value_schema_v2.cpp
@@ -76,7 +76,7 @@ rocksdb::SliceParts value_schema_v2::generate_value(const value_params &params)
     }
 
     params.write_buf.resize(sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint64_t));
-    uint8_t version_2 = 2;
+    const uint8_t version_2 = 2;
     dsn::data_output output(params.write_buf);
     output.write_u8(0x80 | version_2);            // version
     output.write_u32(expire_ts_field->expire_ts); // expire_ts

--- a/src/base/value_schema_v2.cpp
+++ b/src/base/value_schema_v2.cpp
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "value_schema_v2.h"
+
+#include <dsn/utility/endians.h>
+#include <dsn/dist/fmt_logging.h>
+#include <dsn/c/api_utilities.h>
+#include <dsn/utility/smart_pointers.h>
+
+namespace pegasus {
+
+std::unique_ptr<value_field> value_schema_v2::extract_field(dsn::string_view value,
+                                                            value_field_type type)
+{
+    std::unique_ptr<value_field> field = nullptr;
+    switch (type) {
+    case value_field_type::EXPIRE_TIMESTAMP:
+        field = extract_timestamp(value);
+        break;
+    case value_field_type::TIME_TAG:
+        field = extract_time_tag(value);
+        break;
+    default:
+        dassert_f(false, "Unsupported field type: {}", type);
+    }
+    return field;
+}
+
+dsn::blob value_schema_v2::extract_user_data(std::string &&value)
+{
+    auto ret = dsn::blob::create_from_bytes(std::move(value));
+    return ret.range(sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint64_t));
+}
+
+void value_schema_v2::update_field(std::string &value, std::unique_ptr<value_field> field)
+{
+    auto type = field->type();
+    switch (field->type()) {
+    case value_field_type::EXPIRE_TIMESTAMP:
+        update_expire_ts(value, std::move(field));
+        break;
+    default:
+        dassert_f(false, "Unsupported update field type: {}", type);
+    }
+}
+
+rocksdb::SliceParts value_schema_v2::generate_value(const value_params &params)
+{
+    auto expire_ts_field = static_cast<expire_timestamp_field *>(
+        params.fields[value_field_type::EXPIRE_TIMESTAMP].get());
+    auto timetag_field =
+        static_cast<time_tag_field *>(params.fields[value_field_type::TIME_TAG].get());
+    auto data_field =
+        static_cast<user_data_field *>(params.fields[value_field_type::USER_DATA].get());
+    if (dsn_unlikely(expire_ts_field == nullptr || data_field == nullptr ||
+                     timetag_field == nullptr)) {
+        dassert_f(false, "USER_DATA or EXPIRE_TIMESTAMP or TIME_TAG is not provided");
+        return {nullptr, 0};
+    }
+
+    params.write_buf.resize(sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint64_t));
+    uint8_t version_2 = 2;
+    dsn::data_output output(params.write_buf);
+    output.write_u8(0x80 | version_2);            // version
+    output.write_u32(expire_ts_field->expire_ts); // expire_ts
+    output.write_u64(timetag_field->time_tag);    // timetag
+    params.write_slices.clear();
+    params.write_slices.emplace_back(params.write_buf.data(), params.write_buf.size());
+
+    dsn::string_view user_data = data_field->user_data;
+    if (user_data.length() > 0) {
+        params.write_slices.emplace_back(user_data.data(), user_data.length());
+    }
+    return {&params.write_slices[0], static_cast<int>(params.write_slices.size())};
+}
+
+std::unique_ptr<value_field> value_schema_v2::extract_timestamp(dsn::string_view value)
+{
+    dsn::data_input input(value);
+    input.skip(sizeof(uint8_t));
+    return dsn::make_unique<expire_timestamp_field>(input.read_u32());
+}
+
+std::unique_ptr<value_field> value_schema_v2::extract_time_tag(dsn::string_view value)
+{
+    dsn::data_input input(value);
+    input.skip(sizeof(uint8_t));
+    input.skip(sizeof(uint32_t));
+    return dsn::make_unique<time_tag_field>(input.read_u64());
+}
+
+void value_schema_v2::update_expire_ts(std::string &value, std::unique_ptr<value_field> field)
+{
+    dassert_f(value.length() >= sizeof(uint32_t) + sizeof(uint8_t),
+              "value must include 'expire_ts' header");
+    auto expire_field = static_cast<expire_timestamp_field *>(field.get());
+
+    auto new_expire_ts = dsn::endian::hton(expire_field->expire_ts);
+    memcpy(const_cast<char *>(value.data()) + sizeof(uint8_t), &new_expire_ts, sizeof(uint32_t));
+}
+} // namespace pegasus

--- a/src/base/value_schema_v2.cpp
+++ b/src/base/value_schema_v2.cpp
@@ -76,9 +76,9 @@ rocksdb::SliceParts value_schema_v2::generate_value(const value_params &params)
     }
 
     params.write_buf.resize(sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint64_t));
-    const uint8_t version_2 = 2;
+    const uint8_t VERSION_2 = 2;
     dsn::data_output output(params.write_buf);
-    output.write_u8(0x80 | version_2);            // version
+    output.write_u8(0x80 | VERSION_2);            // version
     output.write_u32(expire_ts_field->expire_ts); // expire_ts
     output.write_u64(timetag_field->time_tag);    // timetag
     params.write_slices.clear();

--- a/src/base/value_schema_v2.cpp
+++ b/src/base/value_schema_v2.cpp
@@ -76,11 +76,10 @@ rocksdb::SliceParts value_schema_v2::generate_value(const value_params &params)
     }
 
     params.write_buf.resize(sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint64_t));
-    const uint8_t VERSION_2 = 2;
     dsn::data_output output(params.write_buf);
-    output.write_u8(0x80 | VERSION_2);            // version
-    output.write_u32(expire_ts_field->expire_ts); // expire_ts
-    output.write_u64(timetag_field->time_tag);    // timetag
+    output.write_u8(0x80 | data_version::VERSION_2); // version
+    output.write_u32(expire_ts_field->expire_ts);    // expire_ts
+    output.write_u64(timetag_field->time_tag);       // timetag
     params.write_slices.clear();
     params.write_slices.emplace_back(params.write_buf.data(), params.write_buf.size());
 

--- a/src/base/value_schema_v2.h
+++ b/src/base/value_schema_v2.h
@@ -23,24 +23,23 @@
 
 namespace pegasus {
 /**
- *  rocksdb value: |- expire_ts(4bytes) -|- timetag(8 bytes) -|- user value(bytes) -|
+ *  rocksdb value:
+ *  |- 1bit -|- version(7bits) -|- expire_ts(4bytes) -|- timetag(8 bytes) -|- user value(bytes) -|
  */
-class value_schema_v1 : public value_schema
+class value_schema_v2 : public value_schema
 {
 public:
-    value_schema_v1() = default;
-
+    value_schema_v2() = default;
     std::unique_ptr<value_field> extract_field(dsn::string_view value,
                                                value_field_type type) override;
     dsn::blob extract_user_data(std::string &&value) override;
     void update_field(std::string &value, std::unique_ptr<value_field> field) override;
     rocksdb::SliceParts generate_value(const value_params &params) override;
-    data_version version() const override { return data_version::VERSION_1; }
+    data_version version() const override { return VERSION_2; }
 
 private:
     std::unique_ptr<value_field> extract_timestamp(dsn::string_view value);
     std::unique_ptr<value_field> extract_time_tag(dsn::string_view value);
     void update_expire_ts(std::string &value, std::unique_ptr<value_field> field);
 };
-
 } // namespace pegasus

--- a/src/base/value_schema_v2.h
+++ b/src/base/value_schema_v2.h
@@ -30,12 +30,13 @@ class value_schema_v2 : public value_schema
 {
 public:
     value_schema_v2() = default;
+
     std::unique_ptr<value_field> extract_field(dsn::string_view value,
                                                value_field_type type) override;
     dsn::blob extract_user_data(std::string &&value) override;
     void update_field(std::string &value, std::unique_ptr<value_field> field) override;
     rocksdb::SliceParts generate_value(const value_params &params) override;
-    data_version version() const override { return VERSION_2; }
+    data_version version() const override { return data_version::VERSION_2; }
 
 private:
     std::unique_ptr<value_field> extract_timestamp(dsn::string_view value);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
proposal https://github.com/apache/incubator-pegasus/blob/master/rfcs/2020-10-09-data-version-v3.md
implement value_schema_v2, which represents data version 2.
The format of data version 2:
```
|- 1bit -|- version(7bits) -|- expire_ts(4bytes) -|- timetag(8 bytes) -|- user value(bytes) -|
```

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test