### PR TITLE
fix: fix rdsn and thirdparty dir for ci

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -75,11 +75,10 @@ jobs:
         with:
           filters: |
             rdsn:
-              - 'rdsn/**'
+              - 'src/rdsn/**'
             thirdparty:
               - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
-        working-directory: rdsn
         if: steps.changes.outputs.thirdparty == 'false'
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
@@ -117,11 +116,10 @@ jobs:
         with:
           filters: |
             rdsn:
-              - 'rdsn/**'
+              - 'src/rdsn/**'
             thirdparty:
               - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
-        working-directory: rdsn
         if: steps.changes.outputs.thirdparty == 'false'
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
@@ -159,11 +157,10 @@ jobs:
         with:
           filters: |
             rdsn:
-              - 'rdsn/**'
+              - 'src/rdsn/**'
             thirdparty:
               - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
-        working-directory: rdsn
         if: steps.changes.outputs.thirdparty == 'false'
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
@@ -201,11 +198,10 @@ jobs:
         with:
           filters: |
             rdsn:
-              - 'rdsn/**'
+              - 'src/rdsn/**'
             thirdparty:
               - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
-        working-directory: rdsn
         if: steps.changes.outputs.thirdparty == 'false'
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Rebuild third-parties
@@ -237,24 +233,22 @@ jobs:
         id: changes
         with:
           filters: |
-            rdsn:
-              - 'rdsn/**'
             pegasus:
               - 'src/**'
       - name: Unpack prebuilt third-parties
-        if: steps.changes.outputs.rdsn == 'true' || steps.changes.outputs.pegasus == 'true'
+        if: steps.changes.outputs.pegasus == 'true'
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Compilation
-        if: steps.changes.outputs.rdsn == 'true' || steps.changes.outputs.pegasus == 'true'
+        if: steps.changes.outputs.pegasus == 'true'
         run: ./run.sh build -c -j $(($(nproc)/2+1))
       - name: Packaging Server
-        if: steps.changes.outputs.rdsn == 'true' || steps.changes.outputs.pegasus == 'true'
+        if: steps.changes.outputs.pegasus == 'true'
         run: ./run.sh pack_server
       - name: Packaging Tools
-        if: steps.changes.outputs.rdsn == 'true' || steps.changes.outputs.pegasus == 'true'
+        if: steps.changes.outputs.pegasus == 'true'
         run: ./run.sh pack_tools
       - name: Unit Testing
-        if: steps.changes.outputs.rdsn == 'true' || steps.changes.outputs.pegasus == 'true'
+        if: steps.changes.outputs.pegasus == 'true'
         run: |
           source ./scripts/config_hdfs.sh
           ./run.sh test --on_travis

--- a/.github/workflows/pegasus-regular-build.yml
+++ b/.github/workflows/pegasus-regular-build.yml
@@ -66,8 +66,7 @@ jobs:
       - name: Compilation rdsn on GCC
         if: ${{ matrix.compiler-family == 'gcc' }}
         run: |
-          cd ./rdsn
-          ./run.sh build -c --skip_thirdparty
+          ./run.sh build -c --rdsn --skip_thirdparty
       - name: Compilation pegasus on GCC
         if: ${{ matrix.compiler-family == 'gcc' }}
         run: ./run.sh build -c --skip_thirdparty
@@ -76,8 +75,7 @@ jobs:
         env:
           COMPILER: ${{ matrix.compiler }}
         run: |
-          cd ./rdsn
-          ./run.sh build --compiler $COMPILER --skip_thirdparty
+          ./run.sh build --compiler $COMPILER --rdsn --skip_thirdparty
       - name: Compilation pegasus on Clang
         if: ${{ matrix.compiler-family == 'clang' }}
         env:


### PR DESCRIPTION
This PR is to fix https://github.com/apache/incubator-pegasus/issues/1056.

The reason is that rdsn has been put under `./src`, and thirdparty has also been put under `./src`.