### PR TITLE
fix: ops tools--minos2 have no bootstrap function

### DIFF
--- a/scripts/minos_common.sh
+++ b/scripts/minos_common.sh
@@ -149,8 +149,14 @@ function minos_bootstrap()
     options="$options --task $3"
   fi
   cd $minos_client_dir
-  echo "./deploy bootstrap pegasus $1 $options"
-  ./deploy bootstrap pegasus $1 $options
+  if [ $minos_type -eq 2 ]; then
+    # minos2 have no "bootstrap" function,use "start" function
+    echo "./deploy start pegasus $1 $options"
+    ./deploy start pegasus $1 $options
+  else
+    echo "./deploy bootstrap pegasus $1 $options"
+    ./deploy bootstrap pegasus $1 $options
+  fi
   if [ $? -ne 0 ]; then
     echo "ERROR: minos bootstrap failed"
     exit 1


### PR DESCRIPTION
### What problem does this PR solve?

This script "pegasus_add_node_list.sh" in "/scripts/" used script "minos_common.sh", In "minos_common.sh", function "minos_bootstrap()" has an error when you are using Minos2 to operate clusters. This PR fixed the error.

### What it is now:
When you are using "pegasus_add_node_list.sh" to operate clusters on Minos2：

```
Set meta level to steady...
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./deploy bootstrap pegasus azmbcloudsrv-security --job replica --task 0
usage: deploy.py [-h] [--version] [-v VERBOSITY] [--remote_user REMOTE_USER]
                 {cleanup,decommission,reprocess,fetch,reconfigure,update_rackinfo,start,convert,stop,restart,show,reload,version_list,shell,pack,check,getconf,rolling_update}
                 ...
deploy.py: error: invalid choice: 'bootstrap' (choose from 'cleanup', 'decommission', 'reprocess', 'fetch', 'reconfigure', 'update_rackinfo', 'start', 'convert', 'stop', 'restart', 'show', 'reload', 'version_list', 'shell', 'pack', 'check', 'getconf', 'rolling_update')

```

Tests
Manual test (Test on 2 working clusters)