### PR TITLE
fix: coredump when table name contains '_' and prometheus is enabled

### DIFF
--- a/src/reporter/pegasus_counter_reporter.cpp
+++ b/src/reporter/pegasus_counter_reporter.cpp
@@ -234,8 +234,9 @@ void pegasus_counter_reporter::update()
             const dsn::perf_counters::counter_snapshot &cs) {
             std::string metrics_name = cs.name;
 
-            // split metric_name like "collector*app.pegasus*app_stat_multi_put_qps@1.0.p999" or
-            // "collector*app.pegasus*app_stat_multi_put_qps@1.0"
+            // Splits metric_name like:
+            //   "collector*app.pegasus*app_stat_multi_put_qps@1.0.p999"
+            //   "collector*app.pegasus*app_stat_multi_put_qps@1.0"
             // app[0] = "1" which is the app(app name or app id)
             // app[1] = "0" which is the partition_index
             // app[2] = "p999" or "" which represent the percent


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
After we enable prometheus(set "perf_counter_sink" to "prometheus"), pegasus ended up core dumped after restart.
We debuged the core, found out it was cored while analysing table name that contains "_".
This PR fixes the bug by changing the order of formating table names.

### What is changed and how does it work?
Prometheus does not support some special charactor in metric name.
This original code first formated the table name by replacing special charactor to "_" or "@".
Then, it try to parse gpid as prometheus labels by spliting the foramted name by ":" or "_".
Unfortunately, tables that already contains "_" may results in unexpected group result, which eventually ended up core.

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

##### Code changes

- Has exported function/method change
- Has exported variable/fields change
- Has interface methods change
- Has persistent data change

##### Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

##### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
