### PR TITLE
feat: add some functions for block service manager

### DIFF
--- a/src/rdsn/src/block_service/block_service_manager.cpp
+++ b/src/rdsn/src/block_service/block_service_manager.cpp
@@ -112,6 +112,20 @@ static create_file_response create_block_file_sync(const std::string &remote_fil
     return ret;
 }
 
+error_code block_service_manager::create_block_file(const std::string &remote_file_name,
+                                                    bool ignore_meta,
+                                                    block_filesystem *fs,
+                                                    task_tracker *tracker,
+                                                    /*out*/ create_file_response &create_resp)
+{
+    create_resp = create_block_file_sync(remote_file_name, ignore_meta, fs, tracker);
+    const auto &err = create_resp.err;
+    if (err != ERR_OK) {
+        derror_f("create file({}) failed with error({})", remote_file_name, err.to_string());
+    }
+    return err;
+}
+
 static download_response
 download_block_file_sync(const std::string &local_file_path, block_file *bf, task_tracker *tracker)
 {
@@ -150,19 +164,19 @@ error_code block_service_manager::download_file(const std::string &remote_dir,
     }
 
     task_tracker tracker;
-
     // Create a block_file object.
-    const std::string remote_file_name = utils::filesystem::path_combine(remote_dir, file_name);
-    auto create_resp =
-        create_block_file_sync(remote_file_name, false /*ignore file meta*/, fs, &tracker);
-    error_code err = create_resp.err;
+    create_file_response create_resp;
+    auto err = create_block_file(utils::filesystem::path_combine(remote_dir, file_name),
+                                 false /*ignore file meta*/,
+                                 fs,
+                                 &tracker,
+                                 create_resp);
     if (err != ERR_OK) {
-        derror_f("create file({}) failed with error({})", remote_file_name, err.to_string());
         return err;
     }
-    block_file_ptr bf = create_resp.file_handle;
 
-    download_response resp = download_block_file_sync(local_file_name, bf.get(), &tracker);
+    download_response resp =
+        download_block_file_sync(local_file_name, create_resp.file_handle.get(), &tracker);
     if (resp.err != ERR_OK) {
         // during bulk load process, ERR_OBJECT_NOT_FOUND will be considered as a recoverable
         // error, however, if file damaged on remote file provider, bulk load should stop,
@@ -202,21 +216,20 @@ error_code block_service_manager::upload_file(const std::string &remote_dir,
                                               block_filesystem *fs)
 {
     task_tracker tracker;
-
     // Create a block_file object.
-    const auto &remote_file_name = utils::filesystem::path_combine(remote_dir, file_name);
-    const auto &create_resp =
-        create_block_file_sync(remote_file_name, false /*ignore file meta*/, fs, &tracker);
-    const auto &err = create_resp.err;
+    create_file_response create_resp;
+    auto err = create_block_file(utils::filesystem::path_combine(remote_dir, file_name),
+                                 false /*ignore file meta*/,
+                                 fs,
+                                 &tracker,
+                                 create_resp);
     if (err != ERR_OK) {
-        derror_f("create file({}) failed with error({})", remote_file_name, err.to_string());
         return err;
     }
-    block_file_ptr bf = create_resp.file_handle;
-
     // Upload file
     const auto &local_file_name = utils::filesystem::path_combine(local_dir, file_name);
-    const upload_response &resp = upload_block_file_sync(local_file_name, bf.get(), &tracker);
+    const upload_response &resp =
+        upload_block_file_sync(local_file_name, create_resp.file_handle.get(), &tracker);
     if (resp.err != ERR_OK) {
         return resp.err;
     }
@@ -242,20 +255,17 @@ error_code block_service_manager::write_file(const std::string &remote_dir,
                                              block_filesystem *fs)
 {
     task_tracker tracker;
-
     // Create a block_file object.
+    create_file_response create_resp;
     const auto &remote_file_name = utils::filesystem::path_combine(remote_dir, file_name);
-    const auto &create_resp =
-        create_block_file_sync(remote_file_name, false /*ignore file meta*/, fs, &tracker);
-    const auto &err = create_resp.err;
+    auto err =
+        create_block_file(remote_file_name, false /*ignore file meta*/, fs, &tracker, create_resp);
     if (err != ERR_OK) {
-        derror_f("create file({}) failed with error({})", remote_file_name, err.to_string());
         return err;
     }
-    block_file_ptr bf = create_resp.file_handle;
-
     // Write blob
-    const write_response &resp = write_block_file_sync(value, bf.get(), &tracker);
+    const write_response &resp =
+        write_block_file_sync(value, create_resp.file_handle.get(), &tracker);
     if (resp.err != ERR_OK) {
         return resp.err;
     }
@@ -296,20 +306,17 @@ error_code block_service_manager::read_file(const std::string &remote_dir,
                                             blob &value)
 {
     task_tracker tracker;
-
     // Create a block_file object.
+    create_file_response create_resp;
     const auto &remote_file_name = utils::filesystem::path_combine(remote_dir, file_name);
-    const auto &create_resp =
-        create_block_file_sync(remote_file_name, false /*ignore file meta*/, fs, &tracker);
-    const auto &err = create_resp.err;
+    auto err =
+        create_block_file(remote_file_name, false /*ignore file meta*/, fs, &tracker, create_resp);
     if (err != ERR_OK) {
-        derror_f("create file({}) failed with error({})", remote_file_name, err.to_string());
         return err;
     }
-    block_file_ptr bf = create_resp.file_handle;
-
     // Read blob
-    const read_response &resp = read_block_file_sync(bf.get(), 0, -1, &tracker);
+    const read_response &resp = read_block_file_sync(
+        create_resp.file_handle.get(), 0 /*remote_pos*/, -1 /*remote_length*/, &tracker);
     if (resp.err != ERR_OK) {
         return resp.err;
     }

--- a/src/rdsn/src/block_service/block_service_manager.h
+++ b/src/rdsn/src/block_service/block_service_manager.h
@@ -69,6 +69,14 @@ public:
                              block_filesystem *fs,
                              /*out*/ uint64_t &download_file_size);
 
+    // write blob value onto remote file system
+    // \return  ERR_FILE_OPERATION_FAILED: local file system error
+    // \return  ERR_FS_INTERNAL: remote file system error
+    error_code write_file(const std::string &remote_dir,
+                          const std::string &file_name,
+                          const blob &value,
+                          block_filesystem *fs);
+
 private:
     block_service_registry &_registry_holder;
 

--- a/src/rdsn/src/block_service/block_service_manager.h
+++ b/src/rdsn/src/block_service/block_service_manager.h
@@ -69,6 +69,14 @@ public:
                              block_filesystem *fs,
                              /*out*/ uint64_t &download_file_size);
 
+    // upload files from remote file system
+    // \return  ERR_FILE_OPERATION_FAILED: local file system error
+    // \return  ERR_FS_INTERNAL: remote file system error
+    error_code upload_file(const std::string &remote_dir,
+                           const std::string &local_dir,
+                           const std::string &file_name,
+                           block_filesystem *fs);
+
     // write blob value onto remote file system
     // \return  ERR_FILE_OPERATION_FAILED: local file system error
     // \return  ERR_FS_INTERNAL: remote file system error
@@ -76,6 +84,20 @@ public:
                           const std::string &file_name,
                           const blob &value,
                           block_filesystem *fs);
+
+    // remove path on remote file system
+    // \return ERR_OBJECT_NOT_FOUND: remove path not exist
+    // \return ERR_FS_INTERNAL: remote file system error
+    // \return ERR_DIR_NOT_EMPTY: path not empty
+    error_code remove_path(const std::string &path, bool recursive, block_filesystem *fs);
+
+    // read blob value from remote file system
+    // \return  ERR_FILE_OPERATION_FAILED: local file system error
+    // \return  ERR_FS_INTERNAL: remote file system error
+    error_code read_file(const std::string &remote_dir,
+                         const std::string &file_name,
+                         block_filesystem *fs,
+                         /*out*/ blob &value);
 
 private:
     block_service_registry &_registry_holder;

--- a/src/rdsn/src/block_service/block_service_manager.h
+++ b/src/rdsn/src/block_service/block_service_manager.h
@@ -45,6 +45,14 @@ public:
     ~block_service_manager();
     block_filesystem *get_or_create_block_filesystem(const std::string &provider);
 
+    // create block file
+    // \return  ERR_FS_INTERNAL: remote file system error
+    error_code create_block_file(const std::string &remote_file_name,
+                                 bool ignore_meta,
+                                 block_filesystem *fs,
+                                 task_tracker *tracker,
+                                 /*out*/ create_file_response &resp);
+
     // download files from remote file system
     // \return  ERR_FILE_OPERATION_FAILED: local file system error
     // \return  ERR_FS_INTERNAL: remote file system error

--- a/src/rdsn/src/block_service/test/block_service_manager_test.cpp
+++ b/src/rdsn/src/block_service/test/block_service_manager_test.cpp
@@ -46,6 +46,12 @@ public:
             PROVIDER, LOCAL_DIR, FILE_NAME, _fs.get(), download_size);
     }
 
+    error_code test_write_file()
+    {
+        return _block_service_manager.write_file(
+            PROVIDER, FILE_NAME, blob::create_from_bytes("test_value"), _fs.get());
+    }
+
     void create_local_file(const std::string &file_name)
     {
         std::string whole_name = utils::filesystem::path_combine(LOCAL_DIR, file_name);
@@ -118,6 +124,8 @@ TEST_F(block_service_manager_test, do_download_succeed)
     ASSERT_EQ(test_download_file(download_size), ERR_OK);
     ASSERT_EQ(download_size, _file_meta.size);
 }
+
+TEST_F(block_service_manager_test, write_file_test) { ASSERT_EQ(test_write_file(), ERR_OK); }
 
 } // namespace block_service
 } // namespace dist

--- a/src/rdsn/src/block_service/test/block_service_mock.h
+++ b/src/rdsn/src/block_service/test/block_service_mock.h
@@ -145,7 +145,10 @@ class block_service_mock : public block_filesystem
 {
 public:
     block_service_mock()
-        : block_filesystem(), enable_create_file_fail(false), enable_list_dir_fail(false)
+        : block_filesystem(),
+          enable_create_file_fail(false),
+          enable_list_dir_fail(false),
+          enable_remote_path_fail(false)
     {
     }
     virtual error_code initialize(const std::vector<std::string> &args) { return ERR_OK; }


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1081
This pr adds following functions for block service manager:
- upload_file
- read_file
- write_file
- remove_path

All of them will be used for backup and restore in further prs.