### PR TITLE
feat(op_status_lock): adapt to the modification in rdsn

### DIFF
--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -117,6 +117,8 @@ bool cc_command(command_executor *e, shell_context *sc, arguments args);
 
 bool query_cluster_info(command_executor *e, shell_context *sc, arguments args);
 
+bool unlock_meta_op_status(command_executor *e, shell_context *sc, arguments args);
+
 bool ls_nodes(command_executor *e, shell_context *sc, arguments args);
 
 bool server_info(command_executor *e, shell_context *sc, arguments args);

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -59,6 +59,15 @@ bool query_cluster_info(command_executor *e, shell_context *sc, arguments args)
     return true;
 }
 
+bool unlock_meta_op_status(command_executor *e, shell_context *sc, arguments args)
+{
+    ::dsn::error_code err = sc->ddl_client->unlock_meta_op_status();
+    if (err != ::dsn::ERR_OK) {
+        std::cout << "unlock meta op status failed, error=" << err.to_string() << std::endl;
+    }
+    return true;
+}
+
 bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
 {
     static struct option long_options[] = {{"detailed", no_argument, 0, 'd'},

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -494,6 +494,12 @@ static command_executor commands[] = {
         detect_hotkey,
     },
     {
+        "unlock_meta_op_status",
+        "set op_status of meta to FREE",
+        "",
+        unlock_meta_op_status,
+    },
+    {
         "exit", "exit shell", "", exit_shell,
     },
     {


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/845

Adapt to the modification in rdsn(https://github.com/XiaoMi/rdsn/pull/1014), add a new command to Pegasus shell: "unlock_meta_op_status"