### PR TITLE
feat(bulk-load): add table-level bulk load reject count

### DIFF
--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -220,6 +220,7 @@ info_collector::app_stat_counters *info_collector::get_app_counters(const std::s
     INIT_COUNTER(recent_read_throttling_reject_count);
     INIT_COUNTER(recent_backup_request_throttling_delay_count);
     INIT_COUNTER(recent_backup_request_throttling_reject_count);
+    INIT_COUNTER(recent_write_bulk_load_ingestion_reject_count);
     INIT_COUNTER(storage_mb);
     INIT_COUNTER(storage_count);
     INIT_COUNTER(rdb_block_cache_hit_rate);

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -80,6 +80,8 @@ public:
                 row_stats.recent_backup_request_throttling_delay_count);
             recent_backup_request_throttling_reject_count->set(
                 row_stats.recent_backup_request_throttling_reject_count);
+            recent_write_bulk_load_ingestion_reject_count->set(
+                row_stats.recent_write_bulk_load_ingestion_reject_count);
             storage_mb->set(row_stats.storage_mb);
             storage_count->set(row_stats.storage_count);
             rdb_block_cache_hit_rate->set(convert_to_1M_ratio(
@@ -149,6 +151,7 @@ public:
         ::dsn::perf_counter_wrapper recent_read_throttling_reject_count;
         ::dsn::perf_counter_wrapper recent_backup_request_throttling_delay_count;
         ::dsn::perf_counter_wrapper recent_backup_request_throttling_reject_count;
+        ::dsn::perf_counter_wrapper recent_write_bulk_load_ingestion_reject_count;
         ::dsn::perf_counter_wrapper storage_mb;
         ::dsn::perf_counter_wrapper storage_count;
         ::dsn::perf_counter_wrapper rdb_block_cache_hit_rate;

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -627,6 +627,8 @@ struct row_data
             row.recent_backup_request_throttling_delay_count;
         recent_backup_request_throttling_reject_count +=
             row.recent_backup_request_throttling_reject_count;
+        recent_write_bulk_load_ingestion_reject_count +=
+            row.recent_write_bulk_load_ingestion_reject_count;
         storage_mb += row.storage_mb;
         storage_count += row.storage_count;
         rdb_block_cache_hit_count += row.rdb_block_cache_hit_count;
@@ -684,6 +686,7 @@ struct row_data
     double recent_read_throttling_reject_count = 0;
     double recent_backup_request_throttling_delay_count = 0;
     double recent_backup_request_throttling_reject_count = 0;
+    double recent_write_bulk_load_ingestion_reject_count = 0;
     double storage_mb = 0;
     double storage_count = 0;
     double rdb_block_cache_hit_count = 0;
@@ -766,6 +769,8 @@ update_app_pegasus_perf_counter(row_data &row, const std::string &counter_name, 
         row.recent_backup_request_throttling_delay_count += value;
     else if (counter_name == "recent.backup.request.throttling.reject.count")
         row.recent_backup_request_throttling_reject_count += value;
+    else if (counter_name == "recent.write.bulk.load.ingestion.reject.count")
+        row.recent_write_bulk_load_ingestion_reject_count += value;
     else if (counter_name == "disk.storage.sst(MB)")
         row.storage_mb += value;
     else if (counter_name == "disk.storage.sst.count")

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -511,6 +511,8 @@ bool app_stat(command_executor *e, shell_context *sc, arguments args)
             row.recent_backup_request_throttling_delay_count;
         sum.recent_backup_request_throttling_reject_count +=
             row.recent_backup_request_throttling_reject_count;
+        sum.recent_write_bulk_load_ingestion_reject_count +=
+            row.recent_write_bulk_load_ingestion_reject_count;
         sum.storage_mb += row.storage_mb;
         sum.storage_count += row.storage_count;
         sum.rdb_block_cache_hit_count += row.rdb_block_cache_hit_count;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This pull requests add the table-level rejecting read/write requests count during bulk load ingestion.
```
collector*app.pegasus*app.stat.recent_write_bulk_load_ingestion_reject_count#[table_name] - NUMBER
```

##### Tests <!-- At least one of them must be included. -->
Tests in onebox
