### PR TITLE
fix(script): empty pack_template leads to 'sed: no input files'

### DIFF
--- a/scripts/pack_client.sh
+++ b/scripts/pack_client.sh
@@ -116,7 +116,7 @@ echo "Pegasus Client $version ($commit_id) $platform $build_type" >${pack}/VERSI
 
 tar cfz ${pack}.tar.gz ${pack}
 
-if [ -f $pack_template ]; then
+if [ -f "$pack_template" ]; then
     echo "Modifying $pack_template ..."
     sed -i "/^version:/c version: \"$pack_version\"" $pack_template
     sed -i "/^build:/c build: \"\.\/run.sh pack\"" $pack_template

--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -174,7 +174,7 @@ echo "Pegasus Server $version ($commit_id) $platform $build_type" >${pack}/VERSI
 
 tar cfz ${pack}.tar.gz ${pack}
 
-if [ -f $pack_template ]; then
+if [ -f "$pack_template" ]; then
     echo "Modifying $pack_template ..."
     sed -i "/^version:/c version: \"$pack_version\"" $pack_template
     sed -i "/^build:/c build: \"\.\/run.sh pack\"" $pack_template

--- a/scripts/pack_tools.sh
+++ b/scripts/pack_tools.sh
@@ -151,7 +151,7 @@ echo "Pegasus Tools $version ($commit_id) $platform $build_type" >${pack}/VERSIO
 
 tar cfz ${pack}.tar.gz ${pack}
 
-if [ -f $pack_template ]; then
+if [ -f "$pack_template" ]; then
     echo "Modifying $pack_template ..."
     sed -i "/^version:/c version: \"$pack_version\"" $pack_template
     sed -i "/^build:/c build: \"\.\/run.sh pack_tools\"" $pack_template


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

After the binary is built, we packs `server`, `tools` or `client` by the following commands:
```bash
./run.sh pack_server
./run.sh pack_tools
./run.sh pack_client
```

At the end of the lines printed by the commands described above are the following error messages:
```
Modifying  ...
sed: no input files
sed: no input files
sed: no input files
```

The reason is that `[-f $pack_template]` is still true even if `pack_template` is empty. The solution is wrapping `pack_template` into double-quotes(`""`).

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Manual test