### PR TITLE
fix(script): increase the assign-delay time

### DIFF
--- a/scripts/pegasus_rolling_update.sh
+++ b/scripts/pegasus_rolling_update.sh
@@ -310,6 +310,15 @@ if [ $set_ok -ne 1 ]; then
   exit 1
 fi
 
+echo "Set lb.assign_delay_ms to DEFAULT..."
+echo "remote_command -l $pmeta meta.lb.assign_delay_ms DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
+set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
+if [ $set_ok -ne 1 ]; then
+  echo "ERROR: set lb.assign_delay_ms to DEFAULT failed"
+  exit 1
+fi
+echo
+
 if [ "$type" = "all" ]; then
   echo "=================================================================="
   echo "=================================================================="
@@ -329,14 +338,6 @@ if [ "$rebalance_cluster_after_rolling" == "true" ]; then
   ./scripts/pegasus_rebalance_cluster.sh $cluster $meta_list $rebalance_only_move_primary
 fi
 
-echo "Set lb.assign_delay_ms to DEFAULT..."
-echo "remote_command -l $pmeta meta.lb.assign_delay_ms DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
-set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
-if [ $set_ok -ne 1 ]; then
-  echo "ERROR: set lb.assign_delay_ms to DEFAULT failed"
-  exit 1
-fi
-echo
 
 echo "Finish time: `date`"
 rolling_finish_time=$((`date +%s`))

--- a/scripts/pegasus_rolling_update.sh
+++ b/scripts/pegasus_rolling_update.sh
@@ -338,7 +338,6 @@ if [ "$rebalance_cluster_after_rolling" == "true" ]; then
   ./scripts/pegasus_rebalance_cluster.sh $cluster $meta_list $rebalance_only_move_primary
 fi
 
-
 echo "Finish time: `date`"
 rolling_finish_time=$((`date +%s`))
 echo "Rolling update $type done, elasped time is $((rolling_finish_time - rolling_start_time)) seconds."

--- a/scripts/pegasus_rolling_update.sh
+++ b/scripts/pegasus_rolling_update.sh
@@ -124,7 +124,7 @@ if [ $set_ok -ne 1 ]; then
 fi
 
 echo "Set lb.assign_delay_ms to 60min..."
-echo "remote_command -l $pmeta meta.lb.assign_delay_ms 3600000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
+echo "remote_command -l $pmeta meta.lb.assign_delay_ms 1800000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.assign_delay_ms to 60min failed"

--- a/scripts/pegasus_rolling_update.sh
+++ b/scripts/pegasus_rolling_update.sh
@@ -123,6 +123,14 @@ if [ $set_ok -ne 1 ]; then
   exit 1
 fi
 
+echo "Set lb.assign_delay_ms to 60min..."
+echo "remote_command -l $pmeta meta.lb.assign_delay_ms 3600000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
+set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
+if [ $set_ok -ne 1 ]; then
+  echo "ERROR: set lb.assign_delay_ms to 60min failed"
+  exit 1
+fi
+
 echo
 while read line
 do
@@ -320,6 +328,15 @@ if [ "$rebalance_cluster_after_rolling" == "true" ]; then
   echo "Start to rebalance cluster..."
   ./scripts/pegasus_rebalance_cluster.sh $cluster $meta_list $rebalance_only_move_primary
 fi
+
+echo "Set lb.assign_delay_ms to DEFAULT..."
+echo "remote_command -l $pmeta meta.lb.assign_delay_ms DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
+set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
+if [ $set_ok -ne 1 ]; then
+  echo "ERROR: set lb.assign_delay_ms to DEFAULT failed"
+  exit 1
+fi
+echo
 
 echo "Finish time: `date`"
 rolling_finish_time=$((`date +%s`))

--- a/scripts/pegasus_rolling_update.sh
+++ b/scripts/pegasus_rolling_update.sh
@@ -127,7 +127,7 @@ echo "Set lb.assign_delay_ms to 30min..."
 echo "remote_command -l $pmeta meta.lb.assign_delay_ms 1800000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
 if [ $set_ok -ne 1 ]; then
-  echo "ERROR: set lb.assign_delay_ms to 60min failed"
+  echo "ERROR: set lb.assign_delay_ms to 30min failed"
   exit 1
 fi
 

--- a/scripts/pegasus_rolling_update.sh
+++ b/scripts/pegasus_rolling_update.sh
@@ -123,7 +123,7 @@ if [ $set_ok -ne 1 ]; then
   exit 1
 fi
 
-echo "Set lb.assign_delay_ms to 60min..."
+echo "Set lb.assign_delay_ms to 30min..."
 echo "remote_command -l $pmeta meta.lb.assign_delay_ms 1800000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
 if [ $set_ok -ne 1 ]; then


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
rolling update cluster may cause `learn with copy checkpoint` to new node if updating node is unhealthy for a `long time`,  which will impact on cluster availability.  `the long time` threshold actually is `meta.lb.assign_delay_ms`. 
```
D2021-07-15 16:10:32.947 (1626336632947688521 14680)   meta.meta_state0.0201000000000018: server_load_balancer.cpp:706:on_missing_secondary(): gpid(10.1): is emergency due to lose secondary for a long time, last_dropped_node(.......:54801), drop_time(2021-07-15 16:00:32.857), delay_ms(600000)
D2021-07-15 16:10:32.947 (1626336632947702632 14680)   meta.meta_state0.0201000000000018: server_load_balancer.cpp:726:on_missing_secondary(): gpid(10.1): try to choose node in dropped list, dropped_list(....:54801), prefered_dropped(0)
D2021-07-15 16:10:32.947 (1626336632947708352 14680)   meta.meta_state0.0201000000000018: server_load_balancer.cpp:757:on_missing_secondary(): gpid(10.1): node(.......:54801) at cc.dropped[0] is not alive now, changed prefered_dropped from (0) to (-1)
D2021-07-15 16:10:32.947 (1626336632947723294 14680)   meta.meta_state0.0201000000000018: server_load_balancer.cpp:785:on_missing_secondary(): gpid(10.1): can't find valid node in dropped list to add as secondary, choose new node(.......:54801) with minimal partitions serving

```

This pr increase the `meta.lb.assign_delay_ms` to `60min`

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


##### Related changes
- Need to cherry-pick to the release branch
- Need to be included in the release note
