### PR TITLE
feat: support table level rocksdb compaction perfcounter

### DIFF
--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -242,6 +242,8 @@ info_collector::app_stat_counters *info_collector::get_app_counters(const std::s
     INIT_COUNTER(check_and_mutate_bytes);
     INIT_COUNTER(read_bytes);
     INIT_COUNTER(write_bytes);
+    INIT_COUNTER(recent_rdb_compaction_input_bytes);
+    INIT_COUNTER(recent_rdb_compaction_output_bytes);
     INIT_COUNTER(rdb_read_l2andup_hit_rate);
     INIT_COUNTER(rdb_read_l1_hit_rate);
     INIT_COUNTER(rdb_read_l0_hit_rate);

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -110,6 +110,8 @@ public:
             check_and_mutate_bytes->set(row_stats.check_and_mutate_bytes);
             read_bytes->set(row_stats.get_total_read_bytes());
             write_bytes->set(row_stats.get_total_write_bytes());
+            recent_rdb_compaction_input_bytes->set(row_stats.recent_rdb_compaction_input_bytes);
+            recent_rdb_compaction_output_bytes->set(row_stats.recent_rdb_compaction_output_bytes);
             rdb_read_l2andup_hit_rate->set(convert_to_1M_ratio(
                 row_stats.rdb_read_l2andup_hit_count, row_stats.rdb_block_cache_total_count));
             rdb_read_l1_hit_rate->set(convert_to_1M_ratio(row_stats.rdb_read_l1_hit_count,
@@ -173,6 +175,8 @@ public:
         ::dsn::perf_counter_wrapper check_and_mutate_bytes;
         ::dsn::perf_counter_wrapper read_bytes;
         ::dsn::perf_counter_wrapper write_bytes;
+        ::dsn::perf_counter_wrapper recent_rdb_compaction_input_bytes;
+        ::dsn::perf_counter_wrapper recent_rdb_compaction_output_bytes;
         ::dsn::perf_counter_wrapper rdb_read_l2andup_hit_rate;
         ::dsn::perf_counter_wrapper rdb_read_l1_hit_rate;
         ::dsn::perf_counter_wrapper rdb_read_l0_hit_rate;

--- a/src/server/pegasus_event_listener.cpp
+++ b/src/server/pegasus_event_listener.cpp
@@ -88,6 +88,9 @@ void pegasus_event_listener::OnCompactionCompleted(rocksdb::DB *db,
     _pfc_recent_compaction_completed_count->increment();
     _pfc_recent_compaction_input_bytes->add(ci.stats.total_input_bytes);
     _pfc_recent_compaction_output_bytes->add(ci.stats.total_output_bytes);
+
+    _pfc_recent_rdb_compaction_input_bytes->add(ci.stats.total_input_bytes);
+    _pfc_recent_rdb_compaction_output_bytes->add(ci.stats.total_output_bytes);
 }
 
 void pegasus_event_listener::OnStallConditionsChanged(const rocksdb::WriteStallInfo &info)

--- a/src/server/pegasus_event_listener.cpp
+++ b/src/server/pegasus_event_listener.cpp
@@ -58,6 +58,21 @@ pegasus_event_listener::pegasus_event_listener(replica_base *r) : replica_base(r
         "recent.write.change.stopped.count",
         COUNTER_TYPE_VOLATILE_NUMBER,
         "rocksdb recent write change stopped count");
+
+    // replica-level perfcounter
+    std::string counter_str = fmt::format("recent_rdb_compaction_input_bytes@{}", r->get_gpid());
+    _pfc_recent_rdb_compaction_input_bytes.init_app_counter(
+        "app.pegasus",
+        counter_str.c_str(),
+        COUNTER_TYPE_VOLATILE_NUMBER,
+        "rocksdb recent compaction input bytes");
+
+    counter_str = fmt::format("recent_rdb_compaction_output_bytes@{}", r->get_gpid());
+    _pfc_recent_rdb_compaction_output_bytes.init_app_counter(
+        "app.pegasus",
+        counter_str.c_str(),
+        COUNTER_TYPE_VOLATILE_NUMBER,
+        "rocksdb recent compaction output bytes");
 }
 
 void pegasus_event_listener::OnFlushCompleted(rocksdb::DB *db,

--- a/src/server/pegasus_event_listener.h
+++ b/src/server/pegasus_event_listener.h
@@ -47,6 +47,10 @@ private:
     ::dsn::perf_counter_wrapper _pfc_recent_compaction_output_bytes;
     ::dsn::perf_counter_wrapper _pfc_recent_write_change_delayed_count;
     ::dsn::perf_counter_wrapper _pfc_recent_write_change_stopped_count;
+
+    // replica-level perfcounter
+    ::dsn::perf_counter_wrapper _pfc_recent_rdb_compaction_input_bytes;
+    ::dsn::perf_counter_wrapper _pfc_recent_rdb_compaction_output_bytes;
 };
 
 } // namespace server

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -648,6 +648,8 @@ struct row_data
         multi_put_bytes += row.multi_put_bytes;
         check_and_set_bytes += row.check_and_set_bytes;
         check_and_mutate_bytes += row.check_and_mutate_bytes;
+        recent_rdb_compaction_input_bytes += row.recent_rdb_compaction_input_bytes;
+        recent_rdb_compaction_output_bytes += row.recent_rdb_compaction_output_bytes;
         rdb_read_l2andup_hit_count += row.rdb_read_l2andup_hit_count;
         rdb_read_l1_hit_count += row.rdb_read_l1_hit_count;
         rdb_read_l0_hit_count += row.rdb_read_l0_hit_count;
@@ -705,6 +707,8 @@ struct row_data
     double multi_put_bytes = 0;
     double check_and_set_bytes = 0;
     double check_and_mutate_bytes = 0;
+    double recent_rdb_compaction_input_bytes = 0;
+    double recent_rdb_compaction_output_bytes = 0;
     double rdb_read_l2andup_hit_count = 0;
     double rdb_read_l1_hit_count = 0;
     double rdb_read_l0_hit_count = 0;
@@ -808,6 +812,10 @@ update_app_pegasus_perf_counter(row_data &row, const std::string &counter_name, 
         row.check_and_set_bytes += value;
     else if (counter_name == "check_and_mutate_bytes")
         row.check_and_mutate_bytes += value;
+    else if (counter_name == "recent_rdb_compaction_input_bytes")
+        row.recent_rdb_compaction_input_bytes += value;
+    else if (counter_name == "recent_rdb_compaction_output_bytes")
+        row.recent_rdb_compaction_output_bytes += value;
     else if (counter_name == "rdb.read_l2andup_hit_count")
         row.rdb_read_l2andup_hit_count += value;
     else if (counter_name == "rdb.read_l1_hit_count")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
See https://github.com/apache/incubator-pegasus/issues/744


### Checklist <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
```
1. deploy to test cluster
2. start write operation
3. check the perfcounter 
```
#### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note

## PerfCounter
```diff
+ collector*app.pegasus*app.stat.recent_rdb_compaction_input_bytes#{table_name}
+ collector*app.pegasus*app.stat.recent_rdb_compaction_output_bytes#{table_name}
```
