### PR TITLE
fix(dup_enhancement#22): change batch send config by using rdsn config value

### DIFF
--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -208,11 +208,11 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
             batch_bytes += raw_message.length();
         }
 
-        // since all the plog's mutations of replica belong to same gpid though the hash of
-        // mutation is different, use the last mutation of one batch to get and represents the
-        // current hash value, it will still send to remote correct replica
         if (batch_count == muts.size() ||
             batch_bytes >= dsn::replication::FLAGS_duplicate_log_batch_bytes) {
+            // since all the plog's mutations of replica belong to same gpid though the hash of
+            // mutation is different, use the last mutation of one batch to get and represents the
+            // current hash value, it will still send to remote correct replica
             uint64_t hash = get_hash_from_request(rpc_code, raw_message);
             duplicate_rpc rpc(std::move(batch_request),
                               dsn::apps::RPC_RRDB_RRDB_DUPLICATE,

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -41,10 +41,6 @@ namespace replication {
 namespace pegasus {
 namespace server {
 
-dsn::perf_counter_wrapper _shipping_batch_count;
-dsn::perf_counter_wrapper _shipping_batch_bytes;
-dsn::perf_counter_wrapper _shipping_total_count;
-
 using namespace dsn::literals::chrono_literals;
 
 /*extern*/ uint64_t get_hash_from_request(dsn::task_code tc, const dsn::blob &data)
@@ -78,28 +74,6 @@ pegasus_mutation_duplicator::pegasus_mutation_duplicator(dsn::replication::repli
                                                          dsn::string_view app)
     : mutation_duplicator(r), _remote_cluster(remote_cluster)
 {
-    static std::once_flag flag;
-    std::call_once(flag, [&]() {
-        _shipping_total_count.init_app_counter(
-            "app.pegasus",
-            "dup_ship_total",
-            COUNTER_TYPE_NUMBER_PERCENTILES,
-            "the time (in ms) lag between master and slave in the duplication");
-
-        _shipping_batch_count.init_app_counter(
-            "app.pegasus",
-            "dup_ship_count",
-            COUNTER_TYPE_NUMBER_PERCENTILES,
-            "the time (in ms) lag between master and slave in the duplication");
-
-        _shipping_batch_bytes.init_app_counter(
-            "app.pegasus",
-            "dup_ship_bytes",
-            COUNTER_TYPE_NUMBER_PERCENTILES,
-            "the time (in ms) lag between master and slave in the duplication");
-
-    });
-
     // initialize pegasus-client when this class is first time used.
     static __attribute__((unused)) bool _dummy = pegasus_client_factory::initialize(nullptr);
 

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -238,7 +238,7 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
         // mutation is different, use the last mutation of one batch to get and represents the
         // current hash value, it will still send to remote correct replica
         if (batch_count == muts.size() ||
-            batch_bytes >= (dsn::replication::FLAGS_duplicate_log_batch_kilobytes << 10)) {
+            batch_bytes >= dsn::replication::FLAGS_duplicate_log_batch_bytes) {
             uint64_t hash = get_hash_from_request(rpc_code, raw_message);
             duplicate_rpc rpc(std::move(batch_request),
                               dsn::apps::RPC_RRDB_RRDB_DUPLICATE,

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -216,8 +216,10 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
     _total_shipped_size = 0;
 
     auto batch_request = dsn::make_unique<dsn::apps::duplicate_request>();
+    auto batch_count = 0;
     for (auto mut : muts) {
         // mut: 0=timestamp, 1=rpc_code, 2=raw_message
+        batch_count++;
         dsn::task_code rpc_code = std::get<1>(mut);
         dsn::blob raw_message = std::get<2>(mut);
         auto dreq = dsn::make_unique<dsn::apps::duplicate_request>();
@@ -239,13 +241,15 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
         // since all the plog's mutations of replica belong to same gpid though the hash of
         // mutation is different, use the last mutation of one batch to get and represents the
         // current hash value, it will still send to remote correct replica
-        uint64_t hash = get_hash_from_request(rpc_code, raw_message);
-        duplicate_rpc rpc(std::move(batch_request),
-                          dsn::apps::RPC_RRDB_RRDB_DUPLICATE,
-                          100_s, // TODO(wutao1): configurable timeout.
-                          hash);
-        _inflights[hash].push_back(std::move(rpc));
-        batch_request = dsn::make_unique<dsn::apps::duplicate_request>();
+        if (batch_count == muts.size()) {
+            uint64_t hash = get_hash_from_request(rpc_code, raw_message);
+            duplicate_rpc rpc(std::move(batch_request),
+                              dsn::apps::RPC_RRDB_RRDB_DUPLICATE,
+                              100_s, // TODO(wutao1): configurable timeout.
+                              hash);
+            _inflights[hash].push_back(std::move(rpc));
+            batch_request = dsn::make_unique<dsn::apps::duplicate_request>();
+        }
     }
 
     if (_inflights.empty()) {

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -23,7 +23,6 @@
 
 #include <dsn/cpp/message_utils.h>
 #include <dsn/utility/chrono_literals.h>
-#include <dsn/dist/replication/duplication_common.h>
 #include <rrdb/rrdb.client.h>
 
 namespace dsn {
@@ -45,11 +44,6 @@ namespace server {
 dsn::perf_counter_wrapper _shipping_batch_count;
 dsn::perf_counter_wrapper _shipping_batch_bytes;
 dsn::perf_counter_wrapper _shipping_total_count;
-
-DSN_DEFINE_uint32("pegasus.server",
-                  duplicate_log_batch_kilobytes,
-                  100,
-                  "send mutation log batch KB size per rpc");
 
 using namespace dsn::literals::chrono_literals;
 
@@ -216,7 +210,8 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
     _total_shipped_size = 0;
 
     auto batch_request = dsn::make_unique<dsn::apps::duplicate_request>();
-    auto batch_count = 0;
+    uint batch_count = 0;
+    uint batch_bytes = 0;
     for (auto mut : muts) {
         // mut: 0=timestamp, 1=rpc_code, 2=raw_message
         batch_count++;
@@ -236,12 +231,14 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
             entry.__set_timestamp(std::get<0>(mut));
             entry.__set_cluster_id(get_current_cluster_id());
             batch_request->entries.emplace_back(std::move(entry));
+            batch_bytes += raw_message.length();
         }
 
         // since all the plog's mutations of replica belong to same gpid though the hash of
         // mutation is different, use the last mutation of one batch to get and represents the
         // current hash value, it will still send to remote correct replica
-        if (batch_count == muts.size()) {
+        if (batch_count == muts.size() ||
+            batch_bytes >= (dsn::replication::FLAGS_duplicate_log_batch_kilobytes < 10)) {
             uint64_t hash = get_hash_from_request(rpc_code, raw_message);
             duplicate_rpc rpc(std::move(batch_request),
                               dsn::apps::RPC_RRDB_RRDB_DUPLICATE,
@@ -249,6 +246,7 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
                               hash);
             _inflights[hash].push_back(std::move(rpc));
             batch_request = dsn::make_unique<dsn::apps::duplicate_request>();
+            batch_bytes = 0;
         }
     }
 

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -47,9 +47,9 @@ dsn::perf_counter_wrapper _shipping_batch_bytes;
 dsn::perf_counter_wrapper _shipping_total_count;
 
 DSN_DEFINE_uint32("pegasus",
-                  duplicate_log_batch_megabytes,
-                  4,
-                  "send mutation log batch size per rpc");
+                  duplicate_log_batch_kilobytes,
+                  500,
+                  "send mutation log batch KB size per rpc");
 
 using namespace dsn::literals::chrono_literals;
 
@@ -243,7 +243,7 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
             batch_bytes += raw_message.length();
         }
 
-        if (batch_bytes >= (FLAGS_duplicate_log_batch_megabytes << 20) ||
+        if (batch_bytes >= (FLAGS_duplicate_log_batch_kilobytes << 10) ||
             cur_count == muts.size()) {
             _shipping_batch_count->set(cur_count);
             _shipping_batch_bytes->set(batch_bytes);

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -238,7 +238,7 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
         // mutation is different, use the last mutation of one batch to get and represents the
         // current hash value, it will still send to remote correct replica
         if (batch_count == muts.size() ||
-            batch_bytes >= (dsn::replication::FLAGS_duplicate_log_batch_kilobytes < 10)) {
+            batch_bytes >= (dsn::replication::FLAGS_duplicate_log_batch_kilobytes << 10)) {
             uint64_t hash = get_hash_from_request(rpc_code, raw_message);
             duplicate_rpc rpc(std::move(batch_request),
                               dsn::apps::RPC_RRDB_RRDB_DUPLICATE,

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -42,10 +42,9 @@ namespace replication {
 namespace pegasus {
 namespace server {
 
-    dsn::perf_counter_wrapper _shipping_batch_count;
-    dsn::perf_counter_wrapper _shipping_batch_bytes;
-    dsn::perf_counter_wrapper _shipping_total_count;
-
+dsn::perf_counter_wrapper _shipping_batch_count;
+dsn::perf_counter_wrapper _shipping_batch_bytes;
+dsn::perf_counter_wrapper _shipping_total_count;
 
 DSN_DEFINE_uint32("pegasus",
                   duplicate_log_batch_megabytes,
@@ -88,22 +87,22 @@ pegasus_mutation_duplicator::pegasus_mutation_duplicator(dsn::replication::repli
     static std::once_flag flag;
     std::call_once(flag, [&]() {
         _shipping_total_count.init_app_counter(
-                "app.pegasus",
-                "dup_ship_total",
-                COUNTER_TYPE_NUMBER_PERCENTILES,
-                "the time (in ms) lag between master and slave in the duplication");
+            "app.pegasus",
+            "dup_ship_total",
+            COUNTER_TYPE_NUMBER_PERCENTILES,
+            "the time (in ms) lag between master and slave in the duplication");
 
         _shipping_batch_count.init_app_counter(
-                "app.pegasus",
-                "dup_ship_count",
-                COUNTER_TYPE_NUMBER_PERCENTILES,
-                "the time (in ms) lag between master and slave in the duplication");
+            "app.pegasus",
+            "dup_ship_count",
+            COUNTER_TYPE_NUMBER_PERCENTILES,
+            "the time (in ms) lag between master and slave in the duplication");
 
         _shipping_batch_bytes.init_app_counter(
-                "app.pegasus",
-                "dup_ship_bytes",
-                COUNTER_TYPE_NUMBER_PERCENTILES,
-                "the time (in ms) lag between master and slave in the duplication");
+            "app.pegasus",
+            "dup_ship_bytes",
+            COUNTER_TYPE_NUMBER_PERCENTILES,
+            "the time (in ms) lag between master and slave in the duplication");
 
     });
 
@@ -220,7 +219,7 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
     uint batch_bytes = 0;
     int cur_count = 0;
 
-    _shipping_total_count->add(muts.size());
+    _shipping_total_count->set(muts.size());
     for (auto mut : muts) {
         // mut: 0=timestamp, 1=rpc_code, 2=raw_message
 
@@ -246,8 +245,8 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
 
         if (batch_bytes >= (FLAGS_duplicate_log_batch_megabytes << 20) ||
             cur_count == muts.size()) {
-            _shipping_batch_count->add(cur_count);
-            _shipping_batch_bytes->add(batch_bytes);
+            _shipping_batch_count->set(cur_count);
+            _shipping_batch_bytes->set(batch_bytes);
             // since all the plog's mutations of replica belong to same gpid though the hash of
             // mutation is different, use the last mutation of one batch to get and represents the
             // current hash value, it will still send to remote correct replica

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -46,9 +46,9 @@ dsn::perf_counter_wrapper _shipping_batch_count;
 dsn::perf_counter_wrapper _shipping_batch_bytes;
 dsn::perf_counter_wrapper _shipping_total_count;
 
-DSN_DEFINE_uint32("pegasus",
+DSN_DEFINE_uint32("pegasus.server",
                   duplicate_log_batch_kilobytes,
-                  500,
+                  100,
                   "send mutation log batch KB size per rpc");
 
 using namespace dsn::literals::chrono_literals;

--- a/src/server/pegasus_mutation_duplicator.h
+++ b/src/server/pegasus_mutation_duplicator.h
@@ -23,12 +23,12 @@
 #include <dsn/dist/replication/replica_base.h>
 #include <rrdb/rrdb.code.definition.h>
 #include <dsn/utility/flags.h>
+#include <dsn/dist/replication/duplication_common.h>
 
 #include "client_lib/pegasus_client_factory_impl.h"
 
 namespace pegasus {
 namespace server {
-DSN_DECLARE_uint32(duplicate_log_batch_kilobytes);
 
 using namespace dsn::literals::chrono_literals;
 

--- a/src/server/pegasus_mutation_duplicator.h
+++ b/src/server/pegasus_mutation_duplicator.h
@@ -28,7 +28,7 @@
 
 namespace pegasus {
 namespace server {
-DSN_DECLARE_uint32(duplicate_log_batch_megabytes);
+DSN_DECLARE_uint32(duplicate_log_batch_kilobytes);
 
 using namespace dsn::literals::chrono_literals;
 

--- a/src/server/test/pegasus_mutation_duplicator_test.cpp
+++ b/src/server/test/pegasus_mutation_duplicator_test.cpp
@@ -70,7 +70,7 @@ public:
             muts.insert(std::make_tuple(ts, code, data));
             total_bytes += data.length();
         }
-        auto batch_count = total_bytes / (FLAGS_duplicate_log_batch_megabytes << 20) + 1;
+        auto batch_count = total_bytes / (FLAGS_duplicate_log_batch_kilobytes << 20) + 1;
 
         size_t total_shipped_size = 0;
         auto duplicator_impl = dynamic_cast<pegasus_mutation_duplicator *>(duplicator.get());
@@ -134,7 +134,7 @@ public:
             muts.insert(std::make_tuple(ts, code, data));
             total_bytes += data.length();
         }
-        auto batch_count = total_bytes / (FLAGS_duplicate_log_batch_megabytes << 20) + 1;
+        auto batch_count = total_bytes / (FLAGS_duplicate_log_batch_kilobytes << 20) + 1;
 
         auto duplicator_impl = dynamic_cast<pegasus_mutation_duplicator *>(duplicator.get());
         RPC_MOCKING(duplicate_rpc)
@@ -206,7 +206,7 @@ public:
             muts.insert(std::make_tuple(ts, code, data));
             total_bytes += data.length();
         }
-        auto batch_count = total_bytes / (FLAGS_duplicate_log_batch_megabytes << 20) + 1;
+        auto batch_count = total_bytes / (FLAGS_duplicate_log_batch_kilobytes << 20) + 1;
 
         auto duplicator_impl = dynamic_cast<pegasus_mutation_duplicator *>(duplicator.get());
         RPC_MOCKING(duplicate_rpc)

--- a/src/server/test/pegasus_mutation_duplicator_test.cpp
+++ b/src/server/test/pegasus_mutation_duplicator_test.cpp
@@ -70,7 +70,7 @@ public:
             muts.insert(std::make_tuple(ts, code, data));
             total_bytes += data.length();
         }
-        auto batch_count = total_bytes / (FLAGS_duplicate_log_batch_kilobytes << 20) + 1;
+        auto batch_count = total_bytes / FLAGS_duplicate_log_batch_bytes + 1;
 
         size_t total_shipped_size = 0;
         auto duplicator_impl = dynamic_cast<pegasus_mutation_duplicator *>(duplicator.get());
@@ -134,7 +134,7 @@ public:
             muts.insert(std::make_tuple(ts, code, data));
             total_bytes += data.length();
         }
-        auto batch_count = total_bytes / (FLAGS_duplicate_log_batch_kilobytes << 20) + 1;
+        auto batch_count = total_bytes / FLAGS_duplicate_log_batch_bytes + 1;
 
         auto duplicator_impl = dynamic_cast<pegasus_mutation_duplicator *>(duplicator.get());
         RPC_MOCKING(duplicate_rpc)
@@ -206,7 +206,7 @@ public:
             muts.insert(std::make_tuple(ts, code, data));
             total_bytes += data.length();
         }
-        auto batch_count = total_bytes / (FLAGS_duplicate_log_batch_kilobytes << 20) + 1;
+        auto batch_count = total_bytes / FLAGS_duplicate_log_batch_bytes + 1;
 
         auto duplicator_impl = dynamic_cast<pegasus_mutation_duplicator *>(duplicator.get());
         RPC_MOCKING(duplicate_rpc)

--- a/src/server/test/pegasus_mutation_duplicator_test.cpp
+++ b/src/server/test/pegasus_mutation_duplicator_test.cpp
@@ -57,7 +57,8 @@ public:
 
         mutation_tuple_set muts;
         uint total_bytes = 0;
-        for (uint64_t i = 0; i < 4000; i++) {
+        uint batch_count = 0;
+        for (uint64_t i = 0; i < 400; i++) {
             uint64_t ts = 200 + i;
             dsn::task_code code = dsn::apps::RPC_RRDB_RRDB_PUT;
 
@@ -69,8 +70,12 @@ public:
 
             muts.insert(std::make_tuple(ts, code, data));
             total_bytes += data.length();
+
+            if (total_bytes >= FLAGS_duplicate_log_batch_bytes) {
+                batch_count++;
+                total_bytes = 0;
+            }
         }
-        auto batch_count = total_bytes / FLAGS_duplicate_log_batch_bytes + 1;
 
         size_t total_shipped_size = 0;
         auto duplicator_impl = dynamic_cast<pegasus_mutation_duplicator *>(duplicator.get());
@@ -121,7 +126,8 @@ public:
 
         mutation_tuple_set muts;
         uint total_bytes = 0;
-        for (uint64_t i = 0; i < 4000; i++) {
+        uint batch_count = 0;
+        for (uint64_t i = 0; i < 400; i++) {
             uint64_t ts = 200 + i;
             dsn::task_code code = dsn::apps::RPC_RRDB_RRDB_PUT;
 
@@ -133,8 +139,12 @@ public:
 
             muts.insert(std::make_tuple(ts, code, data));
             total_bytes += data.length();
+
+            if (total_bytes >= FLAGS_duplicate_log_batch_bytes) {
+                batch_count++;
+                total_bytes = 0;
+            }
         }
-        auto batch_count = total_bytes / FLAGS_duplicate_log_batch_bytes + 1;
 
         auto duplicator_impl = dynamic_cast<pegasus_mutation_duplicator *>(duplicator.get());
         RPC_MOCKING(duplicate_rpc)
@@ -193,6 +203,7 @@ public:
 
         mutation_tuple_set muts;
         uint total_bytes = 0;
+        uint batch_count = 0;
         for (uint64_t i = 0; i < total_size; i++) {
             uint64_t ts = 200 + i;
             dsn::task_code code = dsn::apps::RPC_RRDB_RRDB_PUT;
@@ -205,8 +216,12 @@ public:
 
             muts.insert(std::make_tuple(ts, code, data));
             total_bytes += data.length();
+
+            if (total_bytes >= FLAGS_duplicate_log_batch_bytes) {
+                batch_count++;
+                total_bytes = 0;
+            }
         }
-        auto batch_count = total_bytes / FLAGS_duplicate_log_batch_bytes + 1;
 
         auto duplicator_impl = dynamic_cast<pegasus_mutation_duplicator *>(duplicator.get());
         RPC_MOCKING(duplicate_rpc)

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -449,6 +449,7 @@ static command_executor commands[] = {
         "[-s|--skip_prompt] [-o|--output file_name]",
         ddd_diagnose,
     },
+    // todo(jiashuo1) [-f|--freezed] is Deprecated, it will be removed later
     {"add_dup", "add duplication", "<app_name> <remote_cluster_name> [-f|--freezed]", add_dup},
     {"query_dup", "query duplication info", "<app_name> [-d|--detail]", query_dup},
     {"remove_dup", "remove duplication", "<app_name> <dup_id>", remove_dup},


### PR DESCRIPTION
# Ref-Issue
https://github.com/apache/incubator-pegasus/issues/892

# Change
In test, batch send not need `MB`, `bytes` is ok.
```diff
[pegasus.server]
- duplicate_log_batch_megabytes = 4MB
[replication]
+ duplicate_log_batch_bytes = 4096
```

# Note
This pr need be merged after https://github.com/XiaoMi/rdsn/pull/1080 merged