### PR TITLE
feat: support to build a portable rocksdb binary

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -89,6 +89,7 @@ function usage_build()
     echo "   --sanitizer <type>    build with sanitizer to check potential problems,
                                    type: address|leak|thread|undefined"
     echo "   --skip_thirdparty     whether to skip building thirdparties, default no"
+    echo "   --enable_rocksdb_portable      build a portable rocksdb binary"
 }
 function run_build()
 {
@@ -110,6 +111,7 @@ function run_build()
     SKIP_THIRDPARTY=NO
     SANITIZER=""
     TEST_MODULE=""
+    ENABLE_ROCKSDB_PORTABLE=NO
     while [[ $# > 0 ]]; do
         key="$1"
         case $key in
@@ -170,6 +172,9 @@ function run_build()
             --skip_thirdparty)
                 SKIP_THIRDPARTY=YES
                 ;;
+            --enable_rocksdb_portable)
+                ENABLE_ROCKSDB_PORTABLE=YES
+                ;;
             *)
                 echo "ERROR: unknown option \"$key\""
                 echo
@@ -226,6 +231,9 @@ function run_build()
     fi
     if [ ! -z $SANITIZER ]; then
         OPT="$OPT --sanitizer $SANITIZER"
+    fi
+    if [ "$ENABLE_ROCKSDB_PORTABLE" == "YES" ]; then
+        OPT="$OPT --enable_rocksdb_portable"
     fi
     ./run.sh build $OPT --notest
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
## What problem does this PR solve? <!--add issue link with summary if exists-->

Since we've supported portable building for rocksdb in rdsn (https://github.com/XiaoMi/rdsn/pull/690), we should also support this feature in the building for pegasus.

As we've discussed in https://github.com/XiaoMi/rdsn/pull/690, supporting this feature is for the purpose of doing some functional tests or running a sample service on a non-portable node where pegasus server will exit abnormally with `Illegal instruction (core dumped)`. For the performance-critical scenarios, such as production environment, it is better to build pegasus with non-portable mode(default mode), which will make full use of the optimization for the particular platform.

## What is changed and how does it work?

To build pegasus on the portable mode, do `./run.sh build --enable_rocksdb_portable [some other options ...]`. By default, without `--enable_rocksdb_portable` pegasus will be built in the non-portable mode.

## Checklist <!--REMOVE the items that are not applicable-->

### Tests <!-- At least one of them must be included. -->

- with `--enable_rocksdb_portable`, pegasus will be built correctly and run on an `Illegal-instruction` node normally.
- without `--enable_rocksdb_portable`, pegasus will be built correctly and run on the platform-dependent node normally.
