### PR TITLE
feat: Using multi_set in shell tool to speedup data copy

### DIFF
--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -1814,6 +1814,9 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
     if (is_geo_data) {
         op = SCAN_GEN_GEO;
     } else if (use_multi_set) {
+        fprintf(stderr,
+                "WARN: used multi_set will lose accurate ttl time per value! "
+                "ttl time will be assign the max value of this batch data.\n");
         op = SCAN_AND_MULTI_SET;
         // threadpool worker_count should greater than source app scanner count
         int worker_count = dsn_config_get_value_int64("threadpool.THREAD_POOL_DEFAULT",

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -1694,8 +1694,8 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
         return false;
     }
 
-    if (max_multi_set_concurrency < 1) {
-        fprintf(stderr, "ERROR: max_multi_set_concurrency should be greater than 1\n");
+    if (max_multi_set_concurrency <= 0) {
+        fprintf(stderr, "ERROR: max_multi_set_concurrency should be greater than 0\n");
         return false;
     }
 

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -1538,6 +1538,7 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
                                            {"sort_key_filter_pattern", required_argument, 0, 'y'},
                                            {"value_filter_type", required_argument, 0, 'v'},
                                            {"value_filter_pattern", required_argument, 0, 'z'},
+                                           {"max_multi_set_concurrency", required_argument, 0, 'm'},
                                            {"no_overwrite", no_argument, 0, 'n'},
                                            {"no_value", no_argument, 0, 'i'},
                                            {"geo_data", no_argument, 0, 'g'},
@@ -1549,9 +1550,11 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
     std::string target_geo_app_name;
     int32_t partition = -1;
     int max_batch_count = 500;
+    int max_multi_set_concurrency = 20;
     int timeout_ms = sc->timeout_ms;
     bool is_geo_data = false;
     bool no_overwrite = false;
+    bool use_multi_set = false;
     std::string hash_key_filter_type_name("no_filter");
     std::string sort_key_filter_type_name("no_filter");
     pegasus::pegasus_client::filter_type sort_key_filter_type =
@@ -1568,7 +1571,7 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
         int option_index = 0;
         int c;
         c = getopt_long(
-            args.argc, args.argv, "c:a:p:b:t:h:x:s:y:v:z:nige", long_options, &option_index);
+            args.argc, args.argv, "c:a:p:b:t:h:x:s:y:v:z:m:o:nigeu", long_options, &option_index);
         if (c == -1)
             break;
         switch (c) {
@@ -1634,6 +1637,18 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
         case 'z':
             value_filter_pattern = unescape_str(optarg);
             break;
+        case 'm':
+            if (!dsn::buf2int32(optarg, max_multi_set_concurrency)) {
+                fprintf(stderr, "ERROR: parse %s as max_multi_set_concurrency failed\n", optarg);
+                return false;
+            }
+            break;
+        case 'o':
+            if (!dsn::buf2int32(optarg, options.batch_size)) {
+                fprintf(stderr, "ERROR: parse %s as scan_option_batch_size failed\n", optarg);
+                return false;
+            }
+            break;
         case 'n':
             no_overwrite = true;
             break;
@@ -1645,6 +1660,9 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
             break;
         case 'e':
             options.return_expire_ts = false;
+            break;
+        case 'u':
+            use_multi_set = true;
             break;
         default:
             return false;
@@ -1676,12 +1694,27 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
         return false;
     }
 
+    if (max_multi_set_concurrency < 1) {
+        fprintf(stderr, "ERROR: max_multi_set_concurrency should be greater than 1\n");
+        return false;
+    }
+
+    if (use_multi_set && no_overwrite) {
+        fprintf(stderr, "ERROR: copy with multi_set not support no_overwrite!\n");
+        return false;
+    }
+
     fprintf(stderr, "INFO: source_cluster_name = %s\n", sc->pg_client->get_cluster_name());
     fprintf(stderr, "INFO: source_app_name = %s\n", sc->pg_client->get_app_name());
     fprintf(stderr, "INFO: target_cluster_name = %s\n", target_cluster_name.c_str());
     fprintf(stderr, "INFO: target_app_name = %s\n", target_app_name.c_str());
     if (is_geo_data) {
         fprintf(stderr, "INFO: target_geo_app_name = %s\n", target_geo_app_name.c_str());
+    }
+    if (use_multi_set) {
+        fprintf(stderr,
+                "INFO: copy use asyncer_multi_set, max_multi_set_concurrency = %d\n",
+                max_multi_set_concurrency);
     }
     fprintf(stderr,
             "INFO: partition = %s\n",
@@ -1776,21 +1809,47 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
 
     std::atomic_bool error_occurred(false);
     std::vector<std::unique_ptr<scan_data_context>> contexts;
+
+    scan_data_operator op = SCAN_COPY;
+    if (is_geo_data) {
+        op = SCAN_GEN_GEO;
+    } else if (use_multi_set) {
+        op = SCAN_AND_MULTI_SET;
+        // threadpool worker_count should greater than source app scanner count
+        int worker_count = dsn_config_get_value_int64("threadpool.THREAD_POOL_DEFAULT",
+                                                      "worker_count",
+                                                      0,
+                                                      "get THREAD_POOL_DEFAULT worker_count.");
+        fprintf(stderr, "INFO: THREAD_POOL_DEFAULT worker_count = %d\n", worker_count);
+        if (worker_count <= split_count) {
+            fprintf(stderr,
+                    "INFO: THREAD_POOL_DEFAULT worker_count should greater than source app scanner "
+                    "count %d",
+                    split_count);
+            return true;
+        }
+    }
+
     for (int i = 0; i < split_count; i++) {
-        scan_data_context *context = new scan_data_context(is_geo_data ? SCAN_GEN_GEO : SCAN_COPY,
+        scan_data_context *context = new scan_data_context(op,
                                                            i,
                                                            max_batch_count,
                                                            timeout_ms,
                                                            scanners[i],
                                                            target_client,
                                                            target_geo_client.get(),
-                                                           &error_occurred);
+                                                           &error_occurred,
+                                                           max_multi_set_concurrency);
         context->set_sort_key_filter(sort_key_filter_type, sort_key_filter_pattern);
         context->set_value_filter(value_filter_type, value_filter_pattern);
         if (no_overwrite)
             context->set_no_overwrite();
         contexts.emplace_back(context);
-        dsn::tasking::enqueue(LPC_SCAN_DATA, nullptr, std::bind(scan_data_next, context));
+        if (op == SCAN_AND_MULTI_SET) {
+            dsn::tasking::enqueue(LPC_SCAN_DATA, nullptr, std::bind(scan_multi_data_next, context));
+        } else {
+            dsn::tasking::enqueue(LPC_SCAN_DATA, nullptr, std::bind(scan_data_next, context));
+        }
     }
 
     // wait thread complete
@@ -1803,8 +1862,11 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
         long cur_total_rows = 0;
         for (int i = 0; i < split_count; i++) {
             cur_total_rows += contexts[i]->split_rows.load();
-            if (contexts[i]->split_request_count.load() == 0)
+            if (op != SCAN_AND_MULTI_SET && contexts[i]->split_request_count.load() == 0) {
                 completed_split_count++;
+            } else if (contexts[i]->split_completed.load()) {
+                completed_split_count++;
+            }
         }
         if (error_occurred.load()) {
             fprintf(stderr,
@@ -2370,6 +2432,7 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
                                                            sc->pg_client,
                                                            nullptr,
                                                            &error_occurred,
+                                                           0,
                                                            stat_size,
                                                            statistics,
                                                            top_count,

--- a/src/shell/config.ini
+++ b/src/shell/config.ini
@@ -49,7 +49,7 @@ worker_priority = THREAD_xPRIORITY_NORMAL
 
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
-worker_count = 8
+worker_count = 20
 
 [threadpool.THREAD_POOL_META_SERVER]
 name = meta_server

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -275,9 +275,9 @@ static command_executor commands[] = {
         "[-s|--sort_key_filter_type anywhere|prefix|postfix|exact] "
         "[-y|--sort_key_filter_pattern str] "
         "[-v|--value_filter_type anywhere|prefix|postfix|exact] "
-        "[-z|--value_filter_pattern str] "
-        "[-n|--no_overwrite] [-i|--no_value] [-g|--geo_data] "
-        "[-e|--no_ttl]",
+        "[-z|--value_filter_pattern str] [-m|--max_multi_set_concurrency] "
+        "[-o|--scan_option_batch_size] [-e|--no_ttl] "
+        "[-n|--no_overwrite] [-i|--no_value] [-g|--geo_data] [-u|--use_multi_set]",
         data_operations,
     },
     {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/923
pegasus_shell copy_data use async_set write now, I want use async_multi_set improve speed sometimes

### What is changed and how does it work?
You can use pegasus_shell exec "copy_data -c cluster_name -a app_name -u"  for it

### The performance tests between async_set and async_multi_set for copy_data:
The same row show different cost from copy the same table to a new empty table. 
|  total_data_count   | row data pre hash_key | async_set (secs) | async_multi_set (secs)  |
|  ----  | ----  |----  | ----  |
| 152,354 | 1   | 8 | 16 |
| 417,408 | 4   | 29 | 11 |
| 657,950 | 50   | 32 | 9 |
| 2,079,400 | 200   | 87 | 18 |
| 1,842,400 | 800   | 399 | 19 |
| 14,374,001 | 2,000   | 631 | 131 |

You should use async_multi_set for copy when your data have multi count per hash_key.



