### PR TITLE
fix(bulk_load): add ballot check before executing ingestion

### DIFF
--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -390,7 +390,7 @@ int pegasus_write_service::ingest_files(int64_t decree,
     // ingest files asynchronously
     _server->set_ingestion_status(dsn::replication::ingestion_status::IS_RUNNING);
     dsn::tasking::enqueue(LPC_INGESTION, &_server->_tracker, [this, decree, req]() {
-        dsn::error_code err =
+        const auto &err =
             _impl->ingest_files(decree, _server->bulk_load_dir(), req, _server->get_ballot());
         auto status = dsn::replication::ingestion_status::IS_SUCCEED;
         if (err == dsn::ERR_INVALID_VERSION) {

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -502,7 +502,7 @@ public:
 
         // verify external files before ingestion
         std::vector<std::string> sst_file_list;
-        dsn::error_code err = get_external_files_path(bulk_load_dir, req.metadata, sst_file_list);
+        const auto &err = get_external_files_path(bulk_load_dir, req.metadata, sst_file_list);
         if (err != dsn::ERR_OK) {
             return err;
         }


### PR DESCRIPTION
As #877 shows, move files during ingestion will speech up ingestion and decrease disk write throughput. (#864)

However, it exposes that in some error handling cases, it is possible to execute an out-dated ingestion request repeated.

In previous copy_files mode, it won't have problems, just ingest files repeatly, now is move_files mode, once ingestion is succeed, the original files doesn't exist, which will lead to unexpected ingestion failed.

This pull request adds ballot check before executing ingestion request.
