### PR TITLE
fix: update issue-ref github action title format

### DIFF
--- a/.github/workflows/ci-pull-request-issue.yaml
+++ b/.github/workflows/ci-pull-request-issue.yaml
@@ -33,6 +33,5 @@ jobs:
         uses: neofinancial/ticket-check-action@v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ticketPrefix: '#'
           titleFormat: '%title%'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/apache)(\/incubator-pegasus)(\/issues)\/\d+'

--- a/.github/workflows/ci-pull-request-issue.yaml
+++ b/.github/workflows/ci-pull-request-issue.yaml
@@ -34,4 +34,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           titleFormat: '%title%'
+          quiet: true
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/apache)(\/incubator-pegasus)(\/issues)\/\d+'

--- a/.github/workflows/ci-pull-request-issue.yaml
+++ b/.github/workflows/ci-pull-request-issue.yaml
@@ -34,4 +34,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketPrefix: '#'
+          titleFormat: '%title%'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/apache)(\/incubator-pegasus)(\/issues)\/\d+'


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/869 add `issue-ref required`, but it will auto-update the title when request merge new branch of `https://github.com/apache/incubator-pegasus` to master and left bot comment. This pr fix it.

Note: if your pr is from your own repository, it will not trigger this problem