### PR TITLE
fix: revert zk c client to 3.4.10 for compatibility

### DIFF
--- a/scripts/clear_zk.sh
+++ b/scripts/clear_zk.sh
@@ -34,7 +34,7 @@ then
 fi
 
 cd $INSTALL_DIR
-ZOOKEEPER_HOME=`pwd`/apache-zookeeper-3.7.0-bin
+ZOOKEEPER_HOME=`pwd`/apache-zookeeper-3.4.10
 
 if [ -d "$ZOOKEEPER_HOME" ]
 then

--- a/scripts/start_zk.sh
+++ b/scripts/start_zk.sh
@@ -22,6 +22,8 @@ set -e
 #    INSTALL_DIR    <dir>
 #    PORT           <port>
 
+PROJECT_DIR=$(realpath $(dirname $(dirname $(dirname "${BASH_SOURCE[0]}"))))
+
 if [ -z "$INSTALL_DIR" ]
 then
     echo "ERROR: no INSTALL_DIR specified"

--- a/scripts/start_zk.sh
+++ b/scripts/start_zk.sh
@@ -22,8 +22,6 @@ set -e
 #    INSTALL_DIR    <dir>
 #    PORT           <port>
 
-PROJECT_DIR=$(realpath $(dirname $(dirname $(dirname "${BASH_SOURCE[0]}"))))
-
 if [ -z "$INSTALL_DIR" ]
 then
     echo "ERROR: no INSTALL_DIR specified"

--- a/scripts/start_zk.sh
+++ b/scripts/start_zk.sh
@@ -42,14 +42,14 @@ then
     exit 1
 fi
 
-cd "$INSTALL_DIR" || exit
-
-ZOOKEEPER_PKG=${PROJECT_DIR}/thirdparty/build/Download/zookeeper/zookeeper-3.4.10.tar.gz
+ZOOKEEPER_PKG=`pwd`/thirdparty/build/Download/zookeeper/zookeeper-3.4.10.tar.gz
 if [ ! -f ${ZOOKEEPER_PKG} ]; then
     echo "no such file \"${ZOOKEEPER_PKG}\""
     echo "please install third-parties first"
     exit 1
 fi
+
+cd "$INSTALL_DIR" || exit
 
 if [ ! -d zookeeper-3.4.10 ]; then
     echo "Decompressing zookeeper..."

--- a/scripts/start_zk.sh
+++ b/scripts/start_zk.sh
@@ -42,32 +42,24 @@ fi
 
 cd "$INSTALL_DIR" || exit
 
-ZOOKEEPER_ROOT=apache-zookeeper-3.7.0-bin
-ZOOKEEPER_TAR_NAME=${ZOOKEEPER_ROOT}.tar.gz
-ZOOKEEPER_TAR_MD5_VALUE="8ffa97e7e6b0b2cf1d022e5156a7561a"
-
-if [ ! -f $ZOOKEEPER_TAR_NAME ]; then
-    echo "Downloading zookeeper..."
-    download_url="http://pegasus-thirdparty-package.oss-cn-beijing.aliyuncs.com/apache-zookeeper-3.7.0-bin.tar.gz"
-    if ! wget -T 5 -t 1 $download_url; then
-        echo "ERROR: download zookeeper failed"
-        exit 1
-    fi
-    if [ `md5sum $ZOOKEEPER_TAR_NAME | awk '{print$1}'` != $ZOOKEEPER_TAR_MD5_VALUE ]; then
-        echo "check file $ZOOKEEPER_TAR_NAME md5sum failed!"
-        exit 1
-    fi
+ZOOKEEPER_PKG=${PROJECT_DIR}/thirdparty/build/Download/zookeeper/zookeeper-3.4.10.tar.gz
+if [ ! -f ${ZOOKEEPER_PKG} ]; then
+    echo "no such file \"${ZOOKEEPER_PKG}\""
+    echo "please install third-parties first"
+    exit 1
 fi
 
-if [ ! -d $ZOOKEEPER_ROOT ]; then
+if [ ! -d zookeeper-3.4.10 ]; then
     echo "Decompressing zookeeper..."
-    if ! tar xf $ZOOKEEPER_TAR_NAME; then
+    cp ${ZOOKEEPER_PKG} .
+    tar xf zookeeper-3.4.10.tar.gz
+    if [ $? -ne 0 ]; then
         echo "ERROR: decompress zookeeper failed"
         exit 1
     fi
 fi
 
-ZOOKEEPER_HOME=`pwd`/$ZOOKEEPER_ROOT
+ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.10
 ZOOKEEPER_PORT=$PORT
 
 cp $ZOOKEEPER_HOME/conf/zoo_sample.cfg $ZOOKEEPER_HOME/conf/zoo.cfg

--- a/scripts/stop_zk.sh
+++ b/scripts/stop_zk.sh
@@ -33,7 +33,7 @@ then
 fi
 
 cd $INSTALL_DIR
-ZOOKEEPER_HOME=`pwd`/apache-zookeeper-3.7.0-bin
+ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.10
 
 if [ -d "$ZOOKEEPER_HOME" ]
 then

--- a/src/rdsn/src/failure_detector/test/CMakeLists.txt
+++ b/src/rdsn/src/failure_detector/test/CMakeLists.txt
@@ -16,7 +16,6 @@ set(MY_PROJ_LIBS
     dsn_replication_common
     dsn.failure_detector
     gtest
-    hashtable
     )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/rdsn/src/meta/CMakeLists.txt
+++ b/src/rdsn/src/meta/CMakeLists.txt
@@ -21,14 +21,13 @@ set(MY_PROJ_LIBS
     dsn_http
     dsn_runtime
     dsn_aio
-    zookeeper
+    zookeeper_mt
     galaxy-fds-sdk-cpp
     PocoNet
     PocoFoundation
     PocoNetSSL
     PocoJSON
     crypto
-    hashtable
     hdfs
     )
 

--- a/src/rdsn/src/meta/test/CMakeLists.txt
+++ b/src/rdsn/src/meta/test/CMakeLists.txt
@@ -25,8 +25,7 @@ set(MY_PROJ_LIBS
         dsn_http
         dsn_runtime
         dsn_aio
-        zookeeper
-        hashtable
+        zookeeper_mt
         galaxy-fds-sdk-cpp
         PocoNet
         PocoFoundation
@@ -34,7 +33,6 @@ set(MY_PROJ_LIBS
         PocoJSON
         crypto
         gtest
-        ssl
         hdfs)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/rdsn/src/meta/test/balancer_simulator/CMakeLists.txt
+++ b/src/rdsn/src/meta/test/balancer_simulator/CMakeLists.txt
@@ -13,7 +13,6 @@ set(MY_PROJ_LIBS
     dsn_meta_server
     dsn_replication_common
     dsn_runtime
-    hashtable
     gtest)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/rdsn/src/meta/test/meta_state/CMakeLists.txt
+++ b/src/rdsn/src/meta/test/meta_state/CMakeLists.txt
@@ -14,7 +14,6 @@ set(MY_PROJ_LIBS
     dsn_replica_server
     dsn_replication_common
     dsn_runtime
-    hashtable
     gtest
     )
 

--- a/src/rdsn/src/replica/backup/test/CMakeLists.txt
+++ b/src/rdsn/src/replica/backup/test/CMakeLists.txt
@@ -11,7 +11,6 @@ set(MY_PROJ_LIBS dsn_meta_server
         dsn.block_service.local
         dsn.block_service.fds
         dsn_utils
-        hashtable
         gtest
 )
 

--- a/src/rdsn/src/replica/bulk_load/test/CMakeLists.txt
+++ b/src/rdsn/src/replica/bulk_load/test/CMakeLists.txt
@@ -8,7 +8,6 @@ set(MY_PROJ_LIBS dsn_meta_server
         dsn_replica_server
         dsn_replication_common
         dsn_runtime
-        hashtable
         gtest
 )
 

--- a/src/rdsn/src/replica/duplication/test/CMakeLists.txt
+++ b/src/rdsn/src/replica/duplication/test/CMakeLists.txt
@@ -10,8 +10,7 @@ set(MY_PROJ_LIBS dsn_meta_server
         dsn_replication_common
         dsn.failure_detector
         dsn_utils
-        zookeeper
-        hashtable
+        zookeeper_mt
         gtest
 )
 

--- a/src/rdsn/src/replica/split/test/CMakeLists.txt
+++ b/src/rdsn/src/replica/split/test/CMakeLists.txt
@@ -8,7 +8,6 @@ set(MY_PROJ_LIBS dsn_meta_server
         dsn_replica_server
         dsn_replication_common
         dsn_runtime
-        hashtable
         gtest
 )
 

--- a/src/rdsn/src/replica/storage/simple_kv/CMakeLists.txt
+++ b/src/rdsn/src/replica/storage/simple_kv/CMakeLists.txt
@@ -13,7 +13,7 @@ set(MY_PROJ_SRC ${SIMPLE_KV_THRIFT_SRCS})
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_LIBS dsn_replica_server dsn_meta_server dsn_client dsn_runtime hashtable)
+set(MY_PROJ_LIBS dsn_replica_server dsn_meta_server dsn_client dsn_runtime)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
 

--- a/src/rdsn/src/replica/storage/simple_kv/test/CMakeLists.txt
+++ b/src/rdsn/src/replica/storage/simple_kv/test/CMakeLists.txt
@@ -12,8 +12,7 @@ set(MY_PROJ_LIBS dsn_replica_server
                  dsn.failure_detector
                  dsn.replication.zookeeper_provider
                  dsn_runtime
-                 zookeeper
-                 hashtable
+                 zookeeper_mt
                  gtest
                  )
 

--- a/src/rdsn/src/replica/test/CMakeLists.txt
+++ b/src/rdsn/src/replica/test/CMakeLists.txt
@@ -20,8 +20,7 @@ set(MY_PROJ_LIBS dsn_meta_server
                  dsn.failure_detector
                  dsn_http
                  dsn_runtime
-                 zookeeper
-                 hashtable
+                 zookeeper_mt
                  gtest)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/rdsn/src/runtime/security/init.cpp
+++ b/src/rdsn/src/runtime/security/init.cpp
@@ -68,22 +68,5 @@ bool init(bool is_server)
     return true;
 }
 
-bool init_for_zookeeper_client()
-{
-    error_s err = run_kinit();
-    if (!err.is_ok()) {
-        derror_f("initialize kerberos failed, with err = {}", err.description());
-        return false;
-    }
-    ddebug("initialize kerberos for zookeeper client succeed");
-
-    err = init_sasl(false);
-    if (!err.is_ok()) {
-        derror_f("initialize sasl failed, with err = {}", err.description());
-        return false;
-    }
-    ddebug("initialize sasl for zookeeper client succeed");
-    return true;
-}
 } // namespace security
 } // namespace dsn

--- a/src/rdsn/src/runtime/security/init.h
+++ b/src/rdsn/src/runtime/security/init.h
@@ -24,7 +24,5 @@ namespace security {
 // init security(kerberos and sasl)
 bool init(bool is_server);
 
-// init security only for zookeeper client(kerberos and sasl)
-bool init_for_zookeeper_client();
 } // namespace security
 } // namespace dsn

--- a/src/rdsn/src/runtime/security/kinit_context.cpp
+++ b/src/rdsn/src/runtime/security/kinit_context.cpp
@@ -33,7 +33,6 @@
 namespace dsn {
 namespace security {
 DSN_DECLARE_bool(enable_auth);
-DSN_DECLARE_bool(enable_zookeeper_kerberos);
 
 #define KRB5_RETURN_NOT_OK(err, msg)                                                               \
     do {                                                                                           \
@@ -54,9 +53,8 @@ DSN_DEFINE_string("security", service_name, "", "service name");
 // will not pass.
 error_s check_configuration()
 {
-    dassert(FLAGS_enable_auth || FLAGS_enable_zookeeper_kerberos,
-            "There is no need to check configuration if FLAGS_enable_auth"
-            " and FLAGS_enable_zookeeper_kerberos both are not true");
+    dassert(FLAGS_enable_auth,
+            "There is no need to check configuration if FLAGS_enable_auth is not true");
 
     if (0 == strlen(FLAGS_krb5_keytab) || !utils::filesystem::file_exists(FLAGS_krb5_keytab)) {
         return error_s::make(ERR_INVALID_PARAMETERS,

--- a/src/rdsn/src/runtime/security/negotiation.cpp
+++ b/src/rdsn/src/runtime/security/negotiation.cpp
@@ -31,10 +31,6 @@ namespace security {
 const std::set<std::string> supported_mechanisms{"GSSAPI"};
 
 DSN_DEFINE_bool("security", enable_auth, false, "whether open auth or not");
-DSN_DEFINE_bool("security",
-                enable_zookeeper_kerberos,
-                false,
-                "whether to enable kerberos for zookeeper client");
 DSN_DEFINE_bool("security", mandatory_auth, false, "wheter to do authertication mandatorily");
 DSN_TAG_VARIABLE(mandatory_auth, FT_MUTABLE);
 

--- a/src/rdsn/src/runtime/service_api_c.cpp
+++ b/src/rdsn/src/runtime/service_api_c.cpp
@@ -56,7 +56,6 @@
 namespace dsn {
 namespace security {
 DSN_DECLARE_bool(enable_auth);
-DSN_DECLARE_bool(enable_zookeeper_kerberos);
 } // namespace security
 } // namespace dsn
 //
@@ -466,15 +465,6 @@ bool run(const char *config_file,
     // init security if FLAGS_enable_auth == true
     if (dsn::security::FLAGS_enable_auth) {
         if (!dsn::security::init(is_server)) {
-            return false;
-        }
-        // if FLAGS_enable_auth is false but FLAGS_enable_zookeeper_kerberos, we should init
-        // kerberos for it separately
-        // include two steps:
-        // 1) apply kerberos ticket and keep it valid
-        // 2) complete sasl init for client(use FLAGS_sasl_plugin_path)
-    } else if (dsn::security::FLAGS_enable_zookeeper_kerberos && app_list == "meta") {
-        if (!dsn::security::init_for_zookeeper_client()) {
             return false;
         }
     }

--- a/src/rdsn/src/zookeeper/CMakeLists.txt
+++ b/src/rdsn/src/zookeeper/CMakeLists.txt
@@ -10,7 +10,7 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_LIBS zookeeper hashtable ssl crypto)
+set(MY_PROJ_LIBS "")
 
 # Extra files that will be installed
 set(MY_BINPLACES "")

--- a/src/rdsn/src/zookeeper/test/CMakeLists.txt
+++ b/src/rdsn/src/zookeeper/test/CMakeLists.txt
@@ -12,11 +12,8 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 set(MY_PROJ_LIBS 
     dsn.replication.zookeeper_provider
     dsn_runtime
-    zookeeper
-    hashtable
+    zookeeper_mt
     gtest
-    ssl
-    crypto
     )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/rdsn/src/zookeeper/zookeeper_session.cpp
+++ b/src/rdsn/src/zookeeper/zookeeper_session.cpp
@@ -33,22 +33,9 @@
  */
 
 #include <zookeeper/zookeeper.h>
-#include <sasl/sasl.h>
 
 #include "zookeeper_session.h"
 #include "zookeeper_session_mgr.h"
-
-#include <dsn/utility/flags.h>
-
-namespace dsn {
-namespace security {
-DSN_DECLARE_bool(enable_zookeeper_kerberos);
-DSN_DEFINE_string("security",
-                  zookeeper_kerberos_service_name,
-                  "zookeeper",
-                  "zookeeper kerberos service name");
-} // namespace security
-} // namespace dsn
 
 namespace dsn {
 namespace dist {
@@ -154,26 +141,12 @@ int zookeeper_session::attach(void *callback_owner, const state_callback &cb)
 {
     utils::auto_write_lock l(_watcher_lock);
     if (nullptr == _handle) {
-        if (dsn::security::FLAGS_enable_zookeeper_kerberos) {
-            zoo_sasl_params_t sasl_params = {0};
-            sasl_params.service = dsn::security::FLAGS_zookeeper_kerberos_service_name;
-            sasl_params.mechlist = "GSSAPI";
-            _handle = zookeeper_init_sasl(zookeeper_session_mgr::instance().zoo_hosts(),
-                                          global_watcher,
-                                          zookeeper_session_mgr::instance().timeout(),
-                                          nullptr,
-                                          this,
-                                          0,
-                                          NULL,
-                                          &sasl_params);
-        } else {
-            _handle = zookeeper_init(zookeeper_session_mgr::instance().zoo_hosts(),
-                                     global_watcher,
-                                     zookeeper_session_mgr::instance().timeout(),
-                                     nullptr,
-                                     this,
-                                     0);
-        }
+        _handle = zookeeper_init(zookeeper_session_mgr::instance().zoo_hosts(),
+                                 global_watcher,
+                                 zookeeper_session_mgr::instance().timeout(),
+                                 nullptr,
+                                 this,
+                                 0);
         dassert(_handle != nullptr, "zookeeper session init failed");
     }
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -47,7 +47,6 @@ set(MY_PROJ_LIBS
     PocoFoundation
     PocoNetSSL
     PocoJSON
-    hashtable
     )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/server/test/CMakeLists.txt
+++ b/src/server/test/CMakeLists.txt
@@ -58,7 +58,6 @@ set(MY_PROJ_LIBS
         pegasus_base
         gtest
         gmock
-        hashtable
         )
 add_definitions(-DPEGASUS_UNIT_TEST)
 add_definitions(-DENABLE_FAIL)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -200,16 +200,12 @@ else ()
 endif ()
 
 ExternalProject_Add(zookeeper
-        URL ${OSS_URL_PREFIX}/apache-zookeeper-3.7.0.tar.gz
-        http://downloads.apache.org/zookeeper/zookeeper-3.7.0/apache-zookeeper-3.7.0.tar.gz
-        URL_MD5 44c2a33e01931aed94ef7f3d39d0963e
-        PATCH_COMMAND ""
-        COMMAND cd zookeeper-jute && mvn compile && cd ../zookeeper-client/zookeeper-client-c && cmake -DCMAKE_BUILD_TYPE=release -DWANT_CPPUNIT=OFF -DWITH_OPENSSL=OFF -DWITH_CYRUS_SASL=${ZOOKEEPER_WITH_CYRUS_SASL} -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
-        COMMAND cd zookeeper-client/zookeeper-client-c && make
-        COMMAND cp -R zookeeper-client/zookeeper-client-c/include/. ${TP_OUTPUT}/include/zookeeper && cp zookeeper-client/zookeeper-client-c/generated/zookeeper.jute.h ${TP_OUTPUT}/include/zookeeper && cp zookeeper-client/zookeeper-client-c/libzookeeper.a ${TP_OUTPUT}/lib && cp zookeeper-client/zookeeper-client-c/libhashtable.a ${TP_OUTPUT}/lib
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        INSTALL_COMMAND ""
+        URL ${OSS_URL_PREFIX}/zookeeper-3.4.10.tar.gz
+        http://ftp.jaist.ac.jp/pub/apache/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz
+        URL_MD5 e4cf1b1593ca870bf1c7a75188f09678
+        CONFIGURE_COMMAND cd src/c && CFLAGS=${ZOOKEEPER_CFLAGS} ./configure --enable-static=yes --enable-shared=no --prefix=${TP_OUTPUT} --with-pic=yes
+        BUILD_COMMAND cd src/c && make
+        INSTALL_COMMAND cd src/c && make install
         BUILD_IN_SOURCE 1
         )
 if (NOT APPLE)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Related issue: https://github.com/apache/incubator-pegasus/issues/1092

### What is changed and how does it work?

This pr revert zk c client to 3.4.10, this need merge into Pegasus 2.4:  https://github.com/apache/incubator-pegasus/issues/1032

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

##### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
