### PR TITLE
fix: fix 'assert' disabled caused function_test failed bug

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -249,69 +249,69 @@ function run_build()
     fi
 
     echo "INFO: Start build rdsn..."
-    echo "Gen rdsn thrift"
-    python3 $ROOT/scripts/compile_thrift.py
-    BUILD_DIR="$ROOT/src/rdsn/builder"
-    if [ "$CLEAR" == "YES" ]; then
-        echo "Clear $BUILD_DIR ..."
-        rm -rf $BUILD_DIR
-    fi
-    echo "Running cmake..."
-    if [ ! -d "$BUILD_DIR" ]; then
-        mkdir -p $BUILD_DIR
-    fi
-    pushd $BUILD_DIR
-    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DBUILD_TEST=${BUILD_TEST}"
-    cmake ../../.. -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/output $CMAKE_OPTIONS -DBUILD_RDSN=ON -DBUILD_PEGASUS=OFF
-    if [ $? -ne 0 ]; then
-        echo "ERROR: cmake rdsn failed"
-        exit 1
-    fi
-    echo "[$(date)] Building..."
-    make install $MAKE_OPTIONS
-    if [ $? -ne 0 ]
-    then
-        echo "ERROR: build failed"
-        exit 1
-    else
-        echo "[$(date)] Build succeed"
-    fi
-    popd
-
-    if [ "$ONLY_RDSN" == "YES" ]; then
-      exit 0
-    fi
+#    echo "Gen rdsn thrift"
+#    python3 $ROOT/scripts/compile_thrift.py
+#    BUILD_DIR="$ROOT/src/rdsn/builder"
+#    if [ "$CLEAR" == "YES" ]; then
+#        echo "Clear $BUILD_DIR ..."
+#        rm -rf $BUILD_DIR
+#    fi
+#    echo "Running cmake..."
+#    if [ ! -d "$BUILD_DIR" ]; then
+#        mkdir -p $BUILD_DIR
+#    fi
+#    pushd $BUILD_DIR
+#    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DBUILD_TEST=${BUILD_TEST}"
+#    cmake ../../.. -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/output $CMAKE_OPTIONS -DBUILD_RDSN=ON -DBUILD_PEGASUS=OFF
+#    if [ $? -ne 0 ]; then
+#        echo "ERROR: cmake rdsn failed"
+#        exit 1
+#    fi
+#    echo "[$(date)] Building..."
+#    make install $MAKE_OPTIONS
+#    if [ $? -ne 0 ]
+#    then
+#        echo "ERROR: build failed"
+#        exit 1
+#    else
+#        echo "[$(date)] Build succeed"
+#    fi
+#    popd
+#
+#    if [ "$ONLY_RDSN" == "YES" ]; then
+#      exit 0
+#    fi
 
     echo "INFO: start build pegasus..."
-    echo "Gen pegasus thrift"
-    sh scripts/recompile_thrift.sh
-
-    cd "$ROOT/src"
-    PEGASUS_GIT_COMMIT="non-git-repo"
-    if git rev-parse HEAD; then # this is a git repo
-        PEGASUS_GIT_COMMIT=$(git rev-parse HEAD)
-    fi
-    echo "PEGASUS_GIT_COMMIT=${PEGASUS_GIT_COMMIT}"
-    GIT_COMMIT_FILE=include/pegasus/git_commit.h
-    echo "Generating $GIT_COMMIT_FILE..."
-    echo "#pragma once" >$GIT_COMMIT_FILE
-    echo "#define PEGASUS_GIT_COMMIT \"$PEGASUS_GIT_COMMIT\"" >>$GIT_COMMIT_FILE
+#    echo "Gen pegasus thrift"
+#    sh scripts/recompile_thrift.sh
+#
+#    cd "$ROOT/src"
+#    PEGASUS_GIT_COMMIT="non-git-repo"
+#    if git rev-parse HEAD; then # this is a git repo
+#        PEGASUS_GIT_COMMIT=$(git rev-parse HEAD)
+#    fi
+#    echo "PEGASUS_GIT_COMMIT=${PEGASUS_GIT_COMMIT}"
+#    GIT_COMMIT_FILE=include/pegasus/git_commit.h
+#    echo "Generating $GIT_COMMIT_FILE..."
+#    echo "#pragma once" >$GIT_COMMIT_FILE
+#    echo "#define PEGASUS_GIT_COMMIT \"$PEGASUS_GIT_COMMIT\"" >>$GIT_COMMIT_FILE
 
     BUILD_DIR="$ROOT/src/builder"
-    if [ "$CLEAR" == "YES" ]; then
-        echo "Clear $BUILD_DIR ..."
-        rm -rf $BUILD_DIR
-    fi
-    echo "Running cmake..."
-    if [ ! -d "$BUILD_DIR" ]; then
-        mkdir -p $BUILD_DIR
-    fi
+#    if [ "$CLEAR" == "YES" ]; then
+#        echo "Clear $BUILD_DIR ..."
+#        rm -rf $BUILD_DIR
+#    fi
+#    echo "Running cmake..."
+#    if [ ! -d "$BUILD_DIR" ]; then
+#        mkdir -p $BUILD_DIR
+#    fi
     pushd $BUILD_DIR
-    cmake ../.. -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/output $CMAKE_OPTIONS -DBUILD_RDSN=OFF -DBUILD_PEGASUS=ON
-    if [ $? -ne 0 ]; then
-        echo "ERROR: cmake pegasus failed"
-        exit 1
-    fi
+#    cmake ../.. -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/output $CMAKE_OPTIONS -DBUILD_RDSN=OFF -DBUILD_PEGASUS=ON
+#    if [ $? -ne 0 ]; then
+#        echo "ERROR: cmake pegasus failed"
+#        exit 1
+#    fi
     echo "[$(date)] Building..."
     make install $MAKE_OPTIONS
     if [ $? -ne 0 ]

--- a/run.sh
+++ b/run.sh
@@ -249,69 +249,69 @@ function run_build()
     fi
 
     echo "INFO: Start build rdsn..."
-#    echo "Gen rdsn thrift"
-#    python3 $ROOT/scripts/compile_thrift.py
-#    BUILD_DIR="$ROOT/src/rdsn/builder"
-#    if [ "$CLEAR" == "YES" ]; then
-#        echo "Clear $BUILD_DIR ..."
-#        rm -rf $BUILD_DIR
-#    fi
-#    echo "Running cmake..."
-#    if [ ! -d "$BUILD_DIR" ]; then
-#        mkdir -p $BUILD_DIR
-#    fi
-#    pushd $BUILD_DIR
-#    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DBUILD_TEST=${BUILD_TEST}"
-#    cmake ../../.. -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/output $CMAKE_OPTIONS -DBUILD_RDSN=ON -DBUILD_PEGASUS=OFF
-#    if [ $? -ne 0 ]; then
-#        echo "ERROR: cmake rdsn failed"
-#        exit 1
-#    fi
-#    echo "[$(date)] Building..."
-#    make install $MAKE_OPTIONS
-#    if [ $? -ne 0 ]
-#    then
-#        echo "ERROR: build failed"
-#        exit 1
-#    else
-#        echo "[$(date)] Build succeed"
-#    fi
-#    popd
-#
-#    if [ "$ONLY_RDSN" == "YES" ]; then
-#      exit 0
-#    fi
+    echo "Gen rdsn thrift"
+    python3 $ROOT/scripts/compile_thrift.py
+    BUILD_DIR="$ROOT/src/rdsn/builder"
+    if [ "$CLEAR" == "YES" ]; then
+        echo "Clear $BUILD_DIR ..."
+        rm -rf $BUILD_DIR
+    fi
+    echo "Running cmake..."
+    if [ ! -d "$BUILD_DIR" ]; then
+        mkdir -p $BUILD_DIR
+    fi
+    pushd $BUILD_DIR
+    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DBUILD_TEST=${BUILD_TEST}"
+    cmake ../../.. -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/output $CMAKE_OPTIONS -DBUILD_RDSN=ON -DBUILD_PEGASUS=OFF
+    if [ $? -ne 0 ]; then
+        echo "ERROR: cmake rdsn failed"
+        exit 1
+    fi
+    echo "[$(date)] Building..."
+    make install $MAKE_OPTIONS
+    if [ $? -ne 0 ]
+    then
+        echo "ERROR: build failed"
+        exit 1
+    else
+        echo "[$(date)] Build succeed"
+    fi
+    popd
+
+    if [ "$ONLY_RDSN" == "YES" ]; then
+      exit 0
+    fi
 
     echo "INFO: start build pegasus..."
-#    echo "Gen pegasus thrift"
-#    sh scripts/recompile_thrift.sh
-#
-#    cd "$ROOT/src"
-#    PEGASUS_GIT_COMMIT="non-git-repo"
-#    if git rev-parse HEAD; then # this is a git repo
-#        PEGASUS_GIT_COMMIT=$(git rev-parse HEAD)
-#    fi
-#    echo "PEGASUS_GIT_COMMIT=${PEGASUS_GIT_COMMIT}"
-#    GIT_COMMIT_FILE=include/pegasus/git_commit.h
-#    echo "Generating $GIT_COMMIT_FILE..."
-#    echo "#pragma once" >$GIT_COMMIT_FILE
-#    echo "#define PEGASUS_GIT_COMMIT \"$PEGASUS_GIT_COMMIT\"" >>$GIT_COMMIT_FILE
+    echo "Gen pegasus thrift"
+    sh scripts/recompile_thrift.sh
+
+    cd "$ROOT/src"
+    PEGASUS_GIT_COMMIT="non-git-repo"
+    if git rev-parse HEAD; then # this is a git repo
+        PEGASUS_GIT_COMMIT=$(git rev-parse HEAD)
+    fi
+    echo "PEGASUS_GIT_COMMIT=${PEGASUS_GIT_COMMIT}"
+    GIT_COMMIT_FILE=include/pegasus/git_commit.h
+    echo "Generating $GIT_COMMIT_FILE..."
+    echo "#pragma once" >$GIT_COMMIT_FILE
+    echo "#define PEGASUS_GIT_COMMIT \"$PEGASUS_GIT_COMMIT\"" >>$GIT_COMMIT_FILE
 
     BUILD_DIR="$ROOT/src/builder"
-#    if [ "$CLEAR" == "YES" ]; then
-#        echo "Clear $BUILD_DIR ..."
-#        rm -rf $BUILD_DIR
-#    fi
-#    echo "Running cmake..."
-#    if [ ! -d "$BUILD_DIR" ]; then
-#        mkdir -p $BUILD_DIR
-#    fi
+    if [ "$CLEAR" == "YES" ]; then
+        echo "Clear $BUILD_DIR ..."
+        rm -rf $BUILD_DIR
+    fi
+    echo "Running cmake..."
+    if [ ! -d "$BUILD_DIR" ]; then
+        mkdir -p $BUILD_DIR
+    fi
     pushd $BUILD_DIR
-#    cmake ../.. -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/output $CMAKE_OPTIONS -DBUILD_RDSN=OFF -DBUILD_PEGASUS=ON
-#    if [ $? -ne 0 ]; then
-#        echo "ERROR: cmake pegasus failed"
-#        exit 1
-#    fi
+    cmake ../.. -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/output $CMAKE_OPTIONS -DBUILD_RDSN=OFF -DBUILD_PEGASUS=ON
+    if [ $? -ne 0 ]; then
+        echo "ERROR: cmake pegasus failed"
+        exit 1
+    fi
     echo "[$(date)] Building..."
     make install $MAKE_OPTIONS
     if [ $? -ne 0 ]

--- a/src/base/pegasus_utils.cpp
+++ b/src/base/pegasus_utils.cpp
@@ -18,11 +18,15 @@
  */
 
 #include "pegasus_utils.h"
+
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <netdb.h>
 #include <stdlib.h>
 #include <errno.h>
+
+#include "dsn/c/api_utilities.h"
+#include "dsn/dist/fmt_logging.h"
 
 namespace pegasus {
 namespace utils {
@@ -111,8 +115,8 @@ c_escape_string(const char *src, size_t src_len, char *dest, size_t dest_len, bo
 inline unsigned int hex_digit_to_int(char c)
 {
     /* Assume ASCII. */
-    assert('0' == 0x30 && 'A' == 0x41 && 'a' == 0x61);
-    assert(isxdigit(c));
+    dassert_f('0' == 0x30 && 'A' == 0x41 && 'a' == 0x61, "");
+    dassert_f(isxdigit(c), "");
     unsigned int x = static_cast<unsigned char>(c);
     if (x > '9') {
         x += 9;

--- a/src/base/pegasus_value_schema.h
+++ b/src/base/pegasus_value_schema.h
@@ -92,7 +92,7 @@ pegasus_extract_user_data(uint32_t version, std::string &&raw_value, ::dsn::blob
 /// Extracts timetag from a v1 value.
 inline uint64_t pegasus_extract_timetag(int version, dsn::string_view value)
 {
-    dassert(version == 1, "data version(%d) must be v1", version);
+    dcheck_eq(version, 1);
 
     dsn::data_input input(value);
     input.skip(sizeof(uint32_t));

--- a/src/geo/bench/bench.cpp
+++ b/src/geo/bench/bench.cpp
@@ -26,9 +26,10 @@
 #include <rocksdb/statistics.h>
 #include <rocksdb/env.h>
 
-#include <dsn/utility/errors.h>
-#include <dsn/utility/strings.h>
-#include <dsn/utility/string_conv.h>
+#include "dsn/dist/fmt_logging.h"
+#include "dsn/utility/errors.h"
+#include "dsn/utility/strings.h"
+#include "dsn/utility/string_conv.h"
 
 static const int data_count = 10000;
 
@@ -85,7 +86,7 @@ int main(int argc, char **argv)
             std::string value;
             S2LatLng latlng(S2Testing::SamplePoint(rect));
             bool ok = codec.encode_to_value(latlng.lat().degrees(), latlng.lng().degrees(), value);
-            assert(ok);
+            dassert_f(ok, "");
             int ret = my_geo.set(std::to_string(i), "", value, 1000);
             if (ret != pegasus::PERR_OK) {
                 std::cerr << "set data failed. error=" << ret << std::endl;

--- a/src/geo/lib/latlng_codec.cpp
+++ b/src/geo/lib/latlng_codec.cpp
@@ -58,7 +58,7 @@ void extract_indices(const std::string &line,
 
 bool latlng_codec::decode_from_value(const std::string &value, S2LatLng &latlng) const
 {
-    assert(_sorted_indices.size() == 2);
+    dcheck_eq(_sorted_indices.size(), 2);
     std::vector<std::string> data;
     extract_indices(value, _sorted_indices, data, '|');
     if (data.size() != 2) {
@@ -79,7 +79,7 @@ bool latlng_codec::decode_from_value(const std::string &value, S2LatLng &latlng)
 
 bool latlng_codec::encode_to_value(double lat_degrees, double lng_degrees, std::string &value) const
 {
-    assert(_sorted_indices.size() == 2);
+    dcheck_eq(_sorted_indices.size(), 2);
     S2LatLng latlng = S2LatLng::FromDegrees(lat_degrees, lng_degrees);
     if (!latlng.is_valid()) {
         derror_f("latlng is invalid. lat_degrees={}, lng_degrees={}", lat_degrees, lng_degrees);

--- a/src/rdsn/include/dsn/cpp/json_helper.h
+++ b/src/rdsn/include/dsn/cpp/json_helper.h
@@ -41,6 +41,7 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include <dsn/c/api_utilities.h>
 #include <dsn/utility/autoref_ptr.h>
 #include <dsn/utility/utils.h>
 #include <dsn/tool-api/auto_codes.h>
@@ -495,7 +496,7 @@ inline void json_encode(JsonWriter &out, const dsn::ref_ptr<T> &t)
 {
     // when a smart ptr is encoded, caller should ensure the ptr is not nullptr
     // TODO: encoded to null?
-    assert(t.get() != nullptr);
+    dassert_f(t.get(), "");
     json_encode(out, *t);
 }
 
@@ -511,7 +512,7 @@ inline void json_encode(JsonWriter &out, const std::shared_ptr<T> &t)
 {
     // when a smart ptr is encoded, caller should ensure the ptr is not nullptr
     // TODO: encoded to null?
-    assert(t.get() != nullptr);
+    dassert(t.get(), "");
     json_encode(out, *t);
 }
 

--- a/src/rdsn/include/dsn/utility/casts.h
+++ b/src/rdsn/include/dsn/utility/casts.h
@@ -39,7 +39,7 @@ inline To down_cast(From *from)
     // Use RTTI to do double-check, though in practice the unit tests are seldom built in debug
     // mode. For example, the unit tests of github CI for both rDSN and Pegasus are built in
     // release mode.
-    assert(from == NULL || dynamic_cast<To>(from) != NULL);
+    dassert_f(from == NULL || dynamic_cast<To>(from) != NULL, "");
 
     return static_cast<To>(from);
 }

--- a/src/rdsn/include/dsn/utility/endians.h
+++ b/src/rdsn/include/dsn/utility/endians.h
@@ -19,6 +19,9 @@
 
 #include <cstdint>
 #include <cassert>
+
+#include <dsn/c/api_utilities.h>
+#include <dsn/dist/fmt_logging.h>
 #include <dsn/utility/ports.h>
 #include <dsn/utility/string_view.h>
 
@@ -145,7 +148,7 @@ private:
         _size -= sz;
     }
 
-    void ensure(size_t sz) { assert(_size >= sz); }
+    void ensure(size_t sz) { dcheck_ge(_size, sz); }
 
 private:
     const char *_p{nullptr};

--- a/src/rdsn/src/aio/aio_task.cpp
+++ b/src/rdsn/src/aio/aio_task.cpp
@@ -32,9 +32,9 @@ aio_task::aio_task(dsn::task_code code, aio_handler &&cb, int hash, service_node
 {
     _is_null = (_cb == nullptr);
 
-    dassert(TASK_TYPE_AIO == spec().type,
-            "%s is not of AIO type, please use DEFINE_TASK_CODE_AIO to define the task code",
-            spec().name.c_str());
+    dassert_f(TASK_TYPE_AIO == spec().type,
+              "{} is not of AIO type, please use DEFINE_TASK_CODE_AIO to define the task code",
+              spec().name);
     set_error_code(ERR_IO_PENDING);
 
     _aio_ctx = file::prepare_aio_context(this);
@@ -51,10 +51,7 @@ void aio_task::collapse()
             ::memcpy(dest, b.buffer, b.size);
             dest += b.size;
         }
-        dassert(dest - buffer.get() == _aio_ctx->buffer_size,
-                "%u VS %u",
-                dest - buffer.get(),
-                _aio_ctx->buffer_size);
+        dcheck_eq(dest - buffer.get(), _aio_ctx->buffer_size);
         _aio_ctx->buffer = buffer.get();
         _merged_write_buffer_holder.assign(std::move(buffer), 0, _aio_ctx->buffer_size);
     }

--- a/src/rdsn/src/block_service/test/fds_service_test.cpp
+++ b/src/rdsn/src/block_service/test/fds_service_test.cpp
@@ -24,9 +24,11 @@
 #include <gtest/gtest.h>
 #include <memory>
 
-#include <dsn/utility/filesystem.h>
-#include <dsn/utility/rand.h>
-#include <dsn/dist/block_service.h>
+#include "dsn/dist/block_service.h"
+#include "dsn/dist/fmt_logging.h"
+#include "dsn/utility/filesystem.h"
+#include "dsn/utility/rand.h"
+#include "dsn/utility/utils.h"
 
 using namespace dsn;
 using namespace dsn::dist::block_service;
@@ -38,17 +40,6 @@ static std::string server_address = "<server-address>";
 static std::string access_key = "<access-key>";
 static std::string access_secret = "<access-secret>";
 static std::string bucket_name = "<test-bucket-name>";
-
-static void pipe_execute(const char *command, std::stringstream &output)
-{
-    std::array<char, 256> buffer;
-
-    std::shared_ptr<FILE> command_pipe(popen(command, "r"), pclose);
-    while (!feof(command_pipe.get())) {
-        if (fgets(buffer.data(), 256, command_pipe.get()) != NULL)
-            output << buffer.data();
-    }
-}
 
 static void file_eq_compare(const std::string &fname1, const std::string &fname2)
 {
@@ -111,7 +102,7 @@ void FDSClientTest::SetUp()
         fclose(fp);
 
         std::stringstream ss;
-        pipe_execute((std::string("md5sum ") + f1.filename).c_str(), ss);
+        dcheck_eq(utils::pipe_execute((std::string("md5sum ") + f1.filename).c_str(), ss), 0);
         ss >> f1.md5;
         // well, the string of each line in _test_file is 32
         f1.length = 32 * lines;
@@ -127,7 +118,7 @@ void FDSClientTest::SetUp()
         fclose(fp);
 
         std::stringstream ss;
-        pipe_execute((std::string("md5sum ") + f2.filename).c_str(), ss);
+        dcheck_eq(utils::pipe_execute((std::string("md5sum ") + f2.filename).c_str(), ss), 0);
         ss >> f2.md5;
         // well, the string of each line in _test_file is 32
         f2.length = 32 * lines;

--- a/src/rdsn/src/client/partition_resolver_simple.cpp
+++ b/src/rdsn/src/client/partition_resolver_simple.cpp
@@ -370,9 +370,7 @@ void partition_resolver_simple::query_config_reply(error_code err,
         if (!reqs2.empty()) {
             if (_app_partition_count != -1) {
                 for (auto &req : reqs2) {
-                    dassert(req->partition_index == -1,
-                            "invalid partition_index, index = %d",
-                            req->partition_index);
+                    dcheck_eq(req->partition_index, -1);
                     req->partition_index =
                         get_partition_index(_app_partition_count, req->partition_hash);
                 }

--- a/src/rdsn/src/client/replication_ddl_client.cpp
+++ b/src/rdsn/src/client/replication_ddl_client.cpp
@@ -35,6 +35,7 @@
 #include <iostream>
 
 #include <boost/lexical_cast.hpp>
+#include <dsn/dist/fmt_logging.h>
 #include <dsn/dist/replication/duplication_common.h>
 #include <dsn/dist/replication/replication_other_types.h>
 #include <dsn/tool-api/group_address.h>
@@ -99,7 +100,7 @@ dsn::error_code replication_ddl_client::wait_app_ready(const std::string &app_na
                       << std::endl;
             return query_resp.err;
         }
-        dassert(partition_count == query_resp.partition_count, "partition count not equal");
+        dcheck_eq(partition_count, query_resp.partition_count);
         int ready_count = 0;
         for (int i = 0; i < partition_count; i++) {
             const partition_configuration &pc = query_resp.partitions[i];
@@ -384,11 +385,8 @@ dsn::error_code replication_ddl_client::list_apps(const dsn::app_status::type st
                 derror("list app(%s) failed, err = %s", info.app_name.c_str(), r.to_string());
                 return r;
             }
-            dassert(info.app_id == app_id, "invalid app_id, %d VS %d", info.app_id, app_id);
-            dassert(info.partition_count == partition_count,
-                    "invalid partition_count, %d VS %d",
-                    info.partition_count,
-                    partition_count);
+            dcheck_eq(info.app_id, app_id);
+            dcheck_eq(info.partition_count, partition_count);
             int fully_healthy = 0;
             int write_unhealthy = 0;
             int read_unhealthy = 0;

--- a/src/rdsn/src/common/fs_manager.cpp
+++ b/src/rdsn/src/common/fs_manager.cpp
@@ -171,10 +171,7 @@ dsn::error_code fs_manager::initialize(const std::vector<std::string> &data_dirs
                                        bool for_test)
 {
     // create all dir_nodes
-    dassert(data_dirs.size() == tags.size(),
-            "data_dir size(%u) != tags size(%u)",
-            data_dirs.size(),
-            tags.size());
+    dcheck_eq(data_dirs.size(), tags.size());
     for (unsigned i = 0; i < data_dirs.size(); ++i) {
         std::string norm_path;
         utils::filesystem::get_normalized_path(data_dirs[i], norm_path);

--- a/src/rdsn/src/http/http_call_registry.h
+++ b/src/rdsn/src/http/http_call_registry.h
@@ -47,9 +47,7 @@ public:
     {
         auto call = std::shared_ptr<http_call>(call_uptr.release());
         std::lock_guard<std::mutex> guard(_mu);
-        dassert_f(_call_map.find(call->path) == _call_map.end(),
-                  "repeatedly register http call \"{}\"",
-                  call->path);
+        dcheck_eq(_call_map.count(call->path), 0);
         _call_map[call->path] = call;
     }
 

--- a/src/rdsn/src/http/http_call_registry.h
+++ b/src/rdsn/src/http/http_call_registry.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <dsn/dist/fmt_logging.h>
 #include <dsn/http/http_server.h>
 #include <dsn/utility/errors.h>
 
@@ -46,9 +47,9 @@ public:
     {
         auto call = std::shared_ptr<http_call>(call_uptr.release());
         std::lock_guard<std::mutex> guard(_mu);
-        dassert(_call_map.find(call->path) == _call_map.end(),
-                "repeatedly register http call \"%s\"",
-                call->path.c_str());
+        dassert_f(_call_map.find(call->path) == _call_map.end(),
+                  "repeatedly register http call \"{}\"",
+                  call->path);
         _call_map[call->path] = call;
     }
 

--- a/src/rdsn/src/http/http_message_parser.cpp
+++ b/src/rdsn/src/http/http_message_parser.cpp
@@ -26,6 +26,7 @@
 
 #include "http_message_parser.h"
 
+#include <dsn/dist/fmt_logging.h>
 #include <dsn/utility/ports.h>
 #include <dsn/utility/crc.h>
 #include <dsn/tool-api/rpc_message.h>
@@ -218,7 +219,7 @@ void http_message_parser::prepare_on_send(message_ex *msg)
         dsn_size -= buf.length();
         ++dsn_buf_count;
     }
-    dassert(dsn_size == 0, "dsn_size = %u", dsn_size);
+    dcheck_eq(dsn_size, 0);
 
     buffers.resize(dsn_buf_count);
 }

--- a/src/rdsn/src/http/uri_decoder.cpp
+++ b/src/rdsn/src/http/uri_decoder.cpp
@@ -15,8 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <fmt/format.h>
 #include "uri_decoder.h"
+
+#include <fmt/format.h>
+
+#include <dsn/dist/fmt_logging.h>
 
 namespace dsn {
 namespace uri {
@@ -37,7 +40,7 @@ error_with<char> from_hex(const char c)
 
 error_with<char> decode_char(const string_view &hex)
 {
-    assert(2 == hex.size());
+    dcheck_eq(2, hex.size());
 
     auto high = from_hex(hex[0]);
     auto low = from_hex(hex[1]);

--- a/src/rdsn/src/meta/meta_backup_service.cpp
+++ b/src/rdsn/src/meta/meta_backup_service.cpp
@@ -117,11 +117,7 @@ void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
         LPC_DEFAULT_CALLBACK,
         [this, remote_file, buffer, app_id](const dist::block_service::write_response &resp) {
             if (resp.err == dsn::ERR_OK) {
-                dassert_f(resp.written_size == buffer.length(),
-                          "write %s length not match, source(%u), actual(%llu)",
-                          remote_file->file_name().c_str(),
-                          buffer.length(),
-                          resp.written_size);
+                dcheck_eq(resp.written_size, buffer.length());
                 {
                     zauto_lock l(_lock);
                     ddebug("%s: successfully backup app metadata to %s",

--- a/src/rdsn/src/meta/meta_backup_service.cpp
+++ b/src/rdsn/src/meta/meta_backup_service.cpp
@@ -117,11 +117,11 @@ void policy_context::start_backup_app_meta_unlocked(int32_t app_id)
         LPC_DEFAULT_CALLBACK,
         [this, remote_file, buffer, app_id](const dist::block_service::write_response &resp) {
             if (resp.err == dsn::ERR_OK) {
-                dassert(resp.written_size == buffer.length(),
-                        "write %s length not match, source(%u), actual(%llu)",
-                        remote_file->file_name().c_str(),
-                        buffer.length(),
-                        resp.written_size);
+                dassert_f(resp.written_size == buffer.length(),
+                          "write %s length not match, source(%u), actual(%llu)",
+                          remote_file->file_name().c_str(),
+                          buffer.length(),
+                          resp.written_size);
                 {
                     zauto_lock l(_lock);
                     ddebug("%s: successfully backup app metadata to %s",

--- a/src/rdsn/src/runtime/rpc/thrift_message_parser.cpp
+++ b/src/rdsn/src/runtime/rpc/thrift_message_parser.cpp
@@ -292,7 +292,7 @@ message_ex *thrift_message_parser::get_message_on_receive(message_reader *reader
     case 1:
         return parse_request_body_v1(reader, read_next);
     default:
-        assert("invalid header version");
+        dassert_f(false, "invalid header version");
     }
 
     return nullptr;

--- a/src/rdsn/src/runtime/rpc/thrift_message_parser.cpp
+++ b/src/rdsn/src/runtime/rpc/thrift_message_parser.cpp
@@ -292,7 +292,7 @@ message_ex *thrift_message_parser::get_message_on_receive(message_reader *reader
     case 1:
         return parse_request_body_v1(reader, read_next);
     default:
-        dassert_f(false, "invalid header version");
+        dassert_f(false, "invalid header version: {}", _header_version);
     }
 
     return nullptr;

--- a/src/test/bench_test/benchmark.cpp
+++ b/src/test/bench_test/benchmark.cpp
@@ -17,12 +17,14 @@
  * under the License.
  */
 
-#include <sstream>
-#include <pegasus/client.h>
-#include <dsn/dist/fmt_logging.h>
-#include <dsn/c/app_model.h>
-
 #include "benchmark.h"
+
+#include <sstream>
+
+#include "dsn/c/api_utilities.h"
+#include "dsn/c/app_model.h"
+#include "dsn/dist/fmt_logging.h"
+#include "dsn/utility/ports.h"
 #include "rand.h"
 
 namespace pegasus {
@@ -31,7 +33,7 @@ benchmark::benchmark()
 {
     _client = pegasus_client_factory::get_client(config::instance().pegasus_cluster_name.c_str(),
                                                  config::instance().pegasus_app_name.c_str());
-    assert(nullptr != _client);
+    dassert_f(_client, "");
 
     // init operation method map
     _operation_method = {{kUnknown, nullptr},
@@ -58,7 +60,7 @@ void benchmark::run_benchmark(int thread_count, operation_type op_type)
 {
     // get method by operation type
     bench_method method = _operation_method[op_type];
-    assert(method != nullptr);
+    dassert_f(method, "");
 
     // create histogram statistic
     std::shared_ptr<rocksdb::Statistics> hist_stats = rocksdb::CreateDBStatistics();

--- a/src/test/bench_test/benchmark.h
+++ b/src/test/bench_test/benchmark.h
@@ -21,8 +21,9 @@
 
 #include <unordered_map>
 
-#include "statistics.h"
 #include "config.h"
+#include "pegasus/client.h"
+#include "statistics.h"
 
 namespace pegasus {
 namespace test {

--- a/src/test/function_test/global_env.cpp
+++ b/src/test/function_test/global_env.cpp
@@ -17,18 +17,19 @@
  * under the License.
  */
 
+#include "global_env.h"
+
+#include <arpa/inet.h>
 #include <unistd.h>
 #include <libgen.h>
+
 #include <iostream>
-#include <cassert>
 #include <memory>
 
-#include <dsn/utility/utils.h>
-#include <dsn/tool-api/rpc_address.h>
-#include <dsn/c/api_layer1.h>
-#include <arpa/inet.h>
-
-#include "global_env.h"
+#include "dsn/dist/fmt_logging.h"
+#include "dsn/utility/utils.h"
+#include "dsn/tool-api/rpc_address.h"
+#include "dsn/c/api_layer1.h"
 
 global_env::global_env()
 {
@@ -41,26 +42,25 @@ void global_env::get_dirs()
 {
     const char *cmd1 = "ps aux | grep '/meta1/pegasus_server' | grep -v grep | awk '{print $2}'";
     std::stringstream ss1;
-    assert(dsn::utils::pipe_execute(cmd1, ss1) == 0);
+    dcheck_eq(dsn::utils::pipe_execute(cmd1, ss1), 0);
     int meta1_pid;
     ss1 >> meta1_pid;
     std::cout << "meta1 pid: " << meta1_pid << std::endl;
 
     // get the dir of a process in onebox, say: $PEGASUS/onebox/meta1
-    char cmd2[512];
+    char cmd2[512] = {0};
     sprintf(cmd2, "readlink /proc/%d/cwd", meta1_pid);
     std::stringstream ss2;
-    assert(dsn::utils::pipe_execute(cmd2, ss2) == 0);
+    dcheck_eq(dsn::utils::pipe_execute(cmd2, ss2), 0);
     std::string meta1_dir;
     ss2 >> meta1_dir;
     std::cout << "meta1 dir: " << meta1_dir << std::endl;
 
     _pegasus_root = dirname(dirname((char *)meta1_dir.c_str()));
     std::cout << "project root: " << _pegasus_root << std::endl;
-    assert(_pegasus_root != ".");
 
-    char task_target[512];
-    assert(getcwd(task_target, sizeof(task_target)) != nullptr);
+    char task_target[512] = {0};
+    dassert_f(getcwd(task_target, sizeof(task_target)), "");
     _working_dir = task_target;
     std::cout << "working dir: " << _working_dir << std::endl;
 }
@@ -69,9 +69,9 @@ void global_env::get_hostip()
 {
     uint32_t ip = dsn::rpc_address::ipv4_from_network_interface("");
     uint32_t ipnet = htonl(ip);
-    char buffer[512];
+    char buffer[512] = {0};
     memset(buffer, 0, sizeof(buffer));
-    assert(inet_ntop(AF_INET, &ipnet, buffer, sizeof(buffer)));
+    dassert_f(inet_ntop(AF_INET, &ipnet, buffer, sizeof(buffer)), "");
     _host_ip = buffer;
     std::cout << "get ip: " << _host_ip << std::endl;
 }

--- a/src/test/function_test/global_env.h
+++ b/src/test/function_test/global_env.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <sstream>
 
+#include "dsn/utility/singleton.h"
+
 class global_env : public dsn::utils::singleton<global_env>
 {
 public:

--- a/src/test/function_test/test_restore.cpp
+++ b/src/test/function_test/test_restore.cpp
@@ -20,6 +20,7 @@
 #include <libgen.h>
 
 #include <dsn/utility/filesystem.h>
+#include <dsn/dist/fmt_logging.h>
 #include <dsn/dist/replication/replication_ddl_client.h>
 #include <pegasus/client.h>
 #include <gtest/gtest.h>
@@ -64,7 +65,7 @@ public:
         cmd = "grep -A 5 block_service." + backup_provider_name +
               " config-server-test-restore.ini | grep args | cut -f2,3 -d'/'";
         std::stringstream ss;
-        assert(dsn::utils::pipe_execute(cmd.c_str(), ss) == 0);
+        dcheck_eq(dsn::utils::pipe_execute(cmd.c_str(), ss), 0);
         std::string provider_dir = ss.str().substr(0, ss.str().length() - 1);
         policy_dir = "onebox/" + provider_dir + '/' +
                      dsn::utils::filesystem::path_combine(cluster_name, policy_name);
@@ -273,7 +274,7 @@ public:
                                                "tail -n 1 restore_app_from_backup_test_tmp; "
                                                "rm restore_app_from_backup_test_tmp";
         std::stringstream ss;
-        assert(dsn::utils::pipe_execute(cmd.c_str(), ss) == 0);
+        dcheck_eq(dsn::utils::pipe_execute(cmd.c_str(), ss), 0);
         std::string result = ss.str();
         // should remove \n character
         int32_t index = result.size();

--- a/src/test/kill_test/killer_handler_shell.cpp
+++ b/src/test/kill_test/killer_handler_shell.cpp
@@ -17,16 +17,17 @@
  * under the License.
  */
 
+#include "killer_handler_shell.h"
+
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
 #include <sstream>
 #include <fstream>
 
-#include <dsn/utility/config_api.h>
-#include <dsn/c/api_utilities.h>
-
-#include "killer_handler_shell.h"
+#include "dsn/c/api_utilities.h"
+#include "dsn/dist/fmt_logging.h"
+#include "dsn/utility/config_api.h"
 
 namespace pegasus {
 namespace test {
@@ -50,7 +51,7 @@ bool killer_handler_shell::has_meta_dumped_core(int index)
 
     std::stringstream output;
     int core_count;
-    assert(dsn::utils::pipe_execute(find_core, output) == 0);
+    dcheck_eq(dsn::utils::pipe_execute(find_core, output), 0);
     output >> core_count;
 
     return core_count != 0;
@@ -67,7 +68,7 @@ bool killer_handler_shell::has_replica_dumped_core(int index)
 
     std::stringstream output;
     int core_count;
-    assert(dsn::utils::pipe_execute(find_core, output) == 0);
+    dcheck_eq(dsn::utils::pipe_execute(find_core, output), 0);
     output >> core_count;
 
     return core_count != 0;

--- a/src/test/kill_test/process_kill_testor.cpp
+++ b/src/test/kill_test/process_kill_testor.cpp
@@ -29,7 +29,9 @@
 #include <memory>
 #include <sys/time.h>
 
-#include <dsn/dist/replication/replication_ddl_client.h>
+#include "dsn/dist/fmt_logging.h"
+#include "dsn/dist/replication/replication_ddl_client.h"
+
 #include <pegasus/client.h>
 
 #include "killer_registry.h"
@@ -85,7 +87,7 @@ bool process_kill_testor::verifier_process_alive()
     std::stringstream output;
     int process_count;
 
-    assert(dsn::utils::pipe_execute(command, output) == 0);
+    dcheck_eq(dsn::utils::pipe_execute(command, output), 0);
     output >> process_count;
 
     // one for the verifier, one for command

--- a/src/test/upgrade_test/process_upgrader.cpp
+++ b/src/test/upgrade_test/process_upgrader.cpp
@@ -29,7 +29,9 @@
 #include <memory>
 #include <sys/time.h>
 
-#include <dsn/dist/replication/replication_ddl_client.h>
+#include "dsn/dist/fmt_logging.h"
+#include "dsn/dist/replication/replication_ddl_client.h"
+
 #include <pegasus/client.h>
 
 #include "base/pegasus_const.h"
@@ -180,7 +182,7 @@ bool verifier_process_alive()
     std::stringstream output;
     int process_count;
 
-    assert(dsn::utils::pipe_execute(command, output) == 0);
+    dcheck_eq(dsn::utils::pipe_execute(command, output), 0);
     output >> process_count;
 
     // one for the verifier, one for command

--- a/src/test/upgrade_test/upgrader_handler_shell.cpp
+++ b/src/test/upgrade_test/upgrader_handler_shell.cpp
@@ -18,14 +18,17 @@
  */
 
 #include "upgrader_handler_shell.h"
+
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
 #include <sstream>
 #include <fstream>
 #include <unistd.h>
-#include <dsn/utility/config_api.h>
-#include <dsn/c/api_utilities.h>
+
+#include "dsn/c/api_utilities.h"
+#include "dsn/dist/fmt_logging.h"
+#include "dsn/utility/config_api.h"
 
 namespace pegasus {
 namespace test {
@@ -55,7 +58,7 @@ bool upgrader_handler_shell::has_meta_dumped_core(int index)
 
     std::stringstream output;
     int core_count;
-    assert(dsn::utils::pipe_execute(find_core, output) == 0);
+    dcheck_eq(dsn::utils::pipe_execute(find_core, output), 0);
     output >> core_count;
 
     return core_count != 0;
@@ -72,7 +75,7 @@ bool upgrader_handler_shell::has_replica_dumped_core(int index)
 
     std::stringstream output;
     int core_count;
-    assert(dsn::utils::pipe_execute(find_core, output) == 0);
+    dcheck_eq(dsn::utils::pipe_execute(find_core, output), 0);
     output >> core_count;
 
     return core_count != 0;

--- a/src/test/upgrade_test/upgrader_handler_shell.cpp
+++ b/src/test/upgrade_test/upgrader_handler_shell.cpp
@@ -230,7 +230,7 @@ bool upgrader_handler_shell::check(const std::string &job, int index, const std:
     int check_times = 5;
     do {
         sleep(1);
-        dsn::utils::pipe_execute(command.str().c_str(), output);
+        dcheck_eq(dsn::utils::pipe_execute(command.str().c_str(), output), 0);
         output >> process_count;
     } while (check_times-- > 0 and process_count == 1);
 


### PR DESCRIPTION
In https://github.com/apache/incubator-pegasus/pull/1062, we passed the debug/release to CMAKE_BUILD_TYPE in cmake, then `assert` will be disabled. Some function calls are in `assert` in the former, but now build the project in release type, these functions will not be called, which will lead the test failures as described in:
https://github.com/apache/incubator-pegasus/issues/1077