### PR TITLE
feat(online_migration): part3 - support ingestion_behind for pegasus

### DIFF
--- a/src/base/pegasus_const.cpp
+++ b/src/base/pegasus_const.cpp
@@ -99,4 +99,6 @@ const std::string SPLIT_VALIDATE_PARTITION_HASH("replica.split.validate_partitio
 const std::string USER_SPECIFIED_COMPACTION("user_specified_compaction");
 
 const std::string READ_SIZE_THROTTLING("replica.read_throttling_by_size");
+
+const std::string ROCKSDB_ALLOW_INGEST_BEHIND("rocksdb.allow_ingest_behind");
 } // namespace pegasus

--- a/src/base/pegasus_const.h
+++ b/src/base/pegasus_const.h
@@ -70,4 +70,6 @@ extern const std::string SPLIT_VALIDATE_PARTITION_HASH;
 extern const std::string USER_SPECIFIED_COMPACTION;
 
 extern const std::string READ_SIZE_THROTTLING;
+
+extern const std::string ROCKSDB_ALLOW_INGEST_BEHIND;
 } // namespace pegasus

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -284,6 +284,9 @@ private:
 
     void update_throttling_controller(const std::map<std::string, std::string> &envs);
 
+    void update_allow_ingest_behind(const std::map<std::string, std::string> &envs,
+                                    bool default_value);
+
     // return true if parse compression types 'config' success, otherwise return false.
     // 'compression_per_level' will not be changed if parse failed.
     bool parse_compression_types(const std::string &config,
@@ -431,6 +434,8 @@ private:
 
     dsn::replication::ingestion_status::type _ingestion_status{
         dsn::replication::ingestion_status::IS_INVALID};
+
+    bool _allow_ingest_behind{false};
 
     dsn::task_tracker _tracker;
 

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -284,8 +284,7 @@ private:
 
     void update_throttling_controller(const std::map<std::string, std::string> &envs);
 
-    void update_allow_ingest_behind(const std::map<std::string, std::string> &envs,
-                                    bool default_value);
+    bool parse_allow_ingest_behind(const std::map<std::string, std::string> &envs);
 
     // return true if parse compression types 'config' success, otherwise return false.
     // 'compression_per_level' will not be changed if parse failed.
@@ -434,8 +433,6 @@ private:
 
     dsn::replication::ingestion_status::type _ingestion_status{
         dsn::replication::ingestion_status::IS_INVALID};
-
-    bool _allow_ingest_behind{false};
 
     dsn::task_tracker _tracker;
 

--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -195,7 +195,7 @@ void pegasus_server_write::init_non_batch_write_handlers()
         {dsn::apps::RPC_RRDB_RRDB_BULK_LOAD,
          [this](dsn::message_ex *request) -> int {
              auto rpc = ingestion_rpc::auto_reply(request);
-             return _write_svc->ingestion_files(_decree, rpc.request(), rpc.response());
+             return _write_svc->ingest_files(_decree, rpc.request(), rpc.response());
          }},
     };
 }

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -390,8 +390,8 @@ int pegasus_write_service::ingestion_files(int64_t decree,
     // ingest files asynchronously
     _server->set_ingestion_status(dsn::replication::ingestion_status::IS_RUNNING);
     dsn::tasking::enqueue(LPC_INGESTION, &_server->_tracker, [this, decree, req]() {
-        dsn::error_code err =
-            _impl->ingestion_files(decree, _server->bulk_load_dir(), req.metadata);
+        dsn::error_code err = _impl->ingestion_files(
+            decree, _server->bulk_load_dir(), req.metadata, req.ingest_behind);
         if (err == dsn::ERR_OK) {
             _server->set_ingestion_status(dsn::replication::ingestion_status::IS_SUCCEED);
         } else {

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -373,9 +373,9 @@ int pegasus_write_service::duplicate(int64_t decree,
     return empty_put(ctx.decree);
 }
 
-int pegasus_write_service::ingestion_files(int64_t decree,
-                                           const dsn::replication::ingestion_request &req,
-                                           dsn::replication::ingestion_response &resp)
+int pegasus_write_service::ingest_files(int64_t decree,
+                                        const dsn::replication::ingestion_request &req,
+                                        dsn::replication::ingestion_response &resp)
 {
     // TODO(heyuchen): consider cu
 
@@ -390,8 +390,8 @@ int pegasus_write_service::ingestion_files(int64_t decree,
     // ingest files asynchronously
     _server->set_ingestion_status(dsn::replication::ingestion_status::IS_RUNNING);
     dsn::tasking::enqueue(LPC_INGESTION, &_server->_tracker, [this, decree, req]() {
-        dsn::error_code err = _impl->ingestion_files(
-            decree, _server->bulk_load_dir(), req.metadata, req.ingest_behind);
+        dsn::error_code err =
+            _impl->ingest_files(decree, _server->bulk_load_dir(), req.metadata, req.ingest_behind);
         if (err == dsn::ERR_OK) {
             _server->set_ingestion_status(dsn::replication::ingestion_status::IS_SUCCEED);
         } else {

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -142,9 +142,9 @@ public:
                   dsn::apps::duplicate_response &resp);
 
     // Execute bulk load ingestion
-    int ingestion_files(int64_t decree,
-                        const dsn::replication::ingestion_request &req,
-                        dsn::replication::ingestion_response &resp);
+    int ingest_files(int64_t decree,
+                     const dsn::replication::ingestion_request &req,
+                     dsn::replication::ingestion_response &resp);
 
     /// For batch write.
 

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -483,10 +483,10 @@ public:
     // \return ERR_WRONG_CHECKSUM: verify files failed
     // \return ERR_INGESTION_FAILED: rocksdb ingestion failed
     // \return ERR_OK: rocksdb ingestion succeed
-    dsn::error_code ingestion_files(const int64_t decree,
-                                    const std::string &bulk_load_dir,
-                                    const dsn::replication::bulk_load_metadata &metadata,
-                                    const bool ingest_behind)
+    dsn::error_code ingest_files(const int64_t decree,
+                                 const std::string &bulk_load_dir,
+                                 const dsn::replication::bulk_load_metadata &metadata,
+                                 const bool ingest_behind)
     {
         // verify external files before ingestion
         std::vector<std::string> sst_file_list;
@@ -496,7 +496,7 @@ public:
         }
 
         // ingest external files
-        if (dsn_unlikely(_rocksdb_wrapper->ingestion_files(decree, sst_file_list, ingest_behind) !=
+        if (dsn_unlikely(_rocksdb_wrapper->ingest_files(decree, sst_file_list, ingest_behind) !=
                          0)) {
             return dsn::ERR_INGESTION_FAILED;
         }

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -485,7 +485,8 @@ public:
     // \return ERR_OK: rocksdb ingestion succeed
     dsn::error_code ingestion_files(const int64_t decree,
                                     const std::string &bulk_load_dir,
-                                    const dsn::replication::bulk_load_metadata &metadata)
+                                    const dsn::replication::bulk_load_metadata &metadata,
+                                    const bool ingest_behind)
     {
         // verify external files before ingestion
         std::vector<std::string> sst_file_list;
@@ -495,7 +496,8 @@ public:
         }
 
         // ingest external files
-        if (dsn_unlikely(_rocksdb_wrapper->ingestion_files(decree, sst_file_list) != 0)) {
+        if (dsn_unlikely(_rocksdb_wrapper->ingestion_files(decree, sst_file_list, ingest_behind) !=
+                         0)) {
             return dsn::ERR_INGESTION_FAILED;
         }
         return dsn::ERR_OK;

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -180,9 +180,9 @@ int rocksdb_wrapper::write_batch_delete(int64_t decree, dsn::string_view raw_key
 
 void rocksdb_wrapper::clear_up_write_batch() { _write_batch->Clear(); }
 
-int rocksdb_wrapper::ingestion_files(int64_t decree,
-                                     const std::vector<std::string> &sst_file_list,
-                                     bool ingest_behind)
+int rocksdb_wrapper::ingest_files(int64_t decree,
+                                  const std::vector<std::string> &sst_file_list,
+                                  const bool ingest_behind)
 {
     rocksdb::IngestExternalFileOptions ifo;
     ifo.move_files = true;

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -180,9 +180,12 @@ int rocksdb_wrapper::write_batch_delete(int64_t decree, dsn::string_view raw_key
 
 void rocksdb_wrapper::clear_up_write_batch() { _write_batch->Clear(); }
 
-int rocksdb_wrapper::ingestion_files(int64_t decree, const std::vector<std::string> &sst_file_list)
+int rocksdb_wrapper::ingestion_files(int64_t decree,
+                                     const std::vector<std::string> &sst_file_list,
+                                     bool ingest_behind)
 {
     rocksdb::IngestExternalFileOptions ifo;
+    ifo.ingest_behind = ingest_behind;
     rocksdb::Status s = _db->IngestExternalFile(sst_file_list, ifo);
     if (dsn_unlikely(!s.ok())) {
         derror_rocksdb("IngestExternalFile", s.ToString(), "decree = {}", decree);

--- a/src/server/rocksdb_wrapper.h
+++ b/src/server/rocksdb_wrapper.h
@@ -64,7 +64,9 @@ public:
     int write(int64_t decree);
     int write_batch_delete(int64_t decree, dsn::string_view raw_key);
     void clear_up_write_batch();
-    int ingestion_files(int64_t decree, const std::vector<std::string> &sst_file_list);
+    int ingestion_files(int64_t decree,
+                        const std::vector<std::string> &sst_file_list,
+                        bool ingest_behind);
 
     void set_default_ttl(uint32_t ttl);
 

--- a/src/server/rocksdb_wrapper.h
+++ b/src/server/rocksdb_wrapper.h
@@ -64,9 +64,9 @@ public:
     int write(int64_t decree);
     int write_batch_delete(int64_t decree, dsn::string_view raw_key);
     void clear_up_write_batch();
-    int ingestion_files(int64_t decree,
-                        const std::vector<std::string> &sst_file_list,
-                        bool ingest_behind);
+    int ingest_files(int64_t decree,
+                     const std::vector<std::string> &sst_file_list,
+                     const bool ingest_behind);
 
     void set_default_ttl(uint32_t ttl);
 

--- a/src/shell/commands/bulk_load.cpp
+++ b/src/shell/commands/bulk_load.cpp
@@ -24,6 +24,7 @@ bool start_bulk_load(command_executor *e, shell_context *sc, arguments args)
     static struct option long_options[] = {{"app_name", required_argument, 0, 'a'},
                                            {"cluster_name", required_argument, 0, 'c'},
                                            {"file_provider_type", required_argument, 0, 'p'},
+                                           {"root_path", required_argument, 0, 'r'},
                                            {"ingest_behind", no_argument, 0, 'i'},
                                            {0, 0, 0, 0}};
     std::string app_name;

--- a/src/shell/commands/bulk_load.cpp
+++ b/src/shell/commands/bulk_load.cpp
@@ -24,18 +24,19 @@ bool start_bulk_load(command_executor *e, shell_context *sc, arguments args)
     static struct option long_options[] = {{"app_name", required_argument, 0, 'a'},
                                            {"cluster_name", required_argument, 0, 'c'},
                                            {"file_provider_type", required_argument, 0, 'p'},
-                                           {"root_path", required_argument, 0, 'r'},
+                                           {"ingest_behind", no_argument, 0, 'i'},
                                            {0, 0, 0, 0}};
     std::string app_name;
     std::string cluster_name;
     std::string file_provider_type;
     std::string remote_root_path;
+    bool ingest_behind = false;
 
     optind = 0;
     while (true) {
         int option_index = 0;
         int c;
-        c = getopt_long(args.argc, args.argv, "a:c:p:r:", long_options, &option_index);
+        c = getopt_long(args.argc, args.argv, "a:c:p:r:i", long_options, &option_index);
         if (c == -1)
             break;
         switch (c) {
@@ -50,6 +51,9 @@ bool start_bulk_load(command_executor *e, shell_context *sc, arguments args)
             break;
         case 'r':
             remote_root_path = optarg;
+            break;
+        case 'i':
+            ingest_behind = true;
             break;
         default:
             return false;
@@ -76,7 +80,7 @@ bool start_bulk_load(command_executor *e, shell_context *sc, arguments args)
     }
 
     auto err_resp = sc->ddl_client->start_bulk_load(
-        app_name, cluster_name, file_provider_type, remote_root_path);
+        app_name, cluster_name, file_provider_type, remote_root_path, ingest_behind);
     dsn::error_s err = err_resp.get_error();
     std::string hint_msg;
     if (err.is_ok()) {

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -462,7 +462,7 @@ static command_executor commands[] = {
         "start_bulk_load",
         "start app bulk load",
         "<-a --app_name str> <-c --cluster_name str> <-p --file_provider_type str> <-r "
-        "--root_path>",
+        "--root_path> [-i --ingest_behind]",
         start_bulk_load,
     },
     {

--- a/src/test/function_test/run.sh
+++ b/src/test/function_test/run.sh
@@ -48,37 +48,37 @@ test_case=pegasus_function_test
 config_file=config.ini
 table_name=temp
 
-GTEST_OUTPUT="xml:$REPORT_DIR/basic.xml" GTEST_FILTER="basic.*" ./$test_case $config_file $table_name
-exit_if_fail $? "run test basic failed: $test_case $config_file $table_name"
-GTEST_OUTPUT="xml:$REPORT_DIR/incr.xml" GTEST_FILTER="incr.*" ./$test_case $config_file $table_name
-exit_if_fail $? "run test incr failed: $test_case $config_file $table_name"
-GTEST_OUTPUT="xml:$REPORT_DIR/check_and_set.xml" GTEST_FILTER="check_and_set.*" ./$test_case $config_file $table_name
-exit_if_fail $? "run test check_and_set failed: $test_case $config_file $table_name"
-GTEST_OUTPUT="xml:$REPORT_DIR/check_and_mutate.xml" GTEST_FILTER="check_and_mutate.*" ./$test_case $config_file $table_name
-exit_if_fail $? "run test check_and_mutate failed: $test_case $config_file $table_name"
-GTEST_OUTPUT="xml:$REPORT_DIR/scan.xml" GTEST_FILTER="scan.*" ./$test_case $config_file $table_name
-exit_if_fail $? "run test scan failed: $test_case $config_file $table_name"
-GTEST_OUTPUT="xml:$REPORT_DIR/range_read.xml" GTEST_FILTER="range_read_test.*" ./$test_case $config_file $table_name
-exit_if_fail $? "run test range_read failed: $test_case $config_file $table_name"
-GTEST_OUTPUT="xml:$REPORT_DIR/ttl.xml" GTEST_FILTER="ttl.*" ./$test_case $config_file $table_name
-exit_if_fail $? "run test ttl failed: $test_case $config_file $table_name"
-GTEST_OUTPUT="xml:$REPORT_DIR/slog_log.xml" GTEST_FILTER="lost_log.*" ./$test_case $config_file $table_name
-exit_if_fail $? "run test slog_lost failed: $test_case $config_file $table_name"
-GTEST_OUTPUT="xml:$REPORT_DIR/recall.xml" GTEST_FILTER="drop_and_recall.*" ./$test_case $config_file $table_name
-exit_if_fail $? "run test recall failed: $test_case $config_file $table_name"
-if [ $on_travis == "NO" ]; then
-    GTEST_OUTPUT="xml:$REPORT_DIR/restore.xml" GTEST_FILTER="restore_test.*" ./$test_case $config_file $table_name
-    exit_if_fail $? "run test restore_test failed: $test_case $config_file $table_name"
-    GTEST_OUTPUT="xml:$REPORT_DIR/recovery.xml" GTEST_FILTER="recovery_test.*" ./$test_case $config_file $table_name
-    exit_if_fail $? "run test recovery failed: $test_case $config_file $table_name"
+#GTEST_OUTPUT="xml:$REPORT_DIR/basic.xml" GTEST_FILTER="basic.*" ./$test_case $config_file $table_name
+#exit_if_fail $? "run test basic failed: $test_case $config_file $table_name"
+#GTEST_OUTPUT="xml:$REPORT_DIR/incr.xml" GTEST_FILTER="incr.*" ./$test_case $config_file $table_name
+#exit_if_fail $? "run test incr failed: $test_case $config_file $table_name"
+#GTEST_OUTPUT="xml:$REPORT_DIR/check_and_set.xml" GTEST_FILTER="check_and_set.*" ./$test_case $config_file $table_name
+#exit_if_fail $? "run test check_and_set failed: $test_case $config_file $table_name"
+#GTEST_OUTPUT="xml:$REPORT_DIR/check_and_mutate.xml" GTEST_FILTER="check_and_mutate.*" ./$test_case $config_file $table_name
+#exit_if_fail $? "run test check_and_mutate failed: $test_case $config_file $table_name"
+#GTEST_OUTPUT="xml:$REPORT_DIR/scan.xml" GTEST_FILTER="scan.*" ./$test_case $config_file $table_name
+#exit_if_fail $? "run test scan failed: $test_case $config_file $table_name"
+#GTEST_OUTPUT="xml:$REPORT_DIR/range_read.xml" GTEST_FILTER="range_read_test.*" ./$test_case $config_file $table_name
+#exit_if_fail $? "run test range_read failed: $test_case $config_file $table_name"
+#GTEST_OUTPUT="xml:$REPORT_DIR/ttl.xml" GTEST_FILTER="ttl.*" ./$test_case $config_file $table_name
+#exit_if_fail $? "run test ttl failed: $test_case $config_file $table_name"
+#GTEST_OUTPUT="xml:$REPORT_DIR/slog_log.xml" GTEST_FILTER="lost_log.*" ./$test_case $config_file $table_name
+#exit_if_fail $? "run test slog_lost failed: $test_case $config_file $table_name"
+#GTEST_OUTPUT="xml:$REPORT_DIR/recall.xml" GTEST_FILTER="drop_and_recall.*" ./$test_case $config_file $table_name
+#exit_if_fail $? "run test recall failed: $test_case $config_file $table_name"
+#if [ $on_travis == "NO" ]; then
+#    GTEST_OUTPUT="xml:$REPORT_DIR/restore.xml" GTEST_FILTER="restore_test.*" ./$test_case $config_file $table_name
+#    exit_if_fail $? "run test restore_test failed: $test_case $config_file $table_name"
+#    GTEST_OUTPUT="xml:$REPORT_DIR/recovery.xml" GTEST_FILTER="recovery_test.*" ./$test_case $config_file $table_name
+#    exit_if_fail $? "run test recovery failed: $test_case $config_file $table_name"
     GTEST_OUTPUT="xml:$REPORT_DIR/bulk_load.xml" GTEST_FILTER="bulk_load_test.*" ./$test_case $config_file $table_name
     exit_if_fail $? "run test bulk load failed: $test_case $config_file $table_name"
-    GTEST_OUTPUT="xml:$REPORT_DIR/test_detect_hotspot.xml" GTEST_FILTER="test_detect_hotspot.*" ./$test_case $config_file $table_name
-    exit_if_fail $? "run test test_detect_hotspot load failed: $test_case $config_file $table_name"
-    GTEST_OUTPUT="xml:$REPORT_DIR/backup_restore_test.xml" GTEST_FILTER="backup_restore_test.*" ./$test_case $config_file $table_name
-    exit_if_fail $? "run test backup_restore_test load failed: $test_case $config_file $table_name"
-    GTEST_OUTPUT="xml:$REPORT_DIR/split.xml" GTEST_FILTER="partition_split_test.*" ./$test_case $config_file $table_name
-    exit_if_fail $? "run test split failed: $test_case $config_file $table_name"
-    GTEST_OUTPUT="xml:$REPORT_DIR/test_throttle.xml" GTEST_FILTER="test_throttle.*" ./$test_case $config_file $table_name
-    exit_if_fail $? "run test test_throttle load failed: $test_case $config_file $table_name"
-fi
+#    GTEST_OUTPUT="xml:$REPORT_DIR/test_detect_hotspot.xml" GTEST_FILTER="test_detect_hotspot.*" ./$test_case $config_file $table_name
+#    exit_if_fail $? "run test test_detect_hotspot load failed: $test_case $config_file $table_name"
+#    GTEST_OUTPUT="xml:$REPORT_DIR/backup_restore_test.xml" GTEST_FILTER="backup_restore_test.*" ./$test_case $config_file $table_name
+#    exit_if_fail $? "run test backup_restore_test load failed: $test_case $config_file $table_name"
+#    GTEST_OUTPUT="xml:$REPORT_DIR/split.xml" GTEST_FILTER="partition_split_test.*" ./$test_case $config_file $table_name
+#    exit_if_fail $? "run test split failed: $test_case $config_file $table_name"
+#    GTEST_OUTPUT="xml:$REPORT_DIR/test_throttle.xml" GTEST_FILTER="test_throttle.*" ./$test_case $config_file $table_name
+#    exit_if_fail $? "run test test_throttle load failed: $test_case $config_file $table_name"
+#fi

--- a/src/test/function_test/run.sh
+++ b/src/test/function_test/run.sh
@@ -48,37 +48,37 @@ test_case=pegasus_function_test
 config_file=config.ini
 table_name=temp
 
-#GTEST_OUTPUT="xml:$REPORT_DIR/basic.xml" GTEST_FILTER="basic.*" ./$test_case $config_file $table_name
-#exit_if_fail $? "run test basic failed: $test_case $config_file $table_name"
-#GTEST_OUTPUT="xml:$REPORT_DIR/incr.xml" GTEST_FILTER="incr.*" ./$test_case $config_file $table_name
-#exit_if_fail $? "run test incr failed: $test_case $config_file $table_name"
-#GTEST_OUTPUT="xml:$REPORT_DIR/check_and_set.xml" GTEST_FILTER="check_and_set.*" ./$test_case $config_file $table_name
-#exit_if_fail $? "run test check_and_set failed: $test_case $config_file $table_name"
-#GTEST_OUTPUT="xml:$REPORT_DIR/check_and_mutate.xml" GTEST_FILTER="check_and_mutate.*" ./$test_case $config_file $table_name
-#exit_if_fail $? "run test check_and_mutate failed: $test_case $config_file $table_name"
-#GTEST_OUTPUT="xml:$REPORT_DIR/scan.xml" GTEST_FILTER="scan.*" ./$test_case $config_file $table_name
-#exit_if_fail $? "run test scan failed: $test_case $config_file $table_name"
-#GTEST_OUTPUT="xml:$REPORT_DIR/range_read.xml" GTEST_FILTER="range_read_test.*" ./$test_case $config_file $table_name
-#exit_if_fail $? "run test range_read failed: $test_case $config_file $table_name"
-#GTEST_OUTPUT="xml:$REPORT_DIR/ttl.xml" GTEST_FILTER="ttl.*" ./$test_case $config_file $table_name
-#exit_if_fail $? "run test ttl failed: $test_case $config_file $table_name"
-#GTEST_OUTPUT="xml:$REPORT_DIR/slog_log.xml" GTEST_FILTER="lost_log.*" ./$test_case $config_file $table_name
-#exit_if_fail $? "run test slog_lost failed: $test_case $config_file $table_name"
-#GTEST_OUTPUT="xml:$REPORT_DIR/recall.xml" GTEST_FILTER="drop_and_recall.*" ./$test_case $config_file $table_name
-#exit_if_fail $? "run test recall failed: $test_case $config_file $table_name"
-#if [ $on_travis == "NO" ]; then
-#    GTEST_OUTPUT="xml:$REPORT_DIR/restore.xml" GTEST_FILTER="restore_test.*" ./$test_case $config_file $table_name
-#    exit_if_fail $? "run test restore_test failed: $test_case $config_file $table_name"
-#    GTEST_OUTPUT="xml:$REPORT_DIR/recovery.xml" GTEST_FILTER="recovery_test.*" ./$test_case $config_file $table_name
-#    exit_if_fail $? "run test recovery failed: $test_case $config_file $table_name"
+GTEST_OUTPUT="xml:$REPORT_DIR/basic.xml" GTEST_FILTER="basic.*" ./$test_case $config_file $table_name
+exit_if_fail $? "run test basic failed: $test_case $config_file $table_name"
+GTEST_OUTPUT="xml:$REPORT_DIR/incr.xml" GTEST_FILTER="incr.*" ./$test_case $config_file $table_name
+exit_if_fail $? "run test incr failed: $test_case $config_file $table_name"
+GTEST_OUTPUT="xml:$REPORT_DIR/check_and_set.xml" GTEST_FILTER="check_and_set.*" ./$test_case $config_file $table_name
+exit_if_fail $? "run test check_and_set failed: $test_case $config_file $table_name"
+GTEST_OUTPUT="xml:$REPORT_DIR/check_and_mutate.xml" GTEST_FILTER="check_and_mutate.*" ./$test_case $config_file $table_name
+exit_if_fail $? "run test check_and_mutate failed: $test_case $config_file $table_name"
+GTEST_OUTPUT="xml:$REPORT_DIR/scan.xml" GTEST_FILTER="scan.*" ./$test_case $config_file $table_name
+exit_if_fail $? "run test scan failed: $test_case $config_file $table_name"
+GTEST_OUTPUT="xml:$REPORT_DIR/range_read.xml" GTEST_FILTER="range_read_test.*" ./$test_case $config_file $table_name
+exit_if_fail $? "run test range_read failed: $test_case $config_file $table_name"
+GTEST_OUTPUT="xml:$REPORT_DIR/ttl.xml" GTEST_FILTER="ttl.*" ./$test_case $config_file $table_name
+exit_if_fail $? "run test ttl failed: $test_case $config_file $table_name"
+GTEST_OUTPUT="xml:$REPORT_DIR/slog_log.xml" GTEST_FILTER="lost_log.*" ./$test_case $config_file $table_name
+exit_if_fail $? "run test slog_lost failed: $test_case $config_file $table_name"
+GTEST_OUTPUT="xml:$REPORT_DIR/recall.xml" GTEST_FILTER="drop_and_recall.*" ./$test_case $config_file $table_name
+exit_if_fail $? "run test recall failed: $test_case $config_file $table_name"
+if [ $on_travis == "NO" ]; then
+    GTEST_OUTPUT="xml:$REPORT_DIR/restore.xml" GTEST_FILTER="restore_test.*" ./$test_case $config_file $table_name
+    exit_if_fail $? "run test restore_test failed: $test_case $config_file $table_name"
+    GTEST_OUTPUT="xml:$REPORT_DIR/recovery.xml" GTEST_FILTER="recovery_test.*" ./$test_case $config_file $table_name
+    exit_if_fail $? "run test recovery failed: $test_case $config_file $table_name"
     GTEST_OUTPUT="xml:$REPORT_DIR/bulk_load.xml" GTEST_FILTER="bulk_load_test.*" ./$test_case $config_file $table_name
     exit_if_fail $? "run test bulk load failed: $test_case $config_file $table_name"
-#    GTEST_OUTPUT="xml:$REPORT_DIR/test_detect_hotspot.xml" GTEST_FILTER="test_detect_hotspot.*" ./$test_case $config_file $table_name
-#    exit_if_fail $? "run test test_detect_hotspot load failed: $test_case $config_file $table_name"
-#    GTEST_OUTPUT="xml:$REPORT_DIR/backup_restore_test.xml" GTEST_FILTER="backup_restore_test.*" ./$test_case $config_file $table_name
-#    exit_if_fail $? "run test backup_restore_test load failed: $test_case $config_file $table_name"
-#    GTEST_OUTPUT="xml:$REPORT_DIR/split.xml" GTEST_FILTER="partition_split_test.*" ./$test_case $config_file $table_name
-#    exit_if_fail $? "run test split failed: $test_case $config_file $table_name"
-#    GTEST_OUTPUT="xml:$REPORT_DIR/test_throttle.xml" GTEST_FILTER="test_throttle.*" ./$test_case $config_file $table_name
-#    exit_if_fail $? "run test test_throttle load failed: $test_case $config_file $table_name"
-#fi
+    GTEST_OUTPUT="xml:$REPORT_DIR/test_detect_hotspot.xml" GTEST_FILTER="test_detect_hotspot.*" ./$test_case $config_file $table_name
+    exit_if_fail $? "run test test_detect_hotspot load failed: $test_case $config_file $table_name"
+    GTEST_OUTPUT="xml:$REPORT_DIR/backup_restore_test.xml" GTEST_FILTER="backup_restore_test.*" ./$test_case $config_file $table_name
+    exit_if_fail $? "run test backup_restore_test load failed: $test_case $config_file $table_name"
+    GTEST_OUTPUT="xml:$REPORT_DIR/split.xml" GTEST_FILTER="partition_split_test.*" ./$test_case $config_file $table_name
+    exit_if_fail $? "run test split failed: $test_case $config_file $table_name"
+    GTEST_OUTPUT="xml:$REPORT_DIR/test_throttle.xml" GTEST_FILTER="test_throttle.*" ./$test_case $config_file $table_name
+    exit_if_fail $? "run test test_throttle load failed: $test_case $config_file $table_name"
+fi

--- a/src/test/function_test/test_bulk_load.cpp
+++ b/src/test/function_test/test_bulk_load.cpp
@@ -303,7 +303,6 @@ TEST_F(bulk_load_test, bulk_load_ingest_behind_tests)
     // app envs allow_ingest_behind = false, request ingest_behind = true
     ASSERT_EQ(start_bulk_load(true), ERR_INCONSISTENT_STATE);
 
-    // update app allow_
     update_allow_ingest_behind("true");
 
     // write old data


### PR DESCRIPTION
As apache/incubator-pegasus#851 show, we decide to support online migration.

This pull request support it for pegasus, including:
1. Parse `allow_ingest_behind` from app->envs, and set rocksdb `allow_ingest_behind`, reference function `start` and function `update_allow_ingest_behind`.
2. Support `ingest_behind` for ingestion, reference `ingest_files` functions.
3. Update start_bulk_load cmd to support `ingest_behind`
4. Add bulk_load_ingest_behind function test