### PR TITLE
fix: rocksdb options not changed even if update in Pegasus config file

### DIFF
--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -3011,7 +3011,7 @@ void pegasus_server_impl::reset_usage_scenario_options(
     target_opts->max_write_buffer_number = base_opts.max_write_buffer_number;
 }
 
-bool pegasus_server_impl::recalculate_usage_scenario(const rocksdb::ColumnFamilyOptions &cur_opts)
+void pegasus_server_impl::recalculate_usage_scenario(const rocksdb::ColumnFamilyOptions &cur_opts)
 {
     std::unordered_map<std::string, std::string> new_options;
     if (ROCKSDB_ENV_USAGE_SCENARIO_NORMAL == _usage_scenario ||

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -3051,7 +3051,7 @@ void pegasus_server_impl::recalculate_data_cf_options(
     if (ROCKSDB_ENV_USAGE_SCENARIO_NORMAL == _usage_scenario ||
         ROCKSDB_ENV_USAGE_SCENARIO_PREFER_WRITE == _usage_scenario) {
         if (ROCKSDB_ENV_USAGE_SCENARIO_NORMAL == _usage_scenario) {
-            UPDATE_OPTION_IF_NOT_NEARBY(write_buffer_size, data_cf_opts.write_buffer_size);
+            UPDATE_OPTION_IF_NOT_NEARBY(write_buffer_size, _data_cf_opts.write_buffer_size);
             UPDATE_OPTION_IF_NEEDED(level0_file_num_compaction_trigger);
         } else {
             uint64_t buffer_size = dsn::rand::next_u64(_data_cf_opts.write_buffer_size,

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -3026,8 +3026,9 @@ void pegasus_server_impl::recalculate_data_cf_options(
 
 #define UPDATE_BOOL_OPTION_IF_NEEDED(option, value)                                                \
     do {                                                                                           \
-        if ((value) != cur_data_cf_opts.option) {                                                  \
-            if ((value)) {                                                                         \
+        auto _v = (value);                                                                         \
+        if (_v != cur_data_cf_opts.option) {                                                       \
+            if (_v) {                                                                              \
                 new_options[#option] = "true";                                                     \
             } else {                                                                               \
                 new_options[#option] = "false";                                                    \
@@ -3045,8 +3046,9 @@ void pegasus_server_impl::recalculate_data_cf_options(
 
 #define UPDATE_OPTION_IF_NEEDED(option) UPDATE_NUMBER_OPTION_IF_NEEDED(option, _data_cf_opts.option)
 
-    if (_table_data_cf_opts_recalculated)
+    if (_table_data_cf_opts_recalculated) {
         return;
+    }
     std::unordered_map<std::string, std::string> new_options;
     if (ROCKSDB_ENV_USAGE_SCENARIO_NORMAL == _usage_scenario ||
         ROCKSDB_ENV_USAGE_SCENARIO_PREFER_WRITE == _usage_scenario) {
@@ -3056,8 +3058,8 @@ void pegasus_server_impl::recalculate_data_cf_options(
         } else {
             uint64_t buffer_size = dsn::rand::next_u64(_data_cf_opts.write_buffer_size,
                                                        _data_cf_opts.write_buffer_size * 2);
-            if (!(cur_data_cf_opts.write_buffer_size >= _data_cf_opts.write_buffer_size &&
-                  cur_data_cf_opts.write_buffer_size <= _data_cf_opts.write_buffer_size * 2)) {
+            if (cur_data_cf_opts.write_buffer_size < _data_cf_opts.write_buffer_size ||
+                cur_data_cf_opts.write_buffer_size > _data_cf_opts.write_buffer_size * 2) {
                 new_options["write_buffer_size"] = std::to_string(buffer_size);
                 uint64_t max_size = get_random_nearby(_data_cf_opts.max_bytes_for_level_base);
                 new_options["level0_file_num_compaction_trigger"] =

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1704,7 +1704,7 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
     } else {
         // When an old db is opened and the conf is changed, the options related to usage scenario
         // need to be recalculated with new values.
-        recalculate_usage_scenario(_usage_scenario);
+        recalculate_usage_scenario(tmp_data_cf_opts);
     }
 
     dinfo_replica("start the update replica-level rocksdb statistics timer task");

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1563,7 +1563,7 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
     // Here we create a `_table_data_cf_opts` because we don't want to modify `_data_cf_opts`, which
     // will be used elsewhere.
     _table_data_cf_opts = _data_cf_opts;
-    _table_data_cf_opts_recalculated = true;
+    _table_data_cf_opts_recalculated = false;
     bool has_incompatible_db_options = false;
     if (db_exist) {
         // When DB exists, meta CF and data CF must be present.
@@ -3036,7 +3036,7 @@ void pegasus_server_impl::recalculate_data_cf_options(
 
 #define UPDATE_OPTION_IF_NEEDED(option) UPDATE_NUMBER_OPTION_IF_NEEDED(option, _data_cf_opts.option)
 
-    if (!_table_data_cf_opts_recalculated)
+    if (_table_data_cf_opts_recalculated)
         return;
     std::unordered_map<std::string, std::string> new_options;
     if (ROCKSDB_ENV_USAGE_SCENARIO_NORMAL == _usage_scenario ||
@@ -3099,7 +3099,7 @@ void pegasus_server_impl::recalculate_data_cf_options(
                 _usage_scenario);
         }
     }
-    _table_data_cf_opts_recalculated = false;
+    _table_data_cf_opts_recalculated = true;
 #undef UPDATE_OPTION_IF_NEEDED
 #undef UPDATE_BOOL_OPTION_IF_NEEDED
 #undef UPDATE_NUMBER_OPTION_IF_NEEDED

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -3026,10 +3026,11 @@ void pegasus_server_impl::recalculate_data_cf_options(
 #define UPDATE_BOOL_OPTION_IF_NEEDED(option, value)                                                \
     do {                                                                                           \
         if ((value) != cur_data_cf_opts.option) {                                                  \
-            if ((value))                                                                           \
+            if ((value)) {                                                                         \
                 new_options[#option] = "true";                                                     \
-            else                                                                                   \
+            } else {                                                                               \
                 new_options[#option] = "false";                                                    \
+            }                                                                                      \
         }                                                                                          \
     } while (0)
 

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -3016,9 +3016,16 @@ void pegasus_server_impl::reset_usage_scenario_options(
 void pegasus_server_impl::recalculate_data_cf_options(
     const rocksdb::ColumnFamilyOptions &cur_data_cf_opts)
 {
-#define UPDATE_OPTION_IF_NEEDED(option, value, str_value)                                          \
+#define UPDATE_NUMBER_OPTION_IF_NEEDED(option, value)                                              \
     if ((value) != cur_data_cf_opts.option) {                                                      \
-        new_options[#option] = (str_value);                                                        \
+        new_options[#option] = std::to_string((value));                                            \
+    }
+#define UPDATE_BOOL_OPTION_IF_NEEDED(option, value)                                                \
+    if ((value) != cur_data_cf_opts.option) {                                                      \
+        if ((value))                                                                               \
+            new_options[#option] = "true";                                                         \
+        else                                                                                       \
+            new_options[#option] = "false";                                                        \
     }
 
     if (!_is_need_update_data_cf_opts)
@@ -3032,10 +3039,8 @@ void pegasus_server_impl::recalculate_data_cf_options(
                 new_options["write_buffer_size"] =
                     std::to_string(get_random_nearby(_data_cf_opts.write_buffer_size));
             }
-            UPDATE_OPTION_IF_NEEDED(
-                level0_file_num_compaction_trigger,
-                _data_cf_opts.level0_file_num_compaction_trigger,
-                std::to_string(_data_cf_opts.level0_file_num_compaction_trigger));
+            UPDATE_NUMBER_OPTION_IF_NEEDED(level0_file_num_compaction_trigger,
+                                           _data_cf_opts.level0_file_num_compaction_trigger);
         } else {
             uint64_t buffer_size = dsn::rand::next_u64(_data_cf_opts.write_buffer_size,
                                                        _data_cf_opts.write_buffer_size * 2);
@@ -3052,36 +3057,27 @@ void pegasus_server_impl::recalculate_data_cf_options(
                     std::to_string(std::max<uint64_t>(4UL, max_size / buffer_size));
             }
         }
-        UPDATE_OPTION_IF_NEEDED(level0_slowdown_writes_trigger,
-                                _data_cf_opts.level0_slowdown_writes_trigger,
-                                std::to_string(_data_cf_opts.level0_slowdown_writes_trigger));
-        UPDATE_OPTION_IF_NEEDED(level0_stop_writes_trigger,
-                                _data_cf_opts.level0_stop_writes_trigger,
-                                std::to_string(_data_cf_opts.level0_stop_writes_trigger));
-        UPDATE_OPTION_IF_NEEDED(soft_pending_compaction_bytes_limit,
-                                _data_cf_opts.soft_pending_compaction_bytes_limit,
-                                std::to_string(_data_cf_opts.soft_pending_compaction_bytes_limit));
-        UPDATE_OPTION_IF_NEEDED(hard_pending_compaction_bytes_limit,
-                                _data_cf_opts.hard_pending_compaction_bytes_limit,
-                                std::to_string(_data_cf_opts.hard_pending_compaction_bytes_limit));
-        UPDATE_OPTION_IF_NEEDED(disable_auto_compactions, false, "false");
-        UPDATE_OPTION_IF_NEEDED(max_compaction_bytes,
-                                _data_cf_opts.max_compaction_bytes,
-                                std::to_string(_data_cf_opts.max_compaction_bytes));
-        UPDATE_OPTION_IF_NEEDED(max_write_buffer_number,
-                                _data_cf_opts.max_write_buffer_number,
-                                std::to_string(_data_cf_opts.max_write_buffer_number));
+        UPDATE_NUMBER_OPTION_IF_NEEDED(level0_slowdown_writes_trigger,
+                                       _data_cf_opts.level0_slowdown_writes_trigger);
+        UPDATE_NUMBER_OPTION_IF_NEEDED(level0_stop_writes_trigger,
+                                       _data_cf_opts.level0_stop_writes_trigger);
+        UPDATE_NUMBER_OPTION_IF_NEEDED(soft_pending_compaction_bytes_limit,
+                                       _data_cf_opts.soft_pending_compaction_bytes_limit);
+        UPDATE_NUMBER_OPTION_IF_NEEDED(hard_pending_compaction_bytes_limit,
+                                       _data_cf_opts.hard_pending_compaction_bytes_limit);
+        UPDATE_BOOL_OPTION_IF_NEEDED(disable_auto_compactions, false);
+        UPDATE_NUMBER_OPTION_IF_NEEDED(max_compaction_bytes, _data_cf_opts.max_compaction_bytes);
+        UPDATE_NUMBER_OPTION_IF_NEEDED(max_write_buffer_number,
+                                       _data_cf_opts.max_write_buffer_number);
     } else {
         // ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD
-        UPDATE_OPTION_IF_NEEDED(level0_file_num_compaction_trigger, 1000000000, "1000000000");
-        UPDATE_OPTION_IF_NEEDED(level0_slowdown_writes_trigger, 1000000000, "1000000000");
-        UPDATE_OPTION_IF_NEEDED(level0_stop_writes_trigger, 1000000000, "1000000000");
-        UPDATE_OPTION_IF_NEEDED(soft_pending_compaction_bytes_limit, 0, "0");
-        UPDATE_OPTION_IF_NEEDED(hard_pending_compaction_bytes_limit, 0, "0");
-        UPDATE_OPTION_IF_NEEDED(disable_auto_compactions, true, "true");
-        UPDATE_OPTION_IF_NEEDED(max_compaction_bytes,
-                                static_cast<uint64_t>(1) << 60,
-                                std::to_string(static_cast<uint64_t>(1) << 60));
+        UPDATE_NUMBER_OPTION_IF_NEEDED(level0_file_num_compaction_trigger, 1000000000);
+        UPDATE_NUMBER_OPTION_IF_NEEDED(level0_slowdown_writes_trigger, 1000000000);
+        UPDATE_NUMBER_OPTION_IF_NEEDED(level0_stop_writes_trigger, 1000000000);
+        UPDATE_NUMBER_OPTION_IF_NEEDED(soft_pending_compaction_bytes_limit, 0);
+        UPDATE_NUMBER_OPTION_IF_NEEDED(hard_pending_compaction_bytes_limit, 0);
+        UPDATE_BOOL_OPTION_IF_NEEDED(disable_auto_compactions, true);
+        UPDATE_NUMBER_OPTION_IF_NEEDED(max_compaction_bytes, static_cast<uint64_t>(1) << 60);
         if (!check_value_if_nearby(_data_cf_opts.write_buffer_size * 4,
                                    cur_data_cf_opts.write_buffer_size)) {
             new_options["write_buffer_size"] =

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1560,9 +1560,9 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
 
     ddebug_replica("start to open rocksDB's rdb({})", rdb_path);
 
-    // Here we create a `_tmp_data_cf_opts` because we don't want to modify `_data_cf_opts`, which
+    // Here we create a `_table_data_cf_opts` because we don't want to modify `_data_cf_opts`, which
     // will be used elsewhere.
-    _tmp_data_cf_opts = _data_cf_opts;
+    _table_data_cf_opts = _data_cf_opts;
     _is_need_update_data_cf_opts = true;
     bool has_incompatible_db_options = false;
     if (db_exist) {
@@ -1610,7 +1610,7 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
             // We don't use `loaded_data_cf_opts` directly because pointer-typed options will
             // only be initialized with default values when calling 'LoadLatestOptions', see
             // 'rocksdb/utilities/options_util.h'.
-            reset_usage_scenario_options(loaded_data_cf_opts, &_tmp_data_cf_opts);
+            reset_usage_scenario_options(loaded_data_cf_opts, &_table_data_cf_opts);
             _db_opts.allow_ingest_behind = parse_allow_ingest_behind(envs);
         }
     } else {
@@ -1621,7 +1621,7 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
     }
 
     std::vector<rocksdb::ColumnFamilyDescriptor> column_families(
-        {{DATA_COLUMN_FAMILY_NAME, _tmp_data_cf_opts}, {META_COLUMN_FAMILY_NAME, _meta_cf_opts}});
+        {{DATA_COLUMN_FAMILY_NAME, _table_data_cf_opts}, {META_COLUMN_FAMILY_NAME, _meta_cf_opts}});
     auto s = rocksdb::CheckOptionsCompatibility(rdb_path,
                                                 rocksdb::Env::Default(),
                                                 _db_opts,
@@ -2638,7 +2638,7 @@ void pegasus_server_impl::update_usage_scenario(const std::map<std::string, std:
     } else {
         // When an old db is opened and the conf is changed, the options related to usage scenario
         // need to be recalculated with new values.
-        recalculate_data_cf_options(_tmp_data_cf_opts);
+        recalculate_data_cf_options(_table_data_cf_opts);
     }
 }
 

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1704,7 +1704,8 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
     } else {
         // When an old db is opened and the conf is changed, the options related to usage scenario
         // need to be recalculated with new values.
-        recalculate_usage_scenario(tmp_data_cf_opts);
+        // recalculate_usage_scenario(tmp_data_cf_opts);
+        ddebug_replica("wanghao: {}", _usage_scenario);
     }
 
     dinfo_replica("start the update replica-level rocksdb statistics timer task");
@@ -2638,6 +2639,10 @@ void pegasus_server_impl::update_usage_scenario(const std::map<std::string, std:
                            old_usage_scenario,
                            new_usage_scenario);
         }
+    } else {
+        // When an old db is opened and the conf is changed, the options related to usage scenario
+        // need to be recalculated with new values.
+        // recalculate_usage_scenario(tmp_data_cf_opts);
     }
 }
 

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -3011,7 +3011,7 @@ void pegasus_server_impl::reset_usage_scenario_options(
     target_opts->max_write_buffer_number = base_opts.max_write_buffer_number;
 }
 
-bool recalculate_usage_scenario(const rocksdb::ColumnFamilyOptions &cur_opts)
+bool pegasus_server_impl::recalculate_usage_scenario(const rocksdb::ColumnFamilyOptions &cur_opts)
 {
     std::unordered_map<std::string, std::string> new_options;
     if (ROCKSDB_ENV_USAGE_SCENARIO_NORMAL == _usage_scenario ||

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -3017,16 +3017,22 @@ void pegasus_server_impl::recalculate_data_cf_options(
     const rocksdb::ColumnFamilyOptions &cur_data_cf_opts)
 {
 #define UPDATE_NUMBER_OPTION_IF_NEEDED(option, value)                                              \
-    if ((value) != cur_data_cf_opts.option) {                                                      \
-        new_options[#option] = std::to_string((value));                                            \
-    }
+    do {                                                                                           \
+        if ((value) != cur_data_cf_opts.option) {                                                  \
+            new_options[#option] = std::to_string((value));                                        \
+        }                                                                                          \
+    } while (0)
+
 #define UPDATE_BOOL_OPTION_IF_NEEDED(option, value)                                                \
-    if ((value) != cur_data_cf_opts.option) {                                                      \
-        if ((value))                                                                               \
-            new_options[#option] = "true";                                                         \
-        else                                                                                       \
-            new_options[#option] = "false";                                                        \
-    }
+    do {                                                                                           \
+        if ((value) != cur_data_cf_opts.option) {                                                  \
+            if ((value))                                                                           \
+                new_options[#option] = "true";                                                     \
+            else                                                                                   \
+                new_options[#option] = "false";                                                    \
+        }                                                                                          \
+    } while (0)
+
 #define UPDATE_OPTION_IF_NEEDED(option) UPDATE_NUMBER_OPTION_IF_NEEDED(option, _data_cf_opts.option)
 
     if (!_table_data_cf_opts_recalculated)
@@ -3093,6 +3099,9 @@ void pegasus_server_impl::recalculate_data_cf_options(
         }
     }
     _table_data_cf_opts_recalculated = false;
+#undef UPDATE_OPTION_IF_NEEDED
+#undef UPDATE_BOOL_OPTION_IF_NEEDED
+#undef UPDATE_NUMBER_OPTION_IF_NEEDED
 }
 
 bool pegasus_server_impl::set_options(

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1563,7 +1563,7 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
     // Here we create a `_table_data_cf_opts` because we don't want to modify `_data_cf_opts`, which
     // will be used elsewhere.
     _table_data_cf_opts = _data_cf_opts;
-    _is_need_update_data_cf_opts = true;
+    _table_data_cf_opts_recalculated = true;
     bool has_incompatible_db_options = false;
     if (db_exist) {
         // When DB exists, meta CF and data CF must be present.
@@ -2636,8 +2636,8 @@ void pegasus_server_impl::update_usage_scenario(const std::map<std::string, std:
                            new_usage_scenario);
         }
     } else {
-        // When an old db is opened and the conf is changed, the options related to usage scenario
-        // need to be recalculated with new values.
+        // When an old db is opened and the rocksDB related configs in server config.ini has been
+        // changed, the options related to usage scenario need to be recalculated with new values.
         recalculate_data_cf_options(_table_data_cf_opts);
     }
 }
@@ -3027,8 +3027,9 @@ void pegasus_server_impl::recalculate_data_cf_options(
         else                                                                                       \
             new_options[#option] = "false";                                                        \
     }
+#define UPDATE_OPTION_IF_NEEDED(option) UPDATE_NUMBER_OPTION_IF_NEEDED(option, _data_cf_opts.option)
 
-    if (!_is_need_update_data_cf_opts)
+    if (!_table_data_cf_opts_recalculated)
         return;
     std::unordered_map<std::string, std::string> new_options;
     if (ROCKSDB_ENV_USAGE_SCENARIO_NORMAL == _usage_scenario ||
@@ -3039,8 +3040,7 @@ void pegasus_server_impl::recalculate_data_cf_options(
                 new_options["write_buffer_size"] =
                     std::to_string(get_random_nearby(_data_cf_opts.write_buffer_size));
             }
-            UPDATE_NUMBER_OPTION_IF_NEEDED(level0_file_num_compaction_trigger,
-                                           _data_cf_opts.level0_file_num_compaction_trigger);
+            UPDATE_OPTION_IF_NEEDED(level0_file_num_compaction_trigger);
         } else {
             uint64_t buffer_size = dsn::rand::next_u64(_data_cf_opts.write_buffer_size,
                                                        _data_cf_opts.write_buffer_size * 2);
@@ -3057,18 +3057,13 @@ void pegasus_server_impl::recalculate_data_cf_options(
                     std::to_string(std::max<uint64_t>(4UL, max_size / buffer_size));
             }
         }
-        UPDATE_NUMBER_OPTION_IF_NEEDED(level0_slowdown_writes_trigger,
-                                       _data_cf_opts.level0_slowdown_writes_trigger);
-        UPDATE_NUMBER_OPTION_IF_NEEDED(level0_stop_writes_trigger,
-                                       _data_cf_opts.level0_stop_writes_trigger);
-        UPDATE_NUMBER_OPTION_IF_NEEDED(soft_pending_compaction_bytes_limit,
-                                       _data_cf_opts.soft_pending_compaction_bytes_limit);
-        UPDATE_NUMBER_OPTION_IF_NEEDED(hard_pending_compaction_bytes_limit,
-                                       _data_cf_opts.hard_pending_compaction_bytes_limit);
+        UPDATE_OPTION_IF_NEEDED(level0_slowdown_writes_trigger);
+        UPDATE_OPTION_IF_NEEDED(level0_stop_writes_trigger);
+        UPDATE_OPTION_IF_NEEDED(soft_pending_compaction_bytes_limit);
+        UPDATE_OPTION_IF_NEEDED(hard_pending_compaction_bytes_limit);
         UPDATE_BOOL_OPTION_IF_NEEDED(disable_auto_compactions, false);
-        UPDATE_NUMBER_OPTION_IF_NEEDED(max_compaction_bytes, _data_cf_opts.max_compaction_bytes);
-        UPDATE_NUMBER_OPTION_IF_NEEDED(max_write_buffer_number,
-                                       _data_cf_opts.max_write_buffer_number);
+        UPDATE_OPTION_IF_NEEDED(max_compaction_bytes);
+        UPDATE_OPTION_IF_NEEDED(max_write_buffer_number);
     } else {
         // ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD
         UPDATE_NUMBER_OPTION_IF_NEEDED(level0_file_num_compaction_trigger, 1000000000);
@@ -3097,7 +3092,7 @@ void pegasus_server_impl::recalculate_data_cf_options(
                 _usage_scenario);
         }
     }
-    _is_need_update_data_cf_opts = false;
+    _table_data_cf_opts_recalculated = false;
 }
 
 bool pegasus_server_impl::set_options(

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -434,8 +434,8 @@ private:
     rocksdb::ReadOptions _data_cf_rd_opts;
     std::string _usage_scenario;
     std::string _user_specified_compaction;
-    // Whether it is necessary to update the current data_cf, it is required when opening the db at the first time,
-    // but not later
+    // Whether it is necessary to update the current data_cf, it is required when opening the db at
+    // the first time, but not later
     bool _table_data_cf_opts_recalculated;
 
     rocksdb::DB *_db;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -313,7 +313,7 @@ private:
     bool set_usage_scenario(const std::string &usage_scenario);
 
     // recalculate option value if necessary
-    void recalculate_usage_scenario(const rocksdb::ColumnFamilyOptions &cur_opts);
+    void recalculate_data_cf_options(const rocksdb::ColumnFamilyOptions &cur_data_cf_opts);
 
     void reset_usage_scenario_options(const rocksdb::ColumnFamilyOptions &base_opts,
                                       rocksdb::ColumnFamilyOptions *target_opts);
@@ -431,6 +431,9 @@ private:
     rocksdb::ReadOptions _data_cf_rd_opts;
     std::string _usage_scenario;
     std::string _user_specified_compaction;
+    // Whether it is necessary to update the current data_cf, it is required when opening the db,
+    // but not later
+    bool _is_need_update_data_cf_opts;
 
     rocksdb::DB *_db;
     rocksdb::ColumnFamilyHandle *_data_cf;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -312,6 +312,10 @@ private:
     // return true if successfully changed
     bool set_usage_scenario(const std::string &usage_scenario);
 
+    // return true if need recalculate option value
+    bool recalculate_usage_scenario(const std::string &usage_scenario,
+                                    const rocksdb::ColumnFamilyOptions &cur_opts);
+
     void reset_usage_scenario_options(const rocksdb::ColumnFamilyOptions &base_opts,
                                       rocksdb::ColumnFamilyOptions *target_opts);
 
@@ -323,6 +327,13 @@ private:
     {
         uint64_t gap = base_value / 4;
         return dsn::rand::next_u64(base_value - gap, base_value + gap);
+    }
+
+    // return true if value in range of [0.75, 1.25] * base_value
+    bool check_value_if_nearby(uint64_t base_value, uint64_t check_value)
+    {
+        uint64_t gap = base_value / 4;
+        return std::abs(base_value - check_value) <= gap;
     }
 
     // return true if expired

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -426,7 +426,7 @@ private:
     std::shared_ptr<rocksdb::Statistics> _statistics;
     rocksdb::DBOptions _db_opts;
     rocksdb::ColumnFamilyOptions _data_cf_opts;
-    rocksdb::ColumnFamilyOptions _tmp_data_cf_opts;
+    rocksdb::ColumnFamilyOptions _table_data_cf_opts;
     rocksdb::ColumnFamilyOptions _meta_cf_opts;
     rocksdb::ReadOptions _data_cf_rd_opts;
     std::string _usage_scenario;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -434,7 +434,7 @@ private:
     rocksdb::ReadOptions _data_cf_rd_opts;
     std::string _usage_scenario;
     std::string _user_specified_compaction;
-    // Whether it is necessary to update the current data_cf, it is required when opening the db,
+    // Whether it is necessary to update the current data_cf, it is required when opening the db at the first time,
     // but not later
     bool _table_data_cf_opts_recalculated;
 

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -428,7 +428,7 @@ private:
     // The value of option in data_cf according to conf template file config.ini
     rocksdb::ColumnFamilyOptions _data_cf_opts;
     // Dynamically calculate the value of current data_cf option according to the conf module file
-    // and usage mode
+    // and usage scenario
     rocksdb::ColumnFamilyOptions _table_data_cf_opts;
     rocksdb::ColumnFamilyOptions _meta_cf_opts;
     rocksdb::ReadOptions _data_cf_rd_opts;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -426,6 +426,7 @@ private:
     std::shared_ptr<rocksdb::Statistics> _statistics;
     rocksdb::DBOptions _db_opts;
     rocksdb::ColumnFamilyOptions _data_cf_opts;
+    rocksdb::ColumnFamilyOptions _tmp_data_cf_opts;
     rocksdb::ColumnFamilyOptions _meta_cf_opts;
     rocksdb::ReadOptions _data_cf_rd_opts;
     std::string _usage_scenario;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -312,8 +312,8 @@ private:
     // return true if successfully changed
     bool set_usage_scenario(const std::string &usage_scenario);
 
-    // return true if need recalculate option value
-    bool recalculate_usage_scenario(const rocksdb::ColumnFamilyOptions &cur_opts);
+    // recalculate option value if necessary
+    void recalculate_usage_scenario(const rocksdb::ColumnFamilyOptions &cur_opts);
 
     void reset_usage_scenario_options(const rocksdb::ColumnFamilyOptions &base_opts,
                                       rocksdb::ColumnFamilyOptions *target_opts);

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -313,8 +313,7 @@ private:
     bool set_usage_scenario(const std::string &usage_scenario);
 
     // return true if need recalculate option value
-    bool recalculate_usage_scenario(const std::string &usage_scenario,
-                                    const rocksdb::ColumnFamilyOptions &cur_opts);
+    bool recalculate_usage_scenario(const rocksdb::ColumnFamilyOptions &cur_opts);
 
     void reset_usage_scenario_options(const rocksdb::ColumnFamilyOptions &base_opts,
                                       rocksdb::ColumnFamilyOptions *target_opts);

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -332,7 +332,9 @@ private:
     bool check_value_if_nearby(uint64_t base_value, uint64_t check_value)
     {
         uint64_t gap = base_value / 4;
-        return std::abs(base_value - check_value) <= gap;
+        uint64_t actual_gap =
+            (base_value < check_value) ? check_value - base_value : base_value - check_value;
+        return actual_gap <= gap;
     }
 
     // return true if expired

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -433,7 +433,7 @@ private:
     std::string _user_specified_compaction;
     // Whether it is necessary to update the current data_cf, it is required when opening the db,
     // but not later
-    bool _is_need_update_data_cf_opts;
+    bool _table_data_cf_opts_recalculated;
 
     rocksdb::DB *_db;
     rocksdb::ColumnFamilyHandle *_data_cf;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -425,7 +425,10 @@ private:
     std::shared_ptr<KeyWithTTLCompactionFilterFactory> _key_ttl_compaction_filter_factory;
     std::shared_ptr<rocksdb::Statistics> _statistics;
     rocksdb::DBOptions _db_opts;
+    // The value of option in data_cf according to conf template file config.ini
     rocksdb::ColumnFamilyOptions _data_cf_opts;
+    // Dynamically calculate the value of current data_cf option according to the conf module file
+    // and usage mode
     rocksdb::ColumnFamilyOptions _table_data_cf_opts;
     rocksdb::ColumnFamilyOptions _meta_cf_opts;
     rocksdb::ReadOptions _data_cf_rd_opts;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1025

### What is changed and how does it work?

 The specific reason is that if you open an existing rocksdb, the usage scenario will be set to normal first, and then set to the corresponding mode according to the actual usage scenario. This process will change the relevant options, causing rocksdb to execute flush and compact, so in order to avoid this situation (https://github.com/apache/incubator-pegasus/pull/587), rocksdb::LoadLatestOptions is called, and these parameters are initialized with the last value, so the last thing you see is that if the configuration file is modified, and without changing the usage scenario mode, these modified configurations will not take effect after restart.

Options involved:
```
level0_file_num_compaction_trigger
level0_slowdown_writes_trigger
level0_stop_writes_trigger
soft_pending_compaction_bytes_limit
hard_pending_compaction_bytes_limit
disable_auto_compactions
max_compaction_bytes
write_buffer_size
max_write_buffer_number
```
Solution: 
1. After opening rocksdb, calculate the value of the corresponding options according to the usage scenario mode in the environment variable, compare whether there is a change, and call setOpion() if there is a change to set the newly calculated value. 
3. If the usage scenario mode has been changed during this process, the options will be the correct value, and nothing needs to be done.

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

-