### PR TITLE
fix(config): duplicate worker_count and undefined thread pool in server config

### DIFF
--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -101,6 +101,12 @@
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 24
 
+[threadpool.THREAD_POOL_META_SERVER]
+  name = meta_server
+  partitioned = false
+  worker_priority = THREAD_xPRIORITY_NORMAL
+  worker_count = 8
+
 [threadpool.THREAD_POOL_META_STATE]
   name = meta_state
   partitioned = true
@@ -139,7 +145,7 @@
 
 [threadpool.THREAD_POOL_BLOCK_SERVICE]
   name = block_service
-  worker_count = 8
+  partitioned = false
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 8
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

While running the pegasus server with the default server config,  some logs will be found like:
```
overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX from THREAD_POOL_META_SERVER to THREAD_POOL_DEFAULT
overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX_ACK from THREAD_POOL_META_SERVER to THREAD_POOL_DEFAULT

...

WARNING: skip redefinition of option [threadpool.THREAD_POOL_BLOCK_SERVICE] worker_count (line 137), already defined as [threadpool.THREAD_POOL_BLOCK_SERVICE] worker_count (line 135)
```

By checking the server config, we can find:

- `THREAD_POOL_META_SERVER` that is used as a thread pool for meta is not defined in the server config below, thus related tasks are pushed to `THREAD_POOL_DEFAULT`
- There is a duplicate `worker_count` in section `[threadpool.THREAD_POOL_BLOCK_SERVICE]`


### What is changed and how does it work?

- Add the definition of `THREAD_POOL_META_SERVER`
- Replace the duplicate `worker_count` with the missing `partitioned` option

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- No code

##### Code changes

- No changes

##### Side effects

- No

##### Related changes

- No
