### PR TITLE
feat: add an env to enable or disable block cache of an app

### DIFF
--- a/src/base/pegasus_const.cpp
+++ b/src/base/pegasus_const.cpp
@@ -85,6 +85,9 @@ const std::string PEGASUS_CLUSTER_SECTION_NAME("pegasus.clusters");
 /// table level slow query
 const std::string ROCKSDB_ENV_SLOW_QUERY_THRESHOLD("replica.slow_query_threshold");
 
+/// enable or disable block cache of app
+const std::string ROCKSDB_BLOCK_CACHE_ENABLED("replica.rocksdb_block_cache_enabled");
+
 /// time threshold of each rocksdb iteration
 const std::string
     ROCKSDB_ITERATION_THRESHOLD_TIME_MS("replica.rocksdb_iteration_threshold_time_ms");

--- a/src/base/pegasus_const.h
+++ b/src/base/pegasus_const.h
@@ -63,6 +63,8 @@ extern const std::string ROCKSDB_ENV_SLOW_QUERY_THRESHOLD;
 
 extern const std::string ROCKSDB_ITERATION_THRESHOLD_TIME_MS;
 
+extern const std::string ROCKSDB_BLOCK_CACHE_ENABLED;
+
 extern const std::string SPLIT_VALIDATE_PARTITION_HASH;
 
 extern const std::string USER_SPECIFIED_COMPACTION;

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2558,6 +2558,27 @@ void pegasus_server_impl::update_rocksdb_iteration_threshold(
     }
 }
 
+void pegasus_server_impl::update_rocksdb_block_cache_enabled(
+    const std::map<std::string, std::string> &envs)
+{
+    bool cache_enabled = _data_cf_rd_opts.fill_cache;
+    auto find = envs.find(ROCKSDB_BLOCK_CACHE_ENABLED);
+    if (find != envs.end()) {
+        if (!dsn::buf2bool(find->second, cache_enabled)) {
+            derror_replica("{}={} is invalid.", find->first, find->second);
+            return;
+        }
+    }
+
+    if (_data_cf_rd_opts.fill_cache != cache_enabled) {
+        ddebug_replica("update app env[{}] from \"{}\" to \"{}\" succeed",
+                       ROCKSDB_BLOCK_CACHE_ENABLED,
+                       _data_cf_rd_opts.fill_cache,
+                       cache_enabled);
+        _data_cf_rd_opts.fill_cache = cache_enabled;
+    }
+}
+
 void pegasus_server_impl::update_validate_partition_hash(
     const std::map<std::string, std::string> &envs)
 {

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2561,7 +2561,8 @@ void pegasus_server_impl::update_rocksdb_iteration_threshold(
 void pegasus_server_impl::update_rocksdb_block_cache_enabled(
     const std::map<std::string, std::string> &envs)
 {
-    bool cache_enabled = _data_cf_rd_opts.fill_cache;
+    // default of ReadOptions:fill_cache is true
+    bool cache_enabled = true;
     auto find = envs.find(ROCKSDB_BLOCK_CACHE_ENABLED);
     if (find != envs.end()) {
         if (!dsn::buf2bool(find->second, cache_enabled)) {

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -269,6 +269,8 @@ private:
 
     void update_rocksdb_iteration_threshold(const std::map<std::string, std::string> &envs);
 
+    void update_rocksdb_block_cache_enabled(const std::map<std::string, std::string> &envs);
+
     void update_validate_partition_hash(const std::map<std::string, std::string> &envs);
 
     void update_user_specified_compaction(const std::map<std::string, std::string> &envs);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Sometimes, there are some apps of different business in a cluster.Some apps  want to enable block cache, others my be not.
So we need add an env to enable or disable block cache of an app.

##### Related changes
- Need to update the documentation
- Need to be included in the release note
