### PR TITLE
fix: remove user specified compaction if the corresponding appenv was removed

### DIFF
--- a/src/server/compaction_filter_rule.cpp
+++ b/src/server/compaction_filter_rule.cpp
@@ -27,9 +27,9 @@
 
 namespace pegasus {
 namespace server {
-bool string_pattern_match(const std::string &value,
+bool string_pattern_match(dsn::string_view value,
                           string_match_type type,
-                          const std::string &filter_pattern)
+                          dsn::string_view filter_pattern)
 {
     if (filter_pattern.empty())
         return false;
@@ -38,7 +38,7 @@ bool string_pattern_match(const std::string &value,
 
     switch (type) {
     case string_match_type::SMT_MATCH_ANYWHERE:
-        return dsn::string_view(value).find(filter_pattern) != dsn::string_view::npos;
+        return value.find(filter_pattern) != dsn::string_view::npos;
     case string_match_type::SMT_MATCH_PREFIX:
         return memcmp(value.data(), filter_pattern.data(), filter_pattern.length()) == 0;
     case string_match_type::SMT_MATCH_POSTFIX:
@@ -53,27 +53,27 @@ bool string_pattern_match(const std::string &value,
 
 hashkey_pattern_rule::hashkey_pattern_rule(uint32_t data_version) {}
 
-bool hashkey_pattern_rule::match(const std::string &hash_key,
-                                 const std::string &sort_key,
-                                 const std::string &existing_value) const
+bool hashkey_pattern_rule::match(dsn::string_view hash_key,
+                                 dsn::string_view sort_key,
+                                 dsn::string_view existing_value) const
 {
     return string_pattern_match(hash_key, match_type, pattern);
 }
 
 sortkey_pattern_rule::sortkey_pattern_rule(uint32_t data_version) {}
 
-bool sortkey_pattern_rule::match(const std::string &hash_key,
-                                 const std::string &sort_key,
-                                 const std::string &existing_value) const
+bool sortkey_pattern_rule::match(dsn::string_view hash_key,
+                                 dsn::string_view sort_key,
+                                 dsn::string_view existing_value) const
 {
     return string_pattern_match(sort_key, match_type, pattern);
 }
 
 ttl_range_rule::ttl_range_rule(uint32_t data_version) : data_version(data_version) {}
 
-bool ttl_range_rule::match(const std::string &hash_key,
-                           const std::string &sort_key,
-                           const std::string &existing_value) const
+bool ttl_range_rule::match(dsn::string_view hash_key,
+                           dsn::string_view sort_key,
+                           dsn::string_view existing_value) const
 {
     uint32_t expire_ts = pegasus_extract_expire_ts(data_version, existing_value);
     // if start_ttl and stop_ttl = 0, it means we want to delete keys which have no ttl

--- a/src/server/compaction_filter_rule.cpp
+++ b/src/server/compaction_filter_rule.cpp
@@ -55,7 +55,7 @@ hashkey_pattern_rule::hashkey_pattern_rule(uint32_t data_version) {}
 
 bool hashkey_pattern_rule::match(const std::string &hash_key,
                                  const std::string &sort_key,
-                                 const rocksdb::Slice &existing_value) const
+                                 const std::string &existing_value) const
 {
     return string_pattern_match(hash_key, match_type, pattern);
 }
@@ -64,7 +64,7 @@ sortkey_pattern_rule::sortkey_pattern_rule(uint32_t data_version) {}
 
 bool sortkey_pattern_rule::match(const std::string &hash_key,
                                  const std::string &sort_key,
-                                 const rocksdb::Slice &existing_value) const
+                                 const std::string &existing_value) const
 {
     return string_pattern_match(sort_key, match_type, pattern);
 }
@@ -73,10 +73,9 @@ ttl_range_rule::ttl_range_rule(uint32_t data_version) : data_version(data_versio
 
 bool ttl_range_rule::match(const std::string &hash_key,
                            const std::string &sort_key,
-                           const rocksdb::Slice &existing_value) const
+                           const std::string &existing_value) const
 {
-    uint32_t expire_ts =
-        pegasus_extract_expire_ts(data_version, utils::to_string_view(existing_value));
+    uint32_t expire_ts = pegasus_extract_expire_ts(data_version, existing_value);
     // if start_ttl and stop_ttl = 0, it means we want to delete keys which have no ttl
     if (0 == expire_ts && 0 == start_ttl && 0 == stop_ttl) {
         return true;

--- a/src/server/compaction_filter_rule.h
+++ b/src/server/compaction_filter_rule.h
@@ -68,9 +68,9 @@ public:
 
     // TODO(zhaoliwei): we can use `value_filed` to replace existing_value in the later,
     // after the refactor of value schema
-    virtual bool match(const std::string &hash_key,
-                       const std::string &sort_key,
-                       const std::string &existing_value) const = 0;
+    virtual bool match(dsn::string_view hash_key,
+                       dsn::string_view sort_key,
+                       dsn::string_view existing_value) const = 0;
 };
 
 enum string_match_type
@@ -93,9 +93,9 @@ class hashkey_pattern_rule : public compaction_filter_rule
 public:
     hashkey_pattern_rule(uint32_t data_version = VERSION_MAX);
 
-    bool match(const std::string &hash_key,
-               const std::string &sort_key,
-               const std::string &existing_value) const;
+    bool match(dsn::string_view hash_key,
+               dsn::string_view sort_key,
+               dsn::string_view existing_value) const;
     DEFINE_JSON_SERIALIZATION(pattern, match_type)
 
 private:
@@ -115,9 +115,9 @@ class sortkey_pattern_rule : public compaction_filter_rule
 public:
     sortkey_pattern_rule(uint32_t data_version = VERSION_MAX);
 
-    bool match(const std::string &hash_key,
-               const std::string &sort_key,
-               const std::string &existing_value) const;
+    bool match(dsn::string_view hash_key,
+               dsn::string_view sort_key,
+               dsn::string_view existing_value) const;
     DEFINE_JSON_SERIALIZATION(pattern, match_type)
 
 private:
@@ -135,9 +135,9 @@ class ttl_range_rule : public compaction_filter_rule
 public:
     explicit ttl_range_rule(uint32_t data_version);
 
-    bool match(const std::string &hash_key,
-               const std::string &sort_key,
-               const std::string &existing_value) const;
+    bool match(dsn::string_view hash_key,
+               dsn::string_view sort_key,
+               dsn::string_view existing_value) const;
     DEFINE_JSON_SERIALIZATION(start_ttl, stop_ttl)
 
 private:

--- a/src/server/compaction_filter_rule.h
+++ b/src/server/compaction_filter_rule.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include <rocksdb/slice.h>
 #include <dsn/utility/enum_helper.h>
 #include <dsn/cpp/json_helper.h>
 #include <gtest/gtest.h>
@@ -71,7 +70,7 @@ public:
     // after the refactor of value schema
     virtual bool match(const std::string &hash_key,
                        const std::string &sort_key,
-                       const rocksdb::Slice &existing_value) const = 0;
+                       const std::string &existing_value) const = 0;
 };
 
 enum string_match_type
@@ -96,7 +95,7 @@ public:
 
     bool match(const std::string &hash_key,
                const std::string &sort_key,
-               const rocksdb::Slice &existing_value) const;
+               const std::string &existing_value) const;
     DEFINE_JSON_SERIALIZATION(pattern, match_type)
 
 private:
@@ -118,7 +117,7 @@ public:
 
     bool match(const std::string &hash_key,
                const std::string &sort_key,
-               const rocksdb::Slice &existing_value) const;
+               const std::string &existing_value) const;
     DEFINE_JSON_SERIALIZATION(pattern, match_type)
 
 private:
@@ -138,7 +137,7 @@ public:
 
     bool match(const std::string &hash_key,
                const std::string &sort_key,
-               const rocksdb::Slice &existing_value) const;
+               const std::string &existing_value) const;
     DEFINE_JSON_SERIALIZATION(start_ttl, stop_ttl)
 
 private:

--- a/src/server/compaction_operation.cpp
+++ b/src/server/compaction_operation.cpp
@@ -27,7 +27,7 @@ compaction_operation::~compaction_operation() = default;
 
 bool compaction_operation::all_rules_match(const std::string &hash_key,
                                            const std::string &sort_key,
-                                           const rocksdb::Slice &existing_value) const
+                                           const std::string &existing_value) const
 {
     if (rules.empty()) {
         return false;
@@ -52,7 +52,7 @@ delete_key::delete_key(uint32_t data_version) : compaction_operation(data_versio
 
 bool delete_key::filter(const std::string &hash_key,
                         const std::string &sort_key,
-                        const rocksdb::Slice &existing_value,
+                        const std::string &existing_value,
                         std::string *new_value,
                         bool *value_changed) const
 {
@@ -71,7 +71,7 @@ update_ttl::update_ttl(uint32_t data_version) : compaction_operation(data_versio
 
 bool update_ttl::filter(const std::string &hash_key,
                         const std::string &sort_key,
-                        const rocksdb::Slice &existing_value,
+                        const std::string &existing_value,
                         std::string *new_value,
                         bool *value_changed) const
 {
@@ -85,7 +85,7 @@ bool update_ttl::filter(const std::string &hash_key,
         new_ts = utils::epoch_now() + value;
         break;
     case update_ttl_op_type::UTOT_FROM_CURRENT: {
-        auto ttl = pegasus_extract_expire_ts(data_version, utils::to_string_view(existing_value));
+        auto ttl = pegasus_extract_expire_ts(data_version, existing_value);
         if (ttl == 0) {
             return false;
         }
@@ -101,7 +101,7 @@ bool update_ttl::filter(const std::string &hash_key,
         return false;
     }
 
-    *new_value = existing_value.ToString();
+    *new_value = existing_value;
     pegasus_update_expire_ts(data_version, *new_value, new_ts);
     *value_changed = true;
     return false;

--- a/src/server/compaction_operation.cpp
+++ b/src/server/compaction_operation.cpp
@@ -25,9 +25,9 @@ namespace pegasus {
 namespace server {
 compaction_operation::~compaction_operation() = default;
 
-bool compaction_operation::all_rules_match(const std::string &hash_key,
-                                           const std::string &sort_key,
-                                           const std::string &existing_value) const
+bool compaction_operation::all_rules_match(dsn::string_view hash_key,
+                                           dsn::string_view sort_key,
+                                           dsn::string_view existing_value) const
 {
     if (rules.empty()) {
         return false;
@@ -50,9 +50,9 @@ delete_key::delete_key(filter_rules &&rules, uint32_t data_version)
 
 delete_key::delete_key(uint32_t data_version) : compaction_operation(data_version) {}
 
-bool delete_key::filter(const std::string &hash_key,
-                        const std::string &sort_key,
-                        const std::string &existing_value,
+bool delete_key::filter(dsn::string_view hash_key,
+                        dsn::string_view sort_key,
+                        dsn::string_view existing_value,
                         std::string *new_value,
                         bool *value_changed) const
 {
@@ -69,9 +69,9 @@ update_ttl::update_ttl(filter_rules &&rules, uint32_t data_version)
 
 update_ttl::update_ttl(uint32_t data_version) : compaction_operation(data_version) {}
 
-bool update_ttl::filter(const std::string &hash_key,
-                        const std::string &sort_key,
-                        const std::string &existing_value,
+bool update_ttl::filter(dsn::string_view hash_key,
+                        dsn::string_view sort_key,
+                        dsn::string_view existing_value,
                         std::string *new_value,
                         bool *value_changed) const
 {
@@ -101,7 +101,7 @@ bool update_ttl::filter(const std::string &hash_key,
         return false;
     }
 
-    *new_value = existing_value;
+    *new_value = std::string(existing_value.data(), existing_value.size());
     pegasus_update_expire_ts(data_version, *new_value, new_ts);
     *value_changed = true;
     return false;

--- a/src/server/compaction_operation.h
+++ b/src/server/compaction_operation.h
@@ -64,18 +64,18 @@ public:
     explicit compaction_operation(uint32_t data_version) : data_version(data_version) {}
     virtual ~compaction_operation() = 0;
 
-    bool all_rules_match(const std::string &hash_key,
-                         const std::string &sort_key,
-                         const std::string &existing_value) const;
+    bool all_rules_match(dsn::string_view hash_key,
+                         dsn::string_view sort_key,
+                         dsn::string_view existing_value) const;
     void set_rules(filter_rules &&rules);
     /**
      * @return false indicates that this key-value should be removed
      * If you want to modify the existing_value, you can pass it back through new_value and
      * value_changed needs to be set to true in this case.
      */
-    virtual bool filter(const std::string &hash_key,
-                        const std::string &sort_key,
-                        const std::string &existing_value,
+    virtual bool filter(dsn::string_view hash_key,
+                        dsn::string_view sort_key,
+                        dsn::string_view existing_value,
                         std::string *new_value,
                         bool *value_changed) const = 0;
 
@@ -95,9 +95,9 @@ public:
     delete_key(filter_rules &&rules, uint32_t data_version);
     explicit delete_key(uint32_t data_version);
 
-    bool filter(const std::string &hash_key,
-                const std::string &sort_key,
-                const std::string &existing_value,
+    bool filter(dsn::string_view hash_key,
+                dsn::string_view sort_key,
+                dsn::string_view existing_value,
                 std::string *new_value,
                 bool *value_changed) const;
 
@@ -143,9 +143,9 @@ public:
     update_ttl(filter_rules &&rules, uint32_t data_version);
     explicit update_ttl(uint32_t data_version);
 
-    bool filter(const std::string &hash_key,
-                const std::string &sort_key,
-                const std::string &existing_value,
+    bool filter(dsn::string_view hash_key,
+                dsn::string_view sort_key,
+                dsn::string_view existing_value,
                 std::string *new_value,
                 bool *value_changed) const;
     DEFINE_JSON_SERIALIZATION(type, value)

--- a/src/server/compaction_operation.h
+++ b/src/server/compaction_operation.h
@@ -66,7 +66,7 @@ public:
 
     bool all_rules_match(const std::string &hash_key,
                          const std::string &sort_key,
-                         const rocksdb::Slice &existing_value) const;
+                         const std::string &existing_value) const;
     void set_rules(filter_rules &&rules);
     /**
      * @return false indicates that this key-value should be removed
@@ -75,7 +75,7 @@ public:
      */
     virtual bool filter(const std::string &hash_key,
                         const std::string &sort_key,
-                        const rocksdb::Slice &existing_value,
+                        const std::string &existing_value,
                         std::string *new_value,
                         bool *value_changed) const = 0;
 
@@ -97,7 +97,7 @@ public:
 
     bool filter(const std::string &hash_key,
                 const std::string &sort_key,
-                const rocksdb::Slice &existing_value,
+                const std::string &existing_value,
                 std::string *new_value,
                 bool *value_changed) const;
 
@@ -145,7 +145,7 @@ public:
 
     bool filter(const std::string &hash_key,
                 const std::string &sort_key,
-                const rocksdb::Slice &existing_value,
+                const std::string &existing_value,
                 std::string *new_value,
                 bool *value_changed) const;
     DEFINE_JSON_SERIALIZATION(type, value)

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -68,21 +68,22 @@ public:
             return false;
         }
 
+        uint32_t expire_ts =
+            pegasus_extract_expire_ts(_pegasus_data_version, utils::to_string_view(existing_value));
+        if (_default_ttl != 0 && expire_ts == 0) {
+            // should update ttl
+            expire_ts = utils::epoch_now() + _default_ttl;
+            *new_value = existing_value.ToString();
+            pegasus_update_expire_ts(
+                _pegasus_data_version, *new_value, expire_ts);
+            *value_changed = true;
+        }
+
         if (!_user_specified_operations.empty() &&
             user_specified_operation_filter(key, existing_value, new_value, value_changed)) {
             return true;
         }
 
-        uint32_t expire_ts =
-            pegasus_extract_expire_ts(_pegasus_data_version, utils::to_string_view(existing_value));
-        if (_default_ttl != 0 && expire_ts == 0) {
-            // should update ttl
-            *new_value = existing_value.ToString();
-            pegasus_update_expire_ts(
-                _pegasus_data_version, *new_value, utils::epoch_now() + _default_ttl);
-            *value_changed = true;
-            return false;
-        }
         return check_if_ts_expired(utils::epoch_now(), expire_ts) || check_if_stale_split_data(key);
     }
 
@@ -177,6 +178,10 @@ public:
             dsn::utils::auto_write_lock l(_lock);
             _user_specified_operations.swap(operations);
         }
+    }
+    void clear_user_specified_ops() {
+        dsn::utils::auto_write_lock l(_lock);
+        _user_specified_operations.clear();
     }
 
 private:

--- a/src/server/key_ttl_compaction_filter.h
+++ b/src/server/key_ttl_compaction_filter.h
@@ -79,15 +79,11 @@ public:
         }
 
         if (!_user_specified_operations.empty()) {
-            bool need_delete = false;
+            dsn::string_view value_view = utils::to_string_view(existing_value);
             if (*value_changed) {
-                need_delete =
-                    user_specified_operation_filter(key, *new_value, new_value, value_changed);
-            } else {
-                need_delete = user_specified_operation_filter(
-                    key, existing_value.ToString(), new_value, value_changed);
+                value_view = *new_value;
             }
-            if (need_delete) {
+            if (user_specified_operation_filter(key, value_view, new_value, value_changed)) {
                 return true;
             }
         }
@@ -96,7 +92,7 @@ public:
     }
 
     bool user_specified_operation_filter(const rocksdb::Slice &key,
-                                         const std::string &existing_value,
+                                         dsn::string_view existing_value,
                                          std::string *new_value,
                                          bool *value_changed) const
     {

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2611,7 +2611,13 @@ void pegasus_server_impl::update_user_specified_compaction(
     const std::map<std::string, std::string> &envs)
 {
     auto iter = envs.find(USER_SPECIFIED_COMPACTION);
+    if (dsn_unlikely(iter == envs.end() && _user_specified_compaction != "")) {
+        ddebug_replica("clear user specified compaction coz it was deleted");
+        _key_ttl_compaction_filter_factory->clear_user_specified_ops();
+        _user_specified_compaction = "";
+    }
     if (dsn_unlikely(iter != envs.end() && iter->second != _user_specified_compaction)) {
+        ddebug_replica("update user specified compaction coz it was changed");
         _key_ttl_compaction_filter_factory->extract_user_specified_ops(iter->second);
         _user_specified_compaction = iter->second;
     }

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2615,11 +2615,13 @@ void pegasus_server_impl::update_user_specified_compaction(
         ddebug_replica("clear user specified compaction coz it was deleted");
         _key_ttl_compaction_filter_factory->clear_user_specified_ops();
         _user_specified_compaction = "";
+        return;
     }
     if (dsn_unlikely(iter != envs.end() && iter->second != _user_specified_compaction)) {
         ddebug_replica("update user specified compaction coz it was changed");
         _key_ttl_compaction_filter_factory->extract_user_specified_ops(iter->second);
         _user_specified_compaction = iter->second;
+        return;
     }
 }
 

--- a/src/server/test/compaction_filter_rule_test.cpp
+++ b/src/server/test/compaction_filter_rule_test.cpp
@@ -52,12 +52,11 @@ TEST(hashkey_pattern_rule_test, match)
         {"hashkey", "hashkey", SMT_INVALID, false},
     };
 
-    rocksdb::Slice slice;
     hashkey_pattern_rule rule;
     for (const auto &test : tests) {
         rule.match_type = test.match_type;
         rule.pattern = test.pattern;
-        ASSERT_EQ(rule.match(test.hashkey, "", slice), test.match);
+        ASSERT_EQ(rule.match(test.hashkey, "", ""), test.match);
     }
 }
 
@@ -88,12 +87,11 @@ TEST(sortkey_pattern_rule_test, match)
         {"sortkey", "sortkey", SMT_INVALID, false},
     };
 
-    rocksdb::Slice slice;
     sortkey_pattern_rule rule;
     for (const auto &test : tests) {
         rule.match_type = test.match_type;
         rule.pattern = test.pattern;
-        ASSERT_EQ(rule.match("", test.sortkey, slice), test.match);
+        ASSERT_EQ(rule.match("", test.sortkey, ""), test.match);
     }
 }
 
@@ -128,7 +126,7 @@ TEST(ttl_range_rule_test, match)
         rule.stop_ttl = test.stop_ttl;
         rocksdb::SliceParts svalue =
             gen.generate_value(data_version, "", test.expire_ttl + now_ts, 0);
-        ASSERT_EQ(rule.match("", "", svalue.parts[0]), test.match);
+        ASSERT_EQ(rule.match("", "", svalue.parts[0].ToString()), test.match);
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
1. add some logs
2. remove user specified compaction if the corresponding appenv was removed
3. make user specified compaction applicable to default_ttl 


### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### remove user specified compaction if the corresponding appenv was removed
1. insert data into app 'temp'
```
>>> set hashkey sortkey value
OK

app_id          : 2
partition_index : 2
decree          : 36
server          : 10.231.57.100:34803
>>> get hashkey sortkey
"value"

app_id          : 2
partition_index : 2
server          : 10.231.57.100:34803
```
2. add user specified compaction 
```
Pegasus-AdminCli-1.1.0 » add-compaction-operation -o delete --hashkey-pattern "hashkey" --hashkey-match "perfix"
```
3. start manual compaction
```
➜  pegasus git:(fix-compaction) ✗ ./scripts/pegasus_manual_compact.sh -c 127.0.0.1:34601,127.0.0.1:34602 -a temp
```
4. get data from app 'temp', and we can see the data was deleted
```
>>> use temp
OK
>>> get hashkey sortkey
Not found

app_id          : 2
partition_index : 2
server          : 10.231.57.100:34803
```
5. insert data into app 'temp' again
6. del appenv for user specified compaction
```
>>> del_app_envs user_specified_compaction
del app envs succeed
=============================
deleted keys:
    user_specified_compaction
=============================
```
7. start manual compaction again
8. get data from app 'temp', and we can see the data is not deleted
```
>>> get hashkey sortkey
"value"

app_id          : 2
partition_index : 2
server          : 10.231.57.100:34803
```
### make user specified compaction applicable to default_ttl 
1. insert data into table 'temp'
```
>>> set hashkey sortkey value
OK

app_id          : 2
partition_index : 2
decree          : 36
server          : 10.231.57.100:34803
>>> get hashkey sortkey
"value"

app_id          : 2
partition_index : 2
server          : 10.231.57.100:34803
```
2. set default ttl to 1000
```
>>> set_app_envs default_ttl 1000
set app envs succeed
```
3. set user specified compaction operations
```
Pegasus-AdminCli-1.1.0 » add-compaction-operation -o delete --start-ttl 10 --stop-ttl 2000
```
4. start manual compaction
5. get data from app 'temp', and we can see data was removed