### PR TITLE
fix: adapt query_bulk_load_response is_bulk_loading filed optional

### DIFF
--- a/src/shell/commands/bulk_load.cpp
+++ b/src/shell/commands/bulk_load.cpp
@@ -403,7 +403,8 @@ bool query_bulk_load_status(command_executor *e, shell_context *sc, arguments ar
         tp_summary.add_row_name_and_data("partition_bulk_load_status",
                                          get_short_status(resp.partitions_status[pidx]));
     }
-    tp_summary.add_row_name_and_data("is_bulk_loading", resp.is_bulk_loading ? "YES" : "NO");
+    bool is_bulk_loading = resp.__isset.is_bulk_loading ? resp.is_bulk_loading : false;
+    tp_summary.add_row_name_and_data("is_bulk_loading", is_bulk_loading ? "YES" : "NO");
     tp_summary.add_row_name_and_data("app_bulk_load_status", get_short_status(resp.app_status));
     if (bulk_load_status::BLS_FAILED == resp.app_status) {
         tp_summary.add_row_name_and_data("bulk_load_err", resp.err.to_string());


### PR DESCRIPTION
https://github.com/XiaoMi/rdsn/pull/1009 updates `is_bulk_loading` filed of `query_bulk_load_response` optional to support #856. 

This pull request adapt it in shell command.