### PR TITLE
feat(manual_compaction): replica report status part2. implement function query_compact_status

### DIFF
--- a/src/server/pegasus_manual_compact_service.cpp
+++ b/src/server/pegasus_manual_compact_service.cpp
@@ -351,5 +351,32 @@ std::string pegasus_manual_compact_service::query_compact_state() const
     return state.str();
 }
 
+dsn::replication::manual_compaction_status::type
+pegasus_manual_compact_service::query_compact_status() const
+{
+    // Case1. last finish at [-]
+    // - partition is not manual compaction
+    // Case2. last finish at [timestamp], last used {time_used} ms
+    // - partition manual compaction finished
+    // Case3. last finish at [-], recent enqueue at [timestamp]
+    // - partition is in manual compaction queue
+    // Case4. last finish at [-], recent enqueue at [timestamp], recent start at [timestamp]
+    // - partition is running manual compaction
+    uint64_t enqueue_time_ms = _manual_compact_enqueue_time_ms.load();
+    uint64_t start_time_ms = _manual_compact_start_running_time_ms.load();
+    uint64_t last_finish_time_ms = _manual_compact_last_finish_time_ms.load();
+    uint64_t last_time_used_ms = _manual_compact_last_time_used_ms.load();
+
+    if (start_time_ms > 0) {
+        return dsn::replication::manual_compaction_status::RUNNING;
+    } else if (enqueue_time_ms > 0) {
+        return dsn::replication::manual_compaction_status::QUEUING;
+    } else if (last_time_used_ms > 0 && last_finish_time_ms > 0) {
+        return dsn::replication::manual_compaction_status::FINISHED;
+    } else {
+        return dsn::replication::manual_compaction_status::IDLE;
+    }
+}
+
 } // namespace server
 } // namespace pegasus

--- a/src/server/pegasus_manual_compact_service.cpp
+++ b/src/server/pegasus_manual_compact_service.cpp
@@ -355,7 +355,7 @@ dsn::replication::manual_compaction_status::type
 pegasus_manual_compact_service::query_compact_status() const
 {
     // Case1. last finish at [-]
-    // - partition is not manual compaction
+    // - partition is not running manual compaction
     // Case2. last finish at [timestamp], last used {time_used} ms
     // - partition manual compaction finished
     // Case3. last finish at [-], recent enqueue at [timestamp]

--- a/src/server/pegasus_manual_compact_service.h
+++ b/src/server/pegasus_manual_compact_service.h
@@ -23,6 +23,7 @@
 #include <dsn/utility/string_view.h>
 #include <dsn/perf_counter/perf_counter_wrapper.h>
 #include <dsn/dist/replication/replica_base.h>
+#include <dsn/dist/replication/replication_types.h>
 
 namespace pegasus {
 namespace server {
@@ -38,7 +39,10 @@ public:
 
     void start_manual_compact_if_needed(const std::map<std::string, std::string> &envs);
 
+    // Called by pegasus_manual_compaction.sh
     std::string query_compact_state() const;
+
+    dsn::replication::manual_compaction_status::type query_compact_status() const;
 
 private:
     friend class manual_compact_service_test;

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -3107,5 +3107,10 @@ void pegasus_server_impl::on_detect_hotkey(const dsn::replication::detect_hotkey
 
 uint32_t pegasus_server_impl::query_data_version() const { return _pegasus_data_version; }
 
+dsn::replication::manual_compaction_status::type pegasus_server_impl::query_compact_status() const
+{
+    return _manual_compact_svc.query_compact_status();
+}
+
 } // namespace server
 } // namespace pegasus

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -365,6 +365,8 @@ private:
 
     uint32_t query_data_version() const override;
 
+    dsn::replication::manual_compaction_status::type query_compact_status() const override;
+
 private:
     static const std::chrono::seconds kServerStatUpdateTimeSec;
     static const std::string COMPRESSION_HEADER;


### PR DESCRIPTION
As #850 shows, meta server should know the status of manual compaction.
This pull request is the part2 of the replica servers report manual compaction status to meta server, implement function `query_compact_status`.
