### PR TITLE
fix(collector): fix unexpected crash

### DIFF
--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -96,11 +96,7 @@ void hotspot_partition_calculator::init_perf_counter(int partition_count)
 void hotspot_partition_calculator::stat_histories_analyse(uint32_t data_type,
                                                           std::vector<int> &hot_points)
 {
-    int hot_point_size = _hot_points.size();
-    hot_points.resize(hot_point_size);
-    for (int i = 0; i < hot_point_size; i++) {
-        hot_points[i] = 0;
-    }
+    hot_points.assign(_hot_points.size(), 0);
     double table_qps_sum = 0, standard_deviation = 0, table_qps_avg = 0;
     int sample_count = 0;
     for (const auto &one_partition_stat_histories : _partitions_stat_histories) {

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -96,6 +96,11 @@ void hotspot_partition_calculator::init_perf_counter(int partition_count)
 void hotspot_partition_calculator::stat_histories_analyse(uint32_t data_type,
                                                           std::vector<int> &hot_points)
 {
+    int hot_point_size = _hot_points.size();
+    hot_points.resize(hot_point_size);
+    for (int i = 0; i < hot_point_size; i++) {
+        hot_points[i] = 0;
+    }
     double table_qps_sum = 0, standard_deviation = 0, table_qps_avg = 0;
     int sample_count = 0;
     for (const auto &one_partition_stat_histories : _partitions_stat_histories) {
@@ -116,8 +121,6 @@ void hotspot_partition_calculator::stat_histories_analyse(uint32_t data_type,
     }
     standard_deviation = sqrt(standard_deviation / (sample_count - 1));
     const auto &anly_data = _partitions_stat_histories.back();
-    int hot_point_size = _hot_points.size();
-    hot_points.resize(hot_point_size);
     for (int i = 0; i < hot_point_size; i++) {
         double hot_point = 0;
         if (standard_deviation != 0) {

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -96,7 +96,8 @@ void hotspot_partition_calculator::init_perf_counter(int partition_count)
 void hotspot_partition_calculator::stat_histories_analyse(uint32_t data_type,
                                                           std::vector<int> &hot_points)
 {
-    hot_points.assign(_hot_points.size(), 0);
+    int hot_point_size = _hot_points.size();
+    hot_points.assign(hot_point_size, 0);
     double table_qps_sum = 0, standard_deviation = 0, table_qps_avg = 0;
     int sample_count = 0;
     for (const auto &one_partition_stat_histories : _partitions_stat_histories) {


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/985#issue-1251839824

### What problem does this PR solve? <!--add issue link with summary if exists-->

当某张表 partition 为 1 时，可能导致 stat_histories_analyse 提前 return，进而 hot_points 和 _hot_points size 不一致，使得后续的 assert fail

```
D2022-05-28 06:29:48.34 (1653719388034076919 383) collector.default1.0101000000000001: compiler_depend.ts:108:stat_histories_analyse(): _partitions_stat_histories size <= 1, not enough data for calculation
F2022-05-28 06:29:48.34 (1653719388034089894 383) collector.default1.0101000000000001: compiler_depend.ts:135:update_hot_point(): assertion expression: _hot_points.size() == hot_points.size()
F2022-05-28 06:29:48.34 (1653719388034125236 383) collector.default1.0101000000000001: compiler_depend.ts:135:update_hot_point(): 1 vs 0
```

### What is changed and how does it work?

将 hot_points 的 resize 提前到函数入口处，确保其 size 和 _hot_points 的 size 一致

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

##### Code changes

- Has exported function/method change
- Has exported variable/fields change
- Has interface methods change
- Has persistent data change

##### Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

##### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
