### PR TITLE
feat: improve performance of count_data

### DIFF
--- a/idl/rrdb.thrift
+++ b/idl/rrdb.thrift
@@ -295,7 +295,7 @@ struct scan_response
     4:i32           app_id;
     5:i32           partition_index;
     6:string        server;
-    7:optional i32  kv_count = -1;
+    7:optional i32  kv_count;
 }
 
 struct duplicate_request

--- a/idl/rrdb.thrift
+++ b/idl/rrdb.thrift
@@ -285,7 +285,6 @@ struct get_scanner_request
 struct scan_request
 {
     1:i64           context_id;
-    2:optional bool only_return_count;
 }
 
 struct scan_response

--- a/idl/rrdb.thrift
+++ b/idl/rrdb.thrift
@@ -279,7 +279,7 @@ struct get_scanner_request
     11:optional bool    validate_partition_hash;
     12:optional bool    return_expire_ts;
     13:optional bool full_scan; // true means client want to build 'full scan' context with the server side, false otherwise
-    14:optional bool only_return_count;
+    14:optional bool only_return_count = false;
 }
 
 struct scan_request

--- a/idl/rrdb.thrift
+++ b/idl/rrdb.thrift
@@ -279,11 +279,13 @@ struct get_scanner_request
     11:optional bool    validate_partition_hash;
     12:optional bool    return_expire_ts;
     13:optional bool full_scan; // true means client want to build 'full scan' context with the server side, false otherwise
+    14:optional bool only_return_count;
 }
 
 struct scan_request
 {
     1:i64           context_id;
+    2:optional bool only_return_count;
 }
 
 struct scan_response
@@ -294,6 +296,7 @@ struct scan_response
     4:i32           app_id;
     5:i32           partition_index;
     6:string        server;
+    7:optional i32  kv_count = -1;
 }
 
 struct duplicate_request

--- a/src/client_lib/pegasus_client_impl.h
+++ b/src/client_lib/pegasus_client_impl.h
@@ -247,6 +247,13 @@ public:
 
     static void init_error();
 
+    enum class async_scan_type : char
+    {
+        normal,
+        count_only,
+        count_only_finished
+    };
+
     class pegasus_scanner_impl : public pegasus_scanner
     {
     public:
@@ -296,7 +303,7 @@ public:
         volatile bool _rpc_started;
         bool _validate_partition_hash;
         bool _full_scan;
-        bool _already_add_count;
+        async_scan_type _type;
 
         void _async_next_internal();
         void _start_scan();

--- a/src/client_lib/pegasus_client_impl.h
+++ b/src/client_lib/pegasus_client_impl.h
@@ -296,7 +296,6 @@ public:
         volatile bool _rpc_started;
         bool _validate_partition_hash;
         bool _full_scan;
-        bool _only_calculate_count;
         bool _already_add_count;
 
         void _async_next_internal();

--- a/src/client_lib/pegasus_client_impl.h
+++ b/src/client_lib/pegasus_client_impl.h
@@ -249,9 +249,9 @@ public:
 
     enum class async_scan_type : char
     {
-        normal,
-        count_only,
-        count_only_finished
+        NORMAL,
+        COUNT_ONLY,
+        COUNT_ONLY_FINISHED
     };
 
     class pegasus_scanner_impl : public pegasus_scanner

--- a/src/client_lib/pegasus_client_impl.h
+++ b/src/client_lib/pegasus_client_impl.h
@@ -247,21 +247,15 @@ public:
 
     static void init_error();
 
-    enum class async_scan_type : char
-    {
-        NORMAL,
-        COUNT_ONLY,
-        COUNT_ONLY_FINISHED
-    };
-
     class pegasus_scanner_impl : public pegasus_scanner
     {
     public:
         int next(std::string &hashkey,
                  std::string &sortkey,
                  std::string &value,
-                 internal_info *info = nullptr,
-                 int32_t *count = nullptr) override;
+                 internal_info *info = nullptr) override;
+
+        int next(int32_t &count, internal_info *info = nullptr) override;
 
         void async_next(async_scan_next_callback_t &&) override;
 
@@ -285,6 +279,13 @@ public:
                              bool full_scan);
 
     private:
+        enum class async_scan_type : char
+        {
+            NORMAL,
+            COUNT_ONLY,
+            COUNT_ONLY_FINISHED
+        };
+
         ::dsn::apps::rrdb_client *_client;
         ::dsn::blob _start_key;
         ::dsn::blob _stop_key;
@@ -330,13 +331,17 @@ private:
 
         void async_next(async_scan_next_callback_t &&callback) override;
 
+        int next(int32_t &count, internal_info *info = nullptr) override
+        {
+            return _p->next(count, info);
+        }
+
         int next(std::string &hashkey,
                  std::string &sortkey,
                  std::string &value,
-                 internal_info *info,
-                 int32_t *count = nullptr) override
+                 internal_info *info) override
         {
-            return _p->next(hashkey, sortkey, value, info, count);
+            return _p->next(hashkey, sortkey, value, info);
         }
     };
 

--- a/src/client_lib/pegasus_client_impl.h
+++ b/src/client_lib/pegasus_client_impl.h
@@ -253,12 +253,8 @@ public:
         int next(std::string &hashkey,
                  std::string &sortkey,
                  std::string &value,
-                 internal_info *info = nullptr) override;
-
-        int next(std::string &hashkey,
-                 std::string &sortkey,
-                 std::string &value,
-                 int32_t &count_number) override;
+                 internal_info *info = nullptr,
+                 int32_t *count = nullptr) override;
 
         void async_next(async_scan_next_callback_t &&) override;
 
@@ -329,17 +325,10 @@ private:
         int next(std::string &hashkey,
                  std::string &sortkey,
                  std::string &value,
-                 int32_t &count_number) override
+                 internal_info *info,
+                 int32_t *count = nullptr) override
         {
-            return _p->next(hashkey, sortkey, value, count_number);
-        }
-
-        int next(std::string &hashkey,
-                 std::string &sortkey,
-                 std::string &value,
-                 internal_info *info) override
-        {
-            return _p->next(hashkey, sortkey, value, info);
+            return _p->next(hashkey, sortkey, value, info, count);
         }
     };
 

--- a/src/client_lib/pegasus_client_impl.h
+++ b/src/client_lib/pegasus_client_impl.h
@@ -296,6 +296,8 @@ public:
         volatile bool _rpc_started;
         bool _validate_partition_hash;
         bool _full_scan;
+        bool _only_calculate_count;
+        bool _already_add_count;
 
         void _async_next_internal();
         void _start_scan();

--- a/src/client_lib/pegasus_client_impl.h
+++ b/src/client_lib/pegasus_client_impl.h
@@ -255,6 +255,11 @@ public:
                  std::string &value,
                  internal_info *info = nullptr) override;
 
+        int next(std::string &hashkey,
+                 std::string &sortkey,
+                 std::string &value,
+                 int32_t &count_number) override;
+
         void async_next(async_scan_next_callback_t &&) override;
 
         bool safe_destructible() const override;
@@ -287,6 +292,7 @@ public:
         std::vector<::dsn::apps::key_value> _kvs;
         internal_info _info;
         int32_t _p;
+        int32_t _kv_count;
 
         int64_t _context;
         mutable ::dsn::zlock _lock;
@@ -319,6 +325,14 @@ private:
         pegasus_scanner_impl_wrapper(pegasus_scanner *p) : _p(p) {}
 
         void async_next(async_scan_next_callback_t &&callback) override;
+
+        int next(std::string &hashkey,
+                 std::string &sortkey,
+                 std::string &value,
+                 int32_t &count_number) override
+        {
+            return _p->next(hashkey, sortkey, value, count_number);
+        }
 
         int next(std::string &hashkey,
                  std::string &sortkey,

--- a/src/client_lib/pegasus_scanner_impl.cpp
+++ b/src/client_lib/pegasus_scanner_impl.cpp
@@ -56,7 +56,6 @@ pegasus_client_impl::pegasus_scanner_impl::pegasus_scanner_impl(::dsn::apps::rrd
       _rpc_started(false),
       _validate_partition_hash(validate_partition_hash),
       _full_scan(full_scan),
-      _only_calculate_count(false),
       _already_add_count(true)
 {
 }
@@ -174,7 +173,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_async_next_internal()
         std::string hash_key, sort_key, value;
         uint32_t expire_ts_seconds = 0;
 
-        if (!_only_calculate_count) {
+        if (!_options.only_return_count) {
             pegasus_restore_key(_kvs[_p].key, hash_key, sort_key);
             value = std::string(_kvs[_p].value.data(), _kvs[_p].value.length());
             if (_kvs[_p].__isset.expire_ts_seconds) {
@@ -192,7 +191,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_async_next_internal()
                      std::move(info),
                      expire_ts_seconds,
                      _kv_count);
-            if (_only_calculate_count) {
+            if (_options.only_return_count) {
                 _already_add_count = true;
             }
             _lock.lock();
@@ -285,7 +284,6 @@ void pegasus_client_impl::pegasus_scanner_impl::_on_scan_response(::dsn::error_c
             // 2. kv_count is not existed means server is older version
             if (response.__isset.kv_count) {
                 if (response.kv_count != -1) {
-                    _only_calculate_count = true;
                     _already_add_count = false;
                     _kv_count = response.kv_count;
                 }

--- a/src/client_lib/pegasus_scanner_impl.cpp
+++ b/src/client_lib/pegasus_scanner_impl.cpp
@@ -55,7 +55,34 @@ pegasus_client_impl::pegasus_scanner_impl::pegasus_scanner_impl(::dsn::apps::rrd
       _rpc_started(false),
       _validate_partition_hash(validate_partition_hash),
       _full_scan(full_scan)
+
 {
+}
+
+int pegasus_client_impl::pegasus_scanner_impl::next(std::string &hashkey,
+                                                    std::string &sortkey,
+                                                    std::string &value,
+                                                    int32_t &count_number)
+{
+    ::dsn::utils::notify_event op_completed;
+    int ret = -1;
+    auto callback = [&](int err,
+                        std::string &&hash,
+                        std::string &&sort,
+                        std::string &&val,
+                        internal_info &&ii,
+                        uint32_t expire_ts_seconds,
+                        int32_t kv_count) {
+        ret = err;
+        hashkey = std::move(hash);
+        sortkey = std::move(sort);
+        value = std::move(val);
+        count_number = kv_count;
+        op_completed.notify();
+    };
+    async_next(std::move(callback));
+    op_completed.wait();
+    return ret;
 }
 
 int pegasus_client_impl::pegasus_scanner_impl::next(std::string &hashkey,
@@ -70,7 +97,8 @@ int pegasus_client_impl::pegasus_scanner_impl::next(std::string &hashkey,
                         std::string &&sort,
                         std::string &&val,
                         internal_info &&ii,
-                        uint32_t expire_ts_seconds) {
+                        uint32_t expire_ts_seconds,
+                        int32_t kv_count) {
         ret = err;
         hashkey = std::move(hash);
         sortkey = std::move(sort);
@@ -139,7 +167,8 @@ void pegasus_client_impl::pegasus_scanner_impl::_async_next_internal()
                                      std::string(),
                                      std::string(),
                                      std::move(info),
-                                     0);
+                                     0,
+                                     -1);
                         }
                     }
                     return;
@@ -162,13 +191,15 @@ void pegasus_client_impl::pegasus_scanner_impl::_async_next_internal()
         }
 
         // valid data got
-        std::string hash_key, sort_key;
-        pegasus_restore_key(_kvs[_p].key, hash_key, sort_key);
-        std::string value(_kvs[_p].value.data(), _kvs[_p].value.length());
-        uint32_t expire_ts_seconds = _kvs[_p].__isset.expire_ts_seconds
-                                         ? static_cast<uint32_t>(_kvs[_p].expire_ts_seconds)
-                                         : 0;
-
+        std::string hash_key, sort_key, value = "";
+        uint32_t expire_ts_seconds = 0;
+        if (_kv_count == -1) {
+            pegasus_restore_key(_kvs[_p].key, hash_key, sort_key);
+            value = std::string(_kvs[_p].value.data(), _kvs[_p].value.length());
+            if (_kvs[_p].__isset.expire_ts_seconds) {
+                expire_ts_seconds = static_cast<uint32_t>(_kvs[_p].expire_ts_seconds);
+            }
+        }
         auto &callback = _queue.front();
         if (callback) {
             internal_info info(_info);
@@ -178,7 +209,8 @@ void pegasus_client_impl::pegasus_scanner_impl::_async_next_internal()
                      std::move(sort_key),
                      std::move(value),
                      std::move(info),
-                     expire_ts_seconds);
+                     expire_ts_seconds,
+                     _kv_count);
             _lock.lock();
             if (_queue.size() == 1) {
                 // keep the last callback until exit this function
@@ -196,6 +228,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_next_batch()
 {
     ::dsn::apps::scan_request req;
     req.context_id = _context;
+    req.__set_only_return_count(_options.only_return_count);
 
     dassert(!_rpc_started, "");
     _rpc_started = true;
@@ -230,6 +263,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_start_scan()
     req.__set_validate_partition_hash(_validate_partition_hash);
     req.__set_return_expire_ts(_options.return_expire_ts);
     req.__set_full_scan(_full_scan);
+    req.__set_only_return_count(_options.only_return_count);
 
     dassert(!_rpc_started, "");
     _rpc_started = true;
@@ -261,6 +295,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_on_scan_response(::dsn::error_c
             _kvs = std::move(response.kvs);
             _p = -1;
             _context = response.context_id;
+            _kv_count = response.kv_count;
             _async_next_internal();
             return;
         } else if (get_rocksdb_server_error(response.error) == PERR_NOT_FOUND) {
@@ -288,7 +323,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_on_scan_response(::dsn::error_c
 
     for (auto &callback : temp) {
         if (callback) {
-            callback(ret, std::string(), std::string(), std::string(), internal_info(info), 0);
+            callback(ret, std::string(), std::string(), std::string(), internal_info(info), 0, -1);
         }
     }
 }
@@ -323,13 +358,15 @@ void pegasus_client_impl::pegasus_scanner_impl_wrapper::async_next(
                                                                      std::string &&sort_key,
                                                                      std::string &&value,
                                                                      internal_info &&info,
-                                                                     uint32_t expire_ts_seconds) {
+                                                                     uint32_t expire_ts_seconds,
+                                                                     int32_t kv_count) {
         user_callback(error_code,
                       std::move(hash_key),
                       std::move(sort_key),
                       std::move(value),
                       std::move(info),
-                      expire_ts_seconds);
+                      expire_ts_seconds,
+                      kv_count);
     });
 }
 

--- a/src/client_lib/pegasus_scanner_impl.cpp
+++ b/src/client_lib/pegasus_scanner_impl.cpp
@@ -72,8 +72,8 @@ int pegasus_client_impl::pegasus_scanner_impl::next(int32_t &count, internal_inf
                         uint32_t expire_ts_seconds,
                         int32_t kv_count) {
         ret = err;
-        if (info) {
-            (*info) = std::move(ii);
+        if (info != nullptr) {
+            *info = std::move(ii);
         }
         count = kv_count;
         op_completed.notify();

--- a/src/client_lib/pegasus_scanner_impl.cpp
+++ b/src/client_lib/pegasus_scanner_impl.cpp
@@ -170,7 +170,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_async_next_internal()
         // valid data got
         std::string hash_key, sort_key, value;
         uint32_t expire_ts_seconds = 0;
-        // _kv_count == -1 means req just want to get data counts, not include data value
+        // _kv_count > -1 means req just want to get data counts, not include data value
         if (_kv_count == -1) {
             pegasus_restore_key(_kvs[_p].key, hash_key, sort_key);
             value = std::string(_kvs[_p].value.data(), _kvs[_p].value.length());

--- a/src/client_lib/pegasus_scanner_impl.cpp
+++ b/src/client_lib/pegasus_scanner_impl.cpp
@@ -297,12 +297,9 @@ void pegasus_client_impl::pegasus_scanner_impl::_on_scan_response(::dsn::error_c
             _kvs = std::move(response.kvs);
             _p = -1;
             _context = response.context_id;
-            // 1. kv_count exist on response mean (a && b):
-            //   a> server is newer version (added counting size only implementation)
-            //   b> response only have kv size count, but not key && value
-            // 2. kv_count is not existed means (a || b):
-            //   a> server is older version
-            //   b> response still have key and value data
+            // If `kv_count` exists in response, then:
+            //   1) server side supports only counting size, and
+            //   2) `kvs` in response must be empty
             if (response.__isset.kv_count) {
                 _type = async_scan_type::COUNT_ONLY;
                 _kv_count = response.kv_count;

--- a/src/client_lib/pegasus_scanner_impl.cpp
+++ b/src/client_lib/pegasus_scanner_impl.cpp
@@ -56,7 +56,7 @@ pegasus_client_impl::pegasus_scanner_impl::pegasus_scanner_impl(::dsn::apps::rrd
       _rpc_started(false),
       _validate_partition_hash(validate_partition_hash),
       _full_scan(full_scan),
-      _type(async_scan_type::normal)
+      _type(async_scan_type::NORMAL)
 {
 }
 
@@ -128,7 +128,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_async_next_internal()
     std::list<async_scan_next_callback_t> temp;
     while (true) {
         // count_only means should calculate kv counts once
-        while (++_p >= _kvs.size() && _type != async_scan_type::count_only) {
+        while (++_p >= _kvs.size() && _type != async_scan_type::COUNT_ONLY) {
             if (_context == SCAN_CONTEXT_ID_COMPLETED) {
                 // reach the end of one partition
                 if (_splits_hash.empty()) {
@@ -193,7 +193,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_async_next_internal()
                      expire_ts_seconds,
                      _kv_count);
             if (_options.only_return_count) {
-                _type = async_scan_type::count_only_finished;
+                _type = async_scan_type::COUNT_ONLY_FINISHED;
             }
             _lock.lock();
             if (_queue.size() == 1) {
@@ -285,7 +285,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_on_scan_response(::dsn::error_c
             // 2. kv_count is not existed means server is older version
             if (response.__isset.kv_count) {
                 if (response.kv_count != -1) {
-                    _type = async_scan_type::count_only;
+                    _type = async_scan_type::COUNT_ONLY;
                     _kv_count = response.kv_count;
                 }
             }

--- a/src/client_lib/pegasus_scanner_impl.cpp
+++ b/src/client_lib/pegasus_scanner_impl.cpp
@@ -56,7 +56,7 @@ pegasus_client_impl::pegasus_scanner_impl::pegasus_scanner_impl(::dsn::apps::rrd
       _rpc_started(false),
       _validate_partition_hash(validate_partition_hash),
       _full_scan(full_scan),
-      _already_add_count(true)
+      _type(async_scan_type::normal)
 {
 }
 
@@ -127,7 +127,8 @@ void pegasus_client_impl::pegasus_scanner_impl::_async_next_internal()
 
     std::list<async_scan_next_callback_t> temp;
     while (true) {
-        while (++_p >= _kvs.size() && _already_add_count) {
+        // count_only means should calculate kv counts once
+        while (++_p >= _kvs.size() && _type != async_scan_type::count_only) {
             if (_context == SCAN_CONTEXT_ID_COMPLETED) {
                 // reach the end of one partition
                 if (_splits_hash.empty()) {
@@ -192,7 +193,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_async_next_internal()
                      expire_ts_seconds,
                      _kv_count);
             if (_options.only_return_count) {
-                _already_add_count = true;
+                _type = async_scan_type::count_only_finished;
             }
             _lock.lock();
             if (_queue.size() == 1) {
@@ -284,7 +285,7 @@ void pegasus_client_impl::pegasus_scanner_impl::_on_scan_response(::dsn::error_c
             // 2. kv_count is not existed means server is older version
             if (response.__isset.kv_count) {
                 if (response.kv_count != -1) {
-                    _already_add_count = false;
+                    _type = async_scan_type::count_only;
                     _kv_count = response.kv_count;
                 }
             }

--- a/src/geo/lib/geo_client.cpp
+++ b/src/geo/lib/geo_client.cpp
@@ -862,7 +862,8 @@ void geo_client::do_scan(pegasus_client::pegasus_scanner_wrapper scanner_wrapper
             std::string &&geo_sort_key,
             std::string &&value,
             pegasus_client::internal_info &&info,
-            uint32_t expire_ts_seconds) mutable {
+            uint32_t expire_ts_seconds,
+            int32_t kv_count) mutable {
             if (ret == PERR_SCAN_COMPLETE) {
                 cb();
                 return;

--- a/src/include/pegasus/client.h
+++ b/src/include/pegasus/client.h
@@ -345,12 +345,8 @@ public:
         virtual int next(std::string &hashkey,
                          std::string &sortkey,
                          std::string &value,
-                         internal_info *info = nullptr) = 0;
-
-        virtual int next(std::string &hashkey,
-                         std::string &sortkey,
-                         std::string &value,
-                         int32_t &count_number) = 0;
+                         internal_info *info = nullptr,
+                         int32_t *count = nullptr) = 0;
 
         ///
         /// \brief async get the next key-value pair of this scanner

--- a/src/include/pegasus/client.h
+++ b/src/include/pegasus/client.h
@@ -252,6 +252,7 @@ public:
         std::string sort_key_filter_pattern;
         bool no_value; // only fetch hash_key and sort_key, but not fetch value
         bool return_expire_ts;
+        bool only_return_count;
         scan_options()
             : timeout_ms(5000),
               batch_size(100),
@@ -260,7 +261,8 @@ public:
               hash_key_filter_type(FT_NO_FILTER),
               sort_key_filter_type(FT_NO_FILTER),
               no_value(false),
-              return_expire_ts(false)
+              return_expire_ts(false),
+              only_return_count(false)
         {
         }
         scan_options(const scan_options &o)
@@ -273,7 +275,8 @@ public:
               sort_key_filter_type(o.sort_key_filter_type),
               sort_key_filter_pattern(o.sort_key_filter_pattern),
               no_value(o.no_value),
-              return_expire_ts(o.return_expire_ts)
+              return_expire_ts(o.return_expire_ts),
+              only_return_count(o.only_return_count)
         {
         }
     };
@@ -312,7 +315,8 @@ public:
                                std::string && /*sort_key*/,
                                std::string && /*value*/,
                                internal_info && /*info*/,
-                               uint32_t /*expire_ts_seconds*/)>
+                               uint32_t /*expire_ts_seconds*/,
+                               int32_t /*kv_count*/)>
         async_scan_next_callback_t;
     typedef std::function<void(int /*error_code*/, pegasus_scanner * /*hash_scanner*/)>
         async_get_scanner_callback_t;
@@ -342,6 +346,11 @@ public:
                          std::string &sortkey,
                          std::string &value,
                          internal_info *info = nullptr) = 0;
+
+        virtual int next(std::string &hashkey,
+                         std::string &sortkey,
+                         std::string &value,
+                         int32_t &count_number) = 0;
 
         ///
         /// \brief async get the next key-value pair of this scanner

--- a/src/include/pegasus/client.h
+++ b/src/include/pegasus/client.h
@@ -345,8 +345,22 @@ public:
         virtual int next(std::string &hashkey,
                          std::string &sortkey,
                          std::string &value,
-                         internal_info *info = nullptr,
-                         int32_t *count = nullptr) = 0;
+                         internal_info *info = nullptr) = 0;
+
+        ///
+        /// \brief get the next k-v pair count of this scanner
+        //  only used for scanner which option only_return_count is true
+        /// thread-safe
+        /// \param count
+        /// data count value
+        /// \return
+        /// int, the error indicates whether or not the operation is succeeded.
+        /// this error can be converted to a string using get_error_string()
+        /// PERR_OK means a valid k-v pair count got
+        /// PERR_SCAN_COMPLETE means all k-v pair count have been return before this call
+        /// otherwise some error orrured
+        ///
+        virtual int next(int32_t &count, internal_info *info = nullptr) = 0;
 
         ///
         /// \brief async get the next key-value pair of this scanner

--- a/src/server/pegasus_scan_context.h
+++ b/src/server/pegasus_scan_context.h
@@ -43,7 +43,8 @@ struct pegasus_scan_context
                          int32_t batch_size_,
                          bool no_value_,
                          bool validate_partition_hash_,
-                         bool return_expire_ts_)
+                         bool return_expire_ts_,
+                         bool only_return_count_)
         : _stop_holder(std::move(stop_)),
           _hash_key_filter_pattern_holder(std::move(hash_key_filter_pattern_)),
           _sort_key_filter_pattern_holder(std::move(sort_key_filter_pattern_)),
@@ -59,7 +60,8 @@ struct pegasus_scan_context
           batch_size(batch_size_),
           no_value(no_value_),
           validate_partition_hash(validate_partition_hash_),
-          return_expire_ts(return_expire_ts_)
+          return_expire_ts(return_expire_ts_),
+          only_return_count(only_return_count_)
     {
     }
 
@@ -80,6 +82,7 @@ public:
     bool no_value;
     bool validate_partition_hash;
     bool return_expire_ts;
+    bool only_return_count;
 };
 
 class pegasus_context_cache

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1401,7 +1401,7 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
             it->Next();
         }
 
-        if (only_return_count) {
+        if (!only_return_count) {
             resp.kvs.emplace_back(::dsn::apps::key_value());
             resp.__set_kv_count(count);
         }

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1319,7 +1319,6 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
     resp.app_id = _gpid.get_app_id();
     resp.partition_index = _gpid.get_partition_index();
     resp.server = _primary_address;
-    bool only_return_count = false;
 
     if (!_read_size_throttling_controller->available()) {
         rpc.error() = dsn::ERR_BUSY;
@@ -1332,7 +1331,6 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
         rocksdb::Iterator *it = context->iterator.get();
         const rocksdb::Slice &stop = context->stop;
         bool stop_inclusive = context->stop_inclusive;
-        only_return_count = context->only_return_count;
         ::dsn::apps::filter_type::type hash_key_filter_type = context->hash_key_filter_type;
         const ::dsn::blob &hash_key_filter_pattern = context->hash_key_filter_pattern;
         ::dsn::apps::filter_type::type sort_key_filter_type = context->sort_key_filter_type;
@@ -1376,7 +1374,7 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
             switch (state) {
             case range_iteration_state::kNormal:
                 count++;
-                if (!only_return_count) {
+                if (!context->only_return_count) {
                     append_key_value(resp.kvs, it->key(), it->value(), no_value, return_expire_ts);
                 }
                 break;
@@ -1399,7 +1397,7 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
             it->Next();
         }
 
-        if (only_return_count) {
+        if (context->only_return_count) {
             resp.__set_kv_count(count);
         }
 

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1187,8 +1187,7 @@ void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
 
         limiter->add_count();
 
-        auto state = append_key_value_for_scan(
-            resp.kvs,
+        auto state = validate_key_value_for_scan(
             it->key(),
             it->value(),
             request.hash_key_filter_type,
@@ -1196,13 +1195,15 @@ void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
             request.sort_key_filter_type,
             request.sort_key_filter_pattern,
             epoch_now,
-            request.no_value,
-            request.__isset.validate_partition_hash ? request.validate_partition_hash : true,
-            return_expire_ts,
-            !request.only_return_count);
+            request.__isset.validate_partition_hash ? request.validate_partition_hash : true);
+
         switch (state) {
         case range_iteration_state::kNormal:
             count++;
+            if (!request.only_return_count) {
+                append_key_value(
+                    resp.kvs, it->key(), it->value(), request.no_value, return_expire_ts);
+            }
             break;
         case range_iteration_state::kExpired:
             expire_count++;
@@ -1223,6 +1224,7 @@ void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
         it->Next();
     }
     if (request.only_return_count) {
+        // add a null data avoid to refactor the client code
         resp.kvs.emplace_back(::dsn::apps::key_value());
         resp.__set_kv_count(count);
     }
@@ -1303,10 +1305,7 @@ void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
         _pfc_recent_filter_count->add(filter_count);
     }
 
-    // abandon calculate capacity unit
-    if (!request.only_return_count) {
-        _cu_calculator->add_scan_cu(req, resp.error, resp.kvs);
-    }
+    _cu_calculator->add_scan_cu(req, resp.error, resp.kvs);
     _pfc_scan_latency->set(dsn_now_ns() - start_time);
 }
 
@@ -1366,21 +1365,21 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
 
             limiter->add_count();
 
-            auto state = append_key_value_for_scan(resp.kvs,
-                                                   it->key(),
-                                                   it->value(),
-                                                   hash_key_filter_type,
-                                                   hash_key_filter_pattern,
-                                                   sort_key_filter_type,
-                                                   sort_key_filter_pattern,
-                                                   epoch_now,
-                                                   no_value,
-                                                   validate_hash,
-                                                   return_expire_ts,
-                                                   !only_return_count);
+            auto state = validate_key_value_for_scan(it->key(),
+                                                     it->value(),
+                                                     hash_key_filter_type,
+                                                     hash_key_filter_pattern,
+                                                     sort_key_filter_type,
+                                                     sort_key_filter_pattern,
+                                                     epoch_now,
+                                                     validate_hash);
+
             switch (state) {
             case range_iteration_state::kNormal:
                 count++;
+                if (!only_return_count) {
+                    append_key_value(resp.kvs, it->key(), it->value(), no_value, return_expire_ts);
+                }
                 break;
             case range_iteration_state::kExpired:
                 expire_count++;
@@ -1401,7 +1400,7 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
             it->Next();
         }
 
-        if (!only_return_count) {
+        if (only_return_count) {
             resp.kvs.emplace_back(::dsn::apps::key_value());
             resp.__set_kv_count(count);
         }
@@ -1466,10 +1465,7 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
         resp.error = rocksdb::Status::Code::kNotFound;
     }
 
-    // abandon calculate capacity unit
-    if (only_return_count) {
-        _cu_calculator->add_scan_cu(req, resp.error, resp.kvs);
-    }
+    _cu_calculator->add_scan_cu(req, resp.error, resp.kvs);
     _pfc_scan_latency->set(dsn_now_ns() - start_time);
 }
 
@@ -2283,19 +2279,15 @@ bool pegasus_server_impl::validate_filter(::dsn::apps::filter_type::type filter_
     return false;
 }
 
-range_iteration_state
-pegasus_server_impl::append_key_value_for_scan(std::vector<::dsn::apps::key_value> &kvs,
-                                               const rocksdb::Slice &key,
-                                               const rocksdb::Slice &value,
-                                               ::dsn::apps::filter_type::type hash_key_filter_type,
-                                               const ::dsn::blob &hash_key_filter_pattern,
-                                               ::dsn::apps::filter_type::type sort_key_filter_type,
-                                               const ::dsn::blob &sort_key_filter_pattern,
-                                               uint32_t epoch_now,
-                                               bool no_value,
-                                               bool request_validate_hash,
-                                               bool request_expire_ts,
-                                               bool fill_value)
+range_iteration_state pegasus_server_impl::validate_key_value_for_scan(
+    const rocksdb::Slice &key,
+    const rocksdb::Slice &value,
+    ::dsn::apps::filter_type::type hash_key_filter_type,
+    const ::dsn::blob &hash_key_filter_pattern,
+    ::dsn::apps::filter_type::type sort_key_filter_type,
+    const ::dsn::blob &sort_key_filter_pattern,
+    uint32_t epoch_now,
+    bool request_validate_hash)
 {
     if (check_if_record_expired(epoch_now, value)) {
         if (_verbose_log) {
@@ -2335,29 +2327,36 @@ pegasus_server_impl::append_key_value_for_scan(std::vector<::dsn::apps::key_valu
             return range_iteration_state::kFiltered;
         }
     }
-    if (fill_value) {
-        ::dsn::apps::key_value kv;
-
-        std::shared_ptr<char> key_buf(::dsn::utils::make_shared_array<char>(raw_key.length()));
-        ::memcpy(key_buf.get(), raw_key.data(), raw_key.length());
-        kv.key.assign(std::move(key_buf), 0, raw_key.length());
-
-        // extract expire ts if necessary
-        if (request_expire_ts) {
-            auto expire_ts_seconds =
-                pegasus_extract_expire_ts(_pegasus_data_version, utils::to_string_view(value));
-            kv.__set_expire_ts_seconds(static_cast<int32_t>(expire_ts_seconds));
-        }
-
-        // extract value
-        if (!no_value) {
-            std::string value_buf(value.data(), value.size());
-            pegasus_extract_user_data(_pegasus_data_version, std::move(value_buf), kv.value);
-        }
-        kvs.emplace_back(std::move(kv));
-    }
 
     return range_iteration_state::kNormal;
+}
+
+void pegasus_server_impl::append_key_value(std::vector<::dsn::apps::key_value> &kvs,
+                                           const rocksdb::Slice &key,
+                                           const rocksdb::Slice &value,
+                                           bool no_value,
+                                           bool request_expire_ts)
+{
+    ::dsn::apps::key_value kv;
+    ::dsn::blob raw_key(key.data(), 0, key.size());
+    std::shared_ptr<char> key_buf(::dsn::utils::make_shared_array<char>(raw_key.length()));
+    ::memcpy(key_buf.get(), raw_key.data(), raw_key.length());
+    kv.key.assign(std::move(key_buf), 0, raw_key.length());
+
+    // extract expire ts if necessary
+    if (request_expire_ts) {
+        auto expire_ts_seconds =
+            pegasus_extract_expire_ts(_pegasus_data_version, utils::to_string_view(value));
+        kv.__set_expire_ts_seconds(static_cast<int32_t>(expire_ts_seconds));
+    }
+
+    // extract value
+    if (!no_value) {
+        std::string value_buf(value.data(), value.size());
+        pegasus_extract_user_data(_pegasus_data_version, std::move(value_buf), kv.value);
+    }
+
+    kvs.emplace_back(std::move(kv));
 }
 
 range_iteration_state pegasus_server_impl::append_key_value_for_multi_get(

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1199,7 +1199,7 @@ void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
             request.no_value,
             request.__isset.validate_partition_hash ? request.validate_partition_hash : true,
             return_expire_ts,
-            request.only_return_count ? false : true);
+            !request.only_return_count);
         switch (state) {
         case range_iteration_state::kNormal:
             count++;
@@ -1374,7 +1374,7 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
                                                    no_value,
                                                    validate_hash,
                                                    return_expire_ts,
-                                                   request.only_return_count ? false : true);
+                                                   !request.only_return_count);
             switch (state) {
             case range_iteration_state::kNormal:
                 count++;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -235,7 +235,8 @@ private:
                               uint32_t epoch_now,
                               bool no_value,
                               bool request_validate_hash,
-                              bool request_expire_ts);
+                              bool request_expire_ts,
+                              bool fill_value);
 
     range_iteration_state
     append_key_value_for_multi_get(std::vector<::dsn::apps::key_value> &kvs,

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -224,19 +224,21 @@ private:
 
     void set_last_durable_decree(int64_t decree) { _last_durable_decree.store(decree); }
 
+    void append_key_value(std::vector<::dsn::apps::key_value> &kvs,
+                          const rocksdb::Slice &key,
+                          const rocksdb::Slice &value,
+                          bool no_value,
+                          bool request_expire_ts);
+
     range_iteration_state
-    append_key_value_for_scan(std::vector<::dsn::apps::key_value> &kvs,
-                              const rocksdb::Slice &key,
-                              const rocksdb::Slice &value,
-                              ::dsn::apps::filter_type::type hash_key_filter_type,
-                              const ::dsn::blob &hash_key_filter_pattern,
-                              ::dsn::apps::filter_type::type sort_key_filter_type,
-                              const ::dsn::blob &sort_key_filter_pattern,
-                              uint32_t epoch_now,
-                              bool no_value,
-                              bool request_validate_hash,
-                              bool request_expire_ts,
-                              bool fill_value);
+    validate_key_value_for_scan(const rocksdb::Slice &key,
+                                const rocksdb::Slice &value,
+                                ::dsn::apps::filter_type::type hash_key_filter_type,
+                                const ::dsn::blob &hash_key_filter_pattern,
+                                ::dsn::apps::filter_type::type sort_key_filter_type,
+                                const ::dsn::blob &sort_key_filter_pattern,
+                                uint32_t epoch_now,
+                                bool request_validate_hash);
 
     range_iteration_state
     append_key_value_for_multi_get(std::vector<::dsn::apps::key_value> &kvs,

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -405,7 +405,7 @@ inline void scan_data_next(scan_data_context *context)
                                                uint32_t expire_ts_seconds,
                                                int32_t kv_count) {
             if (ret == pegasus::PERR_OK) {
-                if (kv_count == -1 || validate_filter(context, sort_key, value)) {
+                if (kv_count != -1 || validate_filter(context, sort_key, value)) {
                     bool ts_expired = false;
                     int ttl_seconds = 0;
                     switch (context->op) {

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -2398,8 +2398,9 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
     else
         options.no_value = true;
 
-    // cuz option only_return_count not return data(hashkey&sortkey&value) to client
-    // all of this options need check data on client side
+    // Decide whether real data should be returned to client. Once the real data is
+    // decided not to be returned to client side: option `only_return_count` will be
+    // used.
     if (diff_hash_key || stat_size || value_filter_type != pegasus::pegasus_client::FT_NO_FILTER ||
         sort_key_filter_type == pegasus::pegasus_client::FT_MATCH_EXACT) {
         options.only_return_count = false;

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -2333,7 +2333,6 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
         tp.output(std::cout, tp_output_format::kTabular);
         return true;
     }
-    options.only_return_count = true;
 
     if (max_batch_count <= 1) {
         fprintf(stderr, "ERROR: max_batch_count should be greater than 1\n");
@@ -2404,8 +2403,8 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
     if (diff_hash_key || stat_size || value_filter_type != pegasus::pegasus_client::FT_NO_FILTER ||
         sort_key_filter_type == pegasus::pegasus_client::FT_MATCH_EXACT) {
         options.only_return_count = false;
-    }
-    if (options.only_return_count) {
+    } else {
+        options.only_return_count = true;
         fprintf(stderr, "INFO: scanner only return kv count, not return value\n");
     }
 

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -2399,6 +2399,8 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
     else
         options.no_value = true;
 
+    // cuz option only_return_count not return data(hashkey&sortkey&value) to client
+    // all of this options need check data on client side
     if (diff_hash_key || stat_size || value_filter_type != pegasus::pegasus_client::FT_NO_FILTER ||
         sort_key_filter_type == pegasus::pegasus_client::FT_MATCH_EXACT) {
         options.only_return_count = false;

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -2169,7 +2169,6 @@ bool clear_data(command_executor *e, shell_context *sc, arguments args)
 bool count_data(command_executor *e, shell_context *sc, arguments args)
 {
     static struct option long_options[] = {{"precise", no_argument, 0, 'c'},
-                                           {"only_return_data_count", no_argument, 0, 'o'},
                                            {"partition", required_argument, 0, 'p'},
                                            {"max_batch_count", required_argument, 0, 'b'},
                                            {"timeout_ms", required_argument, 0, 't'},
@@ -2212,7 +2211,7 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
         int option_index = 0;
         int c;
         c = getopt_long(
-            args.argc, args.argv, "cop:b:t:h:x:s:y:v:z:dan:r:", long_options, &option_index);
+            args.argc, args.argv, "cp:b:t:h:x:s:y:v:z:dan:r:", long_options, &option_index);
         if (c == -1)
             break;
         // input any valid parameter means you want to get precise count by scanning.
@@ -2220,9 +2219,6 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
         switch (c) {
         case 'c':
             precise = true;
-            break;
-        case 'o':
-            options.only_return_count = true;
             break;
         case 'p':
             if (!dsn::buf2int32(optarg, partition)) {
@@ -2337,6 +2333,7 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
         tp.output(std::cout, tp_output_format::kTabular);
         return true;
     }
+    options.only_return_count = true;
 
     if (max_batch_count <= 1) {
         fprintf(stderr, "ERROR: max_batch_count should be greater than 1\n");
@@ -2403,7 +2400,7 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
         options.no_value = true;
 
     if (diff_hash_key || stat_size || value_filter_type != pegasus::pegasus_client::FT_NO_FILTER ||
-        sort_key_filter_type != pegasus::pegasus_client::FT_NO_FILTER) {
+        sort_key_filter_type == pegasus::pegasus_client::FT_MATCH_EXACT) {
         options.only_return_count = false;
     }
     if (options.only_return_count) {

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -304,7 +304,8 @@ static command_executor commands[] = {
         "[-y|--sort_key_filter_pattern str] "
         "[-v|--value_filter_type anywhere|prefix|postfix|exact] "
         "[-z|--value_filter_pattern str][-d|--diff_hash_key] "
-        "[-a|--stat_size] [-n|--top_count num] [-r|--run_seconds num]",
+        "[-a|--stat_size] [-n|--top_count num] "
+        "[-o|--only_return_data_count] [-r|--run_seconds num]",
         data_operations,
     },
     {

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -304,8 +304,7 @@ static command_executor commands[] = {
         "[-y|--sort_key_filter_pattern str] "
         "[-v|--value_filter_type anywhere|prefix|postfix|exact] "
         "[-z|--value_filter_pattern str][-d|--diff_hash_key] "
-        "[-a|--stat_size] [-n|--top_count num] "
-        "[-o|--only_return_data_count] [-r|--run_seconds num]",
+        "[-a|--stat_size] [-n|--top_count num] [-r|--run_seconds num]",
         data_operations,
     },
     {

--- a/src/test/function_test/test_scan.cpp
+++ b/src/test/function_test/test_scan.cpp
@@ -193,7 +193,11 @@ TEST_F(scan, OVERALL_COUNT_ONLY)
                                            << client->get_error_string(ret);
         delete scanner;
     }
-    ASSERT_EQ(10990, data_counts);
+    int data_sizes = 0;
+    for (auto &m : base) {
+        data_sizes += m.second.size();
+    }
+    ASSERT_EQ(data_sizes, data_counts);
 }
 
 TEST_F(scan, ALL_SORT_KEY)

--- a/src/test/function_test/test_scan.cpp
+++ b/src/test/function_test/test_scan.cpp
@@ -179,14 +179,11 @@ TEST_F(scan, OVERALL_COUNT_ONLY)
                       << client->get_error_string(ret);
     ASSERT_LE(scanners.size(), 3);
 
-    std::string hash_key;
-    std::string sort_key;
-    std::string value;
     int32_t data_count = 0;
     for (auto scanner : scanners) {
         ASSERT_NE(nullptr, scanner);
         int32_t kv_count;
-        while (PERR_OK == (ret = (scanner->next(hash_key, sort_key, value, nullptr, &kv_count)))) {
+        while (PERR_OK == (ret = (scanner->next(kv_count)))) {
             data_count += kv_count;
         }
         ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="

--- a/src/test/function_test/test_scan.cpp
+++ b/src/test/function_test/test_scan.cpp
@@ -183,7 +183,6 @@ TEST_F(scan, OVERALL_COUNT_ONLY)
     std::string sort_key;
     std::string value;
     int32_t data_counts = 0;
-    std::map<std::string, std::map<std::string, std::string>> data;
     for (auto scanner : scanners) {
         ASSERT_NE(nullptr, scanner);
         int32_t kv_count;

--- a/src/test/function_test/test_scan.cpp
+++ b/src/test/function_test/test_scan.cpp
@@ -182,22 +182,22 @@ TEST_F(scan, OVERALL_COUNT_ONLY)
     std::string hash_key;
     std::string sort_key;
     std::string value;
-    int32_t data_counts = 0;
+    int32_t data_count = 0;
     for (auto scanner : scanners) {
         ASSERT_NE(nullptr, scanner);
         int32_t kv_count;
         while (PERR_OK == (ret = (scanner->next(hash_key, sort_key, value, nullptr, &kv_count)))) {
-            data_counts += kv_count;
+            data_count += kv_count;
         }
         ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="
                                            << client->get_error_string(ret);
         delete scanner;
     }
-    int data_sizes = 0;
+    int base_data_count = 0;
     for (auto &m : base) {
-        data_sizes += m.second.size();
+        base_data_count += m.second.size();
     }
-    ASSERT_EQ(data_sizes, data_counts);
+    ASSERT_EQ(base_data_count, data_count);
 }
 
 TEST_F(scan, ALL_SORT_KEY)

--- a/src/test/function_test/test_scan.cpp
+++ b/src/test/function_test/test_scan.cpp
@@ -187,7 +187,7 @@ TEST_F(scan, OVERALL_COUNT_ONLY)
     for (auto scanner : scanners) {
         ASSERT_NE(nullptr, scanner);
         int32_t kv_count;
-        while (PERR_OK == (ret = (scanner->next(hash_key, sort_key, value, kv_count)))) {
+        while (PERR_OK == (ret = (scanner->next(hash_key, sort_key, value, nullptr, &kv_count)))) {
             data_counts += kv_count;
         }
         ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="
@@ -432,7 +432,7 @@ TEST_F(scan, REQUEST_EXPIRE_TS)
                                     std::string &&value,
                                     pegasus::pegasus_client::internal_info &&info,
                                     uint32_t expire_ts_seconds,
-                                    uint32_t kv_count) {
+                                    int32_t kv_count) {
                 if (err == pegasus::PERR_OK) {
                     check_and_put(data, hash_key, sort_key, value);
                     if (expire_ts_seconds > 0) {


### PR DESCRIPTION
### What problem does this PR solve? 

issue: https://github.com/apache/incubator-pegasus/issues/1090
same job as before: https://github.com/apache/incubator-pegasus/pull/728

When we precisely count data for a large table, it will cost minutes or hours. 
However, it's unnecessarily return key-values from server to client. 

### What is changed and how does it work?
Actually, we just need the count of data. So we just need transfer the count of data from server to client, but not the detailed data.

**In my test, it will 2x on onebox faster than before.**
for my bench on onebox：
1> before
![wecom-temp-d7e2a1e011357a0ca4c3ad44d910e69e](https://user-images.githubusercontent.com/48315319/184576502-a657228b-3038-4c34-bb29-c1ab5391bfd2.png)

2> this commit
<img width="813" alt="image" src="https://user-images.githubusercontent.com/48315319/184576461-15dfad35-dbef-4dea-b15b-5a99cf70f527.png">

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

##### Related changes

- Need to update the documentation
- Need to be included in the release note
