### PR TITLE
feat(scripts): update rolling_update and rebalance scripts

### DIFF
--- a/scripts/pegasus_rebalance_cluster.sh
+++ b/scripts/pegasus_rebalance_cluster.sh
@@ -115,7 +115,7 @@ echo "Wait for 3 minutes to do load balance..."
 sleep 180
 ## Number of check times for balanced state, in case that op_count is 0 but
 ## the cluster is in fact unbalanced. Each check waits for 30 secs.
-op_count_check_remain_times=1
+op_count_check_remain_times=3
 while true; do
     op_count=$(echo "cluster_info" | ./run.sh shell --cluster $meta_list | grep balance_operation_count | grep -o 'total=[0-9][0-9]*' | cut -d= -f2)
     if [ -z $op_count ]; then

--- a/scripts/pegasus_rolling_update.sh
+++ b/scripts/pegasus_rolling_update.sh
@@ -124,7 +124,7 @@ if [ $set_ok -ne 1 ]; then
 fi
 
 echo "Set lb.assign_delay_ms to 30min..."
-echo "remote_command -l $pmeta meta.lb.assign_delay_ms 1800000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
+echo "remote_command -l $pmeta meta.lb.assign_delay_ms 180000000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.assign_delay_ms to 30min failed"
@@ -190,7 +190,7 @@ do
   sleeped=0
   while true
   do
-    if [ $((sleeped%10)) -eq 0 ]; then
+    if [ $((sleeped%50)) -eq 0 ]; then
       ./run.sh downgrade_node -c $meta_list -n $node -t run &>/tmp/$UID.$PID.pegasus.rolling_update.downgrade_node
       echo "Send downgrade propose, refer to /tmp/$UID.$PID.pegasus.rolling_update.downgrade_node for details"
     fi
@@ -214,7 +214,7 @@ do
   sleeped=0
   while true
   do
-    if [ $((sleeped%10)) -eq 0 ]; then
+    if [ $((sleeped%50)) -eq 0 ]; then
       echo "Send kill_partition commands to node..."
       grep '^propose ' /tmp/$UID.$PID.pegasus.rolling_update.downgrade_node >/tmp/$UID.$PID.pegasus.rolling_update.downgrade_node.propose
       while read line2


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix pegasus scripts bug;

### What is changed and how does it work?
1) pegasus_rolling_update.sh
Do not let the cluster perform replica learning during the upgrade process，change the meta.lb_assign_delay_ms from 30min to 3000min, Ensure transactional closure;
Added the rounds of closing replica during upgrade to ensure stable data access:

2) pegasus_rebalance_cluster.sh
Change the op_count_check_remain_times value from 1 to 3 to prevents the script from exiting before the load balancing rounds are calculated;

Tests
Manual test (Test on 1 working clusters)