### PR TITLE
feat: add perf counter for backup request limiter

### DIFF
--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -215,6 +215,8 @@ info_collector::app_stat_counters *info_collector::get_app_counters(const std::s
     INIT_COUNTER(recent_write_throttling_reject_count);
     INIT_COUNTER(recent_read_throttling_delay_count);
     INIT_COUNTER(recent_read_throttling_reject_count);
+    INIT_COUNTER(recent_backup_request_throttling_delay_count);
+    INIT_COUNTER(recent_backup_request_throttling_reject_count);
     INIT_COUNTER(storage_mb);
     INIT_COUNTER(storage_count);
     INIT_COUNTER(rdb_block_cache_hit_rate);

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -75,6 +75,10 @@ public:
                 row_stats.recent_write_throttling_reject_count);
             recent_read_throttling_delay_count->set(row_stats.recent_read_throttling_delay_count);
             recent_read_throttling_reject_count->set(row_stats.recent_read_throttling_reject_count);
+            recent_backup_request_throttling_delay_count->set(
+                row_stats.recent_backup_request_throttling_delay_count);
+            recent_backup_request_throttling_reject_count->set(
+                row_stats.recent_backup_request_throttling_reject_count);
             storage_mb->set(row_stats.storage_mb);
             storage_count->set(row_stats.storage_count);
             rdb_block_cache_hit_rate->set(convert_to_1M_ratio(
@@ -129,6 +133,8 @@ public:
         ::dsn::perf_counter_wrapper recent_write_throttling_reject_count;
         ::dsn::perf_counter_wrapper recent_read_throttling_delay_count;
         ::dsn::perf_counter_wrapper recent_read_throttling_reject_count;
+        ::dsn::perf_counter_wrapper recent_backup_request_throttling_delay_count;
+        ::dsn::perf_counter_wrapper recent_backup_request_throttling_reject_count;
         ::dsn::perf_counter_wrapper storage_mb;
         ::dsn::perf_counter_wrapper storage_count;
         ::dsn::perf_counter_wrapper rdb_block_cache_hit_rate;

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -623,9 +623,9 @@ struct row_data
         recent_read_throttling_delay_count += row.recent_read_throttling_delay_count;
         recent_read_throttling_reject_count += row.recent_read_throttling_reject_count;
         recent_backup_request_throttling_delay_count +=
-                row.recent_backup_request_throttling_delay_count;
+            row.recent_backup_request_throttling_delay_count;
         recent_backup_request_throttling_reject_count +=
-                row.recent_backup_request_throttling_reject_count;
+            row.recent_backup_request_throttling_reject_count;
         storage_mb += row.storage_mb;
         storage_count += row.storage_count;
         rdb_block_cache_hit_count += row.rdb_block_cache_hit_count;

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -622,6 +622,10 @@ struct row_data
         recent_write_throttling_reject_count += row.recent_write_throttling_reject_count;
         recent_read_throttling_delay_count += row.recent_read_throttling_delay_count;
         recent_read_throttling_reject_count += row.recent_read_throttling_reject_count;
+        recent_backup_request_throttling_delay_count +=
+                row.recent_backup_request_throttling_delay_count;
+        recent_backup_request_throttling_reject_count +=
+                row.recent_backup_request_throttling_reject_count;
         storage_mb += row.storage_mb;
         storage_count += row.storage_count;
         rdb_block_cache_hit_count += row.rdb_block_cache_hit_count;
@@ -670,6 +674,8 @@ struct row_data
     double recent_write_throttling_reject_count = 0;
     double recent_read_throttling_delay_count = 0;
     double recent_read_throttling_reject_count = 0;
+    double recent_backup_request_throttling_delay_count = 0;
+    double recent_backup_request_throttling_reject_count = 0;
     double storage_mb = 0;
     double storage_count = 0;
     double rdb_block_cache_hit_count = 0;
@@ -740,6 +746,10 @@ update_app_pegasus_perf_counter(row_data &row, const std::string &counter_name, 
         row.recent_read_throttling_delay_count += value;
     else if (counter_name == "recent.read.throttling.reject.count")
         row.recent_read_throttling_reject_count += value;
+    else if (counter_name == "recent.backup.request.throttling.delay.count")
+        row.recent_backup_request_throttling_delay_count += value;
+    else if (counter_name == "recent.backup.request.throttling.reject.count")
+        row.recent_backup_request_throttling_reject_count += value;
     else if (counter_name == "disk.storage.sst(MB)")
         row.storage_mb += value;
     else if (counter_name == "disk.storage.sst.count")

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -507,6 +507,10 @@ bool app_stat(command_executor *e, shell_context *sc, arguments args)
         sum.recent_write_throttling_reject_count += row.recent_write_throttling_reject_count;
         sum.recent_read_throttling_delay_count += row.recent_read_throttling_delay_count;
         sum.recent_read_throttling_reject_count += row.recent_read_throttling_reject_count;
+        sum.recent_backup_request_throttling_delay_count +=
+            row.recent_backup_request_throttling_delay_count;
+        sum.recent_backup_request_throttling_reject_count +=
+            row.recent_backup_request_throttling_reject_count;
         sum.storage_mb += row.storage_mb;
         sum.storage_count += row.storage_count;
         sum.rdb_block_cache_hit_count += row.rdb_block_cache_hit_count;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
 add perf counter for backup request limiter.  Related issue: https://github.com/apache/incubator-pegasus/issues/778

### What is changed and how does it work?


### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1. `set_app_envs replica.backup_request_throttling 1*delay*100`
2. send read request to server with backup request
3. log shows that the backup request is delayed: `[collector*app.pegasus*app.stat.recent_backup_request_throttling_delay_count#_all_, NUMBER, 4.00]`
4.  `set_app_envs replica.backup_request_throttling 1*reject*100`
5. send read request to server with backup request
6. log shows that the backup request is rejected: `[collector*app.pegasus*app.stat.recent_backup_request_throttling_reject_count#_all_, NUMBER, 66.00]`
