### PR TITLE
feat(update_replication_factor#11): add max_reserved_dropped_replicas into server config file

### DIFF
--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -212,6 +212,7 @@
   partition_guardian_type = partition_guardian
   replica_assign_delay_ms_for_dropouts = 600000
   max_replicas_in_group = 3
+  max_reserved_dropped_replicas = 0
   balancer_in_turn = false
   only_primary_balancer = false
   only_move_primary = false


### PR DESCRIPTION
This is a subtask of https://github.com/apache/incubator-pegasus/issues/865.

Firstly, for details about `max_reserved_dropped_replicas` please see https://github.com/XiaoMi/rdsn/pull/1109.

As is described in https://github.com/XiaoMi/rdsn/pull/1109, cluster-level `max_replicas_in_group` has been replaced with `max_reserved_dropped_replicas`. To be consistent with `max_replicas_in_group`, `max_reserved_dropped_replicas` should be set to 0 for production environments. It should be added into server config file and set to 0. 

```diff
[meta_server]
+ max_reserved_dropped_replicas = 0
```