### PR TITLE
WIP feat: support new comparator because of design

### DIFF
--- a/src/base/rrdb_types.cpp
+++ b/src/base/rrdb_types.cpp
@@ -11,5378 +11,5366 @@
 
 #include <thrift/TToString.h>
 
-namespace dsn {
-namespace apps {
+namespace dsn { namespace apps {
 
-int _kfilter_typeValues[] = {filter_type::FT_NO_FILTER,
-                             filter_type::FT_MATCH_ANYWHERE,
-                             filter_type::FT_MATCH_PREFIX,
-                             filter_type::FT_MATCH_POSTFIX};
-const char *_kfilter_typeNames[] = {
-    "FT_NO_FILTER", "FT_MATCH_ANYWHERE", "FT_MATCH_PREFIX", "FT_MATCH_POSTFIX"};
-const std::map<int, const char *> _filter_type_VALUES_TO_NAMES(
-    ::apache::thrift::TEnumIterator(4, _kfilter_typeValues, _kfilter_typeNames),
-    ::apache::thrift::TEnumIterator(-1, NULL, NULL));
+int _kfilter_typeValues[] = {
+  filter_type::FT_NO_FILTER,
+  filter_type::FT_MATCH_ANYWHERE,
+  filter_type::FT_MATCH_PREFIX,
+  filter_type::FT_MATCH_POSTFIX
+};
+const char* _kfilter_typeNames[] = {
+  "FT_NO_FILTER",
+  "FT_MATCH_ANYWHERE",
+  "FT_MATCH_PREFIX",
+  "FT_MATCH_POSTFIX"
+};
+const std::map<int, const char*> _filter_type_VALUES_TO_NAMES(::apache::thrift::TEnumIterator(4, _kfilter_typeValues, _kfilter_typeNames), ::apache::thrift::TEnumIterator(-1, NULL, NULL));
 
-int _kcas_check_typeValues[] = {cas_check_type::CT_NO_CHECK,
-                                cas_check_type::CT_VALUE_NOT_EXIST,
-                                cas_check_type::CT_VALUE_NOT_EXIST_OR_EMPTY,
-                                cas_check_type::CT_VALUE_EXIST,
-                                cas_check_type::CT_VALUE_NOT_EMPTY,
-                                cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                cas_check_type::CT_VALUE_BYTES_LESS,
-                                cas_check_type::CT_VALUE_BYTES_LESS_OR_EQUAL,
-                                cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                cas_check_type::CT_VALUE_BYTES_GREATER_OR_EQUAL,
-                                cas_check_type::CT_VALUE_BYTES_GREATER,
-                                cas_check_type::CT_VALUE_INT_LESS,
-                                cas_check_type::CT_VALUE_INT_LESS_OR_EQUAL,
-                                cas_check_type::CT_VALUE_INT_EQUAL,
-                                cas_check_type::CT_VALUE_INT_GREATER_OR_EQUAL,
-                                cas_check_type::CT_VALUE_INT_GREATER};
-const char *_kcas_check_typeNames[] = {"CT_NO_CHECK",
-                                       "CT_VALUE_NOT_EXIST",
-                                       "CT_VALUE_NOT_EXIST_OR_EMPTY",
-                                       "CT_VALUE_EXIST",
-                                       "CT_VALUE_NOT_EMPTY",
-                                       "CT_VALUE_MATCH_ANYWHERE",
-                                       "CT_VALUE_MATCH_PREFIX",
-                                       "CT_VALUE_MATCH_POSTFIX",
-                                       "CT_VALUE_BYTES_LESS",
-                                       "CT_VALUE_BYTES_LESS_OR_EQUAL",
-                                       "CT_VALUE_BYTES_EQUAL",
-                                       "CT_VALUE_BYTES_GREATER_OR_EQUAL",
-                                       "CT_VALUE_BYTES_GREATER",
-                                       "CT_VALUE_INT_LESS",
-                                       "CT_VALUE_INT_LESS_OR_EQUAL",
-                                       "CT_VALUE_INT_EQUAL",
-                                       "CT_VALUE_INT_GREATER_OR_EQUAL",
-                                       "CT_VALUE_INT_GREATER"};
-const std::map<int, const char *> _cas_check_type_VALUES_TO_NAMES(
-    ::apache::thrift::TEnumIterator(18, _kcas_check_typeValues, _kcas_check_typeNames),
-    ::apache::thrift::TEnumIterator(-1, NULL, NULL));
+int _kcas_check_typeValues[] = {
+  cas_check_type::CT_NO_CHECK,
+  cas_check_type::CT_VALUE_NOT_EXIST,
+  cas_check_type::CT_VALUE_NOT_EXIST_OR_EMPTY,
+  cas_check_type::CT_VALUE_EXIST,
+  cas_check_type::CT_VALUE_NOT_EMPTY,
+  cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+  cas_check_type::CT_VALUE_MATCH_PREFIX,
+  cas_check_type::CT_VALUE_MATCH_POSTFIX,
+  cas_check_type::CT_VALUE_BYTES_LESS,
+  cas_check_type::CT_VALUE_BYTES_LESS_OR_EQUAL,
+  cas_check_type::CT_VALUE_BYTES_EQUAL,
+  cas_check_type::CT_VALUE_BYTES_GREATER_OR_EQUAL,
+  cas_check_type::CT_VALUE_BYTES_GREATER,
+  cas_check_type::CT_VALUE_INT_LESS,
+  cas_check_type::CT_VALUE_INT_LESS_OR_EQUAL,
+  cas_check_type::CT_VALUE_INT_EQUAL,
+  cas_check_type::CT_VALUE_INT_GREATER_OR_EQUAL,
+  cas_check_type::CT_VALUE_INT_GREATER
+};
+const char* _kcas_check_typeNames[] = {
+  "CT_NO_CHECK",
+  "CT_VALUE_NOT_EXIST",
+  "CT_VALUE_NOT_EXIST_OR_EMPTY",
+  "CT_VALUE_EXIST",
+  "CT_VALUE_NOT_EMPTY",
+  "CT_VALUE_MATCH_ANYWHERE",
+  "CT_VALUE_MATCH_PREFIX",
+  "CT_VALUE_MATCH_POSTFIX",
+  "CT_VALUE_BYTES_LESS",
+  "CT_VALUE_BYTES_LESS_OR_EQUAL",
+  "CT_VALUE_BYTES_EQUAL",
+  "CT_VALUE_BYTES_GREATER_OR_EQUAL",
+  "CT_VALUE_BYTES_GREATER",
+  "CT_VALUE_INT_LESS",
+  "CT_VALUE_INT_LESS_OR_EQUAL",
+  "CT_VALUE_INT_EQUAL",
+  "CT_VALUE_INT_GREATER_OR_EQUAL",
+  "CT_VALUE_INT_GREATER"
+};
+const std::map<int, const char*> _cas_check_type_VALUES_TO_NAMES(::apache::thrift::TEnumIterator(18, _kcas_check_typeValues, _kcas_check_typeNames), ::apache::thrift::TEnumIterator(-1, NULL, NULL));
 
-int _kmutate_operationValues[] = {mutate_operation::MO_PUT, mutate_operation::MO_DELETE};
-const char *_kmutate_operationNames[] = {"MO_PUT", "MO_DELETE"};
-const std::map<int, const char *> _mutate_operation_VALUES_TO_NAMES(
-    ::apache::thrift::TEnumIterator(2, _kmutate_operationValues, _kmutate_operationNames),
-    ::apache::thrift::TEnumIterator(-1, NULL, NULL));
+int _kmutate_operationValues[] = {
+  mutate_operation::MO_PUT,
+  mutate_operation::MO_DELETE
+};
+const char* _kmutate_operationNames[] = {
+  "MO_PUT",
+  "MO_DELETE"
+};
+const std::map<int, const char*> _mutate_operation_VALUES_TO_NAMES(::apache::thrift::TEnumIterator(2, _kmutate_operationValues, _kmutate_operationNames), ::apache::thrift::TEnumIterator(-1, NULL, NULL));
 
-update_request::~update_request() throw() {}
 
-void update_request::__set_key(const ::dsn::blob &val) { this->key = val; }
-
-void update_request::__set_value(const ::dsn::blob &val) { this->value = val; }
-
-void update_request::__set_expire_ts_seconds(const int32_t val) { this->expire_ts_seconds = val; }
-
-uint32_t update_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->key.read(iprot);
-                this->__isset.key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->value.read(iprot);
-                this->__isset.value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->expire_ts_seconds);
-                this->__isset.expire_ts_seconds = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
+update_request::~update_request() throw() {
 }
 
-uint32_t update_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("update_request");
 
-    xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->key.write(oprot);
-    xfer += oprot->writeFieldEnd();
+void update_request::__set_key(const  ::dsn::blob& val) {
+  this->key = val;
+}
 
-    xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRUCT, 2);
-    xfer += this->value.write(oprot);
-    xfer += oprot->writeFieldEnd();
+void update_request::__set_value(const  ::dsn::blob& val) {
+  this->value = val;
+}
 
+void update_request::__set_expire_ts_seconds(const int32_t val) {
+  this->expire_ts_seconds = val;
+}
+
+uint32_t update_request::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->key.read(iprot);
+          this->__isset.key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->value.read(iprot);
+          this->__isset.value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->expire_ts_seconds);
+          this->__isset.expire_ts_seconds = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t update_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("update_request");
+
+  xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->value.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("expire_ts_seconds", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->expire_ts_seconds);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(update_request &a, update_request &b) {
+  using ::std::swap;
+  swap(a.key, b.key);
+  swap(a.value, b.value);
+  swap(a.expire_ts_seconds, b.expire_ts_seconds);
+  swap(a.__isset, b.__isset);
+}
+
+update_request::update_request(const update_request& other0) {
+  key = other0.key;
+  value = other0.value;
+  expire_ts_seconds = other0.expire_ts_seconds;
+  __isset = other0.__isset;
+}
+update_request::update_request( update_request&& other1) {
+  key = std::move(other1.key);
+  value = std::move(other1.value);
+  expire_ts_seconds = std::move(other1.expire_ts_seconds);
+  __isset = std::move(other1.__isset);
+}
+update_request& update_request::operator=(const update_request& other2) {
+  key = other2.key;
+  value = other2.value;
+  expire_ts_seconds = other2.expire_ts_seconds;
+  __isset = other2.__isset;
+  return *this;
+}
+update_request& update_request::operator=(update_request&& other3) {
+  key = std::move(other3.key);
+  value = std::move(other3.value);
+  expire_ts_seconds = std::move(other3.expire_ts_seconds);
+  __isset = std::move(other3.__isset);
+  return *this;
+}
+void update_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "update_request(";
+  out << "key=" << to_string(key);
+  out << ", " << "value=" << to_string(value);
+  out << ", " << "expire_ts_seconds=" << to_string(expire_ts_seconds);
+  out << ")";
+}
+
+
+update_response::~update_response() throw() {
+}
+
+
+void update_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void update_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void update_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void update_response::__set_decree(const int64_t val) {
+  this->decree = val;
+}
+
+void update_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t update_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->decree);
+          this->__isset.decree = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t update_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("update_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 2);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("decree", ::apache::thrift::protocol::T_I64, 4);
+  xfer += oprot->writeI64(this->decree);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 5);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(update_response &a, update_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.decree, b.decree);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+update_response::update_response(const update_response& other4) {
+  error = other4.error;
+  app_id = other4.app_id;
+  partition_index = other4.partition_index;
+  decree = other4.decree;
+  server = other4.server;
+  __isset = other4.__isset;
+}
+update_response::update_response( update_response&& other5) {
+  error = std::move(other5.error);
+  app_id = std::move(other5.app_id);
+  partition_index = std::move(other5.partition_index);
+  decree = std::move(other5.decree);
+  server = std::move(other5.server);
+  __isset = std::move(other5.__isset);
+}
+update_response& update_response::operator=(const update_response& other6) {
+  error = other6.error;
+  app_id = other6.app_id;
+  partition_index = other6.partition_index;
+  decree = other6.decree;
+  server = other6.server;
+  __isset = other6.__isset;
+  return *this;
+}
+update_response& update_response::operator=(update_response&& other7) {
+  error = std::move(other7.error);
+  app_id = std::move(other7.app_id);
+  partition_index = std::move(other7.partition_index);
+  decree = std::move(other7.decree);
+  server = std::move(other7.server);
+  __isset = std::move(other7.__isset);
+  return *this;
+}
+void update_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "update_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "decree=" << to_string(decree);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+read_response::~read_response() throw() {
+}
+
+
+void read_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void read_response::__set_value(const  ::dsn::blob& val) {
+  this->value = val;
+}
+
+void read_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void read_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void read_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t read_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->value.read(iprot);
+          this->__isset.value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t read_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("read_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->value.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(read_response &a, read_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.value, b.value);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+read_response::read_response(const read_response& other8) {
+  error = other8.error;
+  value = other8.value;
+  app_id = other8.app_id;
+  partition_index = other8.partition_index;
+  server = other8.server;
+  __isset = other8.__isset;
+}
+read_response::read_response( read_response&& other9) {
+  error = std::move(other9.error);
+  value = std::move(other9.value);
+  app_id = std::move(other9.app_id);
+  partition_index = std::move(other9.partition_index);
+  server = std::move(other9.server);
+  __isset = std::move(other9.__isset);
+}
+read_response& read_response::operator=(const read_response& other10) {
+  error = other10.error;
+  value = other10.value;
+  app_id = other10.app_id;
+  partition_index = other10.partition_index;
+  server = other10.server;
+  __isset = other10.__isset;
+  return *this;
+}
+read_response& read_response::operator=(read_response&& other11) {
+  error = std::move(other11.error);
+  value = std::move(other11.value);
+  app_id = std::move(other11.app_id);
+  partition_index = std::move(other11.partition_index);
+  server = std::move(other11.server);
+  __isset = std::move(other11.__isset);
+  return *this;
+}
+void read_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "read_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "value=" << to_string(value);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+ttl_response::~ttl_response() throw() {
+}
+
+
+void ttl_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void ttl_response::__set_ttl_seconds(const int32_t val) {
+  this->ttl_seconds = val;
+}
+
+void ttl_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void ttl_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void ttl_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t ttl_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->ttl_seconds);
+          this->__isset.ttl_seconds = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t ttl_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("ttl_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("ttl_seconds", ::apache::thrift::protocol::T_I32, 2);
+  xfer += oprot->writeI32(this->ttl_seconds);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(ttl_response &a, ttl_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.ttl_seconds, b.ttl_seconds);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+ttl_response::ttl_response(const ttl_response& other12) {
+  error = other12.error;
+  ttl_seconds = other12.ttl_seconds;
+  app_id = other12.app_id;
+  partition_index = other12.partition_index;
+  server = other12.server;
+  __isset = other12.__isset;
+}
+ttl_response::ttl_response( ttl_response&& other13) {
+  error = std::move(other13.error);
+  ttl_seconds = std::move(other13.ttl_seconds);
+  app_id = std::move(other13.app_id);
+  partition_index = std::move(other13.partition_index);
+  server = std::move(other13.server);
+  __isset = std::move(other13.__isset);
+}
+ttl_response& ttl_response::operator=(const ttl_response& other14) {
+  error = other14.error;
+  ttl_seconds = other14.ttl_seconds;
+  app_id = other14.app_id;
+  partition_index = other14.partition_index;
+  server = other14.server;
+  __isset = other14.__isset;
+  return *this;
+}
+ttl_response& ttl_response::operator=(ttl_response&& other15) {
+  error = std::move(other15.error);
+  ttl_seconds = std::move(other15.ttl_seconds);
+  app_id = std::move(other15.app_id);
+  partition_index = std::move(other15.partition_index);
+  server = std::move(other15.server);
+  __isset = std::move(other15.__isset);
+  return *this;
+}
+void ttl_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "ttl_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "ttl_seconds=" << to_string(ttl_seconds);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+count_response::~count_response() throw() {
+}
+
+
+void count_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void count_response::__set_count(const int64_t val) {
+  this->count = val;
+}
+
+void count_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void count_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void count_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t count_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->count);
+          this->__isset.count = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t count_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("count_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("count", ::apache::thrift::protocol::T_I64, 2);
+  xfer += oprot->writeI64(this->count);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(count_response &a, count_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.count, b.count);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+count_response::count_response(const count_response& other16) {
+  error = other16.error;
+  count = other16.count;
+  app_id = other16.app_id;
+  partition_index = other16.partition_index;
+  server = other16.server;
+  __isset = other16.__isset;
+}
+count_response::count_response( count_response&& other17) {
+  error = std::move(other17.error);
+  count = std::move(other17.count);
+  app_id = std::move(other17.app_id);
+  partition_index = std::move(other17.partition_index);
+  server = std::move(other17.server);
+  __isset = std::move(other17.__isset);
+}
+count_response& count_response::operator=(const count_response& other18) {
+  error = other18.error;
+  count = other18.count;
+  app_id = other18.app_id;
+  partition_index = other18.partition_index;
+  server = other18.server;
+  __isset = other18.__isset;
+  return *this;
+}
+count_response& count_response::operator=(count_response&& other19) {
+  error = std::move(other19.error);
+  count = std::move(other19.count);
+  app_id = std::move(other19.app_id);
+  partition_index = std::move(other19.partition_index);
+  server = std::move(other19.server);
+  __isset = std::move(other19.__isset);
+  return *this;
+}
+void count_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "count_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "count=" << to_string(count);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+key_value::~key_value() throw() {
+}
+
+
+void key_value::__set_key(const  ::dsn::blob& val) {
+  this->key = val;
+}
+
+void key_value::__set_value(const  ::dsn::blob& val) {
+  this->value = val;
+}
+
+void key_value::__set_expire_ts_seconds(const int32_t val) {
+  this->expire_ts_seconds = val;
+__isset.expire_ts_seconds = true;
+}
+
+uint32_t key_value::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->key.read(iprot);
+          this->__isset.key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->value.read(iprot);
+          this->__isset.value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->expire_ts_seconds);
+          this->__isset.expire_ts_seconds = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t key_value::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("key_value");
+
+  xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->value.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  if (this->__isset.expire_ts_seconds) {
     xfer += oprot->writeFieldBegin("expire_ts_seconds", ::apache::thrift::protocol::T_I32, 3);
     xfer += oprot->writeI32(this->expire_ts_seconds);
     xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
 }
 
-void swap(update_request &a, update_request &b)
-{
-    using ::std::swap;
-    swap(a.key, b.key);
-    swap(a.value, b.value);
-    swap(a.expire_ts_seconds, b.expire_ts_seconds);
-    swap(a.__isset, b.__isset);
+void swap(key_value &a, key_value &b) {
+  using ::std::swap;
+  swap(a.key, b.key);
+  swap(a.value, b.value);
+  swap(a.expire_ts_seconds, b.expire_ts_seconds);
+  swap(a.__isset, b.__isset);
 }
 
-update_request::update_request(const update_request &other0)
-{
-    key = other0.key;
-    value = other0.value;
-    expire_ts_seconds = other0.expire_ts_seconds;
-    __isset = other0.__isset;
+key_value::key_value(const key_value& other20) {
+  key = other20.key;
+  value = other20.value;
+  expire_ts_seconds = other20.expire_ts_seconds;
+  __isset = other20.__isset;
 }
-update_request::update_request(update_request &&other1)
-{
-    key = std::move(other1.key);
-    value = std::move(other1.value);
-    expire_ts_seconds = std::move(other1.expire_ts_seconds);
-    __isset = std::move(other1.__isset);
+key_value::key_value( key_value&& other21) {
+  key = std::move(other21.key);
+  value = std::move(other21.value);
+  expire_ts_seconds = std::move(other21.expire_ts_seconds);
+  __isset = std::move(other21.__isset);
 }
-update_request &update_request::operator=(const update_request &other2)
-{
-    key = other2.key;
-    value = other2.value;
-    expire_ts_seconds = other2.expire_ts_seconds;
-    __isset = other2.__isset;
-    return *this;
+key_value& key_value::operator=(const key_value& other22) {
+  key = other22.key;
+  value = other22.value;
+  expire_ts_seconds = other22.expire_ts_seconds;
+  __isset = other22.__isset;
+  return *this;
 }
-update_request &update_request::operator=(update_request &&other3)
-{
-    key = std::move(other3.key);
-    value = std::move(other3.value);
-    expire_ts_seconds = std::move(other3.expire_ts_seconds);
-    __isset = std::move(other3.__isset);
-    return *this;
+key_value& key_value::operator=(key_value&& other23) {
+  key = std::move(other23.key);
+  value = std::move(other23.value);
+  expire_ts_seconds = std::move(other23.expire_ts_seconds);
+  __isset = std::move(other23.__isset);
+  return *this;
 }
-void update_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "update_request(";
-    out << "key=" << to_string(key);
-    out << ", "
-        << "value=" << to_string(value);
-    out << ", "
-        << "expire_ts_seconds=" << to_string(expire_ts_seconds);
-    out << ")";
+void key_value::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "key_value(";
+  out << "key=" << to_string(key);
+  out << ", " << "value=" << to_string(value);
+  out << ", " << "expire_ts_seconds="; (__isset.expire_ts_seconds ? (out << to_string(expire_ts_seconds)) : (out << "<null>"));
+  out << ")";
 }
 
-update_response::~update_response() throw() {}
 
-void update_response::__set_error(const int32_t val) { this->error = val; }
+multi_put_request::~multi_put_request() throw() {
+}
 
-void update_response::__set_app_id(const int32_t val) { this->app_id = val; }
 
-void update_response::__set_partition_index(const int32_t val) { this->partition_index = val; }
+void multi_put_request::__set_hash_key(const  ::dsn::blob& val) {
+  this->hash_key = val;
+}
 
-void update_response::__set_decree(const int64_t val) { this->decree = val; }
+void multi_put_request::__set_kvs(const std::vector<key_value> & val) {
+  this->kvs = val;
+}
 
-void update_response::__set_server(const std::string &val) { this->server = val; }
+void multi_put_request::__set_expire_ts_seconds(const int32_t val) {
+  this->expire_ts_seconds = val;
+}
 
-uint32_t update_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
+uint32_t multi_put_request::read(::apache::thrift::protocol::TProtocol* iprot) {
 
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
 
-    xfer += iprot->readStructBegin(fname);
+  xfer += iprot->readStructBegin(fname);
 
-    using ::apache::thrift::protocol::TProtocolException;
+  using ::apache::thrift::protocol::TProtocolException;
 
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->decree);
-                this->__isset.decree = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
     }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t update_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("update_response");
-
-    xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32(this->error);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 2);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("decree", ::apache::thrift::protocol::T_I64, 4);
-    xfer += oprot->writeI64(this->decree);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 5);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(update_response &a, update_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.decree, b.decree);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-update_response::update_response(const update_response &other4)
-{
-    error = other4.error;
-    app_id = other4.app_id;
-    partition_index = other4.partition_index;
-    decree = other4.decree;
-    server = other4.server;
-    __isset = other4.__isset;
-}
-update_response::update_response(update_response &&other5)
-{
-    error = std::move(other5.error);
-    app_id = std::move(other5.app_id);
-    partition_index = std::move(other5.partition_index);
-    decree = std::move(other5.decree);
-    server = std::move(other5.server);
-    __isset = std::move(other5.__isset);
-}
-update_response &update_response::operator=(const update_response &other6)
-{
-    error = other6.error;
-    app_id = other6.app_id;
-    partition_index = other6.partition_index;
-    decree = other6.decree;
-    server = other6.server;
-    __isset = other6.__isset;
-    return *this;
-}
-update_response &update_response::operator=(update_response &&other7)
-{
-    error = std::move(other7.error);
-    app_id = std::move(other7.app_id);
-    partition_index = std::move(other7.partition_index);
-    decree = std::move(other7.decree);
-    server = std::move(other7.server);
-    __isset = std::move(other7.__isset);
-    return *this;
-}
-void update_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "update_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "decree=" << to_string(decree);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-read_response::~read_response() throw() {}
-
-void read_response::__set_error(const int32_t val) { this->error = val; }
-
-void read_response::__set_value(const ::dsn::blob &val) { this->value = val; }
-
-void read_response::__set_app_id(const int32_t val) { this->app_id = val; }
-
-void read_response::__set_partition_index(const int32_t val) { this->partition_index = val; }
-
-void read_response::__set_server(const std::string &val) { this->server = val; }
-
-uint32_t read_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->value.read(iprot);
-                this->__isset.value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t read_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("read_response");
-
-    xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32(this->error);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRUCT, 2);
-    xfer += this->value.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(read_response &a, read_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.value, b.value);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-read_response::read_response(const read_response &other8)
-{
-    error = other8.error;
-    value = other8.value;
-    app_id = other8.app_id;
-    partition_index = other8.partition_index;
-    server = other8.server;
-    __isset = other8.__isset;
-}
-read_response::read_response(read_response &&other9)
-{
-    error = std::move(other9.error);
-    value = std::move(other9.value);
-    app_id = std::move(other9.app_id);
-    partition_index = std::move(other9.partition_index);
-    server = std::move(other9.server);
-    __isset = std::move(other9.__isset);
-}
-read_response &read_response::operator=(const read_response &other10)
-{
-    error = other10.error;
-    value = other10.value;
-    app_id = other10.app_id;
-    partition_index = other10.partition_index;
-    server = other10.server;
-    __isset = other10.__isset;
-    return *this;
-}
-read_response &read_response::operator=(read_response &&other11)
-{
-    error = std::move(other11.error);
-    value = std::move(other11.value);
-    app_id = std::move(other11.app_id);
-    partition_index = std::move(other11.partition_index);
-    server = std::move(other11.server);
-    __isset = std::move(other11.__isset);
-    return *this;
-}
-void read_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "read_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "value=" << to_string(value);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-ttl_response::~ttl_response() throw() {}
-
-void ttl_response::__set_error(const int32_t val) { this->error = val; }
-
-void ttl_response::__set_ttl_seconds(const int32_t val) { this->ttl_seconds = val; }
-
-void ttl_response::__set_app_id(const int32_t val) { this->app_id = val; }
-
-void ttl_response::__set_partition_index(const int32_t val) { this->partition_index = val; }
-
-void ttl_response::__set_server(const std::string &val) { this->server = val; }
-
-uint32_t ttl_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->ttl_seconds);
-                this->__isset.ttl_seconds = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t ttl_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("ttl_response");
-
-    xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32(this->error);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("ttl_seconds", ::apache::thrift::protocol::T_I32, 2);
-    xfer += oprot->writeI32(this->ttl_seconds);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(ttl_response &a, ttl_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.ttl_seconds, b.ttl_seconds);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-ttl_response::ttl_response(const ttl_response &other12)
-{
-    error = other12.error;
-    ttl_seconds = other12.ttl_seconds;
-    app_id = other12.app_id;
-    partition_index = other12.partition_index;
-    server = other12.server;
-    __isset = other12.__isset;
-}
-ttl_response::ttl_response(ttl_response &&other13)
-{
-    error = std::move(other13.error);
-    ttl_seconds = std::move(other13.ttl_seconds);
-    app_id = std::move(other13.app_id);
-    partition_index = std::move(other13.partition_index);
-    server = std::move(other13.server);
-    __isset = std::move(other13.__isset);
-}
-ttl_response &ttl_response::operator=(const ttl_response &other14)
-{
-    error = other14.error;
-    ttl_seconds = other14.ttl_seconds;
-    app_id = other14.app_id;
-    partition_index = other14.partition_index;
-    server = other14.server;
-    __isset = other14.__isset;
-    return *this;
-}
-ttl_response &ttl_response::operator=(ttl_response &&other15)
-{
-    error = std::move(other15.error);
-    ttl_seconds = std::move(other15.ttl_seconds);
-    app_id = std::move(other15.app_id);
-    partition_index = std::move(other15.partition_index);
-    server = std::move(other15.server);
-    __isset = std::move(other15.__isset);
-    return *this;
-}
-void ttl_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "ttl_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "ttl_seconds=" << to_string(ttl_seconds);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-count_response::~count_response() throw() {}
-
-void count_response::__set_error(const int32_t val) { this->error = val; }
-
-void count_response::__set_count(const int64_t val) { this->count = val; }
-
-void count_response::__set_app_id(const int32_t val) { this->app_id = val; }
-
-void count_response::__set_partition_index(const int32_t val) { this->partition_index = val; }
-
-void count_response::__set_server(const std::string &val) { this->server = val; }
-
-uint32_t count_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->count);
-                this->__isset.count = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t count_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("count_response");
-
-    xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32(this->error);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("count", ::apache::thrift::protocol::T_I64, 2);
-    xfer += oprot->writeI64(this->count);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(count_response &a, count_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.count, b.count);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-count_response::count_response(const count_response &other16)
-{
-    error = other16.error;
-    count = other16.count;
-    app_id = other16.app_id;
-    partition_index = other16.partition_index;
-    server = other16.server;
-    __isset = other16.__isset;
-}
-count_response::count_response(count_response &&other17)
-{
-    error = std::move(other17.error);
-    count = std::move(other17.count);
-    app_id = std::move(other17.app_id);
-    partition_index = std::move(other17.partition_index);
-    server = std::move(other17.server);
-    __isset = std::move(other17.__isset);
-}
-count_response &count_response::operator=(const count_response &other18)
-{
-    error = other18.error;
-    count = other18.count;
-    app_id = other18.app_id;
-    partition_index = other18.partition_index;
-    server = other18.server;
-    __isset = other18.__isset;
-    return *this;
-}
-count_response &count_response::operator=(count_response &&other19)
-{
-    error = std::move(other19.error);
-    count = std::move(other19.count);
-    app_id = std::move(other19.app_id);
-    partition_index = std::move(other19.partition_index);
-    server = std::move(other19.server);
-    __isset = std::move(other19.__isset);
-    return *this;
-}
-void count_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "count_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "count=" << to_string(count);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-key_value::~key_value() throw() {}
-
-void key_value::__set_key(const ::dsn::blob &val) { this->key = val; }
-
-void key_value::__set_value(const ::dsn::blob &val) { this->value = val; }
-
-void key_value::__set_expire_ts_seconds(const int32_t val)
-{
-    this->expire_ts_seconds = val;
-    __isset.expire_ts_seconds = true;
-}
-
-uint32_t key_value::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->key.read(iprot);
-                this->__isset.key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->value.read(iprot);
-                this->__isset.value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->expire_ts_seconds);
-                this->__isset.expire_ts_seconds = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t key_value::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("key_value");
-
-    xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRUCT, 2);
-    xfer += this->value.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    if (this->__isset.expire_ts_seconds) {
-        xfer += oprot->writeFieldBegin("expire_ts_seconds", ::apache::thrift::protocol::T_I32, 3);
-        xfer += oprot->writeI32(this->expire_ts_seconds);
-        xfer += oprot->writeFieldEnd();
-    }
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(key_value &a, key_value &b)
-{
-    using ::std::swap;
-    swap(a.key, b.key);
-    swap(a.value, b.value);
-    swap(a.expire_ts_seconds, b.expire_ts_seconds);
-    swap(a.__isset, b.__isset);
-}
-
-key_value::key_value(const key_value &other20)
-{
-    key = other20.key;
-    value = other20.value;
-    expire_ts_seconds = other20.expire_ts_seconds;
-    __isset = other20.__isset;
-}
-key_value::key_value(key_value &&other21)
-{
-    key = std::move(other21.key);
-    value = std::move(other21.value);
-    expire_ts_seconds = std::move(other21.expire_ts_seconds);
-    __isset = std::move(other21.__isset);
-}
-key_value &key_value::operator=(const key_value &other22)
-{
-    key = other22.key;
-    value = other22.value;
-    expire_ts_seconds = other22.expire_ts_seconds;
-    __isset = other22.__isset;
-    return *this;
-}
-key_value &key_value::operator=(key_value &&other23)
-{
-    key = std::move(other23.key);
-    value = std::move(other23.value);
-    expire_ts_seconds = std::move(other23.expire_ts_seconds);
-    __isset = std::move(other23.__isset);
-    return *this;
-}
-void key_value::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "key_value(";
-    out << "key=" << to_string(key);
-    out << ", "
-        << "value=" << to_string(value);
-    out << ", "
-        << "expire_ts_seconds=";
-    (__isset.expire_ts_seconds ? (out << to_string(expire_ts_seconds)) : (out << "<null>"));
-    out << ")";
-}
-
-multi_put_request::~multi_put_request() throw() {}
-
-void multi_put_request::__set_hash_key(const ::dsn::blob &val) { this->hash_key = val; }
-
-void multi_put_request::__set_kvs(const std::vector<key_value> &val) { this->kvs = val; }
-
-void multi_put_request::__set_expire_ts_seconds(const int32_t val)
-{
-    this->expire_ts_seconds = val;
-}
-
-uint32_t multi_put_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->hash_key.read(iprot);
-                this->__isset.hash_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_LIST) {
-                {
-                    this->kvs.clear();
-                    uint32_t _size24;
-                    ::apache::thrift::protocol::TType _etype27;
-                    xfer += iprot->readListBegin(_etype27, _size24);
-                    this->kvs.resize(_size24);
-                    uint32_t _i28;
-                    for (_i28 = 0; _i28 < _size24; ++_i28) {
-                        xfer += this->kvs[_i28].read(iprot);
-                    }
-                    xfer += iprot->readListEnd();
-                }
-                this->__isset.kvs = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->expire_ts_seconds);
-                this->__isset.expire_ts_seconds = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t multi_put_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("multi_put_request");
-
-    xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->hash_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("kvs", ::apache::thrift::protocol::T_LIST, 2);
+    switch (fid)
     {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT,
-                                      static_cast<uint32_t>(this->kvs.size()));
-        std::vector<key_value>::const_iterator _iter29;
-        for (_iter29 = this->kvs.begin(); _iter29 != this->kvs.end(); ++_iter29) {
-            xfer += (*_iter29).write(oprot);
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->hash_key.read(iprot);
+          this->__isset.hash_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
         }
-        xfer += oprot->writeListEnd();
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->kvs.clear();
+            uint32_t _size24;
+            ::apache::thrift::protocol::TType _etype27;
+            xfer += iprot->readListBegin(_etype27, _size24);
+            this->kvs.resize(_size24);
+            uint32_t _i28;
+            for (_i28 = 0; _i28 < _size24; ++_i28)
+            {
+              xfer += this->kvs[_i28].read(iprot);
+            }
+            xfer += iprot->readListEnd();
+          }
+          this->__isset.kvs = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->expire_ts_seconds);
+          this->__isset.expire_ts_seconds = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
     }
-    xfer += oprot->writeFieldEnd();
+    xfer += iprot->readFieldEnd();
+  }
 
-    xfer += oprot->writeFieldBegin("expire_ts_seconds", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->expire_ts_seconds);
-    xfer += oprot->writeFieldEnd();
+  xfer += iprot->readStructEnd();
 
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
+  return xfer;
 }
 
-void swap(multi_put_request &a, multi_put_request &b)
-{
-    using ::std::swap;
-    swap(a.hash_key, b.hash_key);
-    swap(a.kvs, b.kvs);
-    swap(a.expire_ts_seconds, b.expire_ts_seconds);
-    swap(a.__isset, b.__isset);
-}
+uint32_t multi_put_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("multi_put_request");
 
-multi_put_request::multi_put_request(const multi_put_request &other30)
-{
-    hash_key = other30.hash_key;
-    kvs = other30.kvs;
-    expire_ts_seconds = other30.expire_ts_seconds;
-    __isset = other30.__isset;
-}
-multi_put_request::multi_put_request(multi_put_request &&other31)
-{
-    hash_key = std::move(other31.hash_key);
-    kvs = std::move(other31.kvs);
-    expire_ts_seconds = std::move(other31.expire_ts_seconds);
-    __isset = std::move(other31.__isset);
-}
-multi_put_request &multi_put_request::operator=(const multi_put_request &other32)
-{
-    hash_key = other32.hash_key;
-    kvs = other32.kvs;
-    expire_ts_seconds = other32.expire_ts_seconds;
-    __isset = other32.__isset;
-    return *this;
-}
-multi_put_request &multi_put_request::operator=(multi_put_request &&other33)
-{
-    hash_key = std::move(other33.hash_key);
-    kvs = std::move(other33.kvs);
-    expire_ts_seconds = std::move(other33.expire_ts_seconds);
-    __isset = std::move(other33.__isset);
-    return *this;
-}
-void multi_put_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "multi_put_request(";
-    out << "hash_key=" << to_string(hash_key);
-    out << ", "
-        << "kvs=" << to_string(kvs);
-    out << ", "
-        << "expire_ts_seconds=" << to_string(expire_ts_seconds);
-    out << ")";
-}
+  xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->hash_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
 
-multi_remove_request::~multi_remove_request() throw() {}
-
-void multi_remove_request::__set_hash_key(const ::dsn::blob &val) { this->hash_key = val; }
-
-void multi_remove_request::__set_sort_keys(const std::vector<::dsn::blob> &val)
-{
-    this->sort_keys = val;
-}
-
-void multi_remove_request::__set_max_count(const int64_t val) { this->max_count = val; }
-
-uint32_t multi_remove_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->hash_key.read(iprot);
-                this->__isset.hash_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_LIST) {
-                {
-                    this->sort_keys.clear();
-                    uint32_t _size34;
-                    ::apache::thrift::protocol::TType _etype37;
-                    xfer += iprot->readListBegin(_etype37, _size34);
-                    this->sort_keys.resize(_size34);
-                    uint32_t _i38;
-                    for (_i38 = 0; _i38 < _size34; ++_i38) {
-                        xfer += this->sort_keys[_i38].read(iprot);
-                    }
-                    xfer += iprot->readListEnd();
-                }
-                this->__isset.sort_keys = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->max_count);
-                this->__isset.max_count = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t multi_remove_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("multi_remove_request");
-
-    xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->hash_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("sort_keys", ::apache::thrift::protocol::T_LIST, 2);
+  xfer += oprot->writeFieldBegin("kvs", ::apache::thrift::protocol::T_LIST, 2);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->kvs.size()));
+    std::vector<key_value> ::const_iterator _iter29;
+    for (_iter29 = this->kvs.begin(); _iter29 != this->kvs.end(); ++_iter29)
     {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT,
-                                      static_cast<uint32_t>(this->sort_keys.size()));
-        std::vector<::dsn::blob>::const_iterator _iter39;
-        for (_iter39 = this->sort_keys.begin(); _iter39 != this->sort_keys.end(); ++_iter39) {
-            xfer += (*_iter39).write(oprot);
-        }
-        xfer += oprot->writeListEnd();
+      xfer += (*_iter29).write(oprot);
     }
-    xfer += oprot->writeFieldEnd();
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
 
-    xfer += oprot->writeFieldBegin("max_count", ::apache::thrift::protocol::T_I64, 3);
-    xfer += oprot->writeI64(this->max_count);
-    xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("expire_ts_seconds", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->expire_ts_seconds);
+  xfer += oprot->writeFieldEnd();
 
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
 }
 
-void swap(multi_remove_request &a, multi_remove_request &b)
-{
-    using ::std::swap;
-    swap(a.hash_key, b.hash_key);
-    swap(a.sort_keys, b.sort_keys);
-    swap(a.max_count, b.max_count);
-    swap(a.__isset, b.__isset);
+void swap(multi_put_request &a, multi_put_request &b) {
+  using ::std::swap;
+  swap(a.hash_key, b.hash_key);
+  swap(a.kvs, b.kvs);
+  swap(a.expire_ts_seconds, b.expire_ts_seconds);
+  swap(a.__isset, b.__isset);
 }
 
-multi_remove_request::multi_remove_request(const multi_remove_request &other40)
-{
-    hash_key = other40.hash_key;
-    sort_keys = other40.sort_keys;
-    max_count = other40.max_count;
-    __isset = other40.__isset;
+multi_put_request::multi_put_request(const multi_put_request& other30) {
+  hash_key = other30.hash_key;
+  kvs = other30.kvs;
+  expire_ts_seconds = other30.expire_ts_seconds;
+  __isset = other30.__isset;
 }
-multi_remove_request::multi_remove_request(multi_remove_request &&other41)
-{
-    hash_key = std::move(other41.hash_key);
-    sort_keys = std::move(other41.sort_keys);
-    max_count = std::move(other41.max_count);
-    __isset = std::move(other41.__isset);
+multi_put_request::multi_put_request( multi_put_request&& other31) {
+  hash_key = std::move(other31.hash_key);
+  kvs = std::move(other31.kvs);
+  expire_ts_seconds = std::move(other31.expire_ts_seconds);
+  __isset = std::move(other31.__isset);
 }
-multi_remove_request &multi_remove_request::operator=(const multi_remove_request &other42)
-{
-    hash_key = other42.hash_key;
-    sort_keys = other42.sort_keys;
-    max_count = other42.max_count;
-    __isset = other42.__isset;
-    return *this;
+multi_put_request& multi_put_request::operator=(const multi_put_request& other32) {
+  hash_key = other32.hash_key;
+  kvs = other32.kvs;
+  expire_ts_seconds = other32.expire_ts_seconds;
+  __isset = other32.__isset;
+  return *this;
 }
-multi_remove_request &multi_remove_request::operator=(multi_remove_request &&other43)
-{
-    hash_key = std::move(other43.hash_key);
-    sort_keys = std::move(other43.sort_keys);
-    max_count = std::move(other43.max_count);
-    __isset = std::move(other43.__isset);
-    return *this;
+multi_put_request& multi_put_request::operator=(multi_put_request&& other33) {
+  hash_key = std::move(other33.hash_key);
+  kvs = std::move(other33.kvs);
+  expire_ts_seconds = std::move(other33.expire_ts_seconds);
+  __isset = std::move(other33.__isset);
+  return *this;
 }
-void multi_remove_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "multi_remove_request(";
-    out << "hash_key=" << to_string(hash_key);
-    out << ", "
-        << "sort_keys=" << to_string(sort_keys);
-    out << ", "
-        << "max_count=" << to_string(max_count);
-    out << ")";
+void multi_put_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "multi_put_request(";
+  out << "hash_key=" << to_string(hash_key);
+  out << ", " << "kvs=" << to_string(kvs);
+  out << ", " << "expire_ts_seconds=" << to_string(expire_ts_seconds);
+  out << ")";
 }
 
-multi_remove_response::~multi_remove_response() throw() {}
 
-void multi_remove_response::__set_error(const int32_t val) { this->error = val; }
-
-void multi_remove_response::__set_count(const int64_t val) { this->count = val; }
-
-void multi_remove_response::__set_app_id(const int32_t val) { this->app_id = val; }
-
-void multi_remove_response::__set_partition_index(const int32_t val)
-{
-    this->partition_index = val;
+multi_remove_request::~multi_remove_request() throw() {
 }
 
-void multi_remove_response::__set_decree(const int64_t val) { this->decree = val; }
 
-void multi_remove_response::__set_server(const std::string &val) { this->server = val; }
+void multi_remove_request::__set_hash_key(const  ::dsn::blob& val) {
+  this->hash_key = val;
+}
 
-uint32_t multi_remove_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
+void multi_remove_request::__set_sort_keys(const std::vector< ::dsn::blob> & val) {
+  this->sort_keys = val;
+}
 
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
+void multi_remove_request::__set_max_count(const int64_t val) {
+  this->max_count = val;
+}
 
-    xfer += iprot->readStructBegin(fname);
+uint32_t multi_remove_request::read(::apache::thrift::protocol::TProtocol* iprot) {
 
-    using ::apache::thrift::protocol::TProtocolException;
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
 
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->count);
-                this->__isset.count = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->decree);
-                this->__isset.decree = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
     }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->hash_key.read(iprot);
+          this->__isset.hash_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->sort_keys.clear();
+            uint32_t _size34;
+            ::apache::thrift::protocol::TType _etype37;
+            xfer += iprot->readListBegin(_etype37, _size34);
+            this->sort_keys.resize(_size34);
+            uint32_t _i38;
+            for (_i38 = 0; _i38 < _size34; ++_i38)
+            {
+              xfer += this->sort_keys[_i38].read(iprot);
+            }
+            xfer += iprot->readListEnd();
+          }
+          this->__isset.sort_keys = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->max_count);
+          this->__isset.max_count = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
 
-    xfer += iprot->readStructEnd();
+  xfer += iprot->readStructEnd();
 
-    return xfer;
+  return xfer;
 }
 
-uint32_t multi_remove_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("multi_remove_response");
+uint32_t multi_remove_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("multi_remove_request");
 
+  xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->hash_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("sort_keys", ::apache::thrift::protocol::T_LIST, 2);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->sort_keys.size()));
+    std::vector< ::dsn::blob> ::const_iterator _iter39;
+    for (_iter39 = this->sort_keys.begin(); _iter39 != this->sort_keys.end(); ++_iter39)
+    {
+      xfer += (*_iter39).write(oprot);
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("max_count", ::apache::thrift::protocol::T_I64, 3);
+  xfer += oprot->writeI64(this->max_count);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(multi_remove_request &a, multi_remove_request &b) {
+  using ::std::swap;
+  swap(a.hash_key, b.hash_key);
+  swap(a.sort_keys, b.sort_keys);
+  swap(a.max_count, b.max_count);
+  swap(a.__isset, b.__isset);
+}
+
+multi_remove_request::multi_remove_request(const multi_remove_request& other40) {
+  hash_key = other40.hash_key;
+  sort_keys = other40.sort_keys;
+  max_count = other40.max_count;
+  __isset = other40.__isset;
+}
+multi_remove_request::multi_remove_request( multi_remove_request&& other41) {
+  hash_key = std::move(other41.hash_key);
+  sort_keys = std::move(other41.sort_keys);
+  max_count = std::move(other41.max_count);
+  __isset = std::move(other41.__isset);
+}
+multi_remove_request& multi_remove_request::operator=(const multi_remove_request& other42) {
+  hash_key = other42.hash_key;
+  sort_keys = other42.sort_keys;
+  max_count = other42.max_count;
+  __isset = other42.__isset;
+  return *this;
+}
+multi_remove_request& multi_remove_request::operator=(multi_remove_request&& other43) {
+  hash_key = std::move(other43.hash_key);
+  sort_keys = std::move(other43.sort_keys);
+  max_count = std::move(other43.max_count);
+  __isset = std::move(other43.__isset);
+  return *this;
+}
+void multi_remove_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "multi_remove_request(";
+  out << "hash_key=" << to_string(hash_key);
+  out << ", " << "sort_keys=" << to_string(sort_keys);
+  out << ", " << "max_count=" << to_string(max_count);
+  out << ")";
+}
+
+
+multi_remove_response::~multi_remove_response() throw() {
+}
+
+
+void multi_remove_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void multi_remove_response::__set_count(const int64_t val) {
+  this->count = val;
+}
+
+void multi_remove_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void multi_remove_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void multi_remove_response::__set_decree(const int64_t val) {
+  this->decree = val;
+}
+
+void multi_remove_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t multi_remove_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->count);
+          this->__isset.count = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->decree);
+          this->__isset.decree = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t multi_remove_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("multi_remove_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("count", ::apache::thrift::protocol::T_I64, 2);
+  xfer += oprot->writeI64(this->count);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("decree", ::apache::thrift::protocol::T_I64, 5);
+  xfer += oprot->writeI64(this->decree);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(multi_remove_response &a, multi_remove_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.count, b.count);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.decree, b.decree);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+multi_remove_response::multi_remove_response(const multi_remove_response& other44) {
+  error = other44.error;
+  count = other44.count;
+  app_id = other44.app_id;
+  partition_index = other44.partition_index;
+  decree = other44.decree;
+  server = other44.server;
+  __isset = other44.__isset;
+}
+multi_remove_response::multi_remove_response( multi_remove_response&& other45) {
+  error = std::move(other45.error);
+  count = std::move(other45.count);
+  app_id = std::move(other45.app_id);
+  partition_index = std::move(other45.partition_index);
+  decree = std::move(other45.decree);
+  server = std::move(other45.server);
+  __isset = std::move(other45.__isset);
+}
+multi_remove_response& multi_remove_response::operator=(const multi_remove_response& other46) {
+  error = other46.error;
+  count = other46.count;
+  app_id = other46.app_id;
+  partition_index = other46.partition_index;
+  decree = other46.decree;
+  server = other46.server;
+  __isset = other46.__isset;
+  return *this;
+}
+multi_remove_response& multi_remove_response::operator=(multi_remove_response&& other47) {
+  error = std::move(other47.error);
+  count = std::move(other47.count);
+  app_id = std::move(other47.app_id);
+  partition_index = std::move(other47.partition_index);
+  decree = std::move(other47.decree);
+  server = std::move(other47.server);
+  __isset = std::move(other47.__isset);
+  return *this;
+}
+void multi_remove_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "multi_remove_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "count=" << to_string(count);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "decree=" << to_string(decree);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+multi_get_request::~multi_get_request() throw() {
+}
+
+
+void multi_get_request::__set_hash_key(const  ::dsn::blob& val) {
+  this->hash_key = val;
+}
+
+void multi_get_request::__set_sort_keys(const std::vector< ::dsn::blob> & val) {
+  this->sort_keys = val;
+}
+
+void multi_get_request::__set_max_kv_count(const int32_t val) {
+  this->max_kv_count = val;
+}
+
+void multi_get_request::__set_max_kv_size(const int32_t val) {
+  this->max_kv_size = val;
+}
+
+void multi_get_request::__set_no_value(const bool val) {
+  this->no_value = val;
+}
+
+void multi_get_request::__set_start_sortkey(const  ::dsn::blob& val) {
+  this->start_sortkey = val;
+}
+
+void multi_get_request::__set_stop_sortkey(const  ::dsn::blob& val) {
+  this->stop_sortkey = val;
+}
+
+void multi_get_request::__set_start_inclusive(const bool val) {
+  this->start_inclusive = val;
+}
+
+void multi_get_request::__set_stop_inclusive(const bool val) {
+  this->stop_inclusive = val;
+}
+
+void multi_get_request::__set_sort_key_filter_type(const filter_type::type val) {
+  this->sort_key_filter_type = val;
+}
+
+void multi_get_request::__set_sort_key_filter_pattern(const  ::dsn::blob& val) {
+  this->sort_key_filter_pattern = val;
+}
+
+void multi_get_request::__set_reverse(const bool val) {
+  this->reverse = val;
+}
+
+uint32_t multi_get_request::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->hash_key.read(iprot);
+          this->__isset.hash_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->sort_keys.clear();
+            uint32_t _size48;
+            ::apache::thrift::protocol::TType _etype51;
+            xfer += iprot->readListBegin(_etype51, _size48);
+            this->sort_keys.resize(_size48);
+            uint32_t _i52;
+            for (_i52 = 0; _i52 < _size48; ++_i52)
+            {
+              xfer += this->sort_keys[_i52].read(iprot);
+            }
+            xfer += iprot->readListEnd();
+          }
+          this->__isset.sort_keys = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->max_kv_count);
+          this->__isset.max_kv_count = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->max_kv_size);
+          this->__isset.max_kv_size = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->no_value);
+          this->__isset.no_value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->start_sortkey.read(iprot);
+          this->__isset.start_sortkey = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 7:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->stop_sortkey.read(iprot);
+          this->__isset.stop_sortkey = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 8:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->start_inclusive);
+          this->__isset.start_inclusive = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 9:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->stop_inclusive);
+          this->__isset.stop_inclusive = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 10:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast53;
+          xfer += iprot->readI32(ecast53);
+          this->sort_key_filter_type = (filter_type::type)ecast53;
+          this->__isset.sort_key_filter_type = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 11:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sort_key_filter_pattern.read(iprot);
+          this->__isset.sort_key_filter_pattern = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 12:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->reverse);
+          this->__isset.reverse = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t multi_get_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("multi_get_request");
+
+  xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->hash_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("sort_keys", ::apache::thrift::protocol::T_LIST, 2);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->sort_keys.size()));
+    std::vector< ::dsn::blob> ::const_iterator _iter54;
+    for (_iter54 = this->sort_keys.begin(); _iter54 != this->sort_keys.end(); ++_iter54)
+    {
+      xfer += (*_iter54).write(oprot);
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("max_kv_count", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->max_kv_count);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("max_kv_size", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32(this->max_kv_size);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("no_value", ::apache::thrift::protocol::T_BOOL, 5);
+  xfer += oprot->writeBool(this->no_value);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("start_sortkey", ::apache::thrift::protocol::T_STRUCT, 6);
+  xfer += this->start_sortkey.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("stop_sortkey", ::apache::thrift::protocol::T_STRUCT, 7);
+  xfer += this->stop_sortkey.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("start_inclusive", ::apache::thrift::protocol::T_BOOL, 8);
+  xfer += oprot->writeBool(this->start_inclusive);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("stop_inclusive", ::apache::thrift::protocol::T_BOOL, 9);
+  xfer += oprot->writeBool(this->stop_inclusive);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("sort_key_filter_type", ::apache::thrift::protocol::T_I32, 10);
+  xfer += oprot->writeI32((int32_t)this->sort_key_filter_type);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("sort_key_filter_pattern", ::apache::thrift::protocol::T_STRUCT, 11);
+  xfer += this->sort_key_filter_pattern.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("reverse", ::apache::thrift::protocol::T_BOOL, 12);
+  xfer += oprot->writeBool(this->reverse);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(multi_get_request &a, multi_get_request &b) {
+  using ::std::swap;
+  swap(a.hash_key, b.hash_key);
+  swap(a.sort_keys, b.sort_keys);
+  swap(a.max_kv_count, b.max_kv_count);
+  swap(a.max_kv_size, b.max_kv_size);
+  swap(a.no_value, b.no_value);
+  swap(a.start_sortkey, b.start_sortkey);
+  swap(a.stop_sortkey, b.stop_sortkey);
+  swap(a.start_inclusive, b.start_inclusive);
+  swap(a.stop_inclusive, b.stop_inclusive);
+  swap(a.sort_key_filter_type, b.sort_key_filter_type);
+  swap(a.sort_key_filter_pattern, b.sort_key_filter_pattern);
+  swap(a.reverse, b.reverse);
+  swap(a.__isset, b.__isset);
+}
+
+multi_get_request::multi_get_request(const multi_get_request& other55) {
+  hash_key = other55.hash_key;
+  sort_keys = other55.sort_keys;
+  max_kv_count = other55.max_kv_count;
+  max_kv_size = other55.max_kv_size;
+  no_value = other55.no_value;
+  start_sortkey = other55.start_sortkey;
+  stop_sortkey = other55.stop_sortkey;
+  start_inclusive = other55.start_inclusive;
+  stop_inclusive = other55.stop_inclusive;
+  sort_key_filter_type = other55.sort_key_filter_type;
+  sort_key_filter_pattern = other55.sort_key_filter_pattern;
+  reverse = other55.reverse;
+  __isset = other55.__isset;
+}
+multi_get_request::multi_get_request( multi_get_request&& other56) {
+  hash_key = std::move(other56.hash_key);
+  sort_keys = std::move(other56.sort_keys);
+  max_kv_count = std::move(other56.max_kv_count);
+  max_kv_size = std::move(other56.max_kv_size);
+  no_value = std::move(other56.no_value);
+  start_sortkey = std::move(other56.start_sortkey);
+  stop_sortkey = std::move(other56.stop_sortkey);
+  start_inclusive = std::move(other56.start_inclusive);
+  stop_inclusive = std::move(other56.stop_inclusive);
+  sort_key_filter_type = std::move(other56.sort_key_filter_type);
+  sort_key_filter_pattern = std::move(other56.sort_key_filter_pattern);
+  reverse = std::move(other56.reverse);
+  __isset = std::move(other56.__isset);
+}
+multi_get_request& multi_get_request::operator=(const multi_get_request& other57) {
+  hash_key = other57.hash_key;
+  sort_keys = other57.sort_keys;
+  max_kv_count = other57.max_kv_count;
+  max_kv_size = other57.max_kv_size;
+  no_value = other57.no_value;
+  start_sortkey = other57.start_sortkey;
+  stop_sortkey = other57.stop_sortkey;
+  start_inclusive = other57.start_inclusive;
+  stop_inclusive = other57.stop_inclusive;
+  sort_key_filter_type = other57.sort_key_filter_type;
+  sort_key_filter_pattern = other57.sort_key_filter_pattern;
+  reverse = other57.reverse;
+  __isset = other57.__isset;
+  return *this;
+}
+multi_get_request& multi_get_request::operator=(multi_get_request&& other58) {
+  hash_key = std::move(other58.hash_key);
+  sort_keys = std::move(other58.sort_keys);
+  max_kv_count = std::move(other58.max_kv_count);
+  max_kv_size = std::move(other58.max_kv_size);
+  no_value = std::move(other58.no_value);
+  start_sortkey = std::move(other58.start_sortkey);
+  stop_sortkey = std::move(other58.stop_sortkey);
+  start_inclusive = std::move(other58.start_inclusive);
+  stop_inclusive = std::move(other58.stop_inclusive);
+  sort_key_filter_type = std::move(other58.sort_key_filter_type);
+  sort_key_filter_pattern = std::move(other58.sort_key_filter_pattern);
+  reverse = std::move(other58.reverse);
+  __isset = std::move(other58.__isset);
+  return *this;
+}
+void multi_get_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "multi_get_request(";
+  out << "hash_key=" << to_string(hash_key);
+  out << ", " << "sort_keys=" << to_string(sort_keys);
+  out << ", " << "max_kv_count=" << to_string(max_kv_count);
+  out << ", " << "max_kv_size=" << to_string(max_kv_size);
+  out << ", " << "no_value=" << to_string(no_value);
+  out << ", " << "start_sortkey=" << to_string(start_sortkey);
+  out << ", " << "stop_sortkey=" << to_string(stop_sortkey);
+  out << ", " << "start_inclusive=" << to_string(start_inclusive);
+  out << ", " << "stop_inclusive=" << to_string(stop_inclusive);
+  out << ", " << "sort_key_filter_type=" << to_string(sort_key_filter_type);
+  out << ", " << "sort_key_filter_pattern=" << to_string(sort_key_filter_pattern);
+  out << ", " << "reverse=" << to_string(reverse);
+  out << ")";
+}
+
+
+multi_get_response::~multi_get_response() throw() {
+}
+
+
+void multi_get_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void multi_get_response::__set_kvs(const std::vector<key_value> & val) {
+  this->kvs = val;
+}
+
+void multi_get_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void multi_get_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void multi_get_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t multi_get_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->kvs.clear();
+            uint32_t _size59;
+            ::apache::thrift::protocol::TType _etype62;
+            xfer += iprot->readListBegin(_etype62, _size59);
+            this->kvs.resize(_size59);
+            uint32_t _i63;
+            for (_i63 = 0; _i63 < _size59; ++_i63)
+            {
+              xfer += this->kvs[_i63].read(iprot);
+            }
+            xfer += iprot->readListEnd();
+          }
+          this->__isset.kvs = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t multi_get_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("multi_get_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("kvs", ::apache::thrift::protocol::T_LIST, 2);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->kvs.size()));
+    std::vector<key_value> ::const_iterator _iter64;
+    for (_iter64 = this->kvs.begin(); _iter64 != this->kvs.end(); ++_iter64)
+    {
+      xfer += (*_iter64).write(oprot);
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(multi_get_response &a, multi_get_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.kvs, b.kvs);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+multi_get_response::multi_get_response(const multi_get_response& other65) {
+  error = other65.error;
+  kvs = other65.kvs;
+  app_id = other65.app_id;
+  partition_index = other65.partition_index;
+  server = other65.server;
+  __isset = other65.__isset;
+}
+multi_get_response::multi_get_response( multi_get_response&& other66) {
+  error = std::move(other66.error);
+  kvs = std::move(other66.kvs);
+  app_id = std::move(other66.app_id);
+  partition_index = std::move(other66.partition_index);
+  server = std::move(other66.server);
+  __isset = std::move(other66.__isset);
+}
+multi_get_response& multi_get_response::operator=(const multi_get_response& other67) {
+  error = other67.error;
+  kvs = other67.kvs;
+  app_id = other67.app_id;
+  partition_index = other67.partition_index;
+  server = other67.server;
+  __isset = other67.__isset;
+  return *this;
+}
+multi_get_response& multi_get_response::operator=(multi_get_response&& other68) {
+  error = std::move(other68.error);
+  kvs = std::move(other68.kvs);
+  app_id = std::move(other68.app_id);
+  partition_index = std::move(other68.partition_index);
+  server = std::move(other68.server);
+  __isset = std::move(other68.__isset);
+  return *this;
+}
+void multi_get_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "multi_get_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "kvs=" << to_string(kvs);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+batch_get_request::~batch_get_request() throw() {
+}
+
+
+void batch_get_request::__set_keys(const std::vector<full_key> & val) {
+  this->keys = val;
+}
+
+uint32_t batch_get_request::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->keys.clear();
+            uint32_t _size69;
+            ::apache::thrift::protocol::TType _etype72;
+            xfer += iprot->readListBegin(_etype72, _size69);
+            this->keys.resize(_size69);
+            uint32_t _i73;
+            for (_i73 = 0; _i73 < _size69; ++_i73)
+            {
+              xfer += this->keys[_i73].read(iprot);
+            }
+            xfer += iprot->readListEnd();
+          }
+          this->__isset.keys = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t batch_get_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("batch_get_request");
+
+  xfer += oprot->writeFieldBegin("keys", ::apache::thrift::protocol::T_LIST, 1);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->keys.size()));
+    std::vector<full_key> ::const_iterator _iter74;
+    for (_iter74 = this->keys.begin(); _iter74 != this->keys.end(); ++_iter74)
+    {
+      xfer += (*_iter74).write(oprot);
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(batch_get_request &a, batch_get_request &b) {
+  using ::std::swap;
+  swap(a.keys, b.keys);
+  swap(a.__isset, b.__isset);
+}
+
+batch_get_request::batch_get_request(const batch_get_request& other75) {
+  keys = other75.keys;
+  __isset = other75.__isset;
+}
+batch_get_request::batch_get_request( batch_get_request&& other76) {
+  keys = std::move(other76.keys);
+  __isset = std::move(other76.__isset);
+}
+batch_get_request& batch_get_request::operator=(const batch_get_request& other77) {
+  keys = other77.keys;
+  __isset = other77.__isset;
+  return *this;
+}
+batch_get_request& batch_get_request::operator=(batch_get_request&& other78) {
+  keys = std::move(other78.keys);
+  __isset = std::move(other78.__isset);
+  return *this;
+}
+void batch_get_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "batch_get_request(";
+  out << "keys=" << to_string(keys);
+  out << ")";
+}
+
+
+full_key::~full_key() throw() {
+}
+
+
+void full_key::__set_hash_key(const  ::dsn::blob& val) {
+  this->hash_key = val;
+}
+
+void full_key::__set_sort_key(const  ::dsn::blob& val) {
+  this->sort_key = val;
+}
+
+uint32_t full_key::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->hash_key.read(iprot);
+          this->__isset.hash_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sort_key.read(iprot);
+          this->__isset.sort_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t full_key::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("full_key");
+
+  xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->hash_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("sort_key", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->sort_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(full_key &a, full_key &b) {
+  using ::std::swap;
+  swap(a.hash_key, b.hash_key);
+  swap(a.sort_key, b.sort_key);
+  swap(a.__isset, b.__isset);
+}
+
+full_key::full_key(const full_key& other79) {
+  hash_key = other79.hash_key;
+  sort_key = other79.sort_key;
+  __isset = other79.__isset;
+}
+full_key::full_key( full_key&& other80) {
+  hash_key = std::move(other80.hash_key);
+  sort_key = std::move(other80.sort_key);
+  __isset = std::move(other80.__isset);
+}
+full_key& full_key::operator=(const full_key& other81) {
+  hash_key = other81.hash_key;
+  sort_key = other81.sort_key;
+  __isset = other81.__isset;
+  return *this;
+}
+full_key& full_key::operator=(full_key&& other82) {
+  hash_key = std::move(other82.hash_key);
+  sort_key = std::move(other82.sort_key);
+  __isset = std::move(other82.__isset);
+  return *this;
+}
+void full_key::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "full_key(";
+  out << "hash_key=" << to_string(hash_key);
+  out << ", " << "sort_key=" << to_string(sort_key);
+  out << ")";
+}
+
+
+batch_get_response::~batch_get_response() throw() {
+}
+
+
+void batch_get_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void batch_get_response::__set_data(const std::vector<full_data> & val) {
+  this->data = val;
+}
+
+void batch_get_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void batch_get_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void batch_get_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t batch_get_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->data.clear();
+            uint32_t _size83;
+            ::apache::thrift::protocol::TType _etype86;
+            xfer += iprot->readListBegin(_etype86, _size83);
+            this->data.resize(_size83);
+            uint32_t _i87;
+            for (_i87 = 0; _i87 < _size83; ++_i87)
+            {
+              xfer += this->data[_i87].read(iprot);
+            }
+            xfer += iprot->readListEnd();
+          }
+          this->__isset.data = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t batch_get_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("batch_get_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("data", ::apache::thrift::protocol::T_LIST, 2);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->data.size()));
+    std::vector<full_data> ::const_iterator _iter88;
+    for (_iter88 = this->data.begin(); _iter88 != this->data.end(); ++_iter88)
+    {
+      xfer += (*_iter88).write(oprot);
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(batch_get_response &a, batch_get_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.data, b.data);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+batch_get_response::batch_get_response(const batch_get_response& other89) {
+  error = other89.error;
+  data = other89.data;
+  app_id = other89.app_id;
+  partition_index = other89.partition_index;
+  server = other89.server;
+  __isset = other89.__isset;
+}
+batch_get_response::batch_get_response( batch_get_response&& other90) {
+  error = std::move(other90.error);
+  data = std::move(other90.data);
+  app_id = std::move(other90.app_id);
+  partition_index = std::move(other90.partition_index);
+  server = std::move(other90.server);
+  __isset = std::move(other90.__isset);
+}
+batch_get_response& batch_get_response::operator=(const batch_get_response& other91) {
+  error = other91.error;
+  data = other91.data;
+  app_id = other91.app_id;
+  partition_index = other91.partition_index;
+  server = other91.server;
+  __isset = other91.__isset;
+  return *this;
+}
+batch_get_response& batch_get_response::operator=(batch_get_response&& other92) {
+  error = std::move(other92.error);
+  data = std::move(other92.data);
+  app_id = std::move(other92.app_id);
+  partition_index = std::move(other92.partition_index);
+  server = std::move(other92.server);
+  __isset = std::move(other92.__isset);
+  return *this;
+}
+void batch_get_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "batch_get_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "data=" << to_string(data);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+full_data::~full_data() throw() {
+}
+
+
+void full_data::__set_hash_key(const  ::dsn::blob& val) {
+  this->hash_key = val;
+}
+
+void full_data::__set_sort_key(const  ::dsn::blob& val) {
+  this->sort_key = val;
+}
+
+void full_data::__set_value(const  ::dsn::blob& val) {
+  this->value = val;
+}
+
+uint32_t full_data::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->hash_key.read(iprot);
+          this->__isset.hash_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sort_key.read(iprot);
+          this->__isset.sort_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->value.read(iprot);
+          this->__isset.value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t full_data::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("full_data");
+
+  xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->hash_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("sort_key", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->sort_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRUCT, 3);
+  xfer += this->value.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(full_data &a, full_data &b) {
+  using ::std::swap;
+  swap(a.hash_key, b.hash_key);
+  swap(a.sort_key, b.sort_key);
+  swap(a.value, b.value);
+  swap(a.__isset, b.__isset);
+}
+
+full_data::full_data(const full_data& other93) {
+  hash_key = other93.hash_key;
+  sort_key = other93.sort_key;
+  value = other93.value;
+  __isset = other93.__isset;
+}
+full_data::full_data( full_data&& other94) {
+  hash_key = std::move(other94.hash_key);
+  sort_key = std::move(other94.sort_key);
+  value = std::move(other94.value);
+  __isset = std::move(other94.__isset);
+}
+full_data& full_data::operator=(const full_data& other95) {
+  hash_key = other95.hash_key;
+  sort_key = other95.sort_key;
+  value = other95.value;
+  __isset = other95.__isset;
+  return *this;
+}
+full_data& full_data::operator=(full_data&& other96) {
+  hash_key = std::move(other96.hash_key);
+  sort_key = std::move(other96.sort_key);
+  value = std::move(other96.value);
+  __isset = std::move(other96.__isset);
+  return *this;
+}
+void full_data::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "full_data(";
+  out << "hash_key=" << to_string(hash_key);
+  out << ", " << "sort_key=" << to_string(sort_key);
+  out << ", " << "value=" << to_string(value);
+  out << ")";
+}
+
+
+incr_request::~incr_request() throw() {
+}
+
+
+void incr_request::__set_key(const  ::dsn::blob& val) {
+  this->key = val;
+}
+
+void incr_request::__set_increment(const int64_t val) {
+  this->increment = val;
+}
+
+void incr_request::__set_expire_ts_seconds(const int32_t val) {
+  this->expire_ts_seconds = val;
+}
+
+uint32_t incr_request::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->key.read(iprot);
+          this->__isset.key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->increment);
+          this->__isset.increment = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->expire_ts_seconds);
+          this->__isset.expire_ts_seconds = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t incr_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("incr_request");
+
+  xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("increment", ::apache::thrift::protocol::T_I64, 2);
+  xfer += oprot->writeI64(this->increment);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("expire_ts_seconds", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->expire_ts_seconds);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(incr_request &a, incr_request &b) {
+  using ::std::swap;
+  swap(a.key, b.key);
+  swap(a.increment, b.increment);
+  swap(a.expire_ts_seconds, b.expire_ts_seconds);
+  swap(a.__isset, b.__isset);
+}
+
+incr_request::incr_request(const incr_request& other97) {
+  key = other97.key;
+  increment = other97.increment;
+  expire_ts_seconds = other97.expire_ts_seconds;
+  __isset = other97.__isset;
+}
+incr_request::incr_request( incr_request&& other98) {
+  key = std::move(other98.key);
+  increment = std::move(other98.increment);
+  expire_ts_seconds = std::move(other98.expire_ts_seconds);
+  __isset = std::move(other98.__isset);
+}
+incr_request& incr_request::operator=(const incr_request& other99) {
+  key = other99.key;
+  increment = other99.increment;
+  expire_ts_seconds = other99.expire_ts_seconds;
+  __isset = other99.__isset;
+  return *this;
+}
+incr_request& incr_request::operator=(incr_request&& other100) {
+  key = std::move(other100.key);
+  increment = std::move(other100.increment);
+  expire_ts_seconds = std::move(other100.expire_ts_seconds);
+  __isset = std::move(other100.__isset);
+  return *this;
+}
+void incr_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "incr_request(";
+  out << "key=" << to_string(key);
+  out << ", " << "increment=" << to_string(increment);
+  out << ", " << "expire_ts_seconds=" << to_string(expire_ts_seconds);
+  out << ")";
+}
+
+
+incr_response::~incr_response() throw() {
+}
+
+
+void incr_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void incr_response::__set_new_value(const int64_t val) {
+  this->new_value = val;
+}
+
+void incr_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void incr_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void incr_response::__set_decree(const int64_t val) {
+  this->decree = val;
+}
+
+void incr_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t incr_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->new_value);
+          this->__isset.new_value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->decree);
+          this->__isset.decree = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t incr_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("incr_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("new_value", ::apache::thrift::protocol::T_I64, 2);
+  xfer += oprot->writeI64(this->new_value);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("decree", ::apache::thrift::protocol::T_I64, 5);
+  xfer += oprot->writeI64(this->decree);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(incr_response &a, incr_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.new_value, b.new_value);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.decree, b.decree);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+incr_response::incr_response(const incr_response& other101) {
+  error = other101.error;
+  new_value = other101.new_value;
+  app_id = other101.app_id;
+  partition_index = other101.partition_index;
+  decree = other101.decree;
+  server = other101.server;
+  __isset = other101.__isset;
+}
+incr_response::incr_response( incr_response&& other102) {
+  error = std::move(other102.error);
+  new_value = std::move(other102.new_value);
+  app_id = std::move(other102.app_id);
+  partition_index = std::move(other102.partition_index);
+  decree = std::move(other102.decree);
+  server = std::move(other102.server);
+  __isset = std::move(other102.__isset);
+}
+incr_response& incr_response::operator=(const incr_response& other103) {
+  error = other103.error;
+  new_value = other103.new_value;
+  app_id = other103.app_id;
+  partition_index = other103.partition_index;
+  decree = other103.decree;
+  server = other103.server;
+  __isset = other103.__isset;
+  return *this;
+}
+incr_response& incr_response::operator=(incr_response&& other104) {
+  error = std::move(other104.error);
+  new_value = std::move(other104.new_value);
+  app_id = std::move(other104.app_id);
+  partition_index = std::move(other104.partition_index);
+  decree = std::move(other104.decree);
+  server = std::move(other104.server);
+  __isset = std::move(other104.__isset);
+  return *this;
+}
+void incr_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "incr_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "new_value=" << to_string(new_value);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "decree=" << to_string(decree);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+check_and_set_request::~check_and_set_request() throw() {
+}
+
+
+void check_and_set_request::__set_hash_key(const  ::dsn::blob& val) {
+  this->hash_key = val;
+}
+
+void check_and_set_request::__set_check_sort_key(const  ::dsn::blob& val) {
+  this->check_sort_key = val;
+}
+
+void check_and_set_request::__set_check_type(const cas_check_type::type val) {
+  this->check_type = val;
+}
+
+void check_and_set_request::__set_check_operand(const  ::dsn::blob& val) {
+  this->check_operand = val;
+}
+
+void check_and_set_request::__set_set_diff_sort_key(const bool val) {
+  this->set_diff_sort_key = val;
+}
+
+void check_and_set_request::__set_set_sort_key(const  ::dsn::blob& val) {
+  this->set_sort_key = val;
+}
+
+void check_and_set_request::__set_set_value(const  ::dsn::blob& val) {
+  this->set_value = val;
+}
+
+void check_and_set_request::__set_set_expire_ts_seconds(const int32_t val) {
+  this->set_expire_ts_seconds = val;
+}
+
+void check_and_set_request::__set_return_check_value(const bool val) {
+  this->return_check_value = val;
+}
+
+uint32_t check_and_set_request::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->hash_key.read(iprot);
+          this->__isset.hash_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->check_sort_key.read(iprot);
+          this->__isset.check_sort_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast105;
+          xfer += iprot->readI32(ecast105);
+          this->check_type = (cas_check_type::type)ecast105;
+          this->__isset.check_type = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->check_operand.read(iprot);
+          this->__isset.check_operand = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->set_diff_sort_key);
+          this->__isset.set_diff_sort_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->set_sort_key.read(iprot);
+          this->__isset.set_sort_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 7:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->set_value.read(iprot);
+          this->__isset.set_value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 8:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->set_expire_ts_seconds);
+          this->__isset.set_expire_ts_seconds = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 9:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->return_check_value);
+          this->__isset.return_check_value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t check_and_set_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("check_and_set_request");
+
+  xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->hash_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_sort_key", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->check_sort_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_type", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32((int32_t)this->check_type);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_operand", ::apache::thrift::protocol::T_STRUCT, 4);
+  xfer += this->check_operand.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("set_diff_sort_key", ::apache::thrift::protocol::T_BOOL, 5);
+  xfer += oprot->writeBool(this->set_diff_sort_key);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("set_sort_key", ::apache::thrift::protocol::T_STRUCT, 6);
+  xfer += this->set_sort_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("set_value", ::apache::thrift::protocol::T_STRUCT, 7);
+  xfer += this->set_value.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("set_expire_ts_seconds", ::apache::thrift::protocol::T_I32, 8);
+  xfer += oprot->writeI32(this->set_expire_ts_seconds);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("return_check_value", ::apache::thrift::protocol::T_BOOL, 9);
+  xfer += oprot->writeBool(this->return_check_value);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(check_and_set_request &a, check_and_set_request &b) {
+  using ::std::swap;
+  swap(a.hash_key, b.hash_key);
+  swap(a.check_sort_key, b.check_sort_key);
+  swap(a.check_type, b.check_type);
+  swap(a.check_operand, b.check_operand);
+  swap(a.set_diff_sort_key, b.set_diff_sort_key);
+  swap(a.set_sort_key, b.set_sort_key);
+  swap(a.set_value, b.set_value);
+  swap(a.set_expire_ts_seconds, b.set_expire_ts_seconds);
+  swap(a.return_check_value, b.return_check_value);
+  swap(a.__isset, b.__isset);
+}
+
+check_and_set_request::check_and_set_request(const check_and_set_request& other106) {
+  hash_key = other106.hash_key;
+  check_sort_key = other106.check_sort_key;
+  check_type = other106.check_type;
+  check_operand = other106.check_operand;
+  set_diff_sort_key = other106.set_diff_sort_key;
+  set_sort_key = other106.set_sort_key;
+  set_value = other106.set_value;
+  set_expire_ts_seconds = other106.set_expire_ts_seconds;
+  return_check_value = other106.return_check_value;
+  __isset = other106.__isset;
+}
+check_and_set_request::check_and_set_request( check_and_set_request&& other107) {
+  hash_key = std::move(other107.hash_key);
+  check_sort_key = std::move(other107.check_sort_key);
+  check_type = std::move(other107.check_type);
+  check_operand = std::move(other107.check_operand);
+  set_diff_sort_key = std::move(other107.set_diff_sort_key);
+  set_sort_key = std::move(other107.set_sort_key);
+  set_value = std::move(other107.set_value);
+  set_expire_ts_seconds = std::move(other107.set_expire_ts_seconds);
+  return_check_value = std::move(other107.return_check_value);
+  __isset = std::move(other107.__isset);
+}
+check_and_set_request& check_and_set_request::operator=(const check_and_set_request& other108) {
+  hash_key = other108.hash_key;
+  check_sort_key = other108.check_sort_key;
+  check_type = other108.check_type;
+  check_operand = other108.check_operand;
+  set_diff_sort_key = other108.set_diff_sort_key;
+  set_sort_key = other108.set_sort_key;
+  set_value = other108.set_value;
+  set_expire_ts_seconds = other108.set_expire_ts_seconds;
+  return_check_value = other108.return_check_value;
+  __isset = other108.__isset;
+  return *this;
+}
+check_and_set_request& check_and_set_request::operator=(check_and_set_request&& other109) {
+  hash_key = std::move(other109.hash_key);
+  check_sort_key = std::move(other109.check_sort_key);
+  check_type = std::move(other109.check_type);
+  check_operand = std::move(other109.check_operand);
+  set_diff_sort_key = std::move(other109.set_diff_sort_key);
+  set_sort_key = std::move(other109.set_sort_key);
+  set_value = std::move(other109.set_value);
+  set_expire_ts_seconds = std::move(other109.set_expire_ts_seconds);
+  return_check_value = std::move(other109.return_check_value);
+  __isset = std::move(other109.__isset);
+  return *this;
+}
+void check_and_set_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "check_and_set_request(";
+  out << "hash_key=" << to_string(hash_key);
+  out << ", " << "check_sort_key=" << to_string(check_sort_key);
+  out << ", " << "check_type=" << to_string(check_type);
+  out << ", " << "check_operand=" << to_string(check_operand);
+  out << ", " << "set_diff_sort_key=" << to_string(set_diff_sort_key);
+  out << ", " << "set_sort_key=" << to_string(set_sort_key);
+  out << ", " << "set_value=" << to_string(set_value);
+  out << ", " << "set_expire_ts_seconds=" << to_string(set_expire_ts_seconds);
+  out << ", " << "return_check_value=" << to_string(return_check_value);
+  out << ")";
+}
+
+
+check_and_set_response::~check_and_set_response() throw() {
+}
+
+
+void check_and_set_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void check_and_set_response::__set_check_value_returned(const bool val) {
+  this->check_value_returned = val;
+}
+
+void check_and_set_response::__set_check_value_exist(const bool val) {
+  this->check_value_exist = val;
+}
+
+void check_and_set_response::__set_check_value(const  ::dsn::blob& val) {
+  this->check_value = val;
+}
+
+void check_and_set_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void check_and_set_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void check_and_set_response::__set_decree(const int64_t val) {
+  this->decree = val;
+}
+
+void check_and_set_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t check_and_set_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->check_value_returned);
+          this->__isset.check_value_returned = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->check_value_exist);
+          this->__isset.check_value_exist = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->check_value.read(iprot);
+          this->__isset.check_value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 7:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->decree);
+          this->__isset.decree = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 8:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t check_and_set_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("check_and_set_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_value_returned", ::apache::thrift::protocol::T_BOOL, 2);
+  xfer += oprot->writeBool(this->check_value_returned);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_value_exist", ::apache::thrift::protocol::T_BOOL, 3);
+  xfer += oprot->writeBool(this->check_value_exist);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_value", ::apache::thrift::protocol::T_STRUCT, 4);
+  xfer += this->check_value.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 5);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 6);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("decree", ::apache::thrift::protocol::T_I64, 7);
+  xfer += oprot->writeI64(this->decree);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 8);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(check_and_set_response &a, check_and_set_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.check_value_returned, b.check_value_returned);
+  swap(a.check_value_exist, b.check_value_exist);
+  swap(a.check_value, b.check_value);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.decree, b.decree);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+check_and_set_response::check_and_set_response(const check_and_set_response& other110) {
+  error = other110.error;
+  check_value_returned = other110.check_value_returned;
+  check_value_exist = other110.check_value_exist;
+  check_value = other110.check_value;
+  app_id = other110.app_id;
+  partition_index = other110.partition_index;
+  decree = other110.decree;
+  server = other110.server;
+  __isset = other110.__isset;
+}
+check_and_set_response::check_and_set_response( check_and_set_response&& other111) {
+  error = std::move(other111.error);
+  check_value_returned = std::move(other111.check_value_returned);
+  check_value_exist = std::move(other111.check_value_exist);
+  check_value = std::move(other111.check_value);
+  app_id = std::move(other111.app_id);
+  partition_index = std::move(other111.partition_index);
+  decree = std::move(other111.decree);
+  server = std::move(other111.server);
+  __isset = std::move(other111.__isset);
+}
+check_and_set_response& check_and_set_response::operator=(const check_and_set_response& other112) {
+  error = other112.error;
+  check_value_returned = other112.check_value_returned;
+  check_value_exist = other112.check_value_exist;
+  check_value = other112.check_value;
+  app_id = other112.app_id;
+  partition_index = other112.partition_index;
+  decree = other112.decree;
+  server = other112.server;
+  __isset = other112.__isset;
+  return *this;
+}
+check_and_set_response& check_and_set_response::operator=(check_and_set_response&& other113) {
+  error = std::move(other113.error);
+  check_value_returned = std::move(other113.check_value_returned);
+  check_value_exist = std::move(other113.check_value_exist);
+  check_value = std::move(other113.check_value);
+  app_id = std::move(other113.app_id);
+  partition_index = std::move(other113.partition_index);
+  decree = std::move(other113.decree);
+  server = std::move(other113.server);
+  __isset = std::move(other113.__isset);
+  return *this;
+}
+void check_and_set_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "check_and_set_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "check_value_returned=" << to_string(check_value_returned);
+  out << ", " << "check_value_exist=" << to_string(check_value_exist);
+  out << ", " << "check_value=" << to_string(check_value);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "decree=" << to_string(decree);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+mutate::~mutate() throw() {
+}
+
+
+void mutate::__set_operation(const mutate_operation::type val) {
+  this->operation = val;
+}
+
+void mutate::__set_sort_key(const  ::dsn::blob& val) {
+  this->sort_key = val;
+}
+
+void mutate::__set_value(const  ::dsn::blob& val) {
+  this->value = val;
+}
+
+void mutate::__set_set_expire_ts_seconds(const int32_t val) {
+  this->set_expire_ts_seconds = val;
+}
+
+uint32_t mutate::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast114;
+          xfer += iprot->readI32(ecast114);
+          this->operation = (mutate_operation::type)ecast114;
+          this->__isset.operation = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sort_key.read(iprot);
+          this->__isset.sort_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->value.read(iprot);
+          this->__isset.value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->set_expire_ts_seconds);
+          this->__isset.set_expire_ts_seconds = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t mutate::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("mutate");
+
+  xfer += oprot->writeFieldBegin("operation", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32((int32_t)this->operation);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("sort_key", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->sort_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRUCT, 3);
+  xfer += this->value.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("set_expire_ts_seconds", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32(this->set_expire_ts_seconds);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(mutate &a, mutate &b) {
+  using ::std::swap;
+  swap(a.operation, b.operation);
+  swap(a.sort_key, b.sort_key);
+  swap(a.value, b.value);
+  swap(a.set_expire_ts_seconds, b.set_expire_ts_seconds);
+  swap(a.__isset, b.__isset);
+}
+
+mutate::mutate(const mutate& other115) {
+  operation = other115.operation;
+  sort_key = other115.sort_key;
+  value = other115.value;
+  set_expire_ts_seconds = other115.set_expire_ts_seconds;
+  __isset = other115.__isset;
+}
+mutate::mutate( mutate&& other116) {
+  operation = std::move(other116.operation);
+  sort_key = std::move(other116.sort_key);
+  value = std::move(other116.value);
+  set_expire_ts_seconds = std::move(other116.set_expire_ts_seconds);
+  __isset = std::move(other116.__isset);
+}
+mutate& mutate::operator=(const mutate& other117) {
+  operation = other117.operation;
+  sort_key = other117.sort_key;
+  value = other117.value;
+  set_expire_ts_seconds = other117.set_expire_ts_seconds;
+  __isset = other117.__isset;
+  return *this;
+}
+mutate& mutate::operator=(mutate&& other118) {
+  operation = std::move(other118.operation);
+  sort_key = std::move(other118.sort_key);
+  value = std::move(other118.value);
+  set_expire_ts_seconds = std::move(other118.set_expire_ts_seconds);
+  __isset = std::move(other118.__isset);
+  return *this;
+}
+void mutate::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "mutate(";
+  out << "operation=" << to_string(operation);
+  out << ", " << "sort_key=" << to_string(sort_key);
+  out << ", " << "value=" << to_string(value);
+  out << ", " << "set_expire_ts_seconds=" << to_string(set_expire_ts_seconds);
+  out << ")";
+}
+
+
+check_and_mutate_request::~check_and_mutate_request() throw() {
+}
+
+
+void check_and_mutate_request::__set_hash_key(const  ::dsn::blob& val) {
+  this->hash_key = val;
+}
+
+void check_and_mutate_request::__set_check_sort_key(const  ::dsn::blob& val) {
+  this->check_sort_key = val;
+}
+
+void check_and_mutate_request::__set_check_type(const cas_check_type::type val) {
+  this->check_type = val;
+}
+
+void check_and_mutate_request::__set_check_operand(const  ::dsn::blob& val) {
+  this->check_operand = val;
+}
+
+void check_and_mutate_request::__set_mutate_list(const std::vector<mutate> & val) {
+  this->mutate_list = val;
+}
+
+void check_and_mutate_request::__set_return_check_value(const bool val) {
+  this->return_check_value = val;
+}
+
+uint32_t check_and_mutate_request::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->hash_key.read(iprot);
+          this->__isset.hash_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->check_sort_key.read(iprot);
+          this->__isset.check_sort_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast119;
+          xfer += iprot->readI32(ecast119);
+          this->check_type = (cas_check_type::type)ecast119;
+          this->__isset.check_type = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->check_operand.read(iprot);
+          this->__isset.check_operand = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->mutate_list.clear();
+            uint32_t _size120;
+            ::apache::thrift::protocol::TType _etype123;
+            xfer += iprot->readListBegin(_etype123, _size120);
+            this->mutate_list.resize(_size120);
+            uint32_t _i124;
+            for (_i124 = 0; _i124 < _size120; ++_i124)
+            {
+              xfer += this->mutate_list[_i124].read(iprot);
+            }
+            xfer += iprot->readListEnd();
+          }
+          this->__isset.mutate_list = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->return_check_value);
+          this->__isset.return_check_value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t check_and_mutate_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("check_and_mutate_request");
+
+  xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->hash_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_sort_key", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->check_sort_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_type", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32((int32_t)this->check_type);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_operand", ::apache::thrift::protocol::T_STRUCT, 4);
+  xfer += this->check_operand.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("mutate_list", ::apache::thrift::protocol::T_LIST, 5);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->mutate_list.size()));
+    std::vector<mutate> ::const_iterator _iter125;
+    for (_iter125 = this->mutate_list.begin(); _iter125 != this->mutate_list.end(); ++_iter125)
+    {
+      xfer += (*_iter125).write(oprot);
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("return_check_value", ::apache::thrift::protocol::T_BOOL, 6);
+  xfer += oprot->writeBool(this->return_check_value);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(check_and_mutate_request &a, check_and_mutate_request &b) {
+  using ::std::swap;
+  swap(a.hash_key, b.hash_key);
+  swap(a.check_sort_key, b.check_sort_key);
+  swap(a.check_type, b.check_type);
+  swap(a.check_operand, b.check_operand);
+  swap(a.mutate_list, b.mutate_list);
+  swap(a.return_check_value, b.return_check_value);
+  swap(a.__isset, b.__isset);
+}
+
+check_and_mutate_request::check_and_mutate_request(const check_and_mutate_request& other126) {
+  hash_key = other126.hash_key;
+  check_sort_key = other126.check_sort_key;
+  check_type = other126.check_type;
+  check_operand = other126.check_operand;
+  mutate_list = other126.mutate_list;
+  return_check_value = other126.return_check_value;
+  __isset = other126.__isset;
+}
+check_and_mutate_request::check_and_mutate_request( check_and_mutate_request&& other127) {
+  hash_key = std::move(other127.hash_key);
+  check_sort_key = std::move(other127.check_sort_key);
+  check_type = std::move(other127.check_type);
+  check_operand = std::move(other127.check_operand);
+  mutate_list = std::move(other127.mutate_list);
+  return_check_value = std::move(other127.return_check_value);
+  __isset = std::move(other127.__isset);
+}
+check_and_mutate_request& check_and_mutate_request::operator=(const check_and_mutate_request& other128) {
+  hash_key = other128.hash_key;
+  check_sort_key = other128.check_sort_key;
+  check_type = other128.check_type;
+  check_operand = other128.check_operand;
+  mutate_list = other128.mutate_list;
+  return_check_value = other128.return_check_value;
+  __isset = other128.__isset;
+  return *this;
+}
+check_and_mutate_request& check_and_mutate_request::operator=(check_and_mutate_request&& other129) {
+  hash_key = std::move(other129.hash_key);
+  check_sort_key = std::move(other129.check_sort_key);
+  check_type = std::move(other129.check_type);
+  check_operand = std::move(other129.check_operand);
+  mutate_list = std::move(other129.mutate_list);
+  return_check_value = std::move(other129.return_check_value);
+  __isset = std::move(other129.__isset);
+  return *this;
+}
+void check_and_mutate_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "check_and_mutate_request(";
+  out << "hash_key=" << to_string(hash_key);
+  out << ", " << "check_sort_key=" << to_string(check_sort_key);
+  out << ", " << "check_type=" << to_string(check_type);
+  out << ", " << "check_operand=" << to_string(check_operand);
+  out << ", " << "mutate_list=" << to_string(mutate_list);
+  out << ", " << "return_check_value=" << to_string(return_check_value);
+  out << ")";
+}
+
+
+check_and_mutate_response::~check_and_mutate_response() throw() {
+}
+
+
+void check_and_mutate_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void check_and_mutate_response::__set_check_value_returned(const bool val) {
+  this->check_value_returned = val;
+}
+
+void check_and_mutate_response::__set_check_value_exist(const bool val) {
+  this->check_value_exist = val;
+}
+
+void check_and_mutate_response::__set_check_value(const  ::dsn::blob& val) {
+  this->check_value = val;
+}
+
+void check_and_mutate_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void check_and_mutate_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void check_and_mutate_response::__set_decree(const int64_t val) {
+  this->decree = val;
+}
+
+void check_and_mutate_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t check_and_mutate_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->check_value_returned);
+          this->__isset.check_value_returned = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->check_value_exist);
+          this->__isset.check_value_exist = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->check_value.read(iprot);
+          this->__isset.check_value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 7:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->decree);
+          this->__isset.decree = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 8:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t check_and_mutate_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("check_and_mutate_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_value_returned", ::apache::thrift::protocol::T_BOOL, 2);
+  xfer += oprot->writeBool(this->check_value_returned);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_value_exist", ::apache::thrift::protocol::T_BOOL, 3);
+  xfer += oprot->writeBool(this->check_value_exist);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("check_value", ::apache::thrift::protocol::T_STRUCT, 4);
+  xfer += this->check_value.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 5);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 6);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("decree", ::apache::thrift::protocol::T_I64, 7);
+  xfer += oprot->writeI64(this->decree);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 8);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(check_and_mutate_response &a, check_and_mutate_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.check_value_returned, b.check_value_returned);
+  swap(a.check_value_exist, b.check_value_exist);
+  swap(a.check_value, b.check_value);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.decree, b.decree);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+check_and_mutate_response::check_and_mutate_response(const check_and_mutate_response& other130) {
+  error = other130.error;
+  check_value_returned = other130.check_value_returned;
+  check_value_exist = other130.check_value_exist;
+  check_value = other130.check_value;
+  app_id = other130.app_id;
+  partition_index = other130.partition_index;
+  decree = other130.decree;
+  server = other130.server;
+  __isset = other130.__isset;
+}
+check_and_mutate_response::check_and_mutate_response( check_and_mutate_response&& other131) {
+  error = std::move(other131.error);
+  check_value_returned = std::move(other131.check_value_returned);
+  check_value_exist = std::move(other131.check_value_exist);
+  check_value = std::move(other131.check_value);
+  app_id = std::move(other131.app_id);
+  partition_index = std::move(other131.partition_index);
+  decree = std::move(other131.decree);
+  server = std::move(other131.server);
+  __isset = std::move(other131.__isset);
+}
+check_and_mutate_response& check_and_mutate_response::operator=(const check_and_mutate_response& other132) {
+  error = other132.error;
+  check_value_returned = other132.check_value_returned;
+  check_value_exist = other132.check_value_exist;
+  check_value = other132.check_value;
+  app_id = other132.app_id;
+  partition_index = other132.partition_index;
+  decree = other132.decree;
+  server = other132.server;
+  __isset = other132.__isset;
+  return *this;
+}
+check_and_mutate_response& check_and_mutate_response::operator=(check_and_mutate_response&& other133) {
+  error = std::move(other133.error);
+  check_value_returned = std::move(other133.check_value_returned);
+  check_value_exist = std::move(other133.check_value_exist);
+  check_value = std::move(other133.check_value);
+  app_id = std::move(other133.app_id);
+  partition_index = std::move(other133.partition_index);
+  decree = std::move(other133.decree);
+  server = std::move(other133.server);
+  __isset = std::move(other133.__isset);
+  return *this;
+}
+void check_and_mutate_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "check_and_mutate_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "check_value_returned=" << to_string(check_value_returned);
+  out << ", " << "check_value_exist=" << to_string(check_value_exist);
+  out << ", " << "check_value=" << to_string(check_value);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "decree=" << to_string(decree);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+get_scanner_request::~get_scanner_request() throw() {
+}
+
+
+void get_scanner_request::__set_start_key(const  ::dsn::blob& val) {
+  this->start_key = val;
+}
+
+void get_scanner_request::__set_stop_key(const  ::dsn::blob& val) {
+  this->stop_key = val;
+}
+
+void get_scanner_request::__set_start_inclusive(const bool val) {
+  this->start_inclusive = val;
+}
+
+void get_scanner_request::__set_stop_inclusive(const bool val) {
+  this->stop_inclusive = val;
+}
+
+void get_scanner_request::__set_batch_size(const int32_t val) {
+  this->batch_size = val;
+}
+
+void get_scanner_request::__set_no_value(const bool val) {
+  this->no_value = val;
+}
+
+void get_scanner_request::__set_hash_key_filter_type(const filter_type::type val) {
+  this->hash_key_filter_type = val;
+}
+
+void get_scanner_request::__set_hash_key_filter_pattern(const  ::dsn::blob& val) {
+  this->hash_key_filter_pattern = val;
+}
+
+void get_scanner_request::__set_sort_key_filter_type(const filter_type::type val) {
+  this->sort_key_filter_type = val;
+}
+
+void get_scanner_request::__set_sort_key_filter_pattern(const  ::dsn::blob& val) {
+  this->sort_key_filter_pattern = val;
+}
+
+void get_scanner_request::__set_validate_partition_hash(const bool val) {
+  this->validate_partition_hash = val;
+__isset.validate_partition_hash = true;
+}
+
+void get_scanner_request::__set_return_expire_ts(const bool val) {
+  this->return_expire_ts = val;
+__isset.return_expire_ts = true;
+}
+
+void get_scanner_request::__set_full_scan(const bool val) {
+  this->full_scan = val;
+__isset.full_scan = true;
+}
+
+uint32_t get_scanner_request::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->start_key.read(iprot);
+          this->__isset.start_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->stop_key.read(iprot);
+          this->__isset.stop_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->start_inclusive);
+          this->__isset.start_inclusive = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->stop_inclusive);
+          this->__isset.stop_inclusive = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->batch_size);
+          this->__isset.batch_size = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->no_value);
+          this->__isset.no_value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 7:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast134;
+          xfer += iprot->readI32(ecast134);
+          this->hash_key_filter_type = (filter_type::type)ecast134;
+          this->__isset.hash_key_filter_type = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 8:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->hash_key_filter_pattern.read(iprot);
+          this->__isset.hash_key_filter_pattern = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 9:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast135;
+          xfer += iprot->readI32(ecast135);
+          this->sort_key_filter_type = (filter_type::type)ecast135;
+          this->__isset.sort_key_filter_type = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 10:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sort_key_filter_pattern.read(iprot);
+          this->__isset.sort_key_filter_pattern = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 11:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->validate_partition_hash);
+          this->__isset.validate_partition_hash = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 12:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->return_expire_ts);
+          this->__isset.return_expire_ts = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 13:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->full_scan);
+          this->__isset.full_scan = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t get_scanner_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("get_scanner_request");
+
+  xfer += oprot->writeFieldBegin("start_key", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->start_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("stop_key", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->stop_key.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("start_inclusive", ::apache::thrift::protocol::T_BOOL, 3);
+  xfer += oprot->writeBool(this->start_inclusive);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("stop_inclusive", ::apache::thrift::protocol::T_BOOL, 4);
+  xfer += oprot->writeBool(this->stop_inclusive);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("batch_size", ::apache::thrift::protocol::T_I32, 5);
+  xfer += oprot->writeI32(this->batch_size);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("no_value", ::apache::thrift::protocol::T_BOOL, 6);
+  xfer += oprot->writeBool(this->no_value);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("hash_key_filter_type", ::apache::thrift::protocol::T_I32, 7);
+  xfer += oprot->writeI32((int32_t)this->hash_key_filter_type);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("hash_key_filter_pattern", ::apache::thrift::protocol::T_STRUCT, 8);
+  xfer += this->hash_key_filter_pattern.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("sort_key_filter_type", ::apache::thrift::protocol::T_I32, 9);
+  xfer += oprot->writeI32((int32_t)this->sort_key_filter_type);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("sort_key_filter_pattern", ::apache::thrift::protocol::T_STRUCT, 10);
+  xfer += this->sort_key_filter_pattern.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  if (this->__isset.validate_partition_hash) {
+    xfer += oprot->writeFieldBegin("validate_partition_hash", ::apache::thrift::protocol::T_BOOL, 11);
+    xfer += oprot->writeBool(this->validate_partition_hash);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.return_expire_ts) {
+    xfer += oprot->writeFieldBegin("return_expire_ts", ::apache::thrift::protocol::T_BOOL, 12);
+    xfer += oprot->writeBool(this->return_expire_ts);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.full_scan) {
+    xfer += oprot->writeFieldBegin("full_scan", ::apache::thrift::protocol::T_BOOL, 13);
+    xfer += oprot->writeBool(this->full_scan);
+    xfer += oprot->writeFieldEnd();
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(get_scanner_request &a, get_scanner_request &b) {
+  using ::std::swap;
+  swap(a.start_key, b.start_key);
+  swap(a.stop_key, b.stop_key);
+  swap(a.start_inclusive, b.start_inclusive);
+  swap(a.stop_inclusive, b.stop_inclusive);
+  swap(a.batch_size, b.batch_size);
+  swap(a.no_value, b.no_value);
+  swap(a.hash_key_filter_type, b.hash_key_filter_type);
+  swap(a.hash_key_filter_pattern, b.hash_key_filter_pattern);
+  swap(a.sort_key_filter_type, b.sort_key_filter_type);
+  swap(a.sort_key_filter_pattern, b.sort_key_filter_pattern);
+  swap(a.validate_partition_hash, b.validate_partition_hash);
+  swap(a.return_expire_ts, b.return_expire_ts);
+  swap(a.full_scan, b.full_scan);
+  swap(a.__isset, b.__isset);
+}
+
+get_scanner_request::get_scanner_request(const get_scanner_request& other136) {
+  start_key = other136.start_key;
+  stop_key = other136.stop_key;
+  start_inclusive = other136.start_inclusive;
+  stop_inclusive = other136.stop_inclusive;
+  batch_size = other136.batch_size;
+  no_value = other136.no_value;
+  hash_key_filter_type = other136.hash_key_filter_type;
+  hash_key_filter_pattern = other136.hash_key_filter_pattern;
+  sort_key_filter_type = other136.sort_key_filter_type;
+  sort_key_filter_pattern = other136.sort_key_filter_pattern;
+  validate_partition_hash = other136.validate_partition_hash;
+  return_expire_ts = other136.return_expire_ts;
+  full_scan = other136.full_scan;
+  __isset = other136.__isset;
+}
+get_scanner_request::get_scanner_request( get_scanner_request&& other137) {
+  start_key = std::move(other137.start_key);
+  stop_key = std::move(other137.stop_key);
+  start_inclusive = std::move(other137.start_inclusive);
+  stop_inclusive = std::move(other137.stop_inclusive);
+  batch_size = std::move(other137.batch_size);
+  no_value = std::move(other137.no_value);
+  hash_key_filter_type = std::move(other137.hash_key_filter_type);
+  hash_key_filter_pattern = std::move(other137.hash_key_filter_pattern);
+  sort_key_filter_type = std::move(other137.sort_key_filter_type);
+  sort_key_filter_pattern = std::move(other137.sort_key_filter_pattern);
+  validate_partition_hash = std::move(other137.validate_partition_hash);
+  return_expire_ts = std::move(other137.return_expire_ts);
+  full_scan = std::move(other137.full_scan);
+  __isset = std::move(other137.__isset);
+}
+get_scanner_request& get_scanner_request::operator=(const get_scanner_request& other138) {
+  start_key = other138.start_key;
+  stop_key = other138.stop_key;
+  start_inclusive = other138.start_inclusive;
+  stop_inclusive = other138.stop_inclusive;
+  batch_size = other138.batch_size;
+  no_value = other138.no_value;
+  hash_key_filter_type = other138.hash_key_filter_type;
+  hash_key_filter_pattern = other138.hash_key_filter_pattern;
+  sort_key_filter_type = other138.sort_key_filter_type;
+  sort_key_filter_pattern = other138.sort_key_filter_pattern;
+  validate_partition_hash = other138.validate_partition_hash;
+  return_expire_ts = other138.return_expire_ts;
+  full_scan = other138.full_scan;
+  __isset = other138.__isset;
+  return *this;
+}
+get_scanner_request& get_scanner_request::operator=(get_scanner_request&& other139) {
+  start_key = std::move(other139.start_key);
+  stop_key = std::move(other139.stop_key);
+  start_inclusive = std::move(other139.start_inclusive);
+  stop_inclusive = std::move(other139.stop_inclusive);
+  batch_size = std::move(other139.batch_size);
+  no_value = std::move(other139.no_value);
+  hash_key_filter_type = std::move(other139.hash_key_filter_type);
+  hash_key_filter_pattern = std::move(other139.hash_key_filter_pattern);
+  sort_key_filter_type = std::move(other139.sort_key_filter_type);
+  sort_key_filter_pattern = std::move(other139.sort_key_filter_pattern);
+  validate_partition_hash = std::move(other139.validate_partition_hash);
+  return_expire_ts = std::move(other139.return_expire_ts);
+  full_scan = std::move(other139.full_scan);
+  __isset = std::move(other139.__isset);
+  return *this;
+}
+void get_scanner_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "get_scanner_request(";
+  out << "start_key=" << to_string(start_key);
+  out << ", " << "stop_key=" << to_string(stop_key);
+  out << ", " << "start_inclusive=" << to_string(start_inclusive);
+  out << ", " << "stop_inclusive=" << to_string(stop_inclusive);
+  out << ", " << "batch_size=" << to_string(batch_size);
+  out << ", " << "no_value=" << to_string(no_value);
+  out << ", " << "hash_key_filter_type=" << to_string(hash_key_filter_type);
+  out << ", " << "hash_key_filter_pattern=" << to_string(hash_key_filter_pattern);
+  out << ", " << "sort_key_filter_type=" << to_string(sort_key_filter_type);
+  out << ", " << "sort_key_filter_pattern=" << to_string(sort_key_filter_pattern);
+  out << ", " << "validate_partition_hash="; (__isset.validate_partition_hash ? (out << to_string(validate_partition_hash)) : (out << "<null>"));
+  out << ", " << "return_expire_ts="; (__isset.return_expire_ts ? (out << to_string(return_expire_ts)) : (out << "<null>"));
+  out << ", " << "full_scan="; (__isset.full_scan ? (out << to_string(full_scan)) : (out << "<null>"));
+  out << ")";
+}
+
+
+scan_request::~scan_request() throw() {
+}
+
+
+void scan_request::__set_context_id(const int64_t val) {
+  this->context_id = val;
+}
+
+uint32_t scan_request::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->context_id);
+          this->__isset.context_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t scan_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("scan_request");
+
+  xfer += oprot->writeFieldBegin("context_id", ::apache::thrift::protocol::T_I64, 1);
+  xfer += oprot->writeI64(this->context_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(scan_request &a, scan_request &b) {
+  using ::std::swap;
+  swap(a.context_id, b.context_id);
+  swap(a.__isset, b.__isset);
+}
+
+scan_request::scan_request(const scan_request& other140) {
+  context_id = other140.context_id;
+  __isset = other140.__isset;
+}
+scan_request::scan_request( scan_request&& other141) {
+  context_id = std::move(other141.context_id);
+  __isset = std::move(other141.__isset);
+}
+scan_request& scan_request::operator=(const scan_request& other142) {
+  context_id = other142.context_id;
+  __isset = other142.__isset;
+  return *this;
+}
+scan_request& scan_request::operator=(scan_request&& other143) {
+  context_id = std::move(other143.context_id);
+  __isset = std::move(other143.__isset);
+  return *this;
+}
+void scan_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "scan_request(";
+  out << "context_id=" << to_string(context_id);
+  out << ")";
+}
+
+
+scan_response::~scan_response() throw() {
+}
+
+
+void scan_response::__set_error(const int32_t val) {
+  this->error = val;
+}
+
+void scan_response::__set_kvs(const std::vector<key_value> & val) {
+  this->kvs = val;
+}
+
+void scan_response::__set_context_id(const int64_t val) {
+  this->context_id = val;
+}
+
+void scan_response::__set_app_id(const int32_t val) {
+  this->app_id = val;
+}
+
+void scan_response::__set_partition_index(const int32_t val) {
+  this->partition_index = val;
+}
+
+void scan_response::__set_server(const std::string& val) {
+  this->server = val;
+}
+
+uint32_t scan_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->kvs.clear();
+            uint32_t _size144;
+            ::apache::thrift::protocol::TType _etype147;
+            xfer += iprot->readListBegin(_etype147, _size144);
+            this->kvs.resize(_size144);
+            uint32_t _i148;
+            for (_i148 = 0; _i148 < _size144; ++_i148)
+            {
+              xfer += this->kvs[_i148].read(iprot);
+            }
+            xfer += iprot->readListEnd();
+          }
+          this->__isset.kvs = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->context_id);
+          this->__isset.context_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->app_id);
+          this->__isset.app_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->partition_index);
+          this->__isset.partition_index = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server);
+          this->__isset.server = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t scan_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("scan_response");
+
+  xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32(this->error);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("kvs", ::apache::thrift::protocol::T_LIST, 2);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->kvs.size()));
+    std::vector<key_value> ::const_iterator _iter149;
+    for (_iter149 = this->kvs.begin(); _iter149 != this->kvs.end(); ++_iter149)
+    {
+      xfer += (*_iter149).write(oprot);
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("context_id", ::apache::thrift::protocol::T_I64, 3);
+  xfer += oprot->writeI64(this->context_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32(this->app_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 5);
+  xfer += oprot->writeI32(this->partition_index);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
+  xfer += oprot->writeString(this->server);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(scan_response &a, scan_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.kvs, b.kvs);
+  swap(a.context_id, b.context_id);
+  swap(a.app_id, b.app_id);
+  swap(a.partition_index, b.partition_index);
+  swap(a.server, b.server);
+  swap(a.__isset, b.__isset);
+}
+
+scan_response::scan_response(const scan_response& other150) {
+  error = other150.error;
+  kvs = other150.kvs;
+  context_id = other150.context_id;
+  app_id = other150.app_id;
+  partition_index = other150.partition_index;
+  server = other150.server;
+  __isset = other150.__isset;
+}
+scan_response::scan_response( scan_response&& other151) {
+  error = std::move(other151.error);
+  kvs = std::move(other151.kvs);
+  context_id = std::move(other151.context_id);
+  app_id = std::move(other151.app_id);
+  partition_index = std::move(other151.partition_index);
+  server = std::move(other151.server);
+  __isset = std::move(other151.__isset);
+}
+scan_response& scan_response::operator=(const scan_response& other152) {
+  error = other152.error;
+  kvs = other152.kvs;
+  context_id = other152.context_id;
+  app_id = other152.app_id;
+  partition_index = other152.partition_index;
+  server = other152.server;
+  __isset = other152.__isset;
+  return *this;
+}
+scan_response& scan_response::operator=(scan_response&& other153) {
+  error = std::move(other153.error);
+  kvs = std::move(other153.kvs);
+  context_id = std::move(other153.context_id);
+  app_id = std::move(other153.app_id);
+  partition_index = std::move(other153.partition_index);
+  server = std::move(other153.server);
+  __isset = std::move(other153.__isset);
+  return *this;
+}
+void scan_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "scan_response(";
+  out << "error=" << to_string(error);
+  out << ", " << "kvs=" << to_string(kvs);
+  out << ", " << "context_id=" << to_string(context_id);
+  out << ", " << "app_id=" << to_string(app_id);
+  out << ", " << "partition_index=" << to_string(partition_index);
+  out << ", " << "server=" << to_string(server);
+  out << ")";
+}
+
+
+duplicate_request::~duplicate_request() throw() {
+}
+
+
+void duplicate_request::__set_entries(const std::vector<duplicate_entry> & val) {
+  this->entries = val;
+}
+
+uint32_t duplicate_request::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->entries.clear();
+            uint32_t _size154;
+            ::apache::thrift::protocol::TType _etype157;
+            xfer += iprot->readListBegin(_etype157, _size154);
+            this->entries.resize(_size154);
+            uint32_t _i158;
+            for (_i158 = 0; _i158 < _size154; ++_i158)
+            {
+              xfer += this->entries[_i158].read(iprot);
+            }
+            xfer += iprot->readListEnd();
+          }
+          this->__isset.entries = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t duplicate_request::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("duplicate_request");
+
+  xfer += oprot->writeFieldBegin("entries", ::apache::thrift::protocol::T_LIST, 1);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->entries.size()));
+    std::vector<duplicate_entry> ::const_iterator _iter159;
+    for (_iter159 = this->entries.begin(); _iter159 != this->entries.end(); ++_iter159)
+    {
+      xfer += (*_iter159).write(oprot);
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(duplicate_request &a, duplicate_request &b) {
+  using ::std::swap;
+  swap(a.entries, b.entries);
+  swap(a.__isset, b.__isset);
+}
+
+duplicate_request::duplicate_request(const duplicate_request& other160) {
+  entries = other160.entries;
+  __isset = other160.__isset;
+}
+duplicate_request::duplicate_request( duplicate_request&& other161) {
+  entries = std::move(other161.entries);
+  __isset = std::move(other161.__isset);
+}
+duplicate_request& duplicate_request::operator=(const duplicate_request& other162) {
+  entries = other162.entries;
+  __isset = other162.__isset;
+  return *this;
+}
+duplicate_request& duplicate_request::operator=(duplicate_request&& other163) {
+  entries = std::move(other163.entries);
+  __isset = std::move(other163.__isset);
+  return *this;
+}
+void duplicate_request::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "duplicate_request(";
+  out << "entries=" << to_string(entries);
+  out << ")";
+}
+
+
+duplicate_entry::~duplicate_entry() throw() {
+}
+
+
+void duplicate_entry::__set_timestamp(const int64_t val) {
+  this->timestamp = val;
+__isset.timestamp = true;
+}
+
+void duplicate_entry::__set_task_code(const  ::dsn::task_code& val) {
+  this->task_code = val;
+__isset.task_code = true;
+}
+
+void duplicate_entry::__set_raw_message(const  ::dsn::blob& val) {
+  this->raw_message = val;
+__isset.raw_message = true;
+}
+
+void duplicate_entry::__set_cluster_id(const int8_t val) {
+  this->cluster_id = val;
+__isset.cluster_id = true;
+}
+
+void duplicate_entry::__set_verify_timetag(const bool val) {
+  this->verify_timetag = val;
+__isset.verify_timetag = true;
+}
+
+uint32_t duplicate_entry::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->timestamp);
+          this->__isset.timestamp = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->task_code.read(iprot);
+          this->__isset.task_code = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->raw_message.read(iprot);
+          this->__isset.raw_message = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_BYTE) {
+          xfer += iprot->readByte(this->cluster_id);
+          this->__isset.cluster_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->verify_timetag);
+          this->__isset.verify_timetag = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t duplicate_entry::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("duplicate_entry");
+
+  if (this->__isset.timestamp) {
+    xfer += oprot->writeFieldBegin("timestamp", ::apache::thrift::protocol::T_I64, 1);
+    xfer += oprot->writeI64(this->timestamp);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.task_code) {
+    xfer += oprot->writeFieldBegin("task_code", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->task_code.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.raw_message) {
+    xfer += oprot->writeFieldBegin("raw_message", ::apache::thrift::protocol::T_STRUCT, 3);
+    xfer += this->raw_message.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.cluster_id) {
+    xfer += oprot->writeFieldBegin("cluster_id", ::apache::thrift::protocol::T_BYTE, 4);
+    xfer += oprot->writeByte(this->cluster_id);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.verify_timetag) {
+    xfer += oprot->writeFieldBegin("verify_timetag", ::apache::thrift::protocol::T_BOOL, 5);
+    xfer += oprot->writeBool(this->verify_timetag);
+    xfer += oprot->writeFieldEnd();
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(duplicate_entry &a, duplicate_entry &b) {
+  using ::std::swap;
+  swap(a.timestamp, b.timestamp);
+  swap(a.task_code, b.task_code);
+  swap(a.raw_message, b.raw_message);
+  swap(a.cluster_id, b.cluster_id);
+  swap(a.verify_timetag, b.verify_timetag);
+  swap(a.__isset, b.__isset);
+}
+
+duplicate_entry::duplicate_entry(const duplicate_entry& other164) {
+  timestamp = other164.timestamp;
+  task_code = other164.task_code;
+  raw_message = other164.raw_message;
+  cluster_id = other164.cluster_id;
+  verify_timetag = other164.verify_timetag;
+  __isset = other164.__isset;
+}
+duplicate_entry::duplicate_entry( duplicate_entry&& other165) {
+  timestamp = std::move(other165.timestamp);
+  task_code = std::move(other165.task_code);
+  raw_message = std::move(other165.raw_message);
+  cluster_id = std::move(other165.cluster_id);
+  verify_timetag = std::move(other165.verify_timetag);
+  __isset = std::move(other165.__isset);
+}
+duplicate_entry& duplicate_entry::operator=(const duplicate_entry& other166) {
+  timestamp = other166.timestamp;
+  task_code = other166.task_code;
+  raw_message = other166.raw_message;
+  cluster_id = other166.cluster_id;
+  verify_timetag = other166.verify_timetag;
+  __isset = other166.__isset;
+  return *this;
+}
+duplicate_entry& duplicate_entry::operator=(duplicate_entry&& other167) {
+  timestamp = std::move(other167.timestamp);
+  task_code = std::move(other167.task_code);
+  raw_message = std::move(other167.raw_message);
+  cluster_id = std::move(other167.cluster_id);
+  verify_timetag = std::move(other167.verify_timetag);
+  __isset = std::move(other167.__isset);
+  return *this;
+}
+void duplicate_entry::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "duplicate_entry(";
+  out << "timestamp="; (__isset.timestamp ? (out << to_string(timestamp)) : (out << "<null>"));
+  out << ", " << "task_code="; (__isset.task_code ? (out << to_string(task_code)) : (out << "<null>"));
+  out << ", " << "raw_message="; (__isset.raw_message ? (out << to_string(raw_message)) : (out << "<null>"));
+  out << ", " << "cluster_id="; (__isset.cluster_id ? (out << to_string(cluster_id)) : (out << "<null>"));
+  out << ", " << "verify_timetag="; (__isset.verify_timetag ? (out << to_string(verify_timetag)) : (out << "<null>"));
+  out << ")";
+}
+
+
+duplicate_response::~duplicate_response() throw() {
+}
+
+
+void duplicate_response::__set_error(const int32_t val) {
+  this->error = val;
+__isset.error = true;
+}
+
+void duplicate_response::__set_error_hint(const std::string& val) {
+  this->error_hint = val;
+__isset.error_hint = true;
+}
+
+uint32_t duplicate_response::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->error);
+          this->__isset.error = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->error_hint);
+          this->__isset.error_hint = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t duplicate_response::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("duplicate_response");
+
+  if (this->__isset.error) {
     xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
     xfer += oprot->writeI32(this->error);
     xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("count", ::apache::thrift::protocol::T_I64, 2);
-    xfer += oprot->writeI64(this->count);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("decree", ::apache::thrift::protocol::T_I64, 5);
-    xfer += oprot->writeI64(this->decree);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(multi_remove_response &a, multi_remove_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.count, b.count);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.decree, b.decree);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-multi_remove_response::multi_remove_response(const multi_remove_response &other44)
-{
-    error = other44.error;
-    count = other44.count;
-    app_id = other44.app_id;
-    partition_index = other44.partition_index;
-    decree = other44.decree;
-    server = other44.server;
-    __isset = other44.__isset;
-}
-multi_remove_response::multi_remove_response(multi_remove_response &&other45)
-{
-    error = std::move(other45.error);
-    count = std::move(other45.count);
-    app_id = std::move(other45.app_id);
-    partition_index = std::move(other45.partition_index);
-    decree = std::move(other45.decree);
-    server = std::move(other45.server);
-    __isset = std::move(other45.__isset);
-}
-multi_remove_response &multi_remove_response::operator=(const multi_remove_response &other46)
-{
-    error = other46.error;
-    count = other46.count;
-    app_id = other46.app_id;
-    partition_index = other46.partition_index;
-    decree = other46.decree;
-    server = other46.server;
-    __isset = other46.__isset;
-    return *this;
-}
-multi_remove_response &multi_remove_response::operator=(multi_remove_response &&other47)
-{
-    error = std::move(other47.error);
-    count = std::move(other47.count);
-    app_id = std::move(other47.app_id);
-    partition_index = std::move(other47.partition_index);
-    decree = std::move(other47.decree);
-    server = std::move(other47.server);
-    __isset = std::move(other47.__isset);
-    return *this;
-}
-void multi_remove_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "multi_remove_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "count=" << to_string(count);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "decree=" << to_string(decree);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-multi_get_request::~multi_get_request() throw() {}
-
-void multi_get_request::__set_hash_key(const ::dsn::blob &val) { this->hash_key = val; }
-
-void multi_get_request::__set_sort_keys(const std::vector<::dsn::blob> &val)
-{
-    this->sort_keys = val;
-}
-
-void multi_get_request::__set_max_kv_count(const int32_t val) { this->max_kv_count = val; }
-
-void multi_get_request::__set_max_kv_size(const int32_t val) { this->max_kv_size = val; }
-
-void multi_get_request::__set_no_value(const bool val) { this->no_value = val; }
-
-void multi_get_request::__set_start_sortkey(const ::dsn::blob &val) { this->start_sortkey = val; }
-
-void multi_get_request::__set_stop_sortkey(const ::dsn::blob &val) { this->stop_sortkey = val; }
-
-void multi_get_request::__set_start_inclusive(const bool val) { this->start_inclusive = val; }
-
-void multi_get_request::__set_stop_inclusive(const bool val) { this->stop_inclusive = val; }
-
-void multi_get_request::__set_sort_key_filter_type(const filter_type::type val)
-{
-    this->sort_key_filter_type = val;
-}
-
-void multi_get_request::__set_sort_key_filter_pattern(const ::dsn::blob &val)
-{
-    this->sort_key_filter_pattern = val;
-}
-
-void multi_get_request::__set_reverse(const bool val) { this->reverse = val; }
-
-uint32_t multi_get_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->hash_key.read(iprot);
-                this->__isset.hash_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_LIST) {
-                {
-                    this->sort_keys.clear();
-                    uint32_t _size48;
-                    ::apache::thrift::protocol::TType _etype51;
-                    xfer += iprot->readListBegin(_etype51, _size48);
-                    this->sort_keys.resize(_size48);
-                    uint32_t _i52;
-                    for (_i52 = 0; _i52 < _size48; ++_i52) {
-                        xfer += this->sort_keys[_i52].read(iprot);
-                    }
-                    xfer += iprot->readListEnd();
-                }
-                this->__isset.sort_keys = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->max_kv_count);
-                this->__isset.max_kv_count = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->max_kv_size);
-                this->__isset.max_kv_size = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->no_value);
-                this->__isset.no_value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->start_sortkey.read(iprot);
-                this->__isset.start_sortkey = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 7:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->stop_sortkey.read(iprot);
-                this->__isset.stop_sortkey = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 8:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->start_inclusive);
-                this->__isset.start_inclusive = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 9:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->stop_inclusive);
-                this->__isset.stop_inclusive = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 10:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                int32_t ecast53;
-                xfer += iprot->readI32(ecast53);
-                this->sort_key_filter_type = (filter_type::type)ecast53;
-                this->__isset.sort_key_filter_type = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 11:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->sort_key_filter_pattern.read(iprot);
-                this->__isset.sort_key_filter_pattern = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 12:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->reverse);
-                this->__isset.reverse = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t multi_get_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("multi_get_request");
-
-    xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->hash_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("sort_keys", ::apache::thrift::protocol::T_LIST, 2);
-    {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT,
-                                      static_cast<uint32_t>(this->sort_keys.size()));
-        std::vector<::dsn::blob>::const_iterator _iter54;
-        for (_iter54 = this->sort_keys.begin(); _iter54 != this->sort_keys.end(); ++_iter54) {
-            xfer += (*_iter54).write(oprot);
-        }
-        xfer += oprot->writeListEnd();
-    }
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("max_kv_count", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->max_kv_count);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("max_kv_size", ::apache::thrift::protocol::T_I32, 4);
-    xfer += oprot->writeI32(this->max_kv_size);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("no_value", ::apache::thrift::protocol::T_BOOL, 5);
-    xfer += oprot->writeBool(this->no_value);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("start_sortkey", ::apache::thrift::protocol::T_STRUCT, 6);
-    xfer += this->start_sortkey.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("stop_sortkey", ::apache::thrift::protocol::T_STRUCT, 7);
-    xfer += this->stop_sortkey.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("start_inclusive", ::apache::thrift::protocol::T_BOOL, 8);
-    xfer += oprot->writeBool(this->start_inclusive);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("stop_inclusive", ::apache::thrift::protocol::T_BOOL, 9);
-    xfer += oprot->writeBool(this->stop_inclusive);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("sort_key_filter_type", ::apache::thrift::protocol::T_I32, 10);
-    xfer += oprot->writeI32((int32_t)this->sort_key_filter_type);
-    xfer += oprot->writeFieldEnd();
-
-    xfer +=
-        oprot->writeFieldBegin("sort_key_filter_pattern", ::apache::thrift::protocol::T_STRUCT, 11);
-    xfer += this->sort_key_filter_pattern.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("reverse", ::apache::thrift::protocol::T_BOOL, 12);
-    xfer += oprot->writeBool(this->reverse);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(multi_get_request &a, multi_get_request &b)
-{
-    using ::std::swap;
-    swap(a.hash_key, b.hash_key);
-    swap(a.sort_keys, b.sort_keys);
-    swap(a.max_kv_count, b.max_kv_count);
-    swap(a.max_kv_size, b.max_kv_size);
-    swap(a.no_value, b.no_value);
-    swap(a.start_sortkey, b.start_sortkey);
-    swap(a.stop_sortkey, b.stop_sortkey);
-    swap(a.start_inclusive, b.start_inclusive);
-    swap(a.stop_inclusive, b.stop_inclusive);
-    swap(a.sort_key_filter_type, b.sort_key_filter_type);
-    swap(a.sort_key_filter_pattern, b.sort_key_filter_pattern);
-    swap(a.reverse, b.reverse);
-    swap(a.__isset, b.__isset);
-}
-
-multi_get_request::multi_get_request(const multi_get_request &other55)
-{
-    hash_key = other55.hash_key;
-    sort_keys = other55.sort_keys;
-    max_kv_count = other55.max_kv_count;
-    max_kv_size = other55.max_kv_size;
-    no_value = other55.no_value;
-    start_sortkey = other55.start_sortkey;
-    stop_sortkey = other55.stop_sortkey;
-    start_inclusive = other55.start_inclusive;
-    stop_inclusive = other55.stop_inclusive;
-    sort_key_filter_type = other55.sort_key_filter_type;
-    sort_key_filter_pattern = other55.sort_key_filter_pattern;
-    reverse = other55.reverse;
-    __isset = other55.__isset;
-}
-multi_get_request::multi_get_request(multi_get_request &&other56)
-{
-    hash_key = std::move(other56.hash_key);
-    sort_keys = std::move(other56.sort_keys);
-    max_kv_count = std::move(other56.max_kv_count);
-    max_kv_size = std::move(other56.max_kv_size);
-    no_value = std::move(other56.no_value);
-    start_sortkey = std::move(other56.start_sortkey);
-    stop_sortkey = std::move(other56.stop_sortkey);
-    start_inclusive = std::move(other56.start_inclusive);
-    stop_inclusive = std::move(other56.stop_inclusive);
-    sort_key_filter_type = std::move(other56.sort_key_filter_type);
-    sort_key_filter_pattern = std::move(other56.sort_key_filter_pattern);
-    reverse = std::move(other56.reverse);
-    __isset = std::move(other56.__isset);
-}
-multi_get_request &multi_get_request::operator=(const multi_get_request &other57)
-{
-    hash_key = other57.hash_key;
-    sort_keys = other57.sort_keys;
-    max_kv_count = other57.max_kv_count;
-    max_kv_size = other57.max_kv_size;
-    no_value = other57.no_value;
-    start_sortkey = other57.start_sortkey;
-    stop_sortkey = other57.stop_sortkey;
-    start_inclusive = other57.start_inclusive;
-    stop_inclusive = other57.stop_inclusive;
-    sort_key_filter_type = other57.sort_key_filter_type;
-    sort_key_filter_pattern = other57.sort_key_filter_pattern;
-    reverse = other57.reverse;
-    __isset = other57.__isset;
-    return *this;
-}
-multi_get_request &multi_get_request::operator=(multi_get_request &&other58)
-{
-    hash_key = std::move(other58.hash_key);
-    sort_keys = std::move(other58.sort_keys);
-    max_kv_count = std::move(other58.max_kv_count);
-    max_kv_size = std::move(other58.max_kv_size);
-    no_value = std::move(other58.no_value);
-    start_sortkey = std::move(other58.start_sortkey);
-    stop_sortkey = std::move(other58.stop_sortkey);
-    start_inclusive = std::move(other58.start_inclusive);
-    stop_inclusive = std::move(other58.stop_inclusive);
-    sort_key_filter_type = std::move(other58.sort_key_filter_type);
-    sort_key_filter_pattern = std::move(other58.sort_key_filter_pattern);
-    reverse = std::move(other58.reverse);
-    __isset = std::move(other58.__isset);
-    return *this;
-}
-void multi_get_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "multi_get_request(";
-    out << "hash_key=" << to_string(hash_key);
-    out << ", "
-        << "sort_keys=" << to_string(sort_keys);
-    out << ", "
-        << "max_kv_count=" << to_string(max_kv_count);
-    out << ", "
-        << "max_kv_size=" << to_string(max_kv_size);
-    out << ", "
-        << "no_value=" << to_string(no_value);
-    out << ", "
-        << "start_sortkey=" << to_string(start_sortkey);
-    out << ", "
-        << "stop_sortkey=" << to_string(stop_sortkey);
-    out << ", "
-        << "start_inclusive=" << to_string(start_inclusive);
-    out << ", "
-        << "stop_inclusive=" << to_string(stop_inclusive);
-    out << ", "
-        << "sort_key_filter_type=" << to_string(sort_key_filter_type);
-    out << ", "
-        << "sort_key_filter_pattern=" << to_string(sort_key_filter_pattern);
-    out << ", "
-        << "reverse=" << to_string(reverse);
-    out << ")";
-}
-
-multi_get_response::~multi_get_response() throw() {}
-
-void multi_get_response::__set_error(const int32_t val) { this->error = val; }
-
-void multi_get_response::__set_kvs(const std::vector<key_value> &val) { this->kvs = val; }
-
-void multi_get_response::__set_app_id(const int32_t val) { this->app_id = val; }
-
-void multi_get_response::__set_partition_index(const int32_t val) { this->partition_index = val; }
-
-void multi_get_response::__set_server(const std::string &val) { this->server = val; }
-
-uint32_t multi_get_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_LIST) {
-                {
-                    this->kvs.clear();
-                    uint32_t _size59;
-                    ::apache::thrift::protocol::TType _etype62;
-                    xfer += iprot->readListBegin(_etype62, _size59);
-                    this->kvs.resize(_size59);
-                    uint32_t _i63;
-                    for (_i63 = 0; _i63 < _size59; ++_i63) {
-                        xfer += this->kvs[_i63].read(iprot);
-                    }
-                    xfer += iprot->readListEnd();
-                }
-                this->__isset.kvs = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t multi_get_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("multi_get_response");
-
-    xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32(this->error);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("kvs", ::apache::thrift::protocol::T_LIST, 2);
-    {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT,
-                                      static_cast<uint32_t>(this->kvs.size()));
-        std::vector<key_value>::const_iterator _iter64;
-        for (_iter64 = this->kvs.begin(); _iter64 != this->kvs.end(); ++_iter64) {
-            xfer += (*_iter64).write(oprot);
-        }
-        xfer += oprot->writeListEnd();
-    }
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(multi_get_response &a, multi_get_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.kvs, b.kvs);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-multi_get_response::multi_get_response(const multi_get_response &other65)
-{
-    error = other65.error;
-    kvs = other65.kvs;
-    app_id = other65.app_id;
-    partition_index = other65.partition_index;
-    server = other65.server;
-    __isset = other65.__isset;
-}
-multi_get_response::multi_get_response(multi_get_response &&other66)
-{
-    error = std::move(other66.error);
-    kvs = std::move(other66.kvs);
-    app_id = std::move(other66.app_id);
-    partition_index = std::move(other66.partition_index);
-    server = std::move(other66.server);
-    __isset = std::move(other66.__isset);
-}
-multi_get_response &multi_get_response::operator=(const multi_get_response &other67)
-{
-    error = other67.error;
-    kvs = other67.kvs;
-    app_id = other67.app_id;
-    partition_index = other67.partition_index;
-    server = other67.server;
-    __isset = other67.__isset;
-    return *this;
-}
-multi_get_response &multi_get_response::operator=(multi_get_response &&other68)
-{
-    error = std::move(other68.error);
-    kvs = std::move(other68.kvs);
-    app_id = std::move(other68.app_id);
-    partition_index = std::move(other68.partition_index);
-    server = std::move(other68.server);
-    __isset = std::move(other68.__isset);
-    return *this;
-}
-void multi_get_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "multi_get_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "kvs=" << to_string(kvs);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-batch_get_request::~batch_get_request() throw() {}
-
-void batch_get_request::__set_keys(const std::vector<full_key> &val) { this->keys = val; }
-
-uint32_t batch_get_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_LIST) {
-                {
-                    this->keys.clear();
-                    uint32_t _size69;
-                    ::apache::thrift::protocol::TType _etype72;
-                    xfer += iprot->readListBegin(_etype72, _size69);
-                    this->keys.resize(_size69);
-                    uint32_t _i73;
-                    for (_i73 = 0; _i73 < _size69; ++_i73) {
-                        xfer += this->keys[_i73].read(iprot);
-                    }
-                    xfer += iprot->readListEnd();
-                }
-                this->__isset.keys = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t batch_get_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("batch_get_request");
-
-    xfer += oprot->writeFieldBegin("keys", ::apache::thrift::protocol::T_LIST, 1);
-    {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT,
-                                      static_cast<uint32_t>(this->keys.size()));
-        std::vector<full_key>::const_iterator _iter74;
-        for (_iter74 = this->keys.begin(); _iter74 != this->keys.end(); ++_iter74) {
-            xfer += (*_iter74).write(oprot);
-        }
-        xfer += oprot->writeListEnd();
-    }
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(batch_get_request &a, batch_get_request &b)
-{
-    using ::std::swap;
-    swap(a.keys, b.keys);
-    swap(a.__isset, b.__isset);
-}
-
-batch_get_request::batch_get_request(const batch_get_request &other75)
-{
-    keys = other75.keys;
-    __isset = other75.__isset;
-}
-batch_get_request::batch_get_request(batch_get_request &&other76)
-{
-    keys = std::move(other76.keys);
-    __isset = std::move(other76.__isset);
-}
-batch_get_request &batch_get_request::operator=(const batch_get_request &other77)
-{
-    keys = other77.keys;
-    __isset = other77.__isset;
-    return *this;
-}
-batch_get_request &batch_get_request::operator=(batch_get_request &&other78)
-{
-    keys = std::move(other78.keys);
-    __isset = std::move(other78.__isset);
-    return *this;
-}
-void batch_get_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "batch_get_request(";
-    out << "keys=" << to_string(keys);
-    out << ")";
-}
-
-full_key::~full_key() throw() {}
-
-void full_key::__set_hash_key(const ::dsn::blob &val) { this->hash_key = val; }
-
-void full_key::__set_sort_key(const ::dsn::blob &val) { this->sort_key = val; }
-
-uint32_t full_key::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->hash_key.read(iprot);
-                this->__isset.hash_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->sort_key.read(iprot);
-                this->__isset.sort_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t full_key::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("full_key");
-
-    xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->hash_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("sort_key", ::apache::thrift::protocol::T_STRUCT, 2);
-    xfer += this->sort_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(full_key &a, full_key &b)
-{
-    using ::std::swap;
-    swap(a.hash_key, b.hash_key);
-    swap(a.sort_key, b.sort_key);
-    swap(a.__isset, b.__isset);
-}
-
-full_key::full_key(const full_key &other79)
-{
-    hash_key = other79.hash_key;
-    sort_key = other79.sort_key;
-    __isset = other79.__isset;
-}
-full_key::full_key(full_key &&other80)
-{
-    hash_key = std::move(other80.hash_key);
-    sort_key = std::move(other80.sort_key);
-    __isset = std::move(other80.__isset);
-}
-full_key &full_key::operator=(const full_key &other81)
-{
-    hash_key = other81.hash_key;
-    sort_key = other81.sort_key;
-    __isset = other81.__isset;
-    return *this;
-}
-full_key &full_key::operator=(full_key &&other82)
-{
-    hash_key = std::move(other82.hash_key);
-    sort_key = std::move(other82.sort_key);
-    __isset = std::move(other82.__isset);
-    return *this;
-}
-void full_key::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "full_key(";
-    out << "hash_key=" << to_string(hash_key);
-    out << ", "
-        << "sort_key=" << to_string(sort_key);
-    out << ")";
-}
-
-batch_get_response::~batch_get_response() throw() {}
-
-void batch_get_response::__set_error(const int32_t val) { this->error = val; }
-
-void batch_get_response::__set_data(const std::vector<full_data> &val) { this->data = val; }
-
-void batch_get_response::__set_app_id(const int32_t val) { this->app_id = val; }
-
-void batch_get_response::__set_partition_index(const int32_t val) { this->partition_index = val; }
-
-void batch_get_response::__set_server(const std::string &val) { this->server = val; }
-
-uint32_t batch_get_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_LIST) {
-                {
-                    this->data.clear();
-                    uint32_t _size83;
-                    ::apache::thrift::protocol::TType _etype86;
-                    xfer += iprot->readListBegin(_etype86, _size83);
-                    this->data.resize(_size83);
-                    uint32_t _i87;
-                    for (_i87 = 0; _i87 < _size83; ++_i87) {
-                        xfer += this->data[_i87].read(iprot);
-                    }
-                    xfer += iprot->readListEnd();
-                }
-                this->__isset.data = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t batch_get_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("batch_get_response");
-
-    xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32(this->error);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("data", ::apache::thrift::protocol::T_LIST, 2);
-    {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT,
-                                      static_cast<uint32_t>(this->data.size()));
-        std::vector<full_data>::const_iterator _iter88;
-        for (_iter88 = this->data.begin(); _iter88 != this->data.end(); ++_iter88) {
-            xfer += (*_iter88).write(oprot);
-        }
-        xfer += oprot->writeListEnd();
-    }
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(batch_get_response &a, batch_get_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.data, b.data);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-batch_get_response::batch_get_response(const batch_get_response &other89)
-{
-    error = other89.error;
-    data = other89.data;
-    app_id = other89.app_id;
-    partition_index = other89.partition_index;
-    server = other89.server;
-    __isset = other89.__isset;
-}
-batch_get_response::batch_get_response(batch_get_response &&other90)
-{
-    error = std::move(other90.error);
-    data = std::move(other90.data);
-    app_id = std::move(other90.app_id);
-    partition_index = std::move(other90.partition_index);
-    server = std::move(other90.server);
-    __isset = std::move(other90.__isset);
-}
-batch_get_response &batch_get_response::operator=(const batch_get_response &other91)
-{
-    error = other91.error;
-    data = other91.data;
-    app_id = other91.app_id;
-    partition_index = other91.partition_index;
-    server = other91.server;
-    __isset = other91.__isset;
-    return *this;
-}
-batch_get_response &batch_get_response::operator=(batch_get_response &&other92)
-{
-    error = std::move(other92.error);
-    data = std::move(other92.data);
-    app_id = std::move(other92.app_id);
-    partition_index = std::move(other92.partition_index);
-    server = std::move(other92.server);
-    __isset = std::move(other92.__isset);
-    return *this;
-}
-void batch_get_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "batch_get_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "data=" << to_string(data);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-full_data::~full_data() throw() {}
-
-void full_data::__set_hash_key(const ::dsn::blob &val) { this->hash_key = val; }
-
-void full_data::__set_sort_key(const ::dsn::blob &val) { this->sort_key = val; }
-
-void full_data::__set_value(const ::dsn::blob &val) { this->value = val; }
-
-uint32_t full_data::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->hash_key.read(iprot);
-                this->__isset.hash_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->sort_key.read(iprot);
-                this->__isset.sort_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->value.read(iprot);
-                this->__isset.value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t full_data::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("full_data");
-
-    xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->hash_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("sort_key", ::apache::thrift::protocol::T_STRUCT, 2);
-    xfer += this->sort_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRUCT, 3);
-    xfer += this->value.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(full_data &a, full_data &b)
-{
-    using ::std::swap;
-    swap(a.hash_key, b.hash_key);
-    swap(a.sort_key, b.sort_key);
-    swap(a.value, b.value);
-    swap(a.__isset, b.__isset);
-}
-
-full_data::full_data(const full_data &other93)
-{
-    hash_key = other93.hash_key;
-    sort_key = other93.sort_key;
-    value = other93.value;
-    __isset = other93.__isset;
-}
-full_data::full_data(full_data &&other94)
-{
-    hash_key = std::move(other94.hash_key);
-    sort_key = std::move(other94.sort_key);
-    value = std::move(other94.value);
-    __isset = std::move(other94.__isset);
-}
-full_data &full_data::operator=(const full_data &other95)
-{
-    hash_key = other95.hash_key;
-    sort_key = other95.sort_key;
-    value = other95.value;
-    __isset = other95.__isset;
-    return *this;
-}
-full_data &full_data::operator=(full_data &&other96)
-{
-    hash_key = std::move(other96.hash_key);
-    sort_key = std::move(other96.sort_key);
-    value = std::move(other96.value);
-    __isset = std::move(other96.__isset);
-    return *this;
-}
-void full_data::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "full_data(";
-    out << "hash_key=" << to_string(hash_key);
-    out << ", "
-        << "sort_key=" << to_string(sort_key);
-    out << ", "
-        << "value=" << to_string(value);
-    out << ")";
-}
-
-incr_request::~incr_request() throw() {}
-
-void incr_request::__set_key(const ::dsn::blob &val) { this->key = val; }
-
-void incr_request::__set_increment(const int64_t val) { this->increment = val; }
-
-void incr_request::__set_expire_ts_seconds(const int32_t val) { this->expire_ts_seconds = val; }
-
-uint32_t incr_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->key.read(iprot);
-                this->__isset.key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->increment);
-                this->__isset.increment = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->expire_ts_seconds);
-                this->__isset.expire_ts_seconds = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t incr_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("incr_request");
-
-    xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("increment", ::apache::thrift::protocol::T_I64, 2);
-    xfer += oprot->writeI64(this->increment);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("expire_ts_seconds", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->expire_ts_seconds);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(incr_request &a, incr_request &b)
-{
-    using ::std::swap;
-    swap(a.key, b.key);
-    swap(a.increment, b.increment);
-    swap(a.expire_ts_seconds, b.expire_ts_seconds);
-    swap(a.__isset, b.__isset);
-}
-
-incr_request::incr_request(const incr_request &other97)
-{
-    key = other97.key;
-    increment = other97.increment;
-    expire_ts_seconds = other97.expire_ts_seconds;
-    __isset = other97.__isset;
-}
-incr_request::incr_request(incr_request &&other98)
-{
-    key = std::move(other98.key);
-    increment = std::move(other98.increment);
-    expire_ts_seconds = std::move(other98.expire_ts_seconds);
-    __isset = std::move(other98.__isset);
-}
-incr_request &incr_request::operator=(const incr_request &other99)
-{
-    key = other99.key;
-    increment = other99.increment;
-    expire_ts_seconds = other99.expire_ts_seconds;
-    __isset = other99.__isset;
-    return *this;
-}
-incr_request &incr_request::operator=(incr_request &&other100)
-{
-    key = std::move(other100.key);
-    increment = std::move(other100.increment);
-    expire_ts_seconds = std::move(other100.expire_ts_seconds);
-    __isset = std::move(other100.__isset);
-    return *this;
-}
-void incr_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "incr_request(";
-    out << "key=" << to_string(key);
-    out << ", "
-        << "increment=" << to_string(increment);
-    out << ", "
-        << "expire_ts_seconds=" << to_string(expire_ts_seconds);
-    out << ")";
-}
-
-incr_response::~incr_response() throw() {}
-
-void incr_response::__set_error(const int32_t val) { this->error = val; }
-
-void incr_response::__set_new_value(const int64_t val) { this->new_value = val; }
-
-void incr_response::__set_app_id(const int32_t val) { this->app_id = val; }
-
-void incr_response::__set_partition_index(const int32_t val) { this->partition_index = val; }
-
-void incr_response::__set_decree(const int64_t val) { this->decree = val; }
-
-void incr_response::__set_server(const std::string &val) { this->server = val; }
-
-uint32_t incr_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->new_value);
-                this->__isset.new_value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->decree);
-                this->__isset.decree = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t incr_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("incr_response");
-
-    xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32(this->error);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("new_value", ::apache::thrift::protocol::T_I64, 2);
-    xfer += oprot->writeI64(this->new_value);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 4);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("decree", ::apache::thrift::protocol::T_I64, 5);
-    xfer += oprot->writeI64(this->decree);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(incr_response &a, incr_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.new_value, b.new_value);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.decree, b.decree);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-incr_response::incr_response(const incr_response &other101)
-{
-    error = other101.error;
-    new_value = other101.new_value;
-    app_id = other101.app_id;
-    partition_index = other101.partition_index;
-    decree = other101.decree;
-    server = other101.server;
-    __isset = other101.__isset;
-}
-incr_response::incr_response(incr_response &&other102)
-{
-    error = std::move(other102.error);
-    new_value = std::move(other102.new_value);
-    app_id = std::move(other102.app_id);
-    partition_index = std::move(other102.partition_index);
-    decree = std::move(other102.decree);
-    server = std::move(other102.server);
-    __isset = std::move(other102.__isset);
-}
-incr_response &incr_response::operator=(const incr_response &other103)
-{
-    error = other103.error;
-    new_value = other103.new_value;
-    app_id = other103.app_id;
-    partition_index = other103.partition_index;
-    decree = other103.decree;
-    server = other103.server;
-    __isset = other103.__isset;
-    return *this;
-}
-incr_response &incr_response::operator=(incr_response &&other104)
-{
-    error = std::move(other104.error);
-    new_value = std::move(other104.new_value);
-    app_id = std::move(other104.app_id);
-    partition_index = std::move(other104.partition_index);
-    decree = std::move(other104.decree);
-    server = std::move(other104.server);
-    __isset = std::move(other104.__isset);
-    return *this;
-}
-void incr_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "incr_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "new_value=" << to_string(new_value);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "decree=" << to_string(decree);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-check_and_set_request::~check_and_set_request() throw() {}
-
-void check_and_set_request::__set_hash_key(const ::dsn::blob &val) { this->hash_key = val; }
-
-void check_and_set_request::__set_check_sort_key(const ::dsn::blob &val)
-{
-    this->check_sort_key = val;
-}
-
-void check_and_set_request::__set_check_type(const cas_check_type::type val)
-{
-    this->check_type = val;
-}
-
-void check_and_set_request::__set_check_operand(const ::dsn::blob &val)
-{
-    this->check_operand = val;
-}
-
-void check_and_set_request::__set_set_diff_sort_key(const bool val)
-{
-    this->set_diff_sort_key = val;
-}
-
-void check_and_set_request::__set_set_sort_key(const ::dsn::blob &val) { this->set_sort_key = val; }
-
-void check_and_set_request::__set_set_value(const ::dsn::blob &val) { this->set_value = val; }
-
-void check_and_set_request::__set_set_expire_ts_seconds(const int32_t val)
-{
-    this->set_expire_ts_seconds = val;
-}
-
-void check_and_set_request::__set_return_check_value(const bool val)
-{
-    this->return_check_value = val;
-}
-
-uint32_t check_and_set_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->hash_key.read(iprot);
-                this->__isset.hash_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->check_sort_key.read(iprot);
-                this->__isset.check_sort_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                int32_t ecast105;
-                xfer += iprot->readI32(ecast105);
-                this->check_type = (cas_check_type::type)ecast105;
-                this->__isset.check_type = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->check_operand.read(iprot);
-                this->__isset.check_operand = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->set_diff_sort_key);
-                this->__isset.set_diff_sort_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->set_sort_key.read(iprot);
-                this->__isset.set_sort_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 7:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->set_value.read(iprot);
-                this->__isset.set_value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 8:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->set_expire_ts_seconds);
-                this->__isset.set_expire_ts_seconds = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 9:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->return_check_value);
-                this->__isset.return_check_value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t check_and_set_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("check_and_set_request");
-
-    xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->hash_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_sort_key", ::apache::thrift::protocol::T_STRUCT, 2);
-    xfer += this->check_sort_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_type", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32((int32_t)this->check_type);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_operand", ::apache::thrift::protocol::T_STRUCT, 4);
-    xfer += this->check_operand.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("set_diff_sort_key", ::apache::thrift::protocol::T_BOOL, 5);
-    xfer += oprot->writeBool(this->set_diff_sort_key);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("set_sort_key", ::apache::thrift::protocol::T_STRUCT, 6);
-    xfer += this->set_sort_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("set_value", ::apache::thrift::protocol::T_STRUCT, 7);
-    xfer += this->set_value.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("set_expire_ts_seconds", ::apache::thrift::protocol::T_I32, 8);
-    xfer += oprot->writeI32(this->set_expire_ts_seconds);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("return_check_value", ::apache::thrift::protocol::T_BOOL, 9);
-    xfer += oprot->writeBool(this->return_check_value);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(check_and_set_request &a, check_and_set_request &b)
-{
-    using ::std::swap;
-    swap(a.hash_key, b.hash_key);
-    swap(a.check_sort_key, b.check_sort_key);
-    swap(a.check_type, b.check_type);
-    swap(a.check_operand, b.check_operand);
-    swap(a.set_diff_sort_key, b.set_diff_sort_key);
-    swap(a.set_sort_key, b.set_sort_key);
-    swap(a.set_value, b.set_value);
-    swap(a.set_expire_ts_seconds, b.set_expire_ts_seconds);
-    swap(a.return_check_value, b.return_check_value);
-    swap(a.__isset, b.__isset);
-}
-
-check_and_set_request::check_and_set_request(const check_and_set_request &other106)
-{
-    hash_key = other106.hash_key;
-    check_sort_key = other106.check_sort_key;
-    check_type = other106.check_type;
-    check_operand = other106.check_operand;
-    set_diff_sort_key = other106.set_diff_sort_key;
-    set_sort_key = other106.set_sort_key;
-    set_value = other106.set_value;
-    set_expire_ts_seconds = other106.set_expire_ts_seconds;
-    return_check_value = other106.return_check_value;
-    __isset = other106.__isset;
-}
-check_and_set_request::check_and_set_request(check_and_set_request &&other107)
-{
-    hash_key = std::move(other107.hash_key);
-    check_sort_key = std::move(other107.check_sort_key);
-    check_type = std::move(other107.check_type);
-    check_operand = std::move(other107.check_operand);
-    set_diff_sort_key = std::move(other107.set_diff_sort_key);
-    set_sort_key = std::move(other107.set_sort_key);
-    set_value = std::move(other107.set_value);
-    set_expire_ts_seconds = std::move(other107.set_expire_ts_seconds);
-    return_check_value = std::move(other107.return_check_value);
-    __isset = std::move(other107.__isset);
-}
-check_and_set_request &check_and_set_request::operator=(const check_and_set_request &other108)
-{
-    hash_key = other108.hash_key;
-    check_sort_key = other108.check_sort_key;
-    check_type = other108.check_type;
-    check_operand = other108.check_operand;
-    set_diff_sort_key = other108.set_diff_sort_key;
-    set_sort_key = other108.set_sort_key;
-    set_value = other108.set_value;
-    set_expire_ts_seconds = other108.set_expire_ts_seconds;
-    return_check_value = other108.return_check_value;
-    __isset = other108.__isset;
-    return *this;
-}
-check_and_set_request &check_and_set_request::operator=(check_and_set_request &&other109)
-{
-    hash_key = std::move(other109.hash_key);
-    check_sort_key = std::move(other109.check_sort_key);
-    check_type = std::move(other109.check_type);
-    check_operand = std::move(other109.check_operand);
-    set_diff_sort_key = std::move(other109.set_diff_sort_key);
-    set_sort_key = std::move(other109.set_sort_key);
-    set_value = std::move(other109.set_value);
-    set_expire_ts_seconds = std::move(other109.set_expire_ts_seconds);
-    return_check_value = std::move(other109.return_check_value);
-    __isset = std::move(other109.__isset);
-    return *this;
-}
-void check_and_set_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "check_and_set_request(";
-    out << "hash_key=" << to_string(hash_key);
-    out << ", "
-        << "check_sort_key=" << to_string(check_sort_key);
-    out << ", "
-        << "check_type=" << to_string(check_type);
-    out << ", "
-        << "check_operand=" << to_string(check_operand);
-    out << ", "
-        << "set_diff_sort_key=" << to_string(set_diff_sort_key);
-    out << ", "
-        << "set_sort_key=" << to_string(set_sort_key);
-    out << ", "
-        << "set_value=" << to_string(set_value);
-    out << ", "
-        << "set_expire_ts_seconds=" << to_string(set_expire_ts_seconds);
-    out << ", "
-        << "return_check_value=" << to_string(return_check_value);
-    out << ")";
-}
-
-check_and_set_response::~check_and_set_response() throw() {}
-
-void check_and_set_response::__set_error(const int32_t val) { this->error = val; }
-
-void check_and_set_response::__set_check_value_returned(const bool val)
-{
-    this->check_value_returned = val;
-}
-
-void check_and_set_response::__set_check_value_exist(const bool val)
-{
-    this->check_value_exist = val;
-}
-
-void check_and_set_response::__set_check_value(const ::dsn::blob &val) { this->check_value = val; }
-
-void check_and_set_response::__set_app_id(const int32_t val) { this->app_id = val; }
-
-void check_and_set_response::__set_partition_index(const int32_t val)
-{
-    this->partition_index = val;
-}
-
-void check_and_set_response::__set_decree(const int64_t val) { this->decree = val; }
-
-void check_and_set_response::__set_server(const std::string &val) { this->server = val; }
-
-uint32_t check_and_set_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->check_value_returned);
-                this->__isset.check_value_returned = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->check_value_exist);
-                this->__isset.check_value_exist = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->check_value.read(iprot);
-                this->__isset.check_value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 7:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->decree);
-                this->__isset.decree = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 8:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t check_and_set_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("check_and_set_response");
-
-    xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32(this->error);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_value_returned", ::apache::thrift::protocol::T_BOOL, 2);
-    xfer += oprot->writeBool(this->check_value_returned);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_value_exist", ::apache::thrift::protocol::T_BOOL, 3);
-    xfer += oprot->writeBool(this->check_value_exist);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_value", ::apache::thrift::protocol::T_STRUCT, 4);
-    xfer += this->check_value.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 5);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 6);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("decree", ::apache::thrift::protocol::T_I64, 7);
-    xfer += oprot->writeI64(this->decree);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 8);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(check_and_set_response &a, check_and_set_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.check_value_returned, b.check_value_returned);
-    swap(a.check_value_exist, b.check_value_exist);
-    swap(a.check_value, b.check_value);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.decree, b.decree);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-check_and_set_response::check_and_set_response(const check_and_set_response &other110)
-{
-    error = other110.error;
-    check_value_returned = other110.check_value_returned;
-    check_value_exist = other110.check_value_exist;
-    check_value = other110.check_value;
-    app_id = other110.app_id;
-    partition_index = other110.partition_index;
-    decree = other110.decree;
-    server = other110.server;
-    __isset = other110.__isset;
-}
-check_and_set_response::check_and_set_response(check_and_set_response &&other111)
-{
-    error = std::move(other111.error);
-    check_value_returned = std::move(other111.check_value_returned);
-    check_value_exist = std::move(other111.check_value_exist);
-    check_value = std::move(other111.check_value);
-    app_id = std::move(other111.app_id);
-    partition_index = std::move(other111.partition_index);
-    decree = std::move(other111.decree);
-    server = std::move(other111.server);
-    __isset = std::move(other111.__isset);
-}
-check_and_set_response &check_and_set_response::operator=(const check_and_set_response &other112)
-{
-    error = other112.error;
-    check_value_returned = other112.check_value_returned;
-    check_value_exist = other112.check_value_exist;
-    check_value = other112.check_value;
-    app_id = other112.app_id;
-    partition_index = other112.partition_index;
-    decree = other112.decree;
-    server = other112.server;
-    __isset = other112.__isset;
-    return *this;
-}
-check_and_set_response &check_and_set_response::operator=(check_and_set_response &&other113)
-{
-    error = std::move(other113.error);
-    check_value_returned = std::move(other113.check_value_returned);
-    check_value_exist = std::move(other113.check_value_exist);
-    check_value = std::move(other113.check_value);
-    app_id = std::move(other113.app_id);
-    partition_index = std::move(other113.partition_index);
-    decree = std::move(other113.decree);
-    server = std::move(other113.server);
-    __isset = std::move(other113.__isset);
-    return *this;
-}
-void check_and_set_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "check_and_set_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "check_value_returned=" << to_string(check_value_returned);
-    out << ", "
-        << "check_value_exist=" << to_string(check_value_exist);
-    out << ", "
-        << "check_value=" << to_string(check_value);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "decree=" << to_string(decree);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-mutate::~mutate() throw() {}
-
-void mutate::__set_operation(const mutate_operation::type val) { this->operation = val; }
-
-void mutate::__set_sort_key(const ::dsn::blob &val) { this->sort_key = val; }
-
-void mutate::__set_value(const ::dsn::blob &val) { this->value = val; }
-
-void mutate::__set_set_expire_ts_seconds(const int32_t val) { this->set_expire_ts_seconds = val; }
-
-uint32_t mutate::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                int32_t ecast114;
-                xfer += iprot->readI32(ecast114);
-                this->operation = (mutate_operation::type)ecast114;
-                this->__isset.operation = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->sort_key.read(iprot);
-                this->__isset.sort_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->value.read(iprot);
-                this->__isset.value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->set_expire_ts_seconds);
-                this->__isset.set_expire_ts_seconds = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t mutate::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("mutate");
-
-    xfer += oprot->writeFieldBegin("operation", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32((int32_t)this->operation);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("sort_key", ::apache::thrift::protocol::T_STRUCT, 2);
-    xfer += this->sort_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRUCT, 3);
-    xfer += this->value.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("set_expire_ts_seconds", ::apache::thrift::protocol::T_I32, 4);
-    xfer += oprot->writeI32(this->set_expire_ts_seconds);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(mutate &a, mutate &b)
-{
-    using ::std::swap;
-    swap(a.operation, b.operation);
-    swap(a.sort_key, b.sort_key);
-    swap(a.value, b.value);
-    swap(a.set_expire_ts_seconds, b.set_expire_ts_seconds);
-    swap(a.__isset, b.__isset);
-}
-
-mutate::mutate(const mutate &other115)
-{
-    operation = other115.operation;
-    sort_key = other115.sort_key;
-    value = other115.value;
-    set_expire_ts_seconds = other115.set_expire_ts_seconds;
-    __isset = other115.__isset;
-}
-mutate::mutate(mutate &&other116)
-{
-    operation = std::move(other116.operation);
-    sort_key = std::move(other116.sort_key);
-    value = std::move(other116.value);
-    set_expire_ts_seconds = std::move(other116.set_expire_ts_seconds);
-    __isset = std::move(other116.__isset);
-}
-mutate &mutate::operator=(const mutate &other117)
-{
-    operation = other117.operation;
-    sort_key = other117.sort_key;
-    value = other117.value;
-    set_expire_ts_seconds = other117.set_expire_ts_seconds;
-    __isset = other117.__isset;
-    return *this;
-}
-mutate &mutate::operator=(mutate &&other118)
-{
-    operation = std::move(other118.operation);
-    sort_key = std::move(other118.sort_key);
-    value = std::move(other118.value);
-    set_expire_ts_seconds = std::move(other118.set_expire_ts_seconds);
-    __isset = std::move(other118.__isset);
-    return *this;
-}
-void mutate::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "mutate(";
-    out << "operation=" << to_string(operation);
-    out << ", "
-        << "sort_key=" << to_string(sort_key);
-    out << ", "
-        << "value=" << to_string(value);
-    out << ", "
-        << "set_expire_ts_seconds=" << to_string(set_expire_ts_seconds);
-    out << ")";
-}
-
-check_and_mutate_request::~check_and_mutate_request() throw() {}
-
-void check_and_mutate_request::__set_hash_key(const ::dsn::blob &val) { this->hash_key = val; }
-
-void check_and_mutate_request::__set_check_sort_key(const ::dsn::blob &val)
-{
-    this->check_sort_key = val;
-}
-
-void check_and_mutate_request::__set_check_type(const cas_check_type::type val)
-{
-    this->check_type = val;
-}
-
-void check_and_mutate_request::__set_check_operand(const ::dsn::blob &val)
-{
-    this->check_operand = val;
-}
-
-void check_and_mutate_request::__set_mutate_list(const std::vector<mutate> &val)
-{
-    this->mutate_list = val;
-}
-
-void check_and_mutate_request::__set_return_check_value(const bool val)
-{
-    this->return_check_value = val;
-}
-
-uint32_t check_and_mutate_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->hash_key.read(iprot);
-                this->__isset.hash_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->check_sort_key.read(iprot);
-                this->__isset.check_sort_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                int32_t ecast119;
-                xfer += iprot->readI32(ecast119);
-                this->check_type = (cas_check_type::type)ecast119;
-                this->__isset.check_type = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->check_operand.read(iprot);
-                this->__isset.check_operand = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_LIST) {
-                {
-                    this->mutate_list.clear();
-                    uint32_t _size120;
-                    ::apache::thrift::protocol::TType _etype123;
-                    xfer += iprot->readListBegin(_etype123, _size120);
-                    this->mutate_list.resize(_size120);
-                    uint32_t _i124;
-                    for (_i124 = 0; _i124 < _size120; ++_i124) {
-                        xfer += this->mutate_list[_i124].read(iprot);
-                    }
-                    xfer += iprot->readListEnd();
-                }
-                this->__isset.mutate_list = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->return_check_value);
-                this->__isset.return_check_value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t check_and_mutate_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("check_and_mutate_request");
-
-    xfer += oprot->writeFieldBegin("hash_key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->hash_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_sort_key", ::apache::thrift::protocol::T_STRUCT, 2);
-    xfer += this->check_sort_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_type", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32((int32_t)this->check_type);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_operand", ::apache::thrift::protocol::T_STRUCT, 4);
-    xfer += this->check_operand.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("mutate_list", ::apache::thrift::protocol::T_LIST, 5);
-    {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT,
-                                      static_cast<uint32_t>(this->mutate_list.size()));
-        std::vector<mutate>::const_iterator _iter125;
-        for (_iter125 = this->mutate_list.begin(); _iter125 != this->mutate_list.end();
-             ++_iter125) {
-            xfer += (*_iter125).write(oprot);
-        }
-        xfer += oprot->writeListEnd();
-    }
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("return_check_value", ::apache::thrift::protocol::T_BOOL, 6);
-    xfer += oprot->writeBool(this->return_check_value);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(check_and_mutate_request &a, check_and_mutate_request &b)
-{
-    using ::std::swap;
-    swap(a.hash_key, b.hash_key);
-    swap(a.check_sort_key, b.check_sort_key);
-    swap(a.check_type, b.check_type);
-    swap(a.check_operand, b.check_operand);
-    swap(a.mutate_list, b.mutate_list);
-    swap(a.return_check_value, b.return_check_value);
-    swap(a.__isset, b.__isset);
-}
-
-check_and_mutate_request::check_and_mutate_request(const check_and_mutate_request &other126)
-{
-    hash_key = other126.hash_key;
-    check_sort_key = other126.check_sort_key;
-    check_type = other126.check_type;
-    check_operand = other126.check_operand;
-    mutate_list = other126.mutate_list;
-    return_check_value = other126.return_check_value;
-    __isset = other126.__isset;
-}
-check_and_mutate_request::check_and_mutate_request(check_and_mutate_request &&other127)
-{
-    hash_key = std::move(other127.hash_key);
-    check_sort_key = std::move(other127.check_sort_key);
-    check_type = std::move(other127.check_type);
-    check_operand = std::move(other127.check_operand);
-    mutate_list = std::move(other127.mutate_list);
-    return_check_value = std::move(other127.return_check_value);
-    __isset = std::move(other127.__isset);
-}
-check_and_mutate_request &check_and_mutate_request::
-operator=(const check_and_mutate_request &other128)
-{
-    hash_key = other128.hash_key;
-    check_sort_key = other128.check_sort_key;
-    check_type = other128.check_type;
-    check_operand = other128.check_operand;
-    mutate_list = other128.mutate_list;
-    return_check_value = other128.return_check_value;
-    __isset = other128.__isset;
-    return *this;
-}
-check_and_mutate_request &check_and_mutate_request::operator=(check_and_mutate_request &&other129)
-{
-    hash_key = std::move(other129.hash_key);
-    check_sort_key = std::move(other129.check_sort_key);
-    check_type = std::move(other129.check_type);
-    check_operand = std::move(other129.check_operand);
-    mutate_list = std::move(other129.mutate_list);
-    return_check_value = std::move(other129.return_check_value);
-    __isset = std::move(other129.__isset);
-    return *this;
-}
-void check_and_mutate_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "check_and_mutate_request(";
-    out << "hash_key=" << to_string(hash_key);
-    out << ", "
-        << "check_sort_key=" << to_string(check_sort_key);
-    out << ", "
-        << "check_type=" << to_string(check_type);
-    out << ", "
-        << "check_operand=" << to_string(check_operand);
-    out << ", "
-        << "mutate_list=" << to_string(mutate_list);
-    out << ", "
-        << "return_check_value=" << to_string(return_check_value);
-    out << ")";
-}
-
-check_and_mutate_response::~check_and_mutate_response() throw() {}
-
-void check_and_mutate_response::__set_error(const int32_t val) { this->error = val; }
-
-void check_and_mutate_response::__set_check_value_returned(const bool val)
-{
-    this->check_value_returned = val;
-}
-
-void check_and_mutate_response::__set_check_value_exist(const bool val)
-{
-    this->check_value_exist = val;
-}
-
-void check_and_mutate_response::__set_check_value(const ::dsn::blob &val)
-{
-    this->check_value = val;
-}
-
-void check_and_mutate_response::__set_app_id(const int32_t val) { this->app_id = val; }
-
-void check_and_mutate_response::__set_partition_index(const int32_t val)
-{
-    this->partition_index = val;
-}
-
-void check_and_mutate_response::__set_decree(const int64_t val) { this->decree = val; }
-
-void check_and_mutate_response::__set_server(const std::string &val) { this->server = val; }
-
-uint32_t check_and_mutate_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->check_value_returned);
-                this->__isset.check_value_returned = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->check_value_exist);
-                this->__isset.check_value_exist = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->check_value.read(iprot);
-                this->__isset.check_value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 7:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->decree);
-                this->__isset.decree = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 8:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t check_and_mutate_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("check_and_mutate_response");
-
-    xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32(this->error);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_value_returned", ::apache::thrift::protocol::T_BOOL, 2);
-    xfer += oprot->writeBool(this->check_value_returned);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_value_exist", ::apache::thrift::protocol::T_BOOL, 3);
-    xfer += oprot->writeBool(this->check_value_exist);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("check_value", ::apache::thrift::protocol::T_STRUCT, 4);
-    xfer += this->check_value.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 5);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 6);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("decree", ::apache::thrift::protocol::T_I64, 7);
-    xfer += oprot->writeI64(this->decree);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 8);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(check_and_mutate_response &a, check_and_mutate_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.check_value_returned, b.check_value_returned);
-    swap(a.check_value_exist, b.check_value_exist);
-    swap(a.check_value, b.check_value);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.decree, b.decree);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-check_and_mutate_response::check_and_mutate_response(const check_and_mutate_response &other130)
-{
-    error = other130.error;
-    check_value_returned = other130.check_value_returned;
-    check_value_exist = other130.check_value_exist;
-    check_value = other130.check_value;
-    app_id = other130.app_id;
-    partition_index = other130.partition_index;
-    decree = other130.decree;
-    server = other130.server;
-    __isset = other130.__isset;
-}
-check_and_mutate_response::check_and_mutate_response(check_and_mutate_response &&other131)
-{
-    error = std::move(other131.error);
-    check_value_returned = std::move(other131.check_value_returned);
-    check_value_exist = std::move(other131.check_value_exist);
-    check_value = std::move(other131.check_value);
-    app_id = std::move(other131.app_id);
-    partition_index = std::move(other131.partition_index);
-    decree = std::move(other131.decree);
-    server = std::move(other131.server);
-    __isset = std::move(other131.__isset);
-}
-check_and_mutate_response &check_and_mutate_response::
-operator=(const check_and_mutate_response &other132)
-{
-    error = other132.error;
-    check_value_returned = other132.check_value_returned;
-    check_value_exist = other132.check_value_exist;
-    check_value = other132.check_value;
-    app_id = other132.app_id;
-    partition_index = other132.partition_index;
-    decree = other132.decree;
-    server = other132.server;
-    __isset = other132.__isset;
-    return *this;
-}
-check_and_mutate_response &check_and_mutate_response::
-operator=(check_and_mutate_response &&other133)
-{
-    error = std::move(other133.error);
-    check_value_returned = std::move(other133.check_value_returned);
-    check_value_exist = std::move(other133.check_value_exist);
-    check_value = std::move(other133.check_value);
-    app_id = std::move(other133.app_id);
-    partition_index = std::move(other133.partition_index);
-    decree = std::move(other133.decree);
-    server = std::move(other133.server);
-    __isset = std::move(other133.__isset);
-    return *this;
-}
-void check_and_mutate_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "check_and_mutate_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "check_value_returned=" << to_string(check_value_returned);
-    out << ", "
-        << "check_value_exist=" << to_string(check_value_exist);
-    out << ", "
-        << "check_value=" << to_string(check_value);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "decree=" << to_string(decree);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-get_scanner_request::~get_scanner_request() throw() {}
-
-void get_scanner_request::__set_start_key(const ::dsn::blob &val) { this->start_key = val; }
-
-void get_scanner_request::__set_stop_key(const ::dsn::blob &val) { this->stop_key = val; }
-
-void get_scanner_request::__set_start_inclusive(const bool val) { this->start_inclusive = val; }
-
-void get_scanner_request::__set_stop_inclusive(const bool val) { this->stop_inclusive = val; }
-
-void get_scanner_request::__set_batch_size(const int32_t val) { this->batch_size = val; }
-
-void get_scanner_request::__set_no_value(const bool val) { this->no_value = val; }
-
-void get_scanner_request::__set_hash_key_filter_type(const filter_type::type val)
-{
-    this->hash_key_filter_type = val;
-}
-
-void get_scanner_request::__set_hash_key_filter_pattern(const ::dsn::blob &val)
-{
-    this->hash_key_filter_pattern = val;
-}
-
-void get_scanner_request::__set_sort_key_filter_type(const filter_type::type val)
-{
-    this->sort_key_filter_type = val;
-}
-
-void get_scanner_request::__set_sort_key_filter_pattern(const ::dsn::blob &val)
-{
-    this->sort_key_filter_pattern = val;
-}
-
-void get_scanner_request::__set_validate_partition_hash(const bool val)
-{
-    this->validate_partition_hash = val;
-    __isset.validate_partition_hash = true;
-}
-
-void get_scanner_request::__set_return_expire_ts(const bool val)
-{
-    this->return_expire_ts = val;
-    __isset.return_expire_ts = true;
-}
-
-void get_scanner_request::__set_full_scan(const bool val)
-{
-    this->full_scan = val;
-    __isset.full_scan = true;
-}
-
-uint32_t get_scanner_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->start_key.read(iprot);
-                this->__isset.start_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->stop_key.read(iprot);
-                this->__isset.stop_key = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->start_inclusive);
-                this->__isset.start_inclusive = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->stop_inclusive);
-                this->__isset.stop_inclusive = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->batch_size);
-                this->__isset.batch_size = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->no_value);
-                this->__isset.no_value = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 7:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                int32_t ecast134;
-                xfer += iprot->readI32(ecast134);
-                this->hash_key_filter_type = (filter_type::type)ecast134;
-                this->__isset.hash_key_filter_type = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 8:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->hash_key_filter_pattern.read(iprot);
-                this->__isset.hash_key_filter_pattern = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 9:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                int32_t ecast135;
-                xfer += iprot->readI32(ecast135);
-                this->sort_key_filter_type = (filter_type::type)ecast135;
-                this->__isset.sort_key_filter_type = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 10:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->sort_key_filter_pattern.read(iprot);
-                this->__isset.sort_key_filter_pattern = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 11:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->validate_partition_hash);
-                this->__isset.validate_partition_hash = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 12:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->return_expire_ts);
-                this->__isset.return_expire_ts = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 13:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->full_scan);
-                this->__isset.full_scan = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t get_scanner_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("get_scanner_request");
-
-    xfer += oprot->writeFieldBegin("start_key", ::apache::thrift::protocol::T_STRUCT, 1);
-    xfer += this->start_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("stop_key", ::apache::thrift::protocol::T_STRUCT, 2);
-    xfer += this->stop_key.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("start_inclusive", ::apache::thrift::protocol::T_BOOL, 3);
-    xfer += oprot->writeBool(this->start_inclusive);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("stop_inclusive", ::apache::thrift::protocol::T_BOOL, 4);
-    xfer += oprot->writeBool(this->stop_inclusive);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("batch_size", ::apache::thrift::protocol::T_I32, 5);
-    xfer += oprot->writeI32(this->batch_size);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("no_value", ::apache::thrift::protocol::T_BOOL, 6);
-    xfer += oprot->writeBool(this->no_value);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("hash_key_filter_type", ::apache::thrift::protocol::T_I32, 7);
-    xfer += oprot->writeI32((int32_t)this->hash_key_filter_type);
-    xfer += oprot->writeFieldEnd();
-
-    xfer +=
-        oprot->writeFieldBegin("hash_key_filter_pattern", ::apache::thrift::protocol::T_STRUCT, 8);
-    xfer += this->hash_key_filter_pattern.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("sort_key_filter_type", ::apache::thrift::protocol::T_I32, 9);
-    xfer += oprot->writeI32((int32_t)this->sort_key_filter_type);
-    xfer += oprot->writeFieldEnd();
-
-    xfer +=
-        oprot->writeFieldBegin("sort_key_filter_pattern", ::apache::thrift::protocol::T_STRUCT, 10);
-    xfer += this->sort_key_filter_pattern.write(oprot);
-    xfer += oprot->writeFieldEnd();
-
-    if (this->__isset.validate_partition_hash) {
-        xfer += oprot->writeFieldBegin(
-            "validate_partition_hash", ::apache::thrift::protocol::T_BOOL, 11);
-        xfer += oprot->writeBool(this->validate_partition_hash);
-        xfer += oprot->writeFieldEnd();
-    }
-    if (this->__isset.return_expire_ts) {
-        xfer += oprot->writeFieldBegin("return_expire_ts", ::apache::thrift::protocol::T_BOOL, 12);
-        xfer += oprot->writeBool(this->return_expire_ts);
-        xfer += oprot->writeFieldEnd();
-    }
-    if (this->__isset.full_scan) {
-        xfer += oprot->writeFieldBegin("full_scan", ::apache::thrift::protocol::T_BOOL, 13);
-        xfer += oprot->writeBool(this->full_scan);
-        xfer += oprot->writeFieldEnd();
-    }
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(get_scanner_request &a, get_scanner_request &b)
-{
-    using ::std::swap;
-    swap(a.start_key, b.start_key);
-    swap(a.stop_key, b.stop_key);
-    swap(a.start_inclusive, b.start_inclusive);
-    swap(a.stop_inclusive, b.stop_inclusive);
-    swap(a.batch_size, b.batch_size);
-    swap(a.no_value, b.no_value);
-    swap(a.hash_key_filter_type, b.hash_key_filter_type);
-    swap(a.hash_key_filter_pattern, b.hash_key_filter_pattern);
-    swap(a.sort_key_filter_type, b.sort_key_filter_type);
-    swap(a.sort_key_filter_pattern, b.sort_key_filter_pattern);
-    swap(a.validate_partition_hash, b.validate_partition_hash);
-    swap(a.return_expire_ts, b.return_expire_ts);
-    swap(a.full_scan, b.full_scan);
-    swap(a.__isset, b.__isset);
-}
-
-get_scanner_request::get_scanner_request(const get_scanner_request &other136)
-{
-    start_key = other136.start_key;
-    stop_key = other136.stop_key;
-    start_inclusive = other136.start_inclusive;
-    stop_inclusive = other136.stop_inclusive;
-    batch_size = other136.batch_size;
-    no_value = other136.no_value;
-    hash_key_filter_type = other136.hash_key_filter_type;
-    hash_key_filter_pattern = other136.hash_key_filter_pattern;
-    sort_key_filter_type = other136.sort_key_filter_type;
-    sort_key_filter_pattern = other136.sort_key_filter_pattern;
-    validate_partition_hash = other136.validate_partition_hash;
-    return_expire_ts = other136.return_expire_ts;
-    full_scan = other136.full_scan;
-    __isset = other136.__isset;
-}
-get_scanner_request::get_scanner_request(get_scanner_request &&other137)
-{
-    start_key = std::move(other137.start_key);
-    stop_key = std::move(other137.stop_key);
-    start_inclusive = std::move(other137.start_inclusive);
-    stop_inclusive = std::move(other137.stop_inclusive);
-    batch_size = std::move(other137.batch_size);
-    no_value = std::move(other137.no_value);
-    hash_key_filter_type = std::move(other137.hash_key_filter_type);
-    hash_key_filter_pattern = std::move(other137.hash_key_filter_pattern);
-    sort_key_filter_type = std::move(other137.sort_key_filter_type);
-    sort_key_filter_pattern = std::move(other137.sort_key_filter_pattern);
-    validate_partition_hash = std::move(other137.validate_partition_hash);
-    return_expire_ts = std::move(other137.return_expire_ts);
-    full_scan = std::move(other137.full_scan);
-    __isset = std::move(other137.__isset);
-}
-get_scanner_request &get_scanner_request::operator=(const get_scanner_request &other138)
-{
-    start_key = other138.start_key;
-    stop_key = other138.stop_key;
-    start_inclusive = other138.start_inclusive;
-    stop_inclusive = other138.stop_inclusive;
-    batch_size = other138.batch_size;
-    no_value = other138.no_value;
-    hash_key_filter_type = other138.hash_key_filter_type;
-    hash_key_filter_pattern = other138.hash_key_filter_pattern;
-    sort_key_filter_type = other138.sort_key_filter_type;
-    sort_key_filter_pattern = other138.sort_key_filter_pattern;
-    validate_partition_hash = other138.validate_partition_hash;
-    return_expire_ts = other138.return_expire_ts;
-    full_scan = other138.full_scan;
-    __isset = other138.__isset;
-    return *this;
-}
-get_scanner_request &get_scanner_request::operator=(get_scanner_request &&other139)
-{
-    start_key = std::move(other139.start_key);
-    stop_key = std::move(other139.stop_key);
-    start_inclusive = std::move(other139.start_inclusive);
-    stop_inclusive = std::move(other139.stop_inclusive);
-    batch_size = std::move(other139.batch_size);
-    no_value = std::move(other139.no_value);
-    hash_key_filter_type = std::move(other139.hash_key_filter_type);
-    hash_key_filter_pattern = std::move(other139.hash_key_filter_pattern);
-    sort_key_filter_type = std::move(other139.sort_key_filter_type);
-    sort_key_filter_pattern = std::move(other139.sort_key_filter_pattern);
-    validate_partition_hash = std::move(other139.validate_partition_hash);
-    return_expire_ts = std::move(other139.return_expire_ts);
-    full_scan = std::move(other139.full_scan);
-    __isset = std::move(other139.__isset);
-    return *this;
-}
-void get_scanner_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "get_scanner_request(";
-    out << "start_key=" << to_string(start_key);
-    out << ", "
-        << "stop_key=" << to_string(stop_key);
-    out << ", "
-        << "start_inclusive=" << to_string(start_inclusive);
-    out << ", "
-        << "stop_inclusive=" << to_string(stop_inclusive);
-    out << ", "
-        << "batch_size=" << to_string(batch_size);
-    out << ", "
-        << "no_value=" << to_string(no_value);
-    out << ", "
-        << "hash_key_filter_type=" << to_string(hash_key_filter_type);
-    out << ", "
-        << "hash_key_filter_pattern=" << to_string(hash_key_filter_pattern);
-    out << ", "
-        << "sort_key_filter_type=" << to_string(sort_key_filter_type);
-    out << ", "
-        << "sort_key_filter_pattern=" << to_string(sort_key_filter_pattern);
-    out << ", "
-        << "validate_partition_hash=";
-    (__isset.validate_partition_hash ? (out << to_string(validate_partition_hash))
-                                     : (out << "<null>"));
-    out << ", "
-        << "return_expire_ts=";
-    (__isset.return_expire_ts ? (out << to_string(return_expire_ts)) : (out << "<null>"));
-    out << ", "
-        << "full_scan=";
-    (__isset.full_scan ? (out << to_string(full_scan)) : (out << "<null>"));
-    out << ")";
-}
-
-scan_request::~scan_request() throw() {}
-
-void scan_request::__set_context_id(const int64_t val) { this->context_id = val; }
-
-uint32_t scan_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->context_id);
-                this->__isset.context_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t scan_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("scan_request");
-
-    xfer += oprot->writeFieldBegin("context_id", ::apache::thrift::protocol::T_I64, 1);
-    xfer += oprot->writeI64(this->context_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(scan_request &a, scan_request &b)
-{
-    using ::std::swap;
-    swap(a.context_id, b.context_id);
-    swap(a.__isset, b.__isset);
-}
-
-scan_request::scan_request(const scan_request &other140)
-{
-    context_id = other140.context_id;
-    __isset = other140.__isset;
-}
-scan_request::scan_request(scan_request &&other141)
-{
-    context_id = std::move(other141.context_id);
-    __isset = std::move(other141.__isset);
-}
-scan_request &scan_request::operator=(const scan_request &other142)
-{
-    context_id = other142.context_id;
-    __isset = other142.__isset;
-    return *this;
-}
-scan_request &scan_request::operator=(scan_request &&other143)
-{
-    context_id = std::move(other143.context_id);
-    __isset = std::move(other143.__isset);
-    return *this;
-}
-void scan_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "scan_request(";
-    out << "context_id=" << to_string(context_id);
-    out << ")";
-}
-
-scan_response::~scan_response() throw() {}
-
-void scan_response::__set_error(const int32_t val) { this->error = val; }
-
-void scan_response::__set_kvs(const std::vector<key_value> &val) { this->kvs = val; }
-
-void scan_response::__set_context_id(const int64_t val) { this->context_id = val; }
-
-void scan_response::__set_app_id(const int32_t val) { this->app_id = val; }
-
-void scan_response::__set_partition_index(const int32_t val) { this->partition_index = val; }
-
-void scan_response::__set_server(const std::string &val) { this->server = val; }
-
-uint32_t scan_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_LIST) {
-                {
-                    this->kvs.clear();
-                    uint32_t _size144;
-                    ::apache::thrift::protocol::TType _etype147;
-                    xfer += iprot->readListBegin(_etype147, _size144);
-                    this->kvs.resize(_size144);
-                    uint32_t _i148;
-                    for (_i148 = 0; _i148 < _size144; ++_i148) {
-                        xfer += this->kvs[_i148].read(iprot);
-                    }
-                    xfer += iprot->readListEnd();
-                }
-                this->__isset.kvs = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->context_id);
-                this->__isset.context_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->app_id);
-                this->__isset.app_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->partition_index);
-                this->__isset.partition_index = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 6:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->server);
-                this->__isset.server = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t scan_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("scan_response");
-
-    xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32(this->error);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("kvs", ::apache::thrift::protocol::T_LIST, 2);
-    {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT,
-                                      static_cast<uint32_t>(this->kvs.size()));
-        std::vector<key_value>::const_iterator _iter149;
-        for (_iter149 = this->kvs.begin(); _iter149 != this->kvs.end(); ++_iter149) {
-            xfer += (*_iter149).write(oprot);
-        }
-        xfer += oprot->writeListEnd();
-    }
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("context_id", ::apache::thrift::protocol::T_I64, 3);
-    xfer += oprot->writeI64(this->context_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("app_id", ::apache::thrift::protocol::T_I32, 4);
-    xfer += oprot->writeI32(this->app_id);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("partition_index", ::apache::thrift::protocol::T_I32, 5);
-    xfer += oprot->writeI32(this->partition_index);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldBegin("server", ::apache::thrift::protocol::T_STRING, 6);
-    xfer += oprot->writeString(this->server);
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(scan_response &a, scan_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.kvs, b.kvs);
-    swap(a.context_id, b.context_id);
-    swap(a.app_id, b.app_id);
-    swap(a.partition_index, b.partition_index);
-    swap(a.server, b.server);
-    swap(a.__isset, b.__isset);
-}
-
-scan_response::scan_response(const scan_response &other150)
-{
-    error = other150.error;
-    kvs = other150.kvs;
-    context_id = other150.context_id;
-    app_id = other150.app_id;
-    partition_index = other150.partition_index;
-    server = other150.server;
-    __isset = other150.__isset;
-}
-scan_response::scan_response(scan_response &&other151)
-{
-    error = std::move(other151.error);
-    kvs = std::move(other151.kvs);
-    context_id = std::move(other151.context_id);
-    app_id = std::move(other151.app_id);
-    partition_index = std::move(other151.partition_index);
-    server = std::move(other151.server);
-    __isset = std::move(other151.__isset);
-}
-scan_response &scan_response::operator=(const scan_response &other152)
-{
-    error = other152.error;
-    kvs = other152.kvs;
-    context_id = other152.context_id;
-    app_id = other152.app_id;
-    partition_index = other152.partition_index;
-    server = other152.server;
-    __isset = other152.__isset;
-    return *this;
-}
-scan_response &scan_response::operator=(scan_response &&other153)
-{
-    error = std::move(other153.error);
-    kvs = std::move(other153.kvs);
-    context_id = std::move(other153.context_id);
-    app_id = std::move(other153.app_id);
-    partition_index = std::move(other153.partition_index);
-    server = std::move(other153.server);
-    __isset = std::move(other153.__isset);
-    return *this;
-}
-void scan_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "scan_response(";
-    out << "error=" << to_string(error);
-    out << ", "
-        << "kvs=" << to_string(kvs);
-    out << ", "
-        << "context_id=" << to_string(context_id);
-    out << ", "
-        << "app_id=" << to_string(app_id);
-    out << ", "
-        << "partition_index=" << to_string(partition_index);
-    out << ", "
-        << "server=" << to_string(server);
-    out << ")";
-}
-
-duplicate_request::~duplicate_request() throw() {}
-
-void duplicate_request::__set_entries(const std::vector<duplicate_entry> &val)
-{
-    this->entries = val;
-}
-
-uint32_t duplicate_request::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_LIST) {
-                {
-                    this->entries.clear();
-                    uint32_t _size154;
-                    ::apache::thrift::protocol::TType _etype157;
-                    xfer += iprot->readListBegin(_etype157, _size154);
-                    this->entries.resize(_size154);
-                    uint32_t _i158;
-                    for (_i158 = 0; _i158 < _size154; ++_i158) {
-                        xfer += this->entries[_i158].read(iprot);
-                    }
-                    xfer += iprot->readListEnd();
-                }
-                this->__isset.entries = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t duplicate_request::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("duplicate_request");
-
-    xfer += oprot->writeFieldBegin("entries", ::apache::thrift::protocol::T_LIST, 1);
-    {
-        xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT,
-                                      static_cast<uint32_t>(this->entries.size()));
-        std::vector<duplicate_entry>::const_iterator _iter159;
-        for (_iter159 = this->entries.begin(); _iter159 != this->entries.end(); ++_iter159) {
-            xfer += (*_iter159).write(oprot);
-        }
-        xfer += oprot->writeListEnd();
-    }
-    xfer += oprot->writeFieldEnd();
-
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(duplicate_request &a, duplicate_request &b)
-{
-    using ::std::swap;
-    swap(a.entries, b.entries);
-    swap(a.__isset, b.__isset);
-}
-
-duplicate_request::duplicate_request(const duplicate_request &other160)
-{
-    entries = other160.entries;
-    __isset = other160.__isset;
-}
-duplicate_request::duplicate_request(duplicate_request &&other161)
-{
-    entries = std::move(other161.entries);
-    __isset = std::move(other161.__isset);
-}
-duplicate_request &duplicate_request::operator=(const duplicate_request &other162)
-{
-    entries = other162.entries;
-    __isset = other162.__isset;
-    return *this;
-}
-duplicate_request &duplicate_request::operator=(duplicate_request &&other163)
-{
-    entries = std::move(other163.entries);
-    __isset = std::move(other163.__isset);
-    return *this;
-}
-void duplicate_request::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "duplicate_request(";
-    out << "entries=" << to_string(entries);
-    out << ")";
-}
-
-duplicate_entry::~duplicate_entry() throw() {}
-
-void duplicate_entry::__set_timestamp(const int64_t val)
-{
-    this->timestamp = val;
-    __isset.timestamp = true;
-}
-
-void duplicate_entry::__set_task_code(const ::dsn::task_code &val)
-{
-    this->task_code = val;
-    __isset.task_code = true;
-}
-
-void duplicate_entry::__set_raw_message(const ::dsn::blob &val)
-{
-    this->raw_message = val;
-    __isset.raw_message = true;
-}
-
-void duplicate_entry::__set_cluster_id(const int8_t val)
-{
-    this->cluster_id = val;
-    __isset.cluster_id = true;
-}
-
-void duplicate_entry::__set_verify_timetag(const bool val)
-{
-    this->verify_timetag = val;
-    __isset.verify_timetag = true;
-}
-
-uint32_t duplicate_entry::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I64) {
-                xfer += iprot->readI64(this->timestamp);
-                this->__isset.timestamp = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->task_code.read(iprot);
-                this->__isset.task_code = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 3:
-            if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-                xfer += this->raw_message.read(iprot);
-                this->__isset.raw_message = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 4:
-            if (ftype == ::apache::thrift::protocol::T_BYTE) {
-                xfer += iprot->readByte(this->cluster_id);
-                this->__isset.cluster_id = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 5:
-            if (ftype == ::apache::thrift::protocol::T_BOOL) {
-                xfer += iprot->readBool(this->verify_timetag);
-                this->__isset.verify_timetag = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t duplicate_entry::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("duplicate_entry");
-
-    if (this->__isset.timestamp) {
-        xfer += oprot->writeFieldBegin("timestamp", ::apache::thrift::protocol::T_I64, 1);
-        xfer += oprot->writeI64(this->timestamp);
-        xfer += oprot->writeFieldEnd();
-    }
-    if (this->__isset.task_code) {
-        xfer += oprot->writeFieldBegin("task_code", ::apache::thrift::protocol::T_STRUCT, 2);
-        xfer += this->task_code.write(oprot);
-        xfer += oprot->writeFieldEnd();
-    }
-    if (this->__isset.raw_message) {
-        xfer += oprot->writeFieldBegin("raw_message", ::apache::thrift::protocol::T_STRUCT, 3);
-        xfer += this->raw_message.write(oprot);
-        xfer += oprot->writeFieldEnd();
-    }
-    if (this->__isset.cluster_id) {
-        xfer += oprot->writeFieldBegin("cluster_id", ::apache::thrift::protocol::T_BYTE, 4);
-        xfer += oprot->writeByte(this->cluster_id);
-        xfer += oprot->writeFieldEnd();
-    }
-    if (this->__isset.verify_timetag) {
-        xfer += oprot->writeFieldBegin("verify_timetag", ::apache::thrift::protocol::T_BOOL, 5);
-        xfer += oprot->writeBool(this->verify_timetag);
-        xfer += oprot->writeFieldEnd();
-    }
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(duplicate_entry &a, duplicate_entry &b)
-{
-    using ::std::swap;
-    swap(a.timestamp, b.timestamp);
-    swap(a.task_code, b.task_code);
-    swap(a.raw_message, b.raw_message);
-    swap(a.cluster_id, b.cluster_id);
-    swap(a.verify_timetag, b.verify_timetag);
-    swap(a.__isset, b.__isset);
-}
-
-duplicate_entry::duplicate_entry(const duplicate_entry &other164)
-{
-    timestamp = other164.timestamp;
-    task_code = other164.task_code;
-    raw_message = other164.raw_message;
-    cluster_id = other164.cluster_id;
-    verify_timetag = other164.verify_timetag;
-    __isset = other164.__isset;
-}
-duplicate_entry::duplicate_entry(duplicate_entry &&other165)
-{
-    timestamp = std::move(other165.timestamp);
-    task_code = std::move(other165.task_code);
-    raw_message = std::move(other165.raw_message);
-    cluster_id = std::move(other165.cluster_id);
-    verify_timetag = std::move(other165.verify_timetag);
-    __isset = std::move(other165.__isset);
-}
-duplicate_entry &duplicate_entry::operator=(const duplicate_entry &other166)
-{
-    timestamp = other166.timestamp;
-    task_code = other166.task_code;
-    raw_message = other166.raw_message;
-    cluster_id = other166.cluster_id;
-    verify_timetag = other166.verify_timetag;
-    __isset = other166.__isset;
-    return *this;
-}
-duplicate_entry &duplicate_entry::operator=(duplicate_entry &&other167)
-{
-    timestamp = std::move(other167.timestamp);
-    task_code = std::move(other167.task_code);
-    raw_message = std::move(other167.raw_message);
-    cluster_id = std::move(other167.cluster_id);
-    verify_timetag = std::move(other167.verify_timetag);
-    __isset = std::move(other167.__isset);
-    return *this;
-}
-void duplicate_entry::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "duplicate_entry(";
-    out << "timestamp=";
-    (__isset.timestamp ? (out << to_string(timestamp)) : (out << "<null>"));
-    out << ", "
-        << "task_code=";
-    (__isset.task_code ? (out << to_string(task_code)) : (out << "<null>"));
-    out << ", "
-        << "raw_message=";
-    (__isset.raw_message ? (out << to_string(raw_message)) : (out << "<null>"));
-    out << ", "
-        << "cluster_id=";
-    (__isset.cluster_id ? (out << to_string(cluster_id)) : (out << "<null>"));
-    out << ", "
-        << "verify_timetag=";
-    (__isset.verify_timetag ? (out << to_string(verify_timetag)) : (out << "<null>"));
-    out << ")";
-}
-
-duplicate_response::~duplicate_response() throw() {}
-
-void duplicate_response::__set_error(const int32_t val)
-{
-    this->error = val;
-    __isset.error = true;
-}
-
-void duplicate_response::__set_error_hint(const std::string &val)
-{
-    this->error_hint = val;
-    __isset.error_hint = true;
-}
-
-uint32_t duplicate_response::read(::apache::thrift::protocol::TProtocol *iprot)
-{
-
-    apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-    uint32_t xfer = 0;
-    std::string fname;
-    ::apache::thrift::protocol::TType ftype;
-    int16_t fid;
-
-    xfer += iprot->readStructBegin(fname);
-
-    using ::apache::thrift::protocol::TProtocolException;
-
-    while (true) {
-        xfer += iprot->readFieldBegin(fname, ftype, fid);
-        if (ftype == ::apache::thrift::protocol::T_STOP) {
-            break;
-        }
-        switch (fid) {
-        case 1:
-            if (ftype == ::apache::thrift::protocol::T_I32) {
-                xfer += iprot->readI32(this->error);
-                this->__isset.error = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        case 2:
-            if (ftype == ::apache::thrift::protocol::T_STRING) {
-                xfer += iprot->readString(this->error_hint);
-                this->__isset.error_hint = true;
-            } else {
-                xfer += iprot->skip(ftype);
-            }
-            break;
-        default:
-            xfer += iprot->skip(ftype);
-            break;
-        }
-        xfer += iprot->readFieldEnd();
-    }
-
-    xfer += iprot->readStructEnd();
-
-    return xfer;
-}
-
-uint32_t duplicate_response::write(::apache::thrift::protocol::TProtocol *oprot) const
-{
-    uint32_t xfer = 0;
-    apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-    xfer += oprot->writeStructBegin("duplicate_response");
-
-    if (this->__isset.error) {
-        xfer += oprot->writeFieldBegin("error", ::apache::thrift::protocol::T_I32, 1);
-        xfer += oprot->writeI32(this->error);
-        xfer += oprot->writeFieldEnd();
-    }
-    if (this->__isset.error_hint) {
-        xfer += oprot->writeFieldBegin("error_hint", ::apache::thrift::protocol::T_STRING, 2);
-        xfer += oprot->writeString(this->error_hint);
-        xfer += oprot->writeFieldEnd();
-    }
-    xfer += oprot->writeFieldStop();
-    xfer += oprot->writeStructEnd();
-    return xfer;
-}
-
-void swap(duplicate_response &a, duplicate_response &b)
-{
-    using ::std::swap;
-    swap(a.error, b.error);
-    swap(a.error_hint, b.error_hint);
-    swap(a.__isset, b.__isset);
-}
-
-duplicate_response::duplicate_response(const duplicate_response &other168)
-{
-    error = other168.error;
-    error_hint = other168.error_hint;
-    __isset = other168.__isset;
-}
-duplicate_response::duplicate_response(duplicate_response &&other169)
-{
-    error = std::move(other169.error);
-    error_hint = std::move(other169.error_hint);
-    __isset = std::move(other169.__isset);
-}
-duplicate_response &duplicate_response::operator=(const duplicate_response &other170)
-{
-    error = other170.error;
-    error_hint = other170.error_hint;
-    __isset = other170.__isset;
-    return *this;
-}
-duplicate_response &duplicate_response::operator=(duplicate_response &&other171)
-{
-    error = std::move(other171.error);
-    error_hint = std::move(other171.error_hint);
-    __isset = std::move(other171.__isset);
-    return *this;
-}
-void duplicate_response::printTo(std::ostream &out) const
-{
-    using ::apache::thrift::to_string;
-    out << "duplicate_response(";
-    out << "error=";
-    (__isset.error ? (out << to_string(error)) : (out << "<null>"));
-    out << ", "
-        << "error_hint=";
-    (__isset.error_hint ? (out << to_string(error_hint)) : (out << "<null>"));
-    out << ")";
-}
-}
-} // namespace
+  }
+  if (this->__isset.error_hint) {
+    xfer += oprot->writeFieldBegin("error_hint", ::apache::thrift::protocol::T_STRING, 2);
+    xfer += oprot->writeString(this->error_hint);
+    xfer += oprot->writeFieldEnd();
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(duplicate_response &a, duplicate_response &b) {
+  using ::std::swap;
+  swap(a.error, b.error);
+  swap(a.error_hint, b.error_hint);
+  swap(a.__isset, b.__isset);
+}
+
+duplicate_response::duplicate_response(const duplicate_response& other168) {
+  error = other168.error;
+  error_hint = other168.error_hint;
+  __isset = other168.__isset;
+}
+duplicate_response::duplicate_response( duplicate_response&& other169) {
+  error = std::move(other169.error);
+  error_hint = std::move(other169.error_hint);
+  __isset = std::move(other169.__isset);
+}
+duplicate_response& duplicate_response::operator=(const duplicate_response& other170) {
+  error = other170.error;
+  error_hint = other170.error_hint;
+  __isset = other170.__isset;
+  return *this;
+}
+duplicate_response& duplicate_response::operator=(duplicate_response&& other171) {
+  error = std::move(other171.error);
+  error_hint = std::move(other171.error_hint);
+  __isset = std::move(other171.__isset);
+  return *this;
+}
+void duplicate_response::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "duplicate_response(";
+  out << "error="; (__isset.error ? (out << to_string(error)) : (out << "<null>"));
+  out << ", " << "error_hint="; (__isset.error_hint ? (out << to_string(error_hint)) : (out << "<null>"));
+  out << ")";
+}
+
+}} // namespace

--- a/src/include/rrdb/rrdb_types.h
+++ b/src/include/rrdb/rrdb_types.h
@@ -17,59 +17,53 @@
 #include <thrift/cxxfunctional.h>
 #include <dsn/service_api_cpp.h>
 
-namespace dsn {
-namespace apps {
 
-struct filter_type
-{
-    enum type
-    {
-        FT_NO_FILTER = 0,
-        FT_MATCH_ANYWHERE = 1,
-        FT_MATCH_PREFIX = 2,
-        FT_MATCH_POSTFIX = 3
-    };
+namespace dsn { namespace apps {
+
+struct filter_type {
+  enum type {
+    FT_NO_FILTER = 0,
+    FT_MATCH_ANYWHERE = 1,
+    FT_MATCH_PREFIX = 2,
+    FT_MATCH_POSTFIX = 3
+  };
 };
 
-extern const std::map<int, const char *> _filter_type_VALUES_TO_NAMES;
+extern const std::map<int, const char*> _filter_type_VALUES_TO_NAMES;
 
-struct cas_check_type
-{
-    enum type
-    {
-        CT_NO_CHECK = 0,
-        CT_VALUE_NOT_EXIST = 1,
-        CT_VALUE_NOT_EXIST_OR_EMPTY = 2,
-        CT_VALUE_EXIST = 3,
-        CT_VALUE_NOT_EMPTY = 4,
-        CT_VALUE_MATCH_ANYWHERE = 5,
-        CT_VALUE_MATCH_PREFIX = 6,
-        CT_VALUE_MATCH_POSTFIX = 7,
-        CT_VALUE_BYTES_LESS = 8,
-        CT_VALUE_BYTES_LESS_OR_EQUAL = 9,
-        CT_VALUE_BYTES_EQUAL = 10,
-        CT_VALUE_BYTES_GREATER_OR_EQUAL = 11,
-        CT_VALUE_BYTES_GREATER = 12,
-        CT_VALUE_INT_LESS = 13,
-        CT_VALUE_INT_LESS_OR_EQUAL = 14,
-        CT_VALUE_INT_EQUAL = 15,
-        CT_VALUE_INT_GREATER_OR_EQUAL = 16,
-        CT_VALUE_INT_GREATER = 17
-    };
+struct cas_check_type {
+  enum type {
+    CT_NO_CHECK = 0,
+    CT_VALUE_NOT_EXIST = 1,
+    CT_VALUE_NOT_EXIST_OR_EMPTY = 2,
+    CT_VALUE_EXIST = 3,
+    CT_VALUE_NOT_EMPTY = 4,
+    CT_VALUE_MATCH_ANYWHERE = 5,
+    CT_VALUE_MATCH_PREFIX = 6,
+    CT_VALUE_MATCH_POSTFIX = 7,
+    CT_VALUE_BYTES_LESS = 8,
+    CT_VALUE_BYTES_LESS_OR_EQUAL = 9,
+    CT_VALUE_BYTES_EQUAL = 10,
+    CT_VALUE_BYTES_GREATER_OR_EQUAL = 11,
+    CT_VALUE_BYTES_GREATER = 12,
+    CT_VALUE_INT_LESS = 13,
+    CT_VALUE_INT_LESS_OR_EQUAL = 14,
+    CT_VALUE_INT_EQUAL = 15,
+    CT_VALUE_INT_GREATER_OR_EQUAL = 16,
+    CT_VALUE_INT_GREATER = 17
+  };
 };
 
-extern const std::map<int, const char *> _cas_check_type_VALUES_TO_NAMES;
+extern const std::map<int, const char*> _cas_check_type_VALUES_TO_NAMES;
 
-struct mutate_operation
-{
-    enum type
-    {
-        MO_PUT = 0,
-        MO_DELETE = 1
-    };
+struct mutate_operation {
+  enum type {
+    MO_PUT = 0,
+    MO_DELETE = 1
+  };
 };
 
-extern const std::map<int, const char *> _mutate_operation_VALUES_TO_NAMES;
+extern const std::map<int, const char*> _mutate_operation_VALUES_TO_NAMES;
 
 class update_request;
 
@@ -127,2142 +121,2032 @@ class duplicate_entry;
 
 class duplicate_response;
 
-typedef struct _update_request__isset
-{
-    _update_request__isset() : key(false), value(false), expire_ts_seconds(false) {}
-    bool key : 1;
-    bool value : 1;
-    bool expire_ts_seconds : 1;
+typedef struct _update_request__isset {
+  _update_request__isset() : key(false), value(false), expire_ts_seconds(false) {}
+  bool key :1;
+  bool value :1;
+  bool expire_ts_seconds :1;
 } _update_request__isset;
 
-class update_request
-{
-public:
-    update_request(const update_request &);
-    update_request(update_request &&);
-    update_request &operator=(const update_request &);
-    update_request &operator=(update_request &&);
-    update_request() : expire_ts_seconds(0) {}
+class update_request {
+ public:
 
-    virtual ~update_request() throw();
-    ::dsn::blob key;
-    ::dsn::blob value;
-    int32_t expire_ts_seconds;
+  update_request(const update_request&);
+  update_request(update_request&&);
+  update_request& operator=(const update_request&);
+  update_request& operator=(update_request&&);
+  update_request() : expire_ts_seconds(0) {
+  }
 
-    _update_request__isset __isset;
+  virtual ~update_request() throw();
+   ::dsn::blob key;
+   ::dsn::blob value;
+  int32_t expire_ts_seconds;
 
-    void __set_key(const ::dsn::blob &val);
+  _update_request__isset __isset;
 
-    void __set_value(const ::dsn::blob &val);
+  void __set_key(const  ::dsn::blob& val);
 
-    void __set_expire_ts_seconds(const int32_t val);
+  void __set_value(const  ::dsn::blob& val);
 
-    bool operator==(const update_request &rhs) const
-    {
-        if (!(key == rhs.key))
-            return false;
-        if (!(value == rhs.value))
-            return false;
-        if (!(expire_ts_seconds == rhs.expire_ts_seconds))
-            return false;
-        return true;
-    }
-    bool operator!=(const update_request &rhs) const { return !(*this == rhs); }
+  void __set_expire_ts_seconds(const int32_t val);
 
-    bool operator<(const update_request &) const;
+  bool operator == (const update_request & rhs) const
+  {
+    if (!(key == rhs.key))
+      return false;
+    if (!(value == rhs.value))
+      return false;
+    if (!(expire_ts_seconds == rhs.expire_ts_seconds))
+      return false;
+    return true;
+  }
+  bool operator != (const update_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const update_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(update_request &a, update_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const update_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const update_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _update_response__isset
-{
-    _update_response__isset()
-        : error(false), app_id(false), partition_index(false), decree(false), server(false)
-    {
-    }
-    bool error : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool decree : 1;
-    bool server : 1;
+typedef struct _update_response__isset {
+  _update_response__isset() : error(false), app_id(false), partition_index(false), decree(false), server(false) {}
+  bool error :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool decree :1;
+  bool server :1;
 } _update_response__isset;
 
-class update_response
-{
-public:
-    update_response(const update_response &);
-    update_response(update_response &&);
-    update_response &operator=(const update_response &);
-    update_response &operator=(update_response &&);
-    update_response() : error(0), app_id(0), partition_index(0), decree(0), server() {}
+class update_response {
+ public:
 
-    virtual ~update_response() throw();
-    int32_t error;
-    int32_t app_id;
-    int32_t partition_index;
-    int64_t decree;
-    std::string server;
+  update_response(const update_response&);
+  update_response(update_response&&);
+  update_response& operator=(const update_response&);
+  update_response& operator=(update_response&&);
+  update_response() : error(0), app_id(0), partition_index(0), decree(0), server() {
+  }
 
-    _update_response__isset __isset;
+  virtual ~update_response() throw();
+  int32_t error;
+  int32_t app_id;
+  int32_t partition_index;
+  int64_t decree;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _update_response__isset __isset;
 
-    void __set_app_id(const int32_t val);
+  void __set_error(const int32_t val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_decree(const int64_t val);
+  void __set_partition_index(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_decree(const int64_t val);
 
-    bool operator==(const update_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(decree == rhs.decree))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const update_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const update_response &) const;
+  bool operator == (const update_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(decree == rhs.decree))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const update_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const update_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(update_response &a, update_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const update_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const update_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _read_response__isset
-{
-    _read_response__isset()
-        : error(false), value(false), app_id(false), partition_index(false), server(false)
-    {
-    }
-    bool error : 1;
-    bool value : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool server : 1;
+typedef struct _read_response__isset {
+  _read_response__isset() : error(false), value(false), app_id(false), partition_index(false), server(false) {}
+  bool error :1;
+  bool value :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool server :1;
 } _read_response__isset;
 
-class read_response
-{
-public:
-    read_response(const read_response &);
-    read_response(read_response &&);
-    read_response &operator=(const read_response &);
-    read_response &operator=(read_response &&);
-    read_response() : error(0), app_id(0), partition_index(0), server() {}
+class read_response {
+ public:
 
-    virtual ~read_response() throw();
-    int32_t error;
-    ::dsn::blob value;
-    int32_t app_id;
-    int32_t partition_index;
-    std::string server;
+  read_response(const read_response&);
+  read_response(read_response&&);
+  read_response& operator=(const read_response&);
+  read_response& operator=(read_response&&);
+  read_response() : error(0), app_id(0), partition_index(0), server() {
+  }
 
-    _read_response__isset __isset;
+  virtual ~read_response() throw();
+  int32_t error;
+   ::dsn::blob value;
+  int32_t app_id;
+  int32_t partition_index;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _read_response__isset __isset;
 
-    void __set_value(const ::dsn::blob &val);
+  void __set_error(const int32_t val);
 
-    void __set_app_id(const int32_t val);
+  void __set_value(const  ::dsn::blob& val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_partition_index(const int32_t val);
 
-    bool operator==(const read_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(value == rhs.value))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const read_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const read_response &) const;
+  bool operator == (const read_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(value == rhs.value))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const read_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const read_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(read_response &a, read_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const read_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const read_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _ttl_response__isset
-{
-    _ttl_response__isset()
-        : error(false), ttl_seconds(false), app_id(false), partition_index(false), server(false)
-    {
-    }
-    bool error : 1;
-    bool ttl_seconds : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool server : 1;
+typedef struct _ttl_response__isset {
+  _ttl_response__isset() : error(false), ttl_seconds(false), app_id(false), partition_index(false), server(false) {}
+  bool error :1;
+  bool ttl_seconds :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool server :1;
 } _ttl_response__isset;
 
-class ttl_response
-{
-public:
-    ttl_response(const ttl_response &);
-    ttl_response(ttl_response &&);
-    ttl_response &operator=(const ttl_response &);
-    ttl_response &operator=(ttl_response &&);
-    ttl_response() : error(0), ttl_seconds(0), app_id(0), partition_index(0), server() {}
+class ttl_response {
+ public:
 
-    virtual ~ttl_response() throw();
-    int32_t error;
-    int32_t ttl_seconds;
-    int32_t app_id;
-    int32_t partition_index;
-    std::string server;
+  ttl_response(const ttl_response&);
+  ttl_response(ttl_response&&);
+  ttl_response& operator=(const ttl_response&);
+  ttl_response& operator=(ttl_response&&);
+  ttl_response() : error(0), ttl_seconds(0), app_id(0), partition_index(0), server() {
+  }
 
-    _ttl_response__isset __isset;
+  virtual ~ttl_response() throw();
+  int32_t error;
+  int32_t ttl_seconds;
+  int32_t app_id;
+  int32_t partition_index;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _ttl_response__isset __isset;
 
-    void __set_ttl_seconds(const int32_t val);
+  void __set_error(const int32_t val);
 
-    void __set_app_id(const int32_t val);
+  void __set_ttl_seconds(const int32_t val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_partition_index(const int32_t val);
 
-    bool operator==(const ttl_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(ttl_seconds == rhs.ttl_seconds))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const ttl_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const ttl_response &) const;
+  bool operator == (const ttl_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(ttl_seconds == rhs.ttl_seconds))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const ttl_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const ttl_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(ttl_response &a, ttl_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const ttl_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const ttl_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _count_response__isset
-{
-    _count_response__isset()
-        : error(false), count(false), app_id(false), partition_index(false), server(false)
-    {
-    }
-    bool error : 1;
-    bool count : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool server : 1;
+typedef struct _count_response__isset {
+  _count_response__isset() : error(false), count(false), app_id(false), partition_index(false), server(false) {}
+  bool error :1;
+  bool count :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool server :1;
 } _count_response__isset;
 
-class count_response
-{
-public:
-    count_response(const count_response &);
-    count_response(count_response &&);
-    count_response &operator=(const count_response &);
-    count_response &operator=(count_response &&);
-    count_response() : error(0), count(0), app_id(0), partition_index(0), server() {}
+class count_response {
+ public:
 
-    virtual ~count_response() throw();
-    int32_t error;
-    int64_t count;
-    int32_t app_id;
-    int32_t partition_index;
-    std::string server;
+  count_response(const count_response&);
+  count_response(count_response&&);
+  count_response& operator=(const count_response&);
+  count_response& operator=(count_response&&);
+  count_response() : error(0), count(0), app_id(0), partition_index(0), server() {
+  }
 
-    _count_response__isset __isset;
+  virtual ~count_response() throw();
+  int32_t error;
+  int64_t count;
+  int32_t app_id;
+  int32_t partition_index;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _count_response__isset __isset;
 
-    void __set_count(const int64_t val);
+  void __set_error(const int32_t val);
 
-    void __set_app_id(const int32_t val);
+  void __set_count(const int64_t val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_partition_index(const int32_t val);
 
-    bool operator==(const count_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(count == rhs.count))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const count_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const count_response &) const;
+  bool operator == (const count_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(count == rhs.count))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const count_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const count_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(count_response &a, count_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const count_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const count_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _key_value__isset
-{
-    _key_value__isset() : key(false), value(false), expire_ts_seconds(false) {}
-    bool key : 1;
-    bool value : 1;
-    bool expire_ts_seconds : 1;
+typedef struct _key_value__isset {
+  _key_value__isset() : key(false), value(false), expire_ts_seconds(false) {}
+  bool key :1;
+  bool value :1;
+  bool expire_ts_seconds :1;
 } _key_value__isset;
 
-class key_value
-{
-public:
-    key_value(const key_value &);
-    key_value(key_value &&);
-    key_value &operator=(const key_value &);
-    key_value &operator=(key_value &&);
-    key_value() : expire_ts_seconds(0) {}
+class key_value {
+ public:
 
-    virtual ~key_value() throw();
-    ::dsn::blob key;
-    ::dsn::blob value;
-    int32_t expire_ts_seconds;
+  key_value(const key_value&);
+  key_value(key_value&&);
+  key_value& operator=(const key_value&);
+  key_value& operator=(key_value&&);
+  key_value() : expire_ts_seconds(0) {
+  }
 
-    _key_value__isset __isset;
+  virtual ~key_value() throw();
+   ::dsn::blob key;
+   ::dsn::blob value;
+  int32_t expire_ts_seconds;
 
-    void __set_key(const ::dsn::blob &val);
+  _key_value__isset __isset;
 
-    void __set_value(const ::dsn::blob &val);
+  void __set_key(const  ::dsn::blob& val);
 
-    void __set_expire_ts_seconds(const int32_t val);
+  void __set_value(const  ::dsn::blob& val);
 
-    bool operator==(const key_value &rhs) const
-    {
-        if (!(key == rhs.key))
-            return false;
-        if (!(value == rhs.value))
-            return false;
-        if (__isset.expire_ts_seconds != rhs.__isset.expire_ts_seconds)
-            return false;
-        else if (__isset.expire_ts_seconds && !(expire_ts_seconds == rhs.expire_ts_seconds))
-            return false;
-        return true;
-    }
-    bool operator!=(const key_value &rhs) const { return !(*this == rhs); }
+  void __set_expire_ts_seconds(const int32_t val);
 
-    bool operator<(const key_value &) const;
+  bool operator == (const key_value & rhs) const
+  {
+    if (!(key == rhs.key))
+      return false;
+    if (!(value == rhs.value))
+      return false;
+    if (__isset.expire_ts_seconds != rhs.__isset.expire_ts_seconds)
+      return false;
+    else if (__isset.expire_ts_seconds && !(expire_ts_seconds == rhs.expire_ts_seconds))
+      return false;
+    return true;
+  }
+  bool operator != (const key_value &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const key_value & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(key_value &a, key_value &b);
 
-inline std::ostream &operator<<(std::ostream &out, const key_value &obj)
+inline std::ostream& operator<<(std::ostream& out, const key_value& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _multi_put_request__isset
-{
-    _multi_put_request__isset() : hash_key(false), kvs(false), expire_ts_seconds(false) {}
-    bool hash_key : 1;
-    bool kvs : 1;
-    bool expire_ts_seconds : 1;
+typedef struct _multi_put_request__isset {
+  _multi_put_request__isset() : hash_key(false), kvs(false), expire_ts_seconds(false) {}
+  bool hash_key :1;
+  bool kvs :1;
+  bool expire_ts_seconds :1;
 } _multi_put_request__isset;
 
-class multi_put_request
-{
-public:
-    multi_put_request(const multi_put_request &);
-    multi_put_request(multi_put_request &&);
-    multi_put_request &operator=(const multi_put_request &);
-    multi_put_request &operator=(multi_put_request &&);
-    multi_put_request() : expire_ts_seconds(0) {}
+class multi_put_request {
+ public:
 
-    virtual ~multi_put_request() throw();
-    ::dsn::blob hash_key;
-    std::vector<key_value> kvs;
-    int32_t expire_ts_seconds;
+  multi_put_request(const multi_put_request&);
+  multi_put_request(multi_put_request&&);
+  multi_put_request& operator=(const multi_put_request&);
+  multi_put_request& operator=(multi_put_request&&);
+  multi_put_request() : expire_ts_seconds(0) {
+  }
 
-    _multi_put_request__isset __isset;
+  virtual ~multi_put_request() throw();
+   ::dsn::blob hash_key;
+  std::vector<key_value>  kvs;
+  int32_t expire_ts_seconds;
 
-    void __set_hash_key(const ::dsn::blob &val);
+  _multi_put_request__isset __isset;
 
-    void __set_kvs(const std::vector<key_value> &val);
+  void __set_hash_key(const  ::dsn::blob& val);
 
-    void __set_expire_ts_seconds(const int32_t val);
+  void __set_kvs(const std::vector<key_value> & val);
 
-    bool operator==(const multi_put_request &rhs) const
-    {
-        if (!(hash_key == rhs.hash_key))
-            return false;
-        if (!(kvs == rhs.kvs))
-            return false;
-        if (!(expire_ts_seconds == rhs.expire_ts_seconds))
-            return false;
-        return true;
-    }
-    bool operator!=(const multi_put_request &rhs) const { return !(*this == rhs); }
+  void __set_expire_ts_seconds(const int32_t val);
 
-    bool operator<(const multi_put_request &) const;
+  bool operator == (const multi_put_request & rhs) const
+  {
+    if (!(hash_key == rhs.hash_key))
+      return false;
+    if (!(kvs == rhs.kvs))
+      return false;
+    if (!(expire_ts_seconds == rhs.expire_ts_seconds))
+      return false;
+    return true;
+  }
+  bool operator != (const multi_put_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const multi_put_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(multi_put_request &a, multi_put_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const multi_put_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const multi_put_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _multi_remove_request__isset
-{
-    _multi_remove_request__isset() : hash_key(false), sort_keys(false), max_count(false) {}
-    bool hash_key : 1;
-    bool sort_keys : 1;
-    bool max_count : 1;
+typedef struct _multi_remove_request__isset {
+  _multi_remove_request__isset() : hash_key(false), sort_keys(false), max_count(false) {}
+  bool hash_key :1;
+  bool sort_keys :1;
+  bool max_count :1;
 } _multi_remove_request__isset;
 
-class multi_remove_request
-{
-public:
-    multi_remove_request(const multi_remove_request &);
-    multi_remove_request(multi_remove_request &&);
-    multi_remove_request &operator=(const multi_remove_request &);
-    multi_remove_request &operator=(multi_remove_request &&);
-    multi_remove_request() : max_count(0) {}
+class multi_remove_request {
+ public:
 
-    virtual ~multi_remove_request() throw();
-    ::dsn::blob hash_key;
-    std::vector<::dsn::blob> sort_keys;
-    int64_t max_count;
+  multi_remove_request(const multi_remove_request&);
+  multi_remove_request(multi_remove_request&&);
+  multi_remove_request& operator=(const multi_remove_request&);
+  multi_remove_request& operator=(multi_remove_request&&);
+  multi_remove_request() : max_count(0) {
+  }
 
-    _multi_remove_request__isset __isset;
+  virtual ~multi_remove_request() throw();
+   ::dsn::blob hash_key;
+  std::vector< ::dsn::blob>  sort_keys;
+  int64_t max_count;
 
-    void __set_hash_key(const ::dsn::blob &val);
+  _multi_remove_request__isset __isset;
 
-    void __set_sort_keys(const std::vector<::dsn::blob> &val);
+  void __set_hash_key(const  ::dsn::blob& val);
 
-    void __set_max_count(const int64_t val);
+  void __set_sort_keys(const std::vector< ::dsn::blob> & val);
 
-    bool operator==(const multi_remove_request &rhs) const
-    {
-        if (!(hash_key == rhs.hash_key))
-            return false;
-        if (!(sort_keys == rhs.sort_keys))
-            return false;
-        if (!(max_count == rhs.max_count))
-            return false;
-        return true;
-    }
-    bool operator!=(const multi_remove_request &rhs) const { return !(*this == rhs); }
+  void __set_max_count(const int64_t val);
 
-    bool operator<(const multi_remove_request &) const;
+  bool operator == (const multi_remove_request & rhs) const
+  {
+    if (!(hash_key == rhs.hash_key))
+      return false;
+    if (!(sort_keys == rhs.sort_keys))
+      return false;
+    if (!(max_count == rhs.max_count))
+      return false;
+    return true;
+  }
+  bool operator != (const multi_remove_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const multi_remove_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(multi_remove_request &a, multi_remove_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const multi_remove_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const multi_remove_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _multi_remove_response__isset
-{
-    _multi_remove_response__isset()
-        : error(false),
-          count(false),
-          app_id(false),
-          partition_index(false),
-          decree(false),
-          server(false)
-    {
-    }
-    bool error : 1;
-    bool count : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool decree : 1;
-    bool server : 1;
+typedef struct _multi_remove_response__isset {
+  _multi_remove_response__isset() : error(false), count(false), app_id(false), partition_index(false), decree(false), server(false) {}
+  bool error :1;
+  bool count :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool decree :1;
+  bool server :1;
 } _multi_remove_response__isset;
 
-class multi_remove_response
-{
-public:
-    multi_remove_response(const multi_remove_response &);
-    multi_remove_response(multi_remove_response &&);
-    multi_remove_response &operator=(const multi_remove_response &);
-    multi_remove_response &operator=(multi_remove_response &&);
-    multi_remove_response() : error(0), count(0), app_id(0), partition_index(0), decree(0), server()
-    {
-    }
+class multi_remove_response {
+ public:
 
-    virtual ~multi_remove_response() throw();
-    int32_t error;
-    int64_t count;
-    int32_t app_id;
-    int32_t partition_index;
-    int64_t decree;
-    std::string server;
+  multi_remove_response(const multi_remove_response&);
+  multi_remove_response(multi_remove_response&&);
+  multi_remove_response& operator=(const multi_remove_response&);
+  multi_remove_response& operator=(multi_remove_response&&);
+  multi_remove_response() : error(0), count(0), app_id(0), partition_index(0), decree(0), server() {
+  }
 
-    _multi_remove_response__isset __isset;
+  virtual ~multi_remove_response() throw();
+  int32_t error;
+  int64_t count;
+  int32_t app_id;
+  int32_t partition_index;
+  int64_t decree;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _multi_remove_response__isset __isset;
 
-    void __set_count(const int64_t val);
+  void __set_error(const int32_t val);
 
-    void __set_app_id(const int32_t val);
+  void __set_count(const int64_t val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_decree(const int64_t val);
+  void __set_partition_index(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_decree(const int64_t val);
 
-    bool operator==(const multi_remove_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(count == rhs.count))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(decree == rhs.decree))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const multi_remove_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const multi_remove_response &) const;
+  bool operator == (const multi_remove_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(count == rhs.count))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(decree == rhs.decree))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const multi_remove_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const multi_remove_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(multi_remove_response &a, multi_remove_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const multi_remove_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const multi_remove_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _multi_get_request__isset
-{
-    _multi_get_request__isset()
-        : hash_key(false),
-          sort_keys(false),
-          max_kv_count(false),
-          max_kv_size(false),
-          no_value(false),
-          start_sortkey(false),
-          stop_sortkey(false),
-          start_inclusive(false),
-          stop_inclusive(false),
-          sort_key_filter_type(false),
-          sort_key_filter_pattern(false),
-          reverse(false)
-    {
-    }
-    bool hash_key : 1;
-    bool sort_keys : 1;
-    bool max_kv_count : 1;
-    bool max_kv_size : 1;
-    bool no_value : 1;
-    bool start_sortkey : 1;
-    bool stop_sortkey : 1;
-    bool start_inclusive : 1;
-    bool stop_inclusive : 1;
-    bool sort_key_filter_type : 1;
-    bool sort_key_filter_pattern : 1;
-    bool reverse : 1;
+typedef struct _multi_get_request__isset {
+  _multi_get_request__isset() : hash_key(false), sort_keys(false), max_kv_count(false), max_kv_size(false), no_value(false), start_sortkey(false), stop_sortkey(false), start_inclusive(false), stop_inclusive(false), sort_key_filter_type(false), sort_key_filter_pattern(false), reverse(false) {}
+  bool hash_key :1;
+  bool sort_keys :1;
+  bool max_kv_count :1;
+  bool max_kv_size :1;
+  bool no_value :1;
+  bool start_sortkey :1;
+  bool stop_sortkey :1;
+  bool start_inclusive :1;
+  bool stop_inclusive :1;
+  bool sort_key_filter_type :1;
+  bool sort_key_filter_pattern :1;
+  bool reverse :1;
 } _multi_get_request__isset;
 
-class multi_get_request
-{
-public:
-    multi_get_request(const multi_get_request &);
-    multi_get_request(multi_get_request &&);
-    multi_get_request &operator=(const multi_get_request &);
-    multi_get_request &operator=(multi_get_request &&);
-    multi_get_request()
-        : max_kv_count(0),
-          max_kv_size(0),
-          no_value(0),
-          start_inclusive(0),
-          stop_inclusive(0),
-          sort_key_filter_type((filter_type::type)0),
-          reverse(0)
-    {
-    }
+class multi_get_request {
+ public:
 
-    virtual ~multi_get_request() throw();
-    ::dsn::blob hash_key;
-    std::vector<::dsn::blob> sort_keys;
-    int32_t max_kv_count;
-    int32_t max_kv_size;
-    bool no_value;
-    ::dsn::blob start_sortkey;
-    ::dsn::blob stop_sortkey;
-    bool start_inclusive;
-    bool stop_inclusive;
-    filter_type::type sort_key_filter_type;
-    ::dsn::blob sort_key_filter_pattern;
-    bool reverse;
+  multi_get_request(const multi_get_request&);
+  multi_get_request(multi_get_request&&);
+  multi_get_request& operator=(const multi_get_request&);
+  multi_get_request& operator=(multi_get_request&&);
+  multi_get_request() : max_kv_count(0), max_kv_size(0), no_value(0), start_inclusive(0), stop_inclusive(0), sort_key_filter_type((filter_type::type)0), reverse(0) {
+  }
 
-    _multi_get_request__isset __isset;
+  virtual ~multi_get_request() throw();
+   ::dsn::blob hash_key;
+  std::vector< ::dsn::blob>  sort_keys;
+  int32_t max_kv_count;
+  int32_t max_kv_size;
+  bool no_value;
+   ::dsn::blob start_sortkey;
+   ::dsn::blob stop_sortkey;
+  bool start_inclusive;
+  bool stop_inclusive;
+  filter_type::type sort_key_filter_type;
+   ::dsn::blob sort_key_filter_pattern;
+  bool reverse;
 
-    void __set_hash_key(const ::dsn::blob &val);
+  _multi_get_request__isset __isset;
 
-    void __set_sort_keys(const std::vector<::dsn::blob> &val);
+  void __set_hash_key(const  ::dsn::blob& val);
 
-    void __set_max_kv_count(const int32_t val);
+  void __set_sort_keys(const std::vector< ::dsn::blob> & val);
 
-    void __set_max_kv_size(const int32_t val);
+  void __set_max_kv_count(const int32_t val);
 
-    void __set_no_value(const bool val);
+  void __set_max_kv_size(const int32_t val);
 
-    void __set_start_sortkey(const ::dsn::blob &val);
+  void __set_no_value(const bool val);
 
-    void __set_stop_sortkey(const ::dsn::blob &val);
+  void __set_start_sortkey(const  ::dsn::blob& val);
 
-    void __set_start_inclusive(const bool val);
+  void __set_stop_sortkey(const  ::dsn::blob& val);
 
-    void __set_stop_inclusive(const bool val);
+  void __set_start_inclusive(const bool val);
 
-    void __set_sort_key_filter_type(const filter_type::type val);
+  void __set_stop_inclusive(const bool val);
 
-    void __set_sort_key_filter_pattern(const ::dsn::blob &val);
+  void __set_sort_key_filter_type(const filter_type::type val);
 
-    void __set_reverse(const bool val);
+  void __set_sort_key_filter_pattern(const  ::dsn::blob& val);
 
-    bool operator==(const multi_get_request &rhs) const
-    {
-        if (!(hash_key == rhs.hash_key))
-            return false;
-        if (!(sort_keys == rhs.sort_keys))
-            return false;
-        if (!(max_kv_count == rhs.max_kv_count))
-            return false;
-        if (!(max_kv_size == rhs.max_kv_size))
-            return false;
-        if (!(no_value == rhs.no_value))
-            return false;
-        if (!(start_sortkey == rhs.start_sortkey))
-            return false;
-        if (!(stop_sortkey == rhs.stop_sortkey))
-            return false;
-        if (!(start_inclusive == rhs.start_inclusive))
-            return false;
-        if (!(stop_inclusive == rhs.stop_inclusive))
-            return false;
-        if (!(sort_key_filter_type == rhs.sort_key_filter_type))
-            return false;
-        if (!(sort_key_filter_pattern == rhs.sort_key_filter_pattern))
-            return false;
-        if (!(reverse == rhs.reverse))
-            return false;
-        return true;
-    }
-    bool operator!=(const multi_get_request &rhs) const { return !(*this == rhs); }
+  void __set_reverse(const bool val);
 
-    bool operator<(const multi_get_request &) const;
+  bool operator == (const multi_get_request & rhs) const
+  {
+    if (!(hash_key == rhs.hash_key))
+      return false;
+    if (!(sort_keys == rhs.sort_keys))
+      return false;
+    if (!(max_kv_count == rhs.max_kv_count))
+      return false;
+    if (!(max_kv_size == rhs.max_kv_size))
+      return false;
+    if (!(no_value == rhs.no_value))
+      return false;
+    if (!(start_sortkey == rhs.start_sortkey))
+      return false;
+    if (!(stop_sortkey == rhs.stop_sortkey))
+      return false;
+    if (!(start_inclusive == rhs.start_inclusive))
+      return false;
+    if (!(stop_inclusive == rhs.stop_inclusive))
+      return false;
+    if (!(sort_key_filter_type == rhs.sort_key_filter_type))
+      return false;
+    if (!(sort_key_filter_pattern == rhs.sort_key_filter_pattern))
+      return false;
+    if (!(reverse == rhs.reverse))
+      return false;
+    return true;
+  }
+  bool operator != (const multi_get_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const multi_get_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(multi_get_request &a, multi_get_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const multi_get_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const multi_get_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _multi_get_response__isset
-{
-    _multi_get_response__isset()
-        : error(false), kvs(false), app_id(false), partition_index(false), server(false)
-    {
-    }
-    bool error : 1;
-    bool kvs : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool server : 1;
+typedef struct _multi_get_response__isset {
+  _multi_get_response__isset() : error(false), kvs(false), app_id(false), partition_index(false), server(false) {}
+  bool error :1;
+  bool kvs :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool server :1;
 } _multi_get_response__isset;
 
-class multi_get_response
-{
-public:
-    multi_get_response(const multi_get_response &);
-    multi_get_response(multi_get_response &&);
-    multi_get_response &operator=(const multi_get_response &);
-    multi_get_response &operator=(multi_get_response &&);
-    multi_get_response() : error(0), app_id(0), partition_index(0), server() {}
+class multi_get_response {
+ public:
 
-    virtual ~multi_get_response() throw();
-    int32_t error;
-    std::vector<key_value> kvs;
-    int32_t app_id;
-    int32_t partition_index;
-    std::string server;
+  multi_get_response(const multi_get_response&);
+  multi_get_response(multi_get_response&&);
+  multi_get_response& operator=(const multi_get_response&);
+  multi_get_response& operator=(multi_get_response&&);
+  multi_get_response() : error(0), app_id(0), partition_index(0), server() {
+  }
 
-    _multi_get_response__isset __isset;
+  virtual ~multi_get_response() throw();
+  int32_t error;
+  std::vector<key_value>  kvs;
+  int32_t app_id;
+  int32_t partition_index;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _multi_get_response__isset __isset;
 
-    void __set_kvs(const std::vector<key_value> &val);
+  void __set_error(const int32_t val);
 
-    void __set_app_id(const int32_t val);
+  void __set_kvs(const std::vector<key_value> & val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_partition_index(const int32_t val);
 
-    bool operator==(const multi_get_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(kvs == rhs.kvs))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const multi_get_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const multi_get_response &) const;
+  bool operator == (const multi_get_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(kvs == rhs.kvs))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const multi_get_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const multi_get_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(multi_get_response &a, multi_get_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const multi_get_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const multi_get_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _batch_get_request__isset
-{
-    _batch_get_request__isset() : keys(false) {}
-    bool keys : 1;
+typedef struct _batch_get_request__isset {
+  _batch_get_request__isset() : keys(false) {}
+  bool keys :1;
 } _batch_get_request__isset;
 
-class batch_get_request
-{
-public:
-    batch_get_request(const batch_get_request &);
-    batch_get_request(batch_get_request &&);
-    batch_get_request &operator=(const batch_get_request &);
-    batch_get_request &operator=(batch_get_request &&);
-    batch_get_request() {}
+class batch_get_request {
+ public:
 
-    virtual ~batch_get_request() throw();
-    std::vector<full_key> keys;
+  batch_get_request(const batch_get_request&);
+  batch_get_request(batch_get_request&&);
+  batch_get_request& operator=(const batch_get_request&);
+  batch_get_request& operator=(batch_get_request&&);
+  batch_get_request() {
+  }
 
-    _batch_get_request__isset __isset;
+  virtual ~batch_get_request() throw();
+  std::vector<full_key>  keys;
 
-    void __set_keys(const std::vector<full_key> &val);
+  _batch_get_request__isset __isset;
 
-    bool operator==(const batch_get_request &rhs) const
-    {
-        if (!(keys == rhs.keys))
-            return false;
-        return true;
-    }
-    bool operator!=(const batch_get_request &rhs) const { return !(*this == rhs); }
+  void __set_keys(const std::vector<full_key> & val);
 
-    bool operator<(const batch_get_request &) const;
+  bool operator == (const batch_get_request & rhs) const
+  {
+    if (!(keys == rhs.keys))
+      return false;
+    return true;
+  }
+  bool operator != (const batch_get_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const batch_get_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(batch_get_request &a, batch_get_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const batch_get_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const batch_get_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _full_key__isset
-{
-    _full_key__isset() : hash_key(false), sort_key(false) {}
-    bool hash_key : 1;
-    bool sort_key : 1;
+typedef struct _full_key__isset {
+  _full_key__isset() : hash_key(false), sort_key(false) {}
+  bool hash_key :1;
+  bool sort_key :1;
 } _full_key__isset;
 
-class full_key
-{
-public:
-    full_key(const full_key &);
-    full_key(full_key &&);
-    full_key &operator=(const full_key &);
-    full_key &operator=(full_key &&);
-    full_key() {}
+class full_key {
+ public:
 
-    virtual ~full_key() throw();
-    ::dsn::blob hash_key;
-    ::dsn::blob sort_key;
+  full_key(const full_key&);
+  full_key(full_key&&);
+  full_key& operator=(const full_key&);
+  full_key& operator=(full_key&&);
+  full_key() {
+  }
 
-    _full_key__isset __isset;
+  virtual ~full_key() throw();
+   ::dsn::blob hash_key;
+   ::dsn::blob sort_key;
 
-    void __set_hash_key(const ::dsn::blob &val);
+  _full_key__isset __isset;
 
-    void __set_sort_key(const ::dsn::blob &val);
+  void __set_hash_key(const  ::dsn::blob& val);
 
-    bool operator==(const full_key &rhs) const
-    {
-        if (!(hash_key == rhs.hash_key))
-            return false;
-        if (!(sort_key == rhs.sort_key))
-            return false;
-        return true;
-    }
-    bool operator!=(const full_key &rhs) const { return !(*this == rhs); }
+  void __set_sort_key(const  ::dsn::blob& val);
 
-    bool operator<(const full_key &) const;
+  bool operator == (const full_key & rhs) const
+  {
+    if (!(hash_key == rhs.hash_key))
+      return false;
+    if (!(sort_key == rhs.sort_key))
+      return false;
+    return true;
+  }
+  bool operator != (const full_key &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const full_key & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(full_key &a, full_key &b);
 
-inline std::ostream &operator<<(std::ostream &out, const full_key &obj)
+inline std::ostream& operator<<(std::ostream& out, const full_key& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _batch_get_response__isset
-{
-    _batch_get_response__isset()
-        : error(false), data(false), app_id(false), partition_index(false), server(false)
-    {
-    }
-    bool error : 1;
-    bool data : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool server : 1;
+typedef struct _batch_get_response__isset {
+  _batch_get_response__isset() : error(false), data(false), app_id(false), partition_index(false), server(false) {}
+  bool error :1;
+  bool data :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool server :1;
 } _batch_get_response__isset;
 
-class batch_get_response
-{
-public:
-    batch_get_response(const batch_get_response &);
-    batch_get_response(batch_get_response &&);
-    batch_get_response &operator=(const batch_get_response &);
-    batch_get_response &operator=(batch_get_response &&);
-    batch_get_response() : error(0), app_id(0), partition_index(0), server() {}
+class batch_get_response {
+ public:
 
-    virtual ~batch_get_response() throw();
-    int32_t error;
-    std::vector<full_data> data;
-    int32_t app_id;
-    int32_t partition_index;
-    std::string server;
+  batch_get_response(const batch_get_response&);
+  batch_get_response(batch_get_response&&);
+  batch_get_response& operator=(const batch_get_response&);
+  batch_get_response& operator=(batch_get_response&&);
+  batch_get_response() : error(0), app_id(0), partition_index(0), server() {
+  }
 
-    _batch_get_response__isset __isset;
+  virtual ~batch_get_response() throw();
+  int32_t error;
+  std::vector<full_data>  data;
+  int32_t app_id;
+  int32_t partition_index;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _batch_get_response__isset __isset;
 
-    void __set_data(const std::vector<full_data> &val);
+  void __set_error(const int32_t val);
 
-    void __set_app_id(const int32_t val);
+  void __set_data(const std::vector<full_data> & val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_partition_index(const int32_t val);
 
-    bool operator==(const batch_get_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(data == rhs.data))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const batch_get_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const batch_get_response &) const;
+  bool operator == (const batch_get_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(data == rhs.data))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const batch_get_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const batch_get_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(batch_get_response &a, batch_get_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const batch_get_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const batch_get_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _full_data__isset
-{
-    _full_data__isset() : hash_key(false), sort_key(false), value(false) {}
-    bool hash_key : 1;
-    bool sort_key : 1;
-    bool value : 1;
+typedef struct _full_data__isset {
+  _full_data__isset() : hash_key(false), sort_key(false), value(false) {}
+  bool hash_key :1;
+  bool sort_key :1;
+  bool value :1;
 } _full_data__isset;
 
-class full_data
-{
-public:
-    full_data(const full_data &);
-    full_data(full_data &&);
-    full_data &operator=(const full_data &);
-    full_data &operator=(full_data &&);
-    full_data() {}
+class full_data {
+ public:
 
-    virtual ~full_data() throw();
-    ::dsn::blob hash_key;
-    ::dsn::blob sort_key;
-    ::dsn::blob value;
+  full_data(const full_data&);
+  full_data(full_data&&);
+  full_data& operator=(const full_data&);
+  full_data& operator=(full_data&&);
+  full_data() {
+  }
 
-    _full_data__isset __isset;
+  virtual ~full_data() throw();
+   ::dsn::blob hash_key;
+   ::dsn::blob sort_key;
+   ::dsn::blob value;
 
-    void __set_hash_key(const ::dsn::blob &val);
+  _full_data__isset __isset;
 
-    void __set_sort_key(const ::dsn::blob &val);
+  void __set_hash_key(const  ::dsn::blob& val);
 
-    void __set_value(const ::dsn::blob &val);
+  void __set_sort_key(const  ::dsn::blob& val);
 
-    bool operator==(const full_data &rhs) const
-    {
-        if (!(hash_key == rhs.hash_key))
-            return false;
-        if (!(sort_key == rhs.sort_key))
-            return false;
-        if (!(value == rhs.value))
-            return false;
-        return true;
-    }
-    bool operator!=(const full_data &rhs) const { return !(*this == rhs); }
+  void __set_value(const  ::dsn::blob& val);
 
-    bool operator<(const full_data &) const;
+  bool operator == (const full_data & rhs) const
+  {
+    if (!(hash_key == rhs.hash_key))
+      return false;
+    if (!(sort_key == rhs.sort_key))
+      return false;
+    if (!(value == rhs.value))
+      return false;
+    return true;
+  }
+  bool operator != (const full_data &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const full_data & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(full_data &a, full_data &b);
 
-inline std::ostream &operator<<(std::ostream &out, const full_data &obj)
+inline std::ostream& operator<<(std::ostream& out, const full_data& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _incr_request__isset
-{
-    _incr_request__isset() : key(false), increment(false), expire_ts_seconds(false) {}
-    bool key : 1;
-    bool increment : 1;
-    bool expire_ts_seconds : 1;
+typedef struct _incr_request__isset {
+  _incr_request__isset() : key(false), increment(false), expire_ts_seconds(false) {}
+  bool key :1;
+  bool increment :1;
+  bool expire_ts_seconds :1;
 } _incr_request__isset;
 
-class incr_request
-{
-public:
-    incr_request(const incr_request &);
-    incr_request(incr_request &&);
-    incr_request &operator=(const incr_request &);
-    incr_request &operator=(incr_request &&);
-    incr_request() : increment(0), expire_ts_seconds(0) {}
+class incr_request {
+ public:
 
-    virtual ~incr_request() throw();
-    ::dsn::blob key;
-    int64_t increment;
-    int32_t expire_ts_seconds;
+  incr_request(const incr_request&);
+  incr_request(incr_request&&);
+  incr_request& operator=(const incr_request&);
+  incr_request& operator=(incr_request&&);
+  incr_request() : increment(0), expire_ts_seconds(0) {
+  }
 
-    _incr_request__isset __isset;
+  virtual ~incr_request() throw();
+   ::dsn::blob key;
+  int64_t increment;
+  int32_t expire_ts_seconds;
 
-    void __set_key(const ::dsn::blob &val);
+  _incr_request__isset __isset;
 
-    void __set_increment(const int64_t val);
+  void __set_key(const  ::dsn::blob& val);
 
-    void __set_expire_ts_seconds(const int32_t val);
+  void __set_increment(const int64_t val);
 
-    bool operator==(const incr_request &rhs) const
-    {
-        if (!(key == rhs.key))
-            return false;
-        if (!(increment == rhs.increment))
-            return false;
-        if (!(expire_ts_seconds == rhs.expire_ts_seconds))
-            return false;
-        return true;
-    }
-    bool operator!=(const incr_request &rhs) const { return !(*this == rhs); }
+  void __set_expire_ts_seconds(const int32_t val);
 
-    bool operator<(const incr_request &) const;
+  bool operator == (const incr_request & rhs) const
+  {
+    if (!(key == rhs.key))
+      return false;
+    if (!(increment == rhs.increment))
+      return false;
+    if (!(expire_ts_seconds == rhs.expire_ts_seconds))
+      return false;
+    return true;
+  }
+  bool operator != (const incr_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const incr_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(incr_request &a, incr_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const incr_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const incr_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _incr_response__isset
-{
-    _incr_response__isset()
-        : error(false),
-          new_value(false),
-          app_id(false),
-          partition_index(false),
-          decree(false),
-          server(false)
-    {
-    }
-    bool error : 1;
-    bool new_value : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool decree : 1;
-    bool server : 1;
+typedef struct _incr_response__isset {
+  _incr_response__isset() : error(false), new_value(false), app_id(false), partition_index(false), decree(false), server(false) {}
+  bool error :1;
+  bool new_value :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool decree :1;
+  bool server :1;
 } _incr_response__isset;
 
-class incr_response
-{
-public:
-    incr_response(const incr_response &);
-    incr_response(incr_response &&);
-    incr_response &operator=(const incr_response &);
-    incr_response &operator=(incr_response &&);
-    incr_response() : error(0), new_value(0), app_id(0), partition_index(0), decree(0), server() {}
+class incr_response {
+ public:
 
-    virtual ~incr_response() throw();
-    int32_t error;
-    int64_t new_value;
-    int32_t app_id;
-    int32_t partition_index;
-    int64_t decree;
-    std::string server;
+  incr_response(const incr_response&);
+  incr_response(incr_response&&);
+  incr_response& operator=(const incr_response&);
+  incr_response& operator=(incr_response&&);
+  incr_response() : error(0), new_value(0), app_id(0), partition_index(0), decree(0), server() {
+  }
 
-    _incr_response__isset __isset;
+  virtual ~incr_response() throw();
+  int32_t error;
+  int64_t new_value;
+  int32_t app_id;
+  int32_t partition_index;
+  int64_t decree;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _incr_response__isset __isset;
 
-    void __set_new_value(const int64_t val);
+  void __set_error(const int32_t val);
 
-    void __set_app_id(const int32_t val);
+  void __set_new_value(const int64_t val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_decree(const int64_t val);
+  void __set_partition_index(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_decree(const int64_t val);
 
-    bool operator==(const incr_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(new_value == rhs.new_value))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(decree == rhs.decree))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const incr_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const incr_response &) const;
+  bool operator == (const incr_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(new_value == rhs.new_value))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(decree == rhs.decree))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const incr_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const incr_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(incr_response &a, incr_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const incr_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const incr_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _check_and_set_request__isset
-{
-    _check_and_set_request__isset()
-        : hash_key(false),
-          check_sort_key(false),
-          check_type(false),
-          check_operand(false),
-          set_diff_sort_key(false),
-          set_sort_key(false),
-          set_value(false),
-          set_expire_ts_seconds(false),
-          return_check_value(false)
-    {
-    }
-    bool hash_key : 1;
-    bool check_sort_key : 1;
-    bool check_type : 1;
-    bool check_operand : 1;
-    bool set_diff_sort_key : 1;
-    bool set_sort_key : 1;
-    bool set_value : 1;
-    bool set_expire_ts_seconds : 1;
-    bool return_check_value : 1;
+typedef struct _check_and_set_request__isset {
+  _check_and_set_request__isset() : hash_key(false), check_sort_key(false), check_type(false), check_operand(false), set_diff_sort_key(false), set_sort_key(false), set_value(false), set_expire_ts_seconds(false), return_check_value(false) {}
+  bool hash_key :1;
+  bool check_sort_key :1;
+  bool check_type :1;
+  bool check_operand :1;
+  bool set_diff_sort_key :1;
+  bool set_sort_key :1;
+  bool set_value :1;
+  bool set_expire_ts_seconds :1;
+  bool return_check_value :1;
 } _check_and_set_request__isset;
 
-class check_and_set_request
-{
-public:
-    check_and_set_request(const check_and_set_request &);
-    check_and_set_request(check_and_set_request &&);
-    check_and_set_request &operator=(const check_and_set_request &);
-    check_and_set_request &operator=(check_and_set_request &&);
-    check_and_set_request()
-        : check_type((cas_check_type::type)0),
-          set_diff_sort_key(0),
-          set_expire_ts_seconds(0),
-          return_check_value(0)
-    {
-    }
+class check_and_set_request {
+ public:
 
-    virtual ~check_and_set_request() throw();
-    ::dsn::blob hash_key;
-    ::dsn::blob check_sort_key;
-    cas_check_type::type check_type;
-    ::dsn::blob check_operand;
-    bool set_diff_sort_key;
-    ::dsn::blob set_sort_key;
-    ::dsn::blob set_value;
-    int32_t set_expire_ts_seconds;
-    bool return_check_value;
+  check_and_set_request(const check_and_set_request&);
+  check_and_set_request(check_and_set_request&&);
+  check_and_set_request& operator=(const check_and_set_request&);
+  check_and_set_request& operator=(check_and_set_request&&);
+  check_and_set_request() : check_type((cas_check_type::type)0), set_diff_sort_key(0), set_expire_ts_seconds(0), return_check_value(0) {
+  }
 
-    _check_and_set_request__isset __isset;
+  virtual ~check_and_set_request() throw();
+   ::dsn::blob hash_key;
+   ::dsn::blob check_sort_key;
+  cas_check_type::type check_type;
+   ::dsn::blob check_operand;
+  bool set_diff_sort_key;
+   ::dsn::blob set_sort_key;
+   ::dsn::blob set_value;
+  int32_t set_expire_ts_seconds;
+  bool return_check_value;
 
-    void __set_hash_key(const ::dsn::blob &val);
+  _check_and_set_request__isset __isset;
 
-    void __set_check_sort_key(const ::dsn::blob &val);
+  void __set_hash_key(const  ::dsn::blob& val);
 
-    void __set_check_type(const cas_check_type::type val);
+  void __set_check_sort_key(const  ::dsn::blob& val);
 
-    void __set_check_operand(const ::dsn::blob &val);
+  void __set_check_type(const cas_check_type::type val);
 
-    void __set_set_diff_sort_key(const bool val);
+  void __set_check_operand(const  ::dsn::blob& val);
 
-    void __set_set_sort_key(const ::dsn::blob &val);
+  void __set_set_diff_sort_key(const bool val);
 
-    void __set_set_value(const ::dsn::blob &val);
+  void __set_set_sort_key(const  ::dsn::blob& val);
 
-    void __set_set_expire_ts_seconds(const int32_t val);
+  void __set_set_value(const  ::dsn::blob& val);
 
-    void __set_return_check_value(const bool val);
+  void __set_set_expire_ts_seconds(const int32_t val);
 
-    bool operator==(const check_and_set_request &rhs) const
-    {
-        if (!(hash_key == rhs.hash_key))
-            return false;
-        if (!(check_sort_key == rhs.check_sort_key))
-            return false;
-        if (!(check_type == rhs.check_type))
-            return false;
-        if (!(check_operand == rhs.check_operand))
-            return false;
-        if (!(set_diff_sort_key == rhs.set_diff_sort_key))
-            return false;
-        if (!(set_sort_key == rhs.set_sort_key))
-            return false;
-        if (!(set_value == rhs.set_value))
-            return false;
-        if (!(set_expire_ts_seconds == rhs.set_expire_ts_seconds))
-            return false;
-        if (!(return_check_value == rhs.return_check_value))
-            return false;
-        return true;
-    }
-    bool operator!=(const check_and_set_request &rhs) const { return !(*this == rhs); }
+  void __set_return_check_value(const bool val);
 
-    bool operator<(const check_and_set_request &) const;
+  bool operator == (const check_and_set_request & rhs) const
+  {
+    if (!(hash_key == rhs.hash_key))
+      return false;
+    if (!(check_sort_key == rhs.check_sort_key))
+      return false;
+    if (!(check_type == rhs.check_type))
+      return false;
+    if (!(check_operand == rhs.check_operand))
+      return false;
+    if (!(set_diff_sort_key == rhs.set_diff_sort_key))
+      return false;
+    if (!(set_sort_key == rhs.set_sort_key))
+      return false;
+    if (!(set_value == rhs.set_value))
+      return false;
+    if (!(set_expire_ts_seconds == rhs.set_expire_ts_seconds))
+      return false;
+    if (!(return_check_value == rhs.return_check_value))
+      return false;
+    return true;
+  }
+  bool operator != (const check_and_set_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const check_and_set_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(check_and_set_request &a, check_and_set_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const check_and_set_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const check_and_set_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _check_and_set_response__isset
-{
-    _check_and_set_response__isset()
-        : error(false),
-          check_value_returned(false),
-          check_value_exist(false),
-          check_value(false),
-          app_id(false),
-          partition_index(false),
-          decree(false),
-          server(false)
-    {
-    }
-    bool error : 1;
-    bool check_value_returned : 1;
-    bool check_value_exist : 1;
-    bool check_value : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool decree : 1;
-    bool server : 1;
+typedef struct _check_and_set_response__isset {
+  _check_and_set_response__isset() : error(false), check_value_returned(false), check_value_exist(false), check_value(false), app_id(false), partition_index(false), decree(false), server(false) {}
+  bool error :1;
+  bool check_value_returned :1;
+  bool check_value_exist :1;
+  bool check_value :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool decree :1;
+  bool server :1;
 } _check_and_set_response__isset;
 
-class check_and_set_response
-{
-public:
-    check_and_set_response(const check_and_set_response &);
-    check_and_set_response(check_and_set_response &&);
-    check_and_set_response &operator=(const check_and_set_response &);
-    check_and_set_response &operator=(check_and_set_response &&);
-    check_and_set_response()
-        : error(0),
-          check_value_returned(0),
-          check_value_exist(0),
-          app_id(0),
-          partition_index(0),
-          decree(0),
-          server()
-    {
-    }
+class check_and_set_response {
+ public:
 
-    virtual ~check_and_set_response() throw();
-    int32_t error;
-    bool check_value_returned;
-    bool check_value_exist;
-    ::dsn::blob check_value;
-    int32_t app_id;
-    int32_t partition_index;
-    int64_t decree;
-    std::string server;
+  check_and_set_response(const check_and_set_response&);
+  check_and_set_response(check_and_set_response&&);
+  check_and_set_response& operator=(const check_and_set_response&);
+  check_and_set_response& operator=(check_and_set_response&&);
+  check_and_set_response() : error(0), check_value_returned(0), check_value_exist(0), app_id(0), partition_index(0), decree(0), server() {
+  }
 
-    _check_and_set_response__isset __isset;
+  virtual ~check_and_set_response() throw();
+  int32_t error;
+  bool check_value_returned;
+  bool check_value_exist;
+   ::dsn::blob check_value;
+  int32_t app_id;
+  int32_t partition_index;
+  int64_t decree;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _check_and_set_response__isset __isset;
 
-    void __set_check_value_returned(const bool val);
+  void __set_error(const int32_t val);
 
-    void __set_check_value_exist(const bool val);
+  void __set_check_value_returned(const bool val);
 
-    void __set_check_value(const ::dsn::blob &val);
+  void __set_check_value_exist(const bool val);
 
-    void __set_app_id(const int32_t val);
+  void __set_check_value(const  ::dsn::blob& val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_decree(const int64_t val);
+  void __set_partition_index(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_decree(const int64_t val);
 
-    bool operator==(const check_and_set_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(check_value_returned == rhs.check_value_returned))
-            return false;
-        if (!(check_value_exist == rhs.check_value_exist))
-            return false;
-        if (!(check_value == rhs.check_value))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(decree == rhs.decree))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const check_and_set_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const check_and_set_response &) const;
+  bool operator == (const check_and_set_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(check_value_returned == rhs.check_value_returned))
+      return false;
+    if (!(check_value_exist == rhs.check_value_exist))
+      return false;
+    if (!(check_value == rhs.check_value))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(decree == rhs.decree))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const check_and_set_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const check_and_set_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(check_and_set_response &a, check_and_set_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const check_and_set_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const check_and_set_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _mutate__isset
-{
-    _mutate__isset() : operation(false), sort_key(false), value(false), set_expire_ts_seconds(false)
-    {
-    }
-    bool operation : 1;
-    bool sort_key : 1;
-    bool value : 1;
-    bool set_expire_ts_seconds : 1;
+typedef struct _mutate__isset {
+  _mutate__isset() : operation(false), sort_key(false), value(false), set_expire_ts_seconds(false) {}
+  bool operation :1;
+  bool sort_key :1;
+  bool value :1;
+  bool set_expire_ts_seconds :1;
 } _mutate__isset;
 
-class mutate
-{
-public:
-    mutate(const mutate &);
-    mutate(mutate &&);
-    mutate &operator=(const mutate &);
-    mutate &operator=(mutate &&);
-    mutate() : operation((mutate_operation::type)0), set_expire_ts_seconds(0) {}
+class mutate {
+ public:
 
-    virtual ~mutate() throw();
-    mutate_operation::type operation;
-    ::dsn::blob sort_key;
-    ::dsn::blob value;
-    int32_t set_expire_ts_seconds;
+  mutate(const mutate&);
+  mutate(mutate&&);
+  mutate& operator=(const mutate&);
+  mutate& operator=(mutate&&);
+  mutate() : operation((mutate_operation::type)0), set_expire_ts_seconds(0) {
+  }
 
-    _mutate__isset __isset;
+  virtual ~mutate() throw();
+  mutate_operation::type operation;
+   ::dsn::blob sort_key;
+   ::dsn::blob value;
+  int32_t set_expire_ts_seconds;
 
-    void __set_operation(const mutate_operation::type val);
+  _mutate__isset __isset;
 
-    void __set_sort_key(const ::dsn::blob &val);
+  void __set_operation(const mutate_operation::type val);
 
-    void __set_value(const ::dsn::blob &val);
+  void __set_sort_key(const  ::dsn::blob& val);
 
-    void __set_set_expire_ts_seconds(const int32_t val);
+  void __set_value(const  ::dsn::blob& val);
 
-    bool operator==(const mutate &rhs) const
-    {
-        if (!(operation == rhs.operation))
-            return false;
-        if (!(sort_key == rhs.sort_key))
-            return false;
-        if (!(value == rhs.value))
-            return false;
-        if (!(set_expire_ts_seconds == rhs.set_expire_ts_seconds))
-            return false;
-        return true;
-    }
-    bool operator!=(const mutate &rhs) const { return !(*this == rhs); }
+  void __set_set_expire_ts_seconds(const int32_t val);
 
-    bool operator<(const mutate &) const;
+  bool operator == (const mutate & rhs) const
+  {
+    if (!(operation == rhs.operation))
+      return false;
+    if (!(sort_key == rhs.sort_key))
+      return false;
+    if (!(value == rhs.value))
+      return false;
+    if (!(set_expire_ts_seconds == rhs.set_expire_ts_seconds))
+      return false;
+    return true;
+  }
+  bool operator != (const mutate &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const mutate & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(mutate &a, mutate &b);
 
-inline std::ostream &operator<<(std::ostream &out, const mutate &obj)
+inline std::ostream& operator<<(std::ostream& out, const mutate& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _check_and_mutate_request__isset
-{
-    _check_and_mutate_request__isset()
-        : hash_key(false),
-          check_sort_key(false),
-          check_type(false),
-          check_operand(false),
-          mutate_list(false),
-          return_check_value(false)
-    {
-    }
-    bool hash_key : 1;
-    bool check_sort_key : 1;
-    bool check_type : 1;
-    bool check_operand : 1;
-    bool mutate_list : 1;
-    bool return_check_value : 1;
+typedef struct _check_and_mutate_request__isset {
+  _check_and_mutate_request__isset() : hash_key(false), check_sort_key(false), check_type(false), check_operand(false), mutate_list(false), return_check_value(false) {}
+  bool hash_key :1;
+  bool check_sort_key :1;
+  bool check_type :1;
+  bool check_operand :1;
+  bool mutate_list :1;
+  bool return_check_value :1;
 } _check_and_mutate_request__isset;
 
-class check_and_mutate_request
-{
-public:
-    check_and_mutate_request(const check_and_mutate_request &);
-    check_and_mutate_request(check_and_mutate_request &&);
-    check_and_mutate_request &operator=(const check_and_mutate_request &);
-    check_and_mutate_request &operator=(check_and_mutate_request &&);
-    check_and_mutate_request() : check_type((cas_check_type::type)0), return_check_value(0) {}
+class check_and_mutate_request {
+ public:
 
-    virtual ~check_and_mutate_request() throw();
-    ::dsn::blob hash_key;
-    ::dsn::blob check_sort_key;
-    cas_check_type::type check_type;
-    ::dsn::blob check_operand;
-    std::vector<mutate> mutate_list;
-    bool return_check_value;
+  check_and_mutate_request(const check_and_mutate_request&);
+  check_and_mutate_request(check_and_mutate_request&&);
+  check_and_mutate_request& operator=(const check_and_mutate_request&);
+  check_and_mutate_request& operator=(check_and_mutate_request&&);
+  check_and_mutate_request() : check_type((cas_check_type::type)0), return_check_value(0) {
+  }
 
-    _check_and_mutate_request__isset __isset;
+  virtual ~check_and_mutate_request() throw();
+   ::dsn::blob hash_key;
+   ::dsn::blob check_sort_key;
+  cas_check_type::type check_type;
+   ::dsn::blob check_operand;
+  std::vector<mutate>  mutate_list;
+  bool return_check_value;
 
-    void __set_hash_key(const ::dsn::blob &val);
+  _check_and_mutate_request__isset __isset;
 
-    void __set_check_sort_key(const ::dsn::blob &val);
+  void __set_hash_key(const  ::dsn::blob& val);
 
-    void __set_check_type(const cas_check_type::type val);
+  void __set_check_sort_key(const  ::dsn::blob& val);
 
-    void __set_check_operand(const ::dsn::blob &val);
+  void __set_check_type(const cas_check_type::type val);
 
-    void __set_mutate_list(const std::vector<mutate> &val);
+  void __set_check_operand(const  ::dsn::blob& val);
 
-    void __set_return_check_value(const bool val);
+  void __set_mutate_list(const std::vector<mutate> & val);
 
-    bool operator==(const check_and_mutate_request &rhs) const
-    {
-        if (!(hash_key == rhs.hash_key))
-            return false;
-        if (!(check_sort_key == rhs.check_sort_key))
-            return false;
-        if (!(check_type == rhs.check_type))
-            return false;
-        if (!(check_operand == rhs.check_operand))
-            return false;
-        if (!(mutate_list == rhs.mutate_list))
-            return false;
-        if (!(return_check_value == rhs.return_check_value))
-            return false;
-        return true;
-    }
-    bool operator!=(const check_and_mutate_request &rhs) const { return !(*this == rhs); }
+  void __set_return_check_value(const bool val);
 
-    bool operator<(const check_and_mutate_request &) const;
+  bool operator == (const check_and_mutate_request & rhs) const
+  {
+    if (!(hash_key == rhs.hash_key))
+      return false;
+    if (!(check_sort_key == rhs.check_sort_key))
+      return false;
+    if (!(check_type == rhs.check_type))
+      return false;
+    if (!(check_operand == rhs.check_operand))
+      return false;
+    if (!(mutate_list == rhs.mutate_list))
+      return false;
+    if (!(return_check_value == rhs.return_check_value))
+      return false;
+    return true;
+  }
+  bool operator != (const check_and_mutate_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const check_and_mutate_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(check_and_mutate_request &a, check_and_mutate_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const check_and_mutate_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const check_and_mutate_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _check_and_mutate_response__isset
-{
-    _check_and_mutate_response__isset()
-        : error(false),
-          check_value_returned(false),
-          check_value_exist(false),
-          check_value(false),
-          app_id(false),
-          partition_index(false),
-          decree(false),
-          server(false)
-    {
-    }
-    bool error : 1;
-    bool check_value_returned : 1;
-    bool check_value_exist : 1;
-    bool check_value : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool decree : 1;
-    bool server : 1;
+typedef struct _check_and_mutate_response__isset {
+  _check_and_mutate_response__isset() : error(false), check_value_returned(false), check_value_exist(false), check_value(false), app_id(false), partition_index(false), decree(false), server(false) {}
+  bool error :1;
+  bool check_value_returned :1;
+  bool check_value_exist :1;
+  bool check_value :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool decree :1;
+  bool server :1;
 } _check_and_mutate_response__isset;
 
-class check_and_mutate_response
-{
-public:
-    check_and_mutate_response(const check_and_mutate_response &);
-    check_and_mutate_response(check_and_mutate_response &&);
-    check_and_mutate_response &operator=(const check_and_mutate_response &);
-    check_and_mutate_response &operator=(check_and_mutate_response &&);
-    check_and_mutate_response()
-        : error(0),
-          check_value_returned(0),
-          check_value_exist(0),
-          app_id(0),
-          partition_index(0),
-          decree(0),
-          server()
-    {
-    }
+class check_and_mutate_response {
+ public:
 
-    virtual ~check_and_mutate_response() throw();
-    int32_t error;
-    bool check_value_returned;
-    bool check_value_exist;
-    ::dsn::blob check_value;
-    int32_t app_id;
-    int32_t partition_index;
-    int64_t decree;
-    std::string server;
+  check_and_mutate_response(const check_and_mutate_response&);
+  check_and_mutate_response(check_and_mutate_response&&);
+  check_and_mutate_response& operator=(const check_and_mutate_response&);
+  check_and_mutate_response& operator=(check_and_mutate_response&&);
+  check_and_mutate_response() : error(0), check_value_returned(0), check_value_exist(0), app_id(0), partition_index(0), decree(0), server() {
+  }
 
-    _check_and_mutate_response__isset __isset;
+  virtual ~check_and_mutate_response() throw();
+  int32_t error;
+  bool check_value_returned;
+  bool check_value_exist;
+   ::dsn::blob check_value;
+  int32_t app_id;
+  int32_t partition_index;
+  int64_t decree;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _check_and_mutate_response__isset __isset;
 
-    void __set_check_value_returned(const bool val);
+  void __set_error(const int32_t val);
 
-    void __set_check_value_exist(const bool val);
+  void __set_check_value_returned(const bool val);
 
-    void __set_check_value(const ::dsn::blob &val);
+  void __set_check_value_exist(const bool val);
 
-    void __set_app_id(const int32_t val);
+  void __set_check_value(const  ::dsn::blob& val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_decree(const int64_t val);
+  void __set_partition_index(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_decree(const int64_t val);
 
-    bool operator==(const check_and_mutate_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(check_value_returned == rhs.check_value_returned))
-            return false;
-        if (!(check_value_exist == rhs.check_value_exist))
-            return false;
-        if (!(check_value == rhs.check_value))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(decree == rhs.decree))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const check_and_mutate_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const check_and_mutate_response &) const;
+  bool operator == (const check_and_mutate_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(check_value_returned == rhs.check_value_returned))
+      return false;
+    if (!(check_value_exist == rhs.check_value_exist))
+      return false;
+    if (!(check_value == rhs.check_value))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(decree == rhs.decree))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const check_and_mutate_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const check_and_mutate_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(check_and_mutate_response &a, check_and_mutate_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const check_and_mutate_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const check_and_mutate_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _get_scanner_request__isset
-{
-    _get_scanner_request__isset()
-        : start_key(false),
-          stop_key(false),
-          start_inclusive(false),
-          stop_inclusive(false),
-          batch_size(false),
-          no_value(false),
-          hash_key_filter_type(false),
-          hash_key_filter_pattern(false),
-          sort_key_filter_type(false),
-          sort_key_filter_pattern(false),
-          validate_partition_hash(false),
-          return_expire_ts(false),
-          full_scan(false)
-    {
-    }
-    bool start_key : 1;
-    bool stop_key : 1;
-    bool start_inclusive : 1;
-    bool stop_inclusive : 1;
-    bool batch_size : 1;
-    bool no_value : 1;
-    bool hash_key_filter_type : 1;
-    bool hash_key_filter_pattern : 1;
-    bool sort_key_filter_type : 1;
-    bool sort_key_filter_pattern : 1;
-    bool validate_partition_hash : 1;
-    bool return_expire_ts : 1;
-    bool full_scan : 1;
+typedef struct _get_scanner_request__isset {
+  _get_scanner_request__isset() : start_key(false), stop_key(false), start_inclusive(false), stop_inclusive(false), batch_size(false), no_value(false), hash_key_filter_type(false), hash_key_filter_pattern(false), sort_key_filter_type(false), sort_key_filter_pattern(false), validate_partition_hash(false), return_expire_ts(false), full_scan(false) {}
+  bool start_key :1;
+  bool stop_key :1;
+  bool start_inclusive :1;
+  bool stop_inclusive :1;
+  bool batch_size :1;
+  bool no_value :1;
+  bool hash_key_filter_type :1;
+  bool hash_key_filter_pattern :1;
+  bool sort_key_filter_type :1;
+  bool sort_key_filter_pattern :1;
+  bool validate_partition_hash :1;
+  bool return_expire_ts :1;
+  bool full_scan :1;
 } _get_scanner_request__isset;
 
-class get_scanner_request
-{
-public:
-    get_scanner_request(const get_scanner_request &);
-    get_scanner_request(get_scanner_request &&);
-    get_scanner_request &operator=(const get_scanner_request &);
-    get_scanner_request &operator=(get_scanner_request &&);
-    get_scanner_request()
-        : start_inclusive(0),
-          stop_inclusive(0),
-          batch_size(0),
-          no_value(0),
-          hash_key_filter_type((filter_type::type)0),
-          sort_key_filter_type((filter_type::type)0),
-          validate_partition_hash(0),
-          return_expire_ts(0),
-          full_scan(0)
-    {
-    }
+class get_scanner_request {
+ public:
 
-    virtual ~get_scanner_request() throw();
-    ::dsn::blob start_key;
-    ::dsn::blob stop_key;
-    bool start_inclusive;
-    bool stop_inclusive;
-    int32_t batch_size;
-    bool no_value;
-    filter_type::type hash_key_filter_type;
-    ::dsn::blob hash_key_filter_pattern;
-    filter_type::type sort_key_filter_type;
-    ::dsn::blob sort_key_filter_pattern;
-    bool validate_partition_hash;
-    bool return_expire_ts;
-    bool full_scan;
+  get_scanner_request(const get_scanner_request&);
+  get_scanner_request(get_scanner_request&&);
+  get_scanner_request& operator=(const get_scanner_request&);
+  get_scanner_request& operator=(get_scanner_request&&);
+  get_scanner_request() : start_inclusive(0), stop_inclusive(0), batch_size(0), no_value(0), hash_key_filter_type((filter_type::type)0), sort_key_filter_type((filter_type::type)0), validate_partition_hash(0), return_expire_ts(0), full_scan(0) {
+  }
 
-    _get_scanner_request__isset __isset;
+  virtual ~get_scanner_request() throw();
+   ::dsn::blob start_key;
+   ::dsn::blob stop_key;
+  bool start_inclusive;
+  bool stop_inclusive;
+  int32_t batch_size;
+  bool no_value;
+  filter_type::type hash_key_filter_type;
+   ::dsn::blob hash_key_filter_pattern;
+  filter_type::type sort_key_filter_type;
+   ::dsn::blob sort_key_filter_pattern;
+  bool validate_partition_hash;
+  bool return_expire_ts;
+  bool full_scan;
 
-    void __set_start_key(const ::dsn::blob &val);
+  _get_scanner_request__isset __isset;
 
-    void __set_stop_key(const ::dsn::blob &val);
+  void __set_start_key(const  ::dsn::blob& val);
 
-    void __set_start_inclusive(const bool val);
+  void __set_stop_key(const  ::dsn::blob& val);
 
-    void __set_stop_inclusive(const bool val);
+  void __set_start_inclusive(const bool val);
 
-    void __set_batch_size(const int32_t val);
+  void __set_stop_inclusive(const bool val);
 
-    void __set_no_value(const bool val);
+  void __set_batch_size(const int32_t val);
 
-    void __set_hash_key_filter_type(const filter_type::type val);
+  void __set_no_value(const bool val);
 
-    void __set_hash_key_filter_pattern(const ::dsn::blob &val);
+  void __set_hash_key_filter_type(const filter_type::type val);
 
-    void __set_sort_key_filter_type(const filter_type::type val);
+  void __set_hash_key_filter_pattern(const  ::dsn::blob& val);
 
-    void __set_sort_key_filter_pattern(const ::dsn::blob &val);
+  void __set_sort_key_filter_type(const filter_type::type val);
 
-    void __set_validate_partition_hash(const bool val);
+  void __set_sort_key_filter_pattern(const  ::dsn::blob& val);
 
-    void __set_return_expire_ts(const bool val);
+  void __set_validate_partition_hash(const bool val);
 
-    void __set_full_scan(const bool val);
+  void __set_return_expire_ts(const bool val);
 
-    bool operator==(const get_scanner_request &rhs) const
-    {
-        if (!(start_key == rhs.start_key))
-            return false;
-        if (!(stop_key == rhs.stop_key))
-            return false;
-        if (!(start_inclusive == rhs.start_inclusive))
-            return false;
-        if (!(stop_inclusive == rhs.stop_inclusive))
-            return false;
-        if (!(batch_size == rhs.batch_size))
-            return false;
-        if (!(no_value == rhs.no_value))
-            return false;
-        if (!(hash_key_filter_type == rhs.hash_key_filter_type))
-            return false;
-        if (!(hash_key_filter_pattern == rhs.hash_key_filter_pattern))
-            return false;
-        if (!(sort_key_filter_type == rhs.sort_key_filter_type))
-            return false;
-        if (!(sort_key_filter_pattern == rhs.sort_key_filter_pattern))
-            return false;
-        if (__isset.validate_partition_hash != rhs.__isset.validate_partition_hash)
-            return false;
-        else if (__isset.validate_partition_hash &&
-                 !(validate_partition_hash == rhs.validate_partition_hash))
-            return false;
-        if (__isset.return_expire_ts != rhs.__isset.return_expire_ts)
-            return false;
-        else if (__isset.return_expire_ts && !(return_expire_ts == rhs.return_expire_ts))
-            return false;
-        if (__isset.full_scan != rhs.__isset.full_scan)
-            return false;
-        else if (__isset.full_scan && !(full_scan == rhs.full_scan))
-            return false;
-        return true;
-    }
-    bool operator!=(const get_scanner_request &rhs) const { return !(*this == rhs); }
+  void __set_full_scan(const bool val);
 
-    bool operator<(const get_scanner_request &) const;
+  bool operator == (const get_scanner_request & rhs) const
+  {
+    if (!(start_key == rhs.start_key))
+      return false;
+    if (!(stop_key == rhs.stop_key))
+      return false;
+    if (!(start_inclusive == rhs.start_inclusive))
+      return false;
+    if (!(stop_inclusive == rhs.stop_inclusive))
+      return false;
+    if (!(batch_size == rhs.batch_size))
+      return false;
+    if (!(no_value == rhs.no_value))
+      return false;
+    if (!(hash_key_filter_type == rhs.hash_key_filter_type))
+      return false;
+    if (!(hash_key_filter_pattern == rhs.hash_key_filter_pattern))
+      return false;
+    if (!(sort_key_filter_type == rhs.sort_key_filter_type))
+      return false;
+    if (!(sort_key_filter_pattern == rhs.sort_key_filter_pattern))
+      return false;
+    if (__isset.validate_partition_hash != rhs.__isset.validate_partition_hash)
+      return false;
+    else if (__isset.validate_partition_hash && !(validate_partition_hash == rhs.validate_partition_hash))
+      return false;
+    if (__isset.return_expire_ts != rhs.__isset.return_expire_ts)
+      return false;
+    else if (__isset.return_expire_ts && !(return_expire_ts == rhs.return_expire_ts))
+      return false;
+    if (__isset.full_scan != rhs.__isset.full_scan)
+      return false;
+    else if (__isset.full_scan && !(full_scan == rhs.full_scan))
+      return false;
+    return true;
+  }
+  bool operator != (const get_scanner_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const get_scanner_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(get_scanner_request &a, get_scanner_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const get_scanner_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const get_scanner_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _scan_request__isset
-{
-    _scan_request__isset() : context_id(false) {}
-    bool context_id : 1;
+typedef struct _scan_request__isset {
+  _scan_request__isset() : context_id(false) {}
+  bool context_id :1;
 } _scan_request__isset;
 
-class scan_request
-{
-public:
-    scan_request(const scan_request &);
-    scan_request(scan_request &&);
-    scan_request &operator=(const scan_request &);
-    scan_request &operator=(scan_request &&);
-    scan_request() : context_id(0) {}
+class scan_request {
+ public:
 
-    virtual ~scan_request() throw();
-    int64_t context_id;
+  scan_request(const scan_request&);
+  scan_request(scan_request&&);
+  scan_request& operator=(const scan_request&);
+  scan_request& operator=(scan_request&&);
+  scan_request() : context_id(0) {
+  }
 
-    _scan_request__isset __isset;
+  virtual ~scan_request() throw();
+  int64_t context_id;
 
-    void __set_context_id(const int64_t val);
+  _scan_request__isset __isset;
 
-    bool operator==(const scan_request &rhs) const
-    {
-        if (!(context_id == rhs.context_id))
-            return false;
-        return true;
-    }
-    bool operator!=(const scan_request &rhs) const { return !(*this == rhs); }
+  void __set_context_id(const int64_t val);
 
-    bool operator<(const scan_request &) const;
+  bool operator == (const scan_request & rhs) const
+  {
+    if (!(context_id == rhs.context_id))
+      return false;
+    return true;
+  }
+  bool operator != (const scan_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const scan_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(scan_request &a, scan_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const scan_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const scan_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _scan_response__isset
-{
-    _scan_response__isset()
-        : error(false),
-          kvs(false),
-          context_id(false),
-          app_id(false),
-          partition_index(false),
-          server(false)
-    {
-    }
-    bool error : 1;
-    bool kvs : 1;
-    bool context_id : 1;
-    bool app_id : 1;
-    bool partition_index : 1;
-    bool server : 1;
+typedef struct _scan_response__isset {
+  _scan_response__isset() : error(false), kvs(false), context_id(false), app_id(false), partition_index(false), server(false) {}
+  bool error :1;
+  bool kvs :1;
+  bool context_id :1;
+  bool app_id :1;
+  bool partition_index :1;
+  bool server :1;
 } _scan_response__isset;
 
-class scan_response
-{
-public:
-    scan_response(const scan_response &);
-    scan_response(scan_response &&);
-    scan_response &operator=(const scan_response &);
-    scan_response &operator=(scan_response &&);
-    scan_response() : error(0), context_id(0), app_id(0), partition_index(0), server() {}
+class scan_response {
+ public:
 
-    virtual ~scan_response() throw();
-    int32_t error;
-    std::vector<key_value> kvs;
-    int64_t context_id;
-    int32_t app_id;
-    int32_t partition_index;
-    std::string server;
+  scan_response(const scan_response&);
+  scan_response(scan_response&&);
+  scan_response& operator=(const scan_response&);
+  scan_response& operator=(scan_response&&);
+  scan_response() : error(0), context_id(0), app_id(0), partition_index(0), server() {
+  }
 
-    _scan_response__isset __isset;
+  virtual ~scan_response() throw();
+  int32_t error;
+  std::vector<key_value>  kvs;
+  int64_t context_id;
+  int32_t app_id;
+  int32_t partition_index;
+  std::string server;
 
-    void __set_error(const int32_t val);
+  _scan_response__isset __isset;
 
-    void __set_kvs(const std::vector<key_value> &val);
+  void __set_error(const int32_t val);
 
-    void __set_context_id(const int64_t val);
+  void __set_kvs(const std::vector<key_value> & val);
 
-    void __set_app_id(const int32_t val);
+  void __set_context_id(const int64_t val);
 
-    void __set_partition_index(const int32_t val);
+  void __set_app_id(const int32_t val);
 
-    void __set_server(const std::string &val);
+  void __set_partition_index(const int32_t val);
 
-    bool operator==(const scan_response &rhs) const
-    {
-        if (!(error == rhs.error))
-            return false;
-        if (!(kvs == rhs.kvs))
-            return false;
-        if (!(context_id == rhs.context_id))
-            return false;
-        if (!(app_id == rhs.app_id))
-            return false;
-        if (!(partition_index == rhs.partition_index))
-            return false;
-        if (!(server == rhs.server))
-            return false;
-        return true;
-    }
-    bool operator!=(const scan_response &rhs) const { return !(*this == rhs); }
+  void __set_server(const std::string& val);
 
-    bool operator<(const scan_response &) const;
+  bool operator == (const scan_response & rhs) const
+  {
+    if (!(error == rhs.error))
+      return false;
+    if (!(kvs == rhs.kvs))
+      return false;
+    if (!(context_id == rhs.context_id))
+      return false;
+    if (!(app_id == rhs.app_id))
+      return false;
+    if (!(partition_index == rhs.partition_index))
+      return false;
+    if (!(server == rhs.server))
+      return false;
+    return true;
+  }
+  bool operator != (const scan_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const scan_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(scan_response &a, scan_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const scan_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const scan_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _duplicate_request__isset
-{
-    _duplicate_request__isset() : entries(false) {}
-    bool entries : 1;
+typedef struct _duplicate_request__isset {
+  _duplicate_request__isset() : entries(false) {}
+  bool entries :1;
 } _duplicate_request__isset;
 
-class duplicate_request
-{
-public:
-    duplicate_request(const duplicate_request &);
-    duplicate_request(duplicate_request &&);
-    duplicate_request &operator=(const duplicate_request &);
-    duplicate_request &operator=(duplicate_request &&);
-    duplicate_request() {}
+class duplicate_request {
+ public:
 
-    virtual ~duplicate_request() throw();
-    std::vector<duplicate_entry> entries;
+  duplicate_request(const duplicate_request&);
+  duplicate_request(duplicate_request&&);
+  duplicate_request& operator=(const duplicate_request&);
+  duplicate_request& operator=(duplicate_request&&);
+  duplicate_request() {
+  }
 
-    _duplicate_request__isset __isset;
+  virtual ~duplicate_request() throw();
+  std::vector<duplicate_entry>  entries;
 
-    void __set_entries(const std::vector<duplicate_entry> &val);
+  _duplicate_request__isset __isset;
 
-    bool operator==(const duplicate_request &rhs) const
-    {
-        if (!(entries == rhs.entries))
-            return false;
-        return true;
-    }
-    bool operator!=(const duplicate_request &rhs) const { return !(*this == rhs); }
+  void __set_entries(const std::vector<duplicate_entry> & val);
 
-    bool operator<(const duplicate_request &) const;
+  bool operator == (const duplicate_request & rhs) const
+  {
+    if (!(entries == rhs.entries))
+      return false;
+    return true;
+  }
+  bool operator != (const duplicate_request &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const duplicate_request & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(duplicate_request &a, duplicate_request &b);
 
-inline std::ostream &operator<<(std::ostream &out, const duplicate_request &obj)
+inline std::ostream& operator<<(std::ostream& out, const duplicate_request& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _duplicate_entry__isset
-{
-    _duplicate_entry__isset()
-        : timestamp(false),
-          task_code(false),
-          raw_message(false),
-          cluster_id(false),
-          verify_timetag(false)
-    {
-    }
-    bool timestamp : 1;
-    bool task_code : 1;
-    bool raw_message : 1;
-    bool cluster_id : 1;
-    bool verify_timetag : 1;
+typedef struct _duplicate_entry__isset {
+  _duplicate_entry__isset() : timestamp(false), task_code(false), raw_message(false), cluster_id(false), verify_timetag(false) {}
+  bool timestamp :1;
+  bool task_code :1;
+  bool raw_message :1;
+  bool cluster_id :1;
+  bool verify_timetag :1;
 } _duplicate_entry__isset;
 
-class duplicate_entry
-{
-public:
-    duplicate_entry(const duplicate_entry &);
-    duplicate_entry(duplicate_entry &&);
-    duplicate_entry &operator=(const duplicate_entry &);
-    duplicate_entry &operator=(duplicate_entry &&);
-    duplicate_entry() : timestamp(0), cluster_id(0), verify_timetag(0) {}
+class duplicate_entry {
+ public:
 
-    virtual ~duplicate_entry() throw();
-    int64_t timestamp;
-    ::dsn::task_code task_code;
-    ::dsn::blob raw_message;
-    int8_t cluster_id;
-    bool verify_timetag;
+  duplicate_entry(const duplicate_entry&);
+  duplicate_entry(duplicate_entry&&);
+  duplicate_entry& operator=(const duplicate_entry&);
+  duplicate_entry& operator=(duplicate_entry&&);
+  duplicate_entry() : timestamp(0), cluster_id(0), verify_timetag(0) {
+  }
 
-    _duplicate_entry__isset __isset;
+  virtual ~duplicate_entry() throw();
+  int64_t timestamp;
+   ::dsn::task_code task_code;
+   ::dsn::blob raw_message;
+  int8_t cluster_id;
+  bool verify_timetag;
 
-    void __set_timestamp(const int64_t val);
+  _duplicate_entry__isset __isset;
 
-    void __set_task_code(const ::dsn::task_code &val);
+  void __set_timestamp(const int64_t val);
 
-    void __set_raw_message(const ::dsn::blob &val);
+  void __set_task_code(const  ::dsn::task_code& val);
 
-    void __set_cluster_id(const int8_t val);
+  void __set_raw_message(const  ::dsn::blob& val);
 
-    void __set_verify_timetag(const bool val);
+  void __set_cluster_id(const int8_t val);
 
-    bool operator==(const duplicate_entry &rhs) const
-    {
-        if (__isset.timestamp != rhs.__isset.timestamp)
-            return false;
-        else if (__isset.timestamp && !(timestamp == rhs.timestamp))
-            return false;
-        if (__isset.task_code != rhs.__isset.task_code)
-            return false;
-        else if (__isset.task_code && !(task_code == rhs.task_code))
-            return false;
-        if (__isset.raw_message != rhs.__isset.raw_message)
-            return false;
-        else if (__isset.raw_message && !(raw_message == rhs.raw_message))
-            return false;
-        if (__isset.cluster_id != rhs.__isset.cluster_id)
-            return false;
-        else if (__isset.cluster_id && !(cluster_id == rhs.cluster_id))
-            return false;
-        if (__isset.verify_timetag != rhs.__isset.verify_timetag)
-            return false;
-        else if (__isset.verify_timetag && !(verify_timetag == rhs.verify_timetag))
-            return false;
-        return true;
-    }
-    bool operator!=(const duplicate_entry &rhs) const { return !(*this == rhs); }
+  void __set_verify_timetag(const bool val);
 
-    bool operator<(const duplicate_entry &) const;
+  bool operator == (const duplicate_entry & rhs) const
+  {
+    if (__isset.timestamp != rhs.__isset.timestamp)
+      return false;
+    else if (__isset.timestamp && !(timestamp == rhs.timestamp))
+      return false;
+    if (__isset.task_code != rhs.__isset.task_code)
+      return false;
+    else if (__isset.task_code && !(task_code == rhs.task_code))
+      return false;
+    if (__isset.raw_message != rhs.__isset.raw_message)
+      return false;
+    else if (__isset.raw_message && !(raw_message == rhs.raw_message))
+      return false;
+    if (__isset.cluster_id != rhs.__isset.cluster_id)
+      return false;
+    else if (__isset.cluster_id && !(cluster_id == rhs.cluster_id))
+      return false;
+    if (__isset.verify_timetag != rhs.__isset.verify_timetag)
+      return false;
+    else if (__isset.verify_timetag && !(verify_timetag == rhs.verify_timetag))
+      return false;
+    return true;
+  }
+  bool operator != (const duplicate_entry &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const duplicate_entry & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(duplicate_entry &a, duplicate_entry &b);
 
-inline std::ostream &operator<<(std::ostream &out, const duplicate_entry &obj)
+inline std::ostream& operator<<(std::ostream& out, const duplicate_entry& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
 
-typedef struct _duplicate_response__isset
-{
-    _duplicate_response__isset() : error(false), error_hint(false) {}
-    bool error : 1;
-    bool error_hint : 1;
+typedef struct _duplicate_response__isset {
+  _duplicate_response__isset() : error(false), error_hint(false) {}
+  bool error :1;
+  bool error_hint :1;
 } _duplicate_response__isset;
 
-class duplicate_response
-{
-public:
-    duplicate_response(const duplicate_response &);
-    duplicate_response(duplicate_response &&);
-    duplicate_response &operator=(const duplicate_response &);
-    duplicate_response &operator=(duplicate_response &&);
-    duplicate_response() : error(0), error_hint() {}
+class duplicate_response {
+ public:
 
-    virtual ~duplicate_response() throw();
-    int32_t error;
-    std::string error_hint;
+  duplicate_response(const duplicate_response&);
+  duplicate_response(duplicate_response&&);
+  duplicate_response& operator=(const duplicate_response&);
+  duplicate_response& operator=(duplicate_response&&);
+  duplicate_response() : error(0), error_hint() {
+  }
 
-    _duplicate_response__isset __isset;
+  virtual ~duplicate_response() throw();
+  int32_t error;
+  std::string error_hint;
 
-    void __set_error(const int32_t val);
+  _duplicate_response__isset __isset;
 
-    void __set_error_hint(const std::string &val);
+  void __set_error(const int32_t val);
 
-    bool operator==(const duplicate_response &rhs) const
-    {
-        if (__isset.error != rhs.__isset.error)
-            return false;
-        else if (__isset.error && !(error == rhs.error))
-            return false;
-        if (__isset.error_hint != rhs.__isset.error_hint)
-            return false;
-        else if (__isset.error_hint && !(error_hint == rhs.error_hint))
-            return false;
-        return true;
-    }
-    bool operator!=(const duplicate_response &rhs) const { return !(*this == rhs); }
+  void __set_error_hint(const std::string& val);
 
-    bool operator<(const duplicate_response &) const;
+  bool operator == (const duplicate_response & rhs) const
+  {
+    if (__isset.error != rhs.__isset.error)
+      return false;
+    else if (__isset.error && !(error == rhs.error))
+      return false;
+    if (__isset.error_hint != rhs.__isset.error_hint)
+      return false;
+    else if (__isset.error_hint && !(error_hint == rhs.error_hint))
+      return false;
+    return true;
+  }
+  bool operator != (const duplicate_response &rhs) const {
+    return !(*this == rhs);
+  }
 
-    uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
-    uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+  bool operator < (const duplicate_response & ) const;
 
-    virtual void printTo(std::ostream &out) const;
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+  virtual void printTo(std::ostream& out) const;
 };
 
 void swap(duplicate_response &a, duplicate_response &b);
 
-inline std::ostream &operator<<(std::ostream &out, const duplicate_response &obj)
+inline std::ostream& operator<<(std::ostream& out, const duplicate_response& obj)
 {
-    obj.printTo(out);
-    return out;
+  obj.printTo(out);
+  return out;
 }
-}
-} // namespace
+
+}} // namespace
 
 #endif

--- a/src/server/pegasus_comparator.h
+++ b/src/server/pegasus_comparator.h
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <rocksdb/comparator.h>
+
+namespace rocksdb {
+
+inline bool IsLittleEndian() {
+    static int32_t number = 0x88;
+    const char* array = reinterpret_cast<const char*>(&number);
+    return (array[0] == 0x88);
+}
+
+// The function is copied from rocksdb/util/coding.h
+
+// Lower-level versions of Get... that read directly from a character buffer
+// without any bounds checking.
+inline uint16_t DecodeFixed16(const char* ptr) {
+  // port::kLittleEndian
+  if (IsLittleEndian()) {
+    // Load the raw bytes
+    uint16_t result;
+    memcpy(&result, ptr, sizeof(result));  // gcc optimizes this to a plain load
+    return result;
+  } else {
+    return ((static_cast<uint16_t>(static_cast<unsigned char>(ptr[0]))) |
+            (static_cast<uint16_t>(static_cast<unsigned char>(ptr[1])) << 8));
+  }
+}
+
+// The function is copied from rocksdb/util/coding.h
+inline bool GetFixed16(Slice* input, uint16_t* value) {
+  if (input->size() < sizeof(uint16_t)) {
+    return false;
+  }
+  *value = DecodeFixed16(input->data());
+  input->remove_prefix(sizeof(uint16_t));
+  return true;
+}
+
+} // namespace rocksdb
+
+namespace pegasus {
+namespace server {
+
+class PegasusComparator : public rocksdb::Comparator {
+public:
+    PegasusComparator() {}
+    virtual const char* Name() const {
+        return "PegasusComparator";
+    }
+    virtual int Compare(const rocksdb::Slice& left, const rocksdb::Slice& right) const {
+        rocksdb::Slice left_slice(left);
+        uint16_t left_length;
+        rocksdb::GetFixed16(&left_slice, &left_length);
+
+        rocksdb::Slice right_slice(right);
+        uint16_t right_length;
+        rocksdb::GetFixed16(&right_slice, &right_length);
+
+        rocksdb::Slice left_hash_key(left_slice.data(), left_length);
+        rocksdb::Slice right_hash_key(right_slice.data(), right_length);
+        int ret = left_hash_key.compare(right_hash_key);
+        if (ret != 0) {
+            return ret;
+        }
+        left_slice.remove_prefix(left_length);
+        right_slice.remove_prefix(right_length);
+
+        return left_slice.compare(right_slice);
+    }
+    virtual void FindShortestSeparator(std::string* start,
+                                       const rocksdb::Slice& limit) const {
+        (void) start;
+        (void) limit;
+        // TODO
+    }
+    virtual void FindShortSuccessor(std::string* key) const {
+        (void) key;
+        // TODO
+    }
+};
+
+} // namespace server
+} // namespace pegasus
+
+/* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -27,6 +27,7 @@
 #include "capacity_unit_calculator.h"
 #include "hashkey_transform.h"
 #include "meta_store.h"
+#include "pegasus_comparator.h"
 #include "pegasus_event_listener.h"
 #include "pegasus_server_write.h"
 #include "hotkey_collector.h"
@@ -294,6 +295,11 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
                                         "rocksdb_level0_stop_writes_trigger",
                                         60,
                                         "rocksdb options.level0_stop_writes_trigger");
+    // user-defined comparator
+    const dsn::app_info* app_info = get_app_info();
+    if (app_info->comparator == dsn::comparator_type::PEGASUS) {
+        _data_cf_opts.comparator = new pegasus::server::PegasusComparator();
+    }
 
     std::string compression_str = dsn_config_get_value_string(
         "pegasus.server",

--- a/src/server/test/hashkey_transform_test.cpp
+++ b/src/server/test/hashkey_transform_test.cpp
@@ -23,6 +23,7 @@
 #include <rocksdb/comparator.h>
 
 #include "base/pegasus_key_schema.h"
+#include "server/pegasus_comparator.h"
 
 // User define SliceTransform must obey the 4 rules of ColumnFamilyOptions.prefix_extractor:
 // 1) key.starts_with(prefix(key))
@@ -76,4 +77,20 @@ TEST(HashkeyTransformTest, Basic)
               prefix_extractor.Transform(skey3));
     ASSERT_EQ(prefix_extractor.Transform(prefix_extractor.Transform(skey4)),
               prefix_extractor.Transform(skey4));
+}
+
+TEST(HashkeyTransformTest, PegasusComparator) {
+    rocksdb::Comparator *comp = new pegasus::server::PegasusComparator();
+    const rocksdb::Comparator *bytes_comp = rocksdb::BytewiseComparator();
+
+    dsn::blob bkey1, bkey2, bkey3, bkey4;
+    pegasus::pegasus_generate_key(bkey1, std::string("z"), std::string(""));
+    pegasus::pegasus_generate_key(bkey2, std::string("aaa"), std::string(""));
+    rocksdb::Slice skey1(bkey1.data(), bkey1.size());
+    rocksdb::Slice skey2(bkey2.data(), bkey2.size());
+
+    ASSERT_TRUE(bytes_comp->Compare(skey1, skey2) < 0);
+    ASSERT_TRUE(comp->Compare(skey1, skey2) > 0);
+
+    delete comp;
 }

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -106,6 +106,11 @@ TEST_F(pegasus_server_impl_test, test_open_db_with_latest_options)
     ASSERT_EQ(opts.disable_auto_compactions, _server->_db->GetOptions().disable_auto_compactions);
 }
 
+TEST_F(pegasus_server_impl_test, test_open_db_with_comparator) {
+    // open a new db
+    start();
+    
+}
 TEST_F(pegasus_server_impl_test, test_open_db_with_app_envs)
 {
     std::map<std::string, std::string> envs;

--- a/src/test/function_test/test_basic.cpp
+++ b/src/test/function_test/test_basic.cpp
@@ -1852,3 +1852,14 @@ TEST(basic, full_scan_with_filter)
     ASSERT_EQ(PERR_OK, ret);
     ASSERT_EQ(8, deleted_count);
 }
+
+TEST_F(basic, TestCreateTable) {
+    static const std::string table_with_default_comparator = "table_with_default_comparator";
+    static const std::string table_with_pegasus_comparator = "table_with_pegasus_comparator";
+
+    client = pegasus_client_factory::get_client("mycluster", table_with_default_comparator);
+
+    client = pegasus_client_factory::get_client("mycluster", table_with_pegasus_comparator);
+
+}
+


### PR DESCRIPTION
    add a pegasus comparator to support a normal users' sort.
Using new pegasus comparator will solve many scan timeout problems.
Pegasus can be compatible apps(tables) using the old comparator.
pegasus comparator will be the new table's default comparator.

    more details at: https://github.com/apache/incubator-pegasus/issues/729

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how does it work?


### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

##### Code changes

- Has exported function/method change
- Has exported variable/fields change
- Has interface methods change
- Has persistent data change

##### Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

##### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
