### PR TITLE
feat: support to restrict the size of rocksdb info logs

### DIFF
--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -356,6 +356,10 @@
   rocksdb_total_size_across_write_buffer = 0
   rocksdb_max_open_files = -1
 
+  rocksdb_max_log_file_size = 8388608
+  rocksdb_log_file_time_to_roll = 86400
+  rocksdb_keep_log_file_num = 32
+
   rocksdb_index_type = binary_search
   rocksdb_partition_filters = false
   rocksdb_metadata_block_size = 4096

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -119,7 +119,7 @@ DSN_DEFINE_uint64("pegasus.server",
                   24 * 60 * 60,
                   "specify time for the info log file to roll (in seconds): if this option is "
                   "specified with non-zero value, log file will be rolled if it has been active "
-                  "longer than this option; it this options is set to 0, log file will never be "
+                  "longer than this option; if this options is set to 0, log file will never be "
                   "rolled by life time");
 DSN_TAG_VARIABLE(rocksdb_log_file_time_to_roll, FT_MUTABLE);
 

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -126,7 +126,8 @@ DSN_TAG_VARIABLE(rocksdb_log_file_time_to_roll, FT_MUTABLE);
 DSN_DEFINE_uint64("pegasus.server",
                   rocksdb_keep_log_file_num,
                   32,
-                  "specify the maximal numbers of info log files to be kept.");
+                  "specify the maximal numbers of info log files to be kept: once the number of "
+                  "info logs goes beyond this option, stale log files will be cleaned.");
 DSN_TAG_VARIABLE(rocksdb_keep_log_file_num, FT_MUTABLE);
 
 static const std::unordered_map<std::string, rocksdb::BlockBasedTableOptions::IndexType>

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -112,7 +112,6 @@ DSN_DEFINE_uint64("pegasus.server",
                   "specify the maximal size of the info log file: once the log file is larger "
                   "than this option, a new info log file will be created; if this option is set "
                   "to 0, all logs will be written to one log file.");
-DSN_TAG_VARIABLE(rocksdb_max_log_file_size, FT_MUTABLE);
 
 DSN_DEFINE_uint64("pegasus.server",
                   rocksdb_log_file_time_to_roll,
@@ -121,14 +120,12 @@ DSN_DEFINE_uint64("pegasus.server",
                   "specified with non-zero value, log file will be rolled if it has been active "
                   "longer than this option; otherwise, if this options is set to 0, log file will "
                   "never be rolled by life time");
-DSN_TAG_VARIABLE(rocksdb_log_file_time_to_roll, FT_MUTABLE);
 
 DSN_DEFINE_uint64("pegasus.server",
                   rocksdb_keep_log_file_num,
                   32,
                   "specify the maximal numbers of info log files to be kept: once the number of "
                   "info logs goes beyond this option, stale log files will be cleaned.");
-DSN_TAG_VARIABLE(rocksdb_keep_log_file_num, FT_MUTABLE);
 
 static const std::unordered_map<std::string, rocksdb::BlockBasedTableOptions::IndexType>
     INDEX_TYPE_STRING_MAP = {

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -103,9 +103,9 @@ DSN_TAG_VARIABLE(rocksdb_abnormal_batch_get_count_threshold, FT_MUTABLE);
 // that for `rocksdb_keep_log_file_num` can be set to 32, which means log files for recent one
 // month will be reserved.
 //
-// On the other hand, the max size of a log file is also be restricted to 8MB. In practice, the
-// size of logs over a day tends to be less than 1MB; however, once errors are reported very
-// frequently, the log file will grow larger and go far beyond several hundreds of KB.
+// On the other hand, the max size of a log file is restricted to 8MB. In practice, the size of
+// logs over a day tends to be less than 1MB; however, once errors are reported very frequently,
+// the log file will grow larger and go far beyond several hundreds of KB.
 DSN_DEFINE_uint64("pegasus.server",
                   rocksdb_max_log_file_size,
                   8 * 1024 * 1024,

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -119,8 +119,8 @@ DSN_DEFINE_uint64("pegasus.server",
                   24 * 60 * 60,
                   "specify time for the info log file to roll (in seconds): if this option is "
                   "specified with non-zero value, log file will be rolled if it has been active "
-                  "longer than this option; if this options is set to 0, log file will never be "
-                  "rolled by life time");
+                  "longer than this option; otherwise, if this options is set to 0, log file will "
+                  "never be rolled by life time");
 DSN_TAG_VARIABLE(rocksdb_log_file_time_to_roll, FT_MUTABLE);
 
 DSN_DEFINE_uint64("pegasus.server",


### PR DESCRIPTION
# 1. Motivation
This PR is to solve the problem of https://github.com/apache/incubator-pegasus/issues/994. 

The replica server can run for a very long without any fault. Each instance of rocksdb will generate a lot of info logs that occupies considerable disk spaces. Thus each instance of rocksdb should clear out-dated logs themselves periodically.

# 2. Implementation
We can use 3 options provided by `rocksdb::DBOptions` to restrict the size of info logs: 

- `max_log_file_size`
- `log_file_time_to_roll`
- `keep_log_file_num`

## 2.1 `max_log_file_size`
This option specifies the maximal size of the info log file.

Once the log file is larger than this option, a new info log file will be created.

If this option is set to 0, all logs will be written to one log file.");

## 2.2 `log_file_time_to_roll`
This options specifies time for the info log file to roll (in seconds).

If this option is specified with non-zero value, log file will be rolled if it has been active longer than this option.

Otherwise, if this options is set to 0, log file will never be rolled by life time.

## 2.3 `keep_log_file_num`

This options specifies the maximal numbers of info log files to be kept.

Once the number of info logs goes beyond this option, stale log files will be cleaned.

## 2.4 default values
In production environment, it has been observed that an instance of rocksdb about 20GB in total size which has run beyond 199 days, generated a big log file sized 96MB, with 492KB for each day.

Accordingly, default value for `rocksdb_log_file_time_to_roll` can be set to one day, and that for `rocksdb_keep_log_file_num` can be set to 32, which means log files for recent one month will be reserved.

On the other hand, the max size of a log file is restricted to 8MB. In practice, the size of logs over a day tends to be less than 1MB; however, once errors are reported very frequently, the log file will grow larger and go far beyond several hundreds of KB.

# 3. Configurations
The added configurations are listed below, which have been set to the default values:
```diff
+  rocksdb_max_log_file_size = 8388608
+  rocksdb_log_file_time_to_roll = 86400
+  rocksdb_keep_log_file_num = 32
```