### PR TITLE
feat: The conf server_list of meta_server support use fqdn:port

### DIFF
--- a/src/rdsn/src/common/replication_common.cpp
+++ b/src/rdsn/src/common/replication_common.cpp
@@ -480,19 +480,19 @@ bool replica_helper::load_meta_servers(/*out*/ std::vector<dsn::rpc_address> &se
         std::vector<std::string> hostname_port;
         uint32_t ip = 0;
         utils::split_args(s.c_str(), hostname_port, ':');
-        dassert(2 == hostname_port.size(),
-                "invalid address '{}' specified in config [{}].{}",
-                s.c_str(),
-                section,
-                key);
-        unsigned int port_num;
-        dassert(dsn::internal::buf2unsigned(hostname_port[1], port_num) && port_num < UINT16_MAX,
-                "invalid address '{}' specified in config [{}].{}",
-                s.c_str(),
-                section,
-                key);
+        dassert_f(2 == hostname_port.size(),
+                  "invalid address '{}' specified in config [{}].{}",
+                  s.c_str(),
+                  section,
+                  key);
+        uint32_t port_num = 0;
+        dassert_f(dsn::internal::buf2unsigned(hostname_port[1], port_num) && port_num < UINT16_MAX,
+                  "invalid address '{}' specified in config [{}].{}",
+                  s.c_str(),
+                  section,
+                  key);
         if (0 != (ip = ::dsn::rpc_address::ipv4_from_host(hostname_port[0].c_str()))) {
-            addr.assign_ipv4(ip, (uint16_t)port_num);
+            addr.assign_ipv4(ip, static_cast<uint16_t>(port_num));
         } else if (!addr.from_string_ipv4(s.c_str())) {
             derror_f("invalid address '{}' specified in config [{}].{}", s, section, key);
             return false;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1058

### What is changed and how does it work?
meta server conf change:
```
[meta_server]
    server_list = hybrid01.com.deployoctopus-xxxx-debugbox:8170
```


##### Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
1. change the configuration server_list of the meta server to fqdn:port 
2. The service can be started 
3. The related pegasus shell is running normally


