### PR TITLE
fix: use reference to catch exception

### DIFF
--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -64,7 +64,7 @@ int pegasus_server_write::on_batched_write_requests(dsn::message_ex **requests,
             dassert_f(count == 1, "count = {}", count);
             return iter->second(requests[0]);
         }
-    } catch (TTransportException ex) {
+    } catch (TTransportException &ex) {
         _pfc_recent_corrupt_write_count->increment();
         derror_replica("pegasus not batch write handler failed, from = {}, exception = {}",
                        requests[0]->header->from_address.to_string(),
@@ -108,7 +108,7 @@ int pegasus_server_write::on_batched_writes(dsn::message_ex **requests, int coun
                         dfatal_f("rpc code not handled: {}", rpc_code.to_string());
                     }
                 }
-            } catch (TTransportException ex) {
+            } catch (TTransportException &ex) {
                 _pfc_recent_corrupt_write_count->increment();
                 derror_replica("pegasus batch writes handler failed, from = {}, exception = {}",
                                requests[i]->header->from_address.to_string(),


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
use reference to catch exception, to avoid build error.

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1. send a dirty request by java client
2. and we can see there is a log about it
```
E2021-08-02 10:04:42.28 (1627869882028274338 6762) replica.replica0.0304000000000098: pegasus_server_write.cpp:115:on_batched_writes(): [2.4@{ip}:{port}] pegasus batch writes handler failed, from = {ip}:{port}, exception = no more data to read after end-of-buffer

```