### PR TITLE
refactor: make the script support different cluster version

### DIFF
--- a/scripts/pegasus_add_node_list.sh
+++ b/scripts/pegasus_add_node_list.sh
@@ -22,7 +22,7 @@
 PID=$$
 
 if [ $# -le 2 ]; then
-  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list> <nfs_rate_megabytes_per_disk>(default 100)"
+  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <replica-task-id-list> <nfs_rate_megabytes>(default 100)"
   echo
   echo "For example:"
   echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602 1,2,3 100"
@@ -41,9 +41,9 @@ meta_list=$2
 replica_task_id_list=$3
 
 if [ -z $4 ]; then
-  nfs_rate_megabytes_per_disk=100
+  nfs_rate_megabytes=100
 else
-  nfs_rate_megabytes_per_disk=$4
+  nfs_rate_megabytes=$4
 fi
 
 pwd="$( cd "$( dirname "$0"  )" && pwd )"
@@ -52,6 +52,9 @@ cd $shell_dir
 
 echo "Check the argument..."
 source ./scripts/pegasus_check_arguments.sh add_node_list $cluster $meta_list $replica_task_id_list
+
+echo "Check the cluster version..."
+source ./scripts/pegasus_command_version.sh $cluster $meta_list
 
 if [ $? -ne 0 ]; then
     echo "ERROR: the argument check failed"
@@ -77,7 +80,7 @@ do
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 done
 
-./scripts/pegasus_rebalance_cluster.sh $cluster $meta_list true $nfs_rate_megabytes_per_disk
+./scripts/pegasus_rebalance_cluster.sh $cluster $meta_list true $nfs_rate_megabytes
 
 echo "Finish time: `date`"
 add_node_finish_time=$((`date +%s`))

--- a/scripts/pegasus_command_version.sh
+++ b/scripts/pegasus_command_version.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Check offline_node_list.sh and add_node_list.sh arguments.
+#
+
+
+# different pegasus versions have different remote command, this script init it base version
+PID=$$
+
+if [ $# -le 3 ]; then
+  echo "USAGE: $0 <cluster-name> <cluster-meta-list> <version>"
+  echo
+  echo "init pegasus remote command base version, for example:"
+  echo "  $0 onebox 127.0.0.1:34601,127.0.0.1:34602"
+  echo
+  exit 1
+fi
+
+meta_list=$2
+version=$3
+
+if [ "$version" = "" ]; then
+  echo "check pegasus server version"
+  echo "server_info" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.command.version
+  version=`grep 'Pegasus Server' /tmp/$UID.$PID.pegasus.command.version | head -n 1`
+  if [ "$version" = "" ]; then
+    echo "check pegasus server version failed"
+    exit 1
+  fi
+  echo "current cluster version is $version"
+fi
+
+# list all remote command, default `server-info` that is supported by all version to avoid some version set no supported command and return error
+meta.lb.assign_secondary_black_list="server-info"
+meta.live_percentage="server-info"
+meta.lb.assign_delay_ms="server-info"
+meta.lb.only_move_primary="server-info"
+meta.lb.add_secondary_max_count_for_one_node="server-info"
+
+replica.kill_partition="server-info"
+replica.query-app-envs="server-info"
+replica.query-compact="server-info"
+replica.trigger-checkpoint="server-info"
+
+nfs.max_copy_rate_megabytes="server-info"
+nfs.max_send_rate_megabytes="server-info"
+
+if [[ ($version = ~"1.1.6") || ($version = ~"1.12.2") || ($version = ~"1.12.3") || ($version = ~"2.0.0") || ($version = ~"2.0-write-optm") ]];then
+  meta.lb.assign_secondary_black_list="meta.lb.assign_secondary_black_list"
+  meta.live_percentage="meta.live_percentage"
+  meta.lb.assign_delay_ms="meta.lb.assign_delay_ms"
+  meta.lb.only_move_primary="meta.lb.only_move_primary"
+  meta.lb.add_secondary_max_count_for_one_node="meta.lb.add_secondary_max_count_for_one_node"
+
+  replica.kill_partition="replica.kill_partition"
+  replica.query-app-envs="replica.query-app-envs"
+  replica.query-compact="replica.query-compact"
+  replica.trigger-checkpoint="replica.trigger-checkpoint"
+elif [[ ($version = ~"2.1.1") ]];then
+  meta.lb.assign_secondary_black_list="meta.lb.assign_secondary_black_list"
+  meta.live_percentage="live_percentage"
+  meta.lb.assign_delay_ms="lb.assign_delay_ms"
+  meta.lb.only_move_primary="lb.only_move_primary"
+  meta.lb.add_secondary_max_count_for_one_node="lb.add_secondary_max_count_for_one_node"
+
+  replica.kill_partition="kill_partition"
+  replica.query-app-envs="query-app-envs"
+  replica.query-compact="query-compact"
+  replica.trigger-checkpoint="trigger-checkpoint"
+
+  nfs.max_copy_rate_megabytes="nfs.max_copy_rate_megabytes"
+elif [[ ($version = ~"2.2.1") || ($version = ~"2.2.2") || ($version = ~"2.2.3") ]];then
+  meta.lb.assign_secondary_black_list="meta.lb.assign_secondary_black_list"
+  meta.live_percentage="meta.live_percentage"
+  meta.lb.assign_delay_ms="meta.lb.assign_delay_ms"
+  meta.lb.only_move_primary="meta.lb.only_move_primary"
+  meta.lb.add_secondary_max_count_for_one_node="meta.lb.add_secondary_max_count_for_one_node"
+
+  replica.kill_partition="replica.kill_partition"
+  replica.query-app-envs="replica.query-app-envs"
+  replica.query-compact="replica.query-compact"
+  replica.trigger-checkpoint="replica.trigger-checkpoint"
+
+  nfs.max_copy_rate_megabytes="nfs.max_copy_rate_megabytes"
+elif [[ ($version = ~"2.3.0") || ($version = ~"2.3.1") ]];then
+  meta.lb.assign_secondary_black_list="meta.lb.assign_secondary_black_list"
+  meta.live_percentage="meta.live_percentage"
+  meta.lb.assign_delay_ms="meta.lb.assign_delay_ms"
+  meta.lb.only_move_primary="meta.lb.only_move_primary"
+  meta.lb.add_secondary_max_count_for_one_node="meta.lb.add_secondary_max_count_for_one_node"
+
+  replica.kill_partition="replica.kill_partition"
+  replica.query-app-envs="replica.query-app-envs"
+  replica.query-compact="replica.query-compact"
+  replica.trigger-checkpoint="replica.trigger-checkpoint"
+
+  nfs.max_copy_rate_megabytes="nfs.max_copy_rate_megabytes"
+  nfs.max_send_rate_megabytes="nfs.max_send_rate_megabytes"
+else
+  meta.lb.assign_secondary_black_list="meta.lb.assign_secondary_black_list"
+  meta.live_percentage="meta.live_percentage"
+  meta.lb.assign_delay_ms="meta.lb.assign_delay_ms"
+  meta.lb.only_move_primary="meta.lb.only_move_primary"
+  meta.lb.add_secondary_max_count_for_one_node="meta.lb.add_secondary_max_count_for_one_node"
+
+  replica.kill_partition="replica.kill_partition"
+  replica.query-app-envs="replica.query-app-envs"
+  replica.query-compact="replica.query-compact"
+  replica.trigger-checkpoint="replica.trigger-checkpoint"
+
+  nfs.max_copy_rate_megabytes="nfs.max_copy_rate_megabytes_per_disk"
+  nfs.max_send_rate_megabytes="nfs.max_send_rate_megabytes_per_disk"
+fi
+

--- a/scripts/pegasus_manual_compact.sh
+++ b/scripts/pegasus_manual_compact.sh
@@ -107,7 +107,7 @@ function wait_manual_compact()
     trigger_time=$2
     total_replica_count=$3
 
-    query_cmd="remote_command -t replica-server replica.query-compact ${app_id}"
+    query_cmd="remote_command -t replica-server ${replica.query-compact} ${app_id}"
     earliest_finish_time_ms=$(date -d @${trigger_time} +"%Y-%m-%d %H:%M:%S.000")
     echo "Checking once compact progress since [$trigger_time] [$earliest_finish_time_ms]..."
 
@@ -148,7 +148,7 @@ function create_checkpoint()
 
     echo "Start to create checkpoint..."
     chkpt_log_file="/tmp/$UID.$PID.pegasus.trigger_checkpoint.${app_id}"
-    echo "remote_command -t replica-server replica.trigger-checkpoint ${app_id}" | ./run.sh shell --cluster ${cluster} &>${chkpt_log_file}
+    echo "remote_command -t replica-server ${replica.trigger-checkpoint} ${app_id}" | ./run.sh shell --cluster ${cluster} &>${chkpt_log_file}
     not_found_count=`grep '^    .*not found' ${chkpt_log_file} | wc -l`
     triggered_count=`grep '^    .*triggered' ${chkpt_log_file} | wc -l`
     ignored_count=`grep '^    .*ignored' ${chkpt_log_file} | wc -l`
@@ -222,6 +222,9 @@ if [ "${cluster}" == "" ]; then
     echo "ERROR: invalid cluster: ${cluster}"
     exit 1
 fi
+
+echo "Check the cluster version..."
+source ./scripts/pegasus_command_version.sh "" $cluster
 
 # check app_name
 if [ "${app_name}" == "" ]; then

--- a/scripts/pegasus_offline_node.sh
+++ b/scripts/pegasus_offline_node.sh
@@ -51,6 +51,9 @@ echo "Start time: `date`"
 all_start_time=$((`date +%s`))
 echo
 
+echo "Check the cluster version..."
+source ./scripts/pegasus_command_version.sh $cluster $meta_list
+
 rs_list_file="/tmp/$UID.$PID.pegasus.rolling_update.rs.list"
 echo "Generating $rs_list_file..."
 minos_show_replica $cluster $rs_list_file
@@ -90,7 +93,7 @@ if [ $set_ok -ne 1 ]; then
 fi
 
 echo "Set lb.assign_delay_ms to 10..."
-echo "remote_command -l $pmeta meta.lb.assign_delay_ms 10" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.offline_node.assign_delay_ms
+echo "remote_command -l $pmeta ${meta.lb.assign_delay_ms} 10" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.offline_node.assign_delay_ms
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.offline_node.assign_delay_ms | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.assign_delay_ms to 10 failed"
@@ -159,7 +162,7 @@ do
   while read line2 
   do
     gpid=`echo $line2 | awk '{print $3}' | sed 's/\./ /'`
-    echo "remote_command -l $node replica.kill_partition $gpid" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.offline_node.kill_partition
+    echo "remote_command -l $node ${replica.kill_partition} $gpid" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.offline_node.kill_partition
   done </tmp/$UID.$PID.pegasus.offline_node.downgrade_node.propose
   echo "Sent kill_partition to `cat /tmp/$UID.$PID.pegasus.offline_node.downgrade_node.propose | wc -l` partitions"
   echo
@@ -188,7 +191,7 @@ do
 done <$rs_list_file
 
 echo "Set lb.assign_delay_ms to DEFAULT..."
-echo "remote_command -l $pmeta meta.lb.assign_delay_ms DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.offline_node.assign_delay_ms
+echo "remote_command -l $pmeta ${meta.lb.assign_delay_ms} DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.offline_node.assign_delay_ms
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.offline_node.assign_delay_ms | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.assign_delay_ms to DEFAULT failed"

--- a/scripts/pegasus_restart_node.sh
+++ b/scripts/pegasus_restart_node.sh
@@ -51,6 +51,9 @@ echo "Start time: `date`"
 all_start_time=$((`date +%s`))
 echo
 
+echo "Check the cluster version..."
+source ./scripts/pegasus_command_version.sh $cluster $meta_list
+
 rs_list_file="/tmp/$UID.$PID.pegasus.rolling_update.rs.list"
 echo "Generating $rs_list_file..."
 minos_show_replica $cluster $rs_list_file
@@ -129,7 +132,7 @@ do
   sleep 1
 
   echo "Set lb.add_secondary_max_count_for_one_node to 0..."
-  echo "remote_command -l $pmeta meta.lb.add_secondary_max_count_for_one_node 0" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.restart_node.add_secondary_max_count_for_one_node
+  echo "remote_command -l $pmeta ${meta.lb.add_secondary_max_count_for_one_node} 0" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.restart_node.add_secondary_max_count_for_one_node
   set_ok=`grep OK /tmp/$UID.$PID.pegasus.restart_node.add_secondary_max_count_for_one_node | wc -l`
   if [ $set_ok -ne 1 ]; then
     echo "ERROR: set lb.add_secondary_max_count_for_one_node to 0 failed"
@@ -160,7 +163,7 @@ do
   while read line2 
   do
     gpid=`echo $line2 | awk '{print $3}' | sed 's/\./ /'`
-    echo "remote_command -l $node replica.kill_partition $gpid" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.restart_node.kill_partition
+    echo "remote_command -l $node ${replica.kill_partition} $gpid" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.restart_node.kill_partition
   done </tmp/$UID.$PID.pegasus.restart_node.downgrade_node.propose
   echo "Sent kill_partition to `cat /tmp/$UID.$PID.pegasus.restart_node.downgrade_node.propose | wc -l` partitions"
   echo
@@ -171,7 +174,7 @@ do
   sleep 30
 
   echo "Set lb.add_secondary_max_count_for_one_node to 100..."
-  echo "remote_command -l $pmeta meta.lb.add_secondary_max_count_for_one_node 100" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.restart_node.add_secondary_max_count_for_one_node
+  echo "remote_command -l $pmeta ${meta.lb.add_secondary_max_count_for_one_node} 100" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.restart_node.add_secondary_max_count_for_one_node
   set_ok=`grep OK /tmp/$UID.$PID.pegasus.restart_node.add_secondary_max_count_for_one_node | wc -l`
   if [ $set_ok -ne 1 ]; then
     echo "ERROR: set lb.add_secondary_max_count_for_one_node to 100 failed"
@@ -202,7 +205,7 @@ do
 done <$rs_list_file
 
 echo "Set lb.add_secondary_max_count_for_one_node to DEFAULT..."
-echo "remote_command -l $pmeta meta.lb.add_secondary_max_count_for_one_node DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.restart_node.add_secondary_max_count_for_one_node
+echo "remote_command -l $pmeta ${meta.lb.add_secondary_max_count_for_one_node} DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.restart_node.add_secondary_max_count_for_one_node
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.restart_node.add_secondary_max_count_for_one_node | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.add_secondary_max_count_for_one_node to DEFAULT failed"

--- a/scripts/pegasus_rolling_update.sh
+++ b/scripts/pegasus_rolling_update.sh
@@ -85,6 +85,9 @@ echo "Start time: `date`"
 rolling_start_time=$((`date +%s`))
 echo
 
+echo "Check the cluster version..."
+source ./scripts/pegasus_command_version.sh $cluster $meta_list
+
 rs_list_file="/tmp/$UID.$PID.pegasus.rolling_update.rs.list"
 echo "Generating $rs_list_file..."
 minos_show_replica $cluster $rs_list_file
@@ -124,7 +127,7 @@ if [ $set_ok -ne 1 ]; then
 fi
 
 echo "Set lb.assign_delay_ms to 30min..."
-echo "remote_command -l $pmeta meta.lb.assign_delay_ms 180000000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
+echo "remote_command -l $pmeta ${meta.lb.assign_delay_ms} 180000000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.assign_delay_ms to 30min failed"
@@ -154,7 +157,7 @@ do
   echo
 
   echo "Set lb.add_secondary_max_count_for_one_node to 0..."
-  echo "remote_command -l $pmeta meta.lb.add_secondary_max_count_for_one_node 0" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_update.add_secondary_max_count_for_one_node
+  echo "remote_command -l $pmeta ${meta.lb.add_secondary_max_count_for_one_node} 0" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_update.add_secondary_max_count_for_one_node
   set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_update.add_secondary_max_count_for_one_node | wc -l`
   if [ $set_ok -ne 1 ]; then
     echo "ERROR: set lb.add_secondary_max_count_for_one_node to 0 failed"
@@ -223,7 +226,7 @@ do
       while read line2
       do
         gpid=`echo $line2 | awk '{print $3}' | sed 's/\./ /'`
-        echo "remote_command -l $node replica.kill_partition $gpid" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_update.kill_partition
+        echo "remote_command -l $node ${replica.kill_partition} $gpid" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_update.kill_partition
       done </tmp/$UID.$PID.pegasus.rolling_update.downgrade_node.propose
       echo "Sent to `cat /tmp/$UID.$PID.pegasus.rolling_update.downgrade_node.propose | wc -l` partitions."
     fi
@@ -274,7 +277,7 @@ do
   sleep 1
 
   echo "Set lb.add_secondary_max_count_for_one_node to 100..."
-  echo "remote_command -l $pmeta meta.lb.add_secondary_max_count_for_one_node 100" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_update.add_secondary_max_count_for_one_node
+  echo "remote_command -l $pmeta ${meta.lb.add_secondary_max_count_for_one_node} 100" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_update.add_secondary_max_count_for_one_node
   set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_update.add_secondary_max_count_for_one_node | wc -l`
   if [ $set_ok -ne 1 ]; then
     echo "ERROR: set lb.add_secondary_max_count_for_one_node to 100 failed"
@@ -306,7 +309,7 @@ do
 done <$rs_list_file
 
 echo "Set lb.add_secondary_max_count_for_one_node to DEFAULT..."
-echo "remote_command -l $pmeta meta.lb.add_secondary_max_count_for_one_node DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_update.add_secondary_max_count_for_one_node
+echo "remote_command -l $pmeta ${meta.lb.add_secondary_max_count_for_one_node} DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_update.add_secondary_max_count_for_one_node
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_update.add_secondary_max_count_for_one_node | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.add_secondary_max_count_for_one_node to DEFAULT failed"
@@ -314,7 +317,7 @@ if [ $set_ok -ne 1 ]; then
 fi
 
 echo "Set lb.assign_delay_ms to DEFAULT..."
-echo "remote_command -l $pmeta meta.lb.assign_delay_ms DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
+echo "remote_command -l $pmeta ${meta.lb.assign_delay_ms} DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.assign_delay_ms to DEFAULT failed"

--- a/scripts/pegasus_set_usage_scenario.sh
+++ b/scripts/pegasus_set_usage_scenario.sh
@@ -48,6 +48,10 @@ echo "Start time: `date`"
 all_start_time=$((`date +%s`))
 echo
 
+
+echo "Check the cluster version..."
+source ./scripts/pegasus_command_version.sh  "" $cluster
+
 echo -e "use $app_name\nset_app_envs $scenario_key $scenario" | ./run.sh shell --cluster $cluster &>/tmp/$UID.$PID.pegasus.set_app_envs
 set_fail=`grep 'set app env failed' /tmp/$UID.$PID.pegasus.set_app_envs | wc -l`
 if [ $set_fail -eq 1 ]; then
@@ -76,7 +80,7 @@ do
     sleeped=0
     while true
     do
-      echo "remote_command -t replica-server replica.query-app-envs $gid" | ./run.sh shell --cluster $cluster &>/tmp/$UID.$PID.pegasus.query_app_envs.$app
+      echo "remote_command -t replica-server ${replica.query-app-envs} $gid" | ./run.sh shell --cluster $cluster &>/tmp/$UID.$PID.pegasus.query_app_envs.$app
       effect_count=`grep "$scenario_key=$scenario" /tmp/$UID.$PID.pegasus.query_app_envs.$app | wc -l`
       total_count=$((partition_count * replica_count))
       if [ $effect_count -ge $total_count ]; then

--- a/scripts/pegasus_update_ingest_behind.sh
+++ b/scripts/pegasus_update_ingest_behind.sh
@@ -99,6 +99,9 @@ echo "Start time: `date`"
 total_start_time=$((`date +%s`))
 echo
 
+echo "Check the cluster version..."
+source ./scripts/pegasus_command_version.sh $cluster $meta_list
+
 echo "Generating /tmp/$UID.$PID.pegasus.update_ingestion_behind.cluster_info..."
 echo cluster_info | ./run.sh shell --cluster $meta_list 2>&1 | sed 's/ *$//' >/tmp/$UID.$PID.pegasus.update_ingestion_behind.cluster_info
 cname=`grep zookeeper_root /tmp/$UID.$PID.pegasus.update_ingestion_behind.cluster_info | grep -o '/[^/]*$' | grep -o '[^/]*$'`
@@ -152,7 +155,7 @@ echo "Sleep 30 seconds to wait app envs working..."
 sleep 30
 
 echo "Set lb.assign_delay_ms to 30min..."
-echo "remote_command -l $pmeta meta.lb.assign_delay_ms 180000000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
+echo "remote_command -l $pmeta ${meta.lb.assign_delay_ms} 180000000" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.assign_delay_ms to 30min failed"
@@ -180,7 +183,7 @@ do
   echo
 
   echo "Set lb.add_secondary_max_count_for_one_node to 0..."
-  echo "remote_command -l $pmeta meta.lb.add_secondary_max_count_for_one_node 0" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.update_ingestion_behind.add_secondary_max_count_for_one_node
+  echo "remote_command -l $pmeta ${meta.lb.add_secondary_max_count_for_one_node} 0" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.update_ingestion_behind.add_secondary_max_count_for_one_node
   set_ok=`grep OK /tmp/$UID.$PID.pegasus.update_ingestion_behind.add_secondary_max_count_for_one_node | wc -l`
   if [ $set_ok -ne 1 ]; then
     echo "ERROR: set lb.add_secondary_max_count_for_one_node to 0 failed"
@@ -246,7 +249,7 @@ do
       while read line2
       do
         gpid=`echo $line2 | awk '{print $3}' | sed 's/\./ /'`
-        echo "remote_command -l $node replica.kill_partition $gpid" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.update_ingestion_behind.kill_partition
+        echo "remote_command -l $node ${replica.kill_partition} $gpid" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.update_ingestion_behind.kill_partition
       done </tmp/$UID.$PID.pegasus.update_ingestion_behind.downgrade_node.propose
       echo "Sent to `cat /tmp/$UID.$PID.pegasus.update_ingestion_behind.downgrade_node.propose | wc -l` partitions."
     fi
@@ -277,7 +280,7 @@ do
   echo "remote_command -l $node flush-log" | ./run.sh shell --cluster $meta_list &>/dev/null
 
   echo "Set lb.add_secondary_max_count_for_one_node to 100..."
-  echo "remote_command -l $pmeta meta.lb.add_secondary_max_count_for_one_node 100" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.update_ingestion_behind.add_secondary_max_count_for_one_node
+  echo "remote_command -l $pmeta ${meta.lb.add_secondary_max_count_for_one_node} 100" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.update_ingestion_behind.add_secondary_max_count_for_one_node
   set_ok=`grep OK /tmp/$UID.$PID.pegasus.update_ingestion_behind.add_secondary_max_count_for_one_node | wc -l`
   if [ $set_ok -ne 1 ]; then
     echo "ERROR: set lb.add_secondary_max_count_for_one_node to 100 failed"
@@ -308,7 +311,7 @@ echo "=================================================================="
 echo "=================================================================="
 
 echo "Set lb.add_secondary_max_count_for_one_node to DEFAULT..."
-echo "remote_command -l $pmeta meta.lb.add_secondary_max_count_for_one_node DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.update_ingestion_behind.add_secondary_max_count_for_one_node
+echo "remote_command -l $pmeta ${meta.lb.add_secondary_max_count_for_one_node} DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.update_ingestion_behind.add_secondary_max_count_for_one_node
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.update_ingestion_behind.add_secondary_max_count_for_one_node | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.add_secondary_max_count_for_one_node to DEFAULT failed"
@@ -316,7 +319,7 @@ if [ $set_ok -ne 1 ]; then
 fi
 
 echo "Set lb.assign_delay_ms to DEFAULT..."
-echo "remote_command -l $pmeta meta.lb.assign_delay_ms DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
+echo "remote_command -l $pmeta ${meta.lb.assign_delay_ms} DEFAULT" | ./run.sh shell --cluster $meta_list &>/tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms
 set_ok=`grep OK /tmp/$UID.$PID.pegasus.rolling_node.assign_delay_ms | wc -l`
 if [ $set_ok -ne 1 ]; then
   echo "ERROR: set lb.assign_delay_ms to DEFAULT failed"


### PR DESCRIPTION
# Related-Issue
https://github.com/apache/incubator-pegasus/issues/903

# Change
Different pegasus version has different remote-command, which make scripts complex for sre operation. this pr refactor it to auto-fetch cluster version and send right remote-command