### PR TITLE
feat: support dup_recent_mutation_loss_count perf-counter

### DIFF
--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -206,6 +206,7 @@ info_collector::app_stat_counters *info_collector::get_app_counters(const std::s
     INIT_COUNTER(duplicate_qps);
     INIT_COUNTER(dup_shipped_ops);
     INIT_COUNTER(dup_failed_shipping_ops);
+    INIT_COUNTER(dup_recent_mutation_loss_count);
     INIT_COUNTER(recent_read_cu);
     INIT_COUNTER(recent_write_cu);
     INIT_COUNTER(recent_expire_count);

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -65,6 +65,7 @@ public:
             duplicate_qps->set(row_stats.duplicate_qps);
             dup_shipped_ops->set(row_stats.dup_shipped_ops);
             dup_failed_shipping_ops->set(row_stats.dup_failed_shipping_ops);
+            dup_recent_mutation_loss_count->set(row_stats.dup_recent_mutation_loss_count);
             recent_read_cu->set(row_stats.recent_read_cu);
             recent_write_cu->set(row_stats.recent_write_cu);
             recent_expire_count->set(row_stats.recent_expire_count);
@@ -124,6 +125,7 @@ public:
         ::dsn::perf_counter_wrapper duplicate_qps;
         ::dsn::perf_counter_wrapper dup_shipped_ops;
         ::dsn::perf_counter_wrapper dup_failed_shipping_ops;
+        ::dsn::perf_counter_wrapper dup_recent_mutation_loss_count;
         ::dsn::perf_counter_wrapper recent_read_cu;
         ::dsn::perf_counter_wrapper recent_write_cu;
         ::dsn::perf_counter_wrapper recent_expire_count;

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -613,6 +613,7 @@ struct row_data
         duplicate_qps += row.duplicate_qps;
         dup_shipped_ops += row.dup_shipped_ops;
         dup_failed_shipping_ops += row.dup_failed_shipping_ops;
+        dup_recent_mutation_loss_count += row.dup_recent_mutation_loss_count;
         recent_read_cu += row.recent_read_cu;
         recent_write_cu += row.recent_write_cu;
         recent_expire_count += row.recent_expire_count;
@@ -665,6 +666,7 @@ struct row_data
     double duplicate_qps = 0;
     double dup_shipped_ops = 0;
     double dup_failed_shipping_ops = 0;
+    double dup_recent_mutation_loss_count = 0;
     double recent_read_cu = 0;
     double recent_write_cu = 0;
     double recent_expire_count = 0;
@@ -728,6 +730,8 @@ update_app_pegasus_perf_counter(row_data &row, const std::string &counter_name, 
         row.dup_shipped_ops += value;
     else if (counter_name == "dup_failed_shipping_ops")
         row.dup_failed_shipping_ops += value;
+    else if (counter_name == "dup_recent_mutation_loss_count")
+        row.dup_recent_mutation_loss_count += value;
     else if (counter_name == "recent.read.cu")
         row.recent_read_cu += value;
     else if (counter_name == "recent.write.cu")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
See https://github.com/XiaoMi/rdsn/pull/862, this pr support table level `dup_recent_mutation_loss_count` perfcounter

##### Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)

##### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note

## Perf-Counter
```diff
+ collector*app.pegasus*app.stat.dup_recent_mutation_loss_count#{table_name}
```