### PR TITLE
fix(actions): fix docker images conflict on different branches

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -55,7 +55,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache
@@ -142,7 +142,7 @@ jobs:
     needs: build_Release
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2
@@ -168,7 +168,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache
@@ -249,7 +249,7 @@ jobs:
     needs: build_ASAN
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2
@@ -275,7 +275,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache
@@ -356,7 +356,7 @@ jobs:
     needs: build_UBSAN
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -55,7 +55,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache
@@ -142,7 +142,7 @@ jobs:
     needs: build_Release
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2
@@ -168,7 +168,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache
@@ -249,7 +249,7 @@ jobs:
     needs: build_ASAN
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2
@@ -275,7 +275,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache
@@ -356,7 +356,7 @@ jobs:
     needs: build_UBSAN
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804
+      image: apache/pegasus:thirdparties-bin-ubuntu1804-{{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -72,6 +72,7 @@ jobs:
               - 'cmake_modules/**'
               - 'CMakeLists.txt'
               - 'run.sh'
+              - '.github/workflows/lint_and_test_cpp.yaml'
             src:
               - 'src/**'
             thirdparty:
@@ -185,6 +186,7 @@ jobs:
               - 'cmake_modules/**'
               - 'CMakeLists.txt'
               - 'run.sh'
+              - '.github/workflows/lint_and_test_cpp.yaml'
             src:
               - 'src/**'
             thirdparty:
@@ -292,6 +294,7 @@ jobs:
               - 'cmake_modules/**'
               - 'CMakeLists.txt'
               - 'run.sh'
+              - '.github/workflows/lint_and_test_cpp.yaml'
             src:
               - 'src/**'
             thirdparty:

--- a/.github/workflows/pegasus-regular-build.yml
+++ b/.github/workflows/pegasus-regular-build.yml
@@ -51,7 +51,7 @@ jobs:
             compiler: "clang-9,clang++-9"
             os: ubuntu1804
     container:
-      image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-master
+      image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-${{ github.ref_name }}
     defaults:
       run:
         working-directory: /root/incubator-pegasus

--- a/.github/workflows/pegasus-regular-build.yml
+++ b/.github/workflows/pegasus-regular-build.yml
@@ -51,7 +51,7 @@ jobs:
             compiler: "clang-9,clang++-9"
             os: ubuntu1804
     container:
-      image: apache/pegasus:thirdparties-bin-${{ matrix.os }}
+      image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-master
     defaults:
       run:
         working-directory: /root/incubator-pegasus

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -93,7 +93,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-${{ matrix.osversion }}-master
+            apache/pegasus:thirdparties-bin-${{ matrix.osversion }}-${{ github.ref_name }}
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -93,7 +93,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-${{ matrix.osversion }}-${{ github.ref_name }}
+            apache/pegasus:thirdparties-bin-${{ matrix.osversion }}-master
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -58,7 +58,7 @@ jobs:
           file: ./docker/thirdparties-src/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-src-${{ github.ref_name }}
+            apache/pegasus:thirdparties-src-master
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
       - name: Image digest

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -58,7 +58,7 @@ jobs:
           file: ./docker/thirdparties-src/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-src
+            apache/pegasus:thirdparties-src-${{ github.ref_name }}
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
       - name: Image digest
@@ -93,7 +93,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-${{ matrix.osversion }}
+            apache/pegasus:thirdparties-bin-${{ matrix.osversion }}-${{ github.ref_name }}
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -58,7 +58,7 @@ jobs:
           file: ./docker/thirdparties-src/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-src-master
+            apache/pegasus:thirdparties-src-${{ github.ref_name }}
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
       - name: Image digest

--- a/docker/README.md
+++ b/docker/README.md
@@ -51,14 +51,14 @@ It packages the downloaded sources into a zip in the container, so that
 other repos can easily extract third-parties from the container (via `docker cp`),
 without downloading from the cloud object storage.
 
-- `apache/pegasus:thirdparties-src`
+- `apache/pegasus:thirdparties-src-<branch>`
 
 ## thirdparties-bin
 
 This is a Docker image for Pegasus unit-testing. It prebuilts the thirdparty libraries,
 so jobs based on this image can skip building third-parties.
 
-- `apache/pegasus:thirdparties-bin-centos7`
-- `apache/pegasus:thirdparties-bin-ubuntu1604`
-- `apache/pegasus:thirdparties-bin-ubuntu1804`
-- `apache/pegasus:thirdparties-bin-ubuntu2004`
+- `apache/pegasus:thirdparties-bin-centos7-master`
+- `apache/pegasus:thirdparties-bin-ubuntu1604-master`
+- `apache/pegasus:thirdparties-bin-ubuntu1804-master`
+- `apache/pegasus:thirdparties-bin-ubuntu2004-master`

--- a/docker/thirdparties-bin/Dockerfile
+++ b/docker/thirdparties-bin/Dockerfile
@@ -16,9 +16,8 @@
 # under the License.
 
 ARG GITHUB_BRANCH=master
-FROM apache/pegasus:thirdparties-src-${GITHUB_BRANCH} as builder
-
 ARG OS_VERSION=centos7
+FROM apache/pegasus:thirdparties-src-${GITHUB_BRANCH} as builder
 FROM apache/pegasus:build-env-${OS_VERSION}
 
 WORKDIR /root

--- a/docker/thirdparties-bin/Dockerfile
+++ b/docker/thirdparties-bin/Dockerfile
@@ -16,6 +16,7 @@
 # under the License.
 
 ARG OS_VERSION=centos7
+ARG GITHUB_BRANCH=master
 FROM apache/pegasus:thirdparties-src-${GITHUB_BRANCH} as builder
 
 ARG OS_VERSION=centos7
@@ -25,7 +26,6 @@ WORKDIR /root
 
 COPY --from=builder /root/thirdparties-src.zip /root/thirdparties-src.zip
 
-ARG GITHUB_BRANCH=master
 ARG GITHUB_REPOSITORY_URL=https://github.com/apache/incubator-pegasus.git
 RUN git clone --depth=1 --branch=${GITHUB_BRANCH} ${GITHUB_REPOSITORY_URL} \
     && cd incubator-pegasus/thirdparty \

--- a/docker/thirdparties-bin/Dockerfile
+++ b/docker/thirdparties-bin/Dockerfile
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARG OS_VERSION=centos7
 ARG GITHUB_BRANCH=master
 FROM apache/pegasus:thirdparties-src-${GITHUB_BRANCH} as builder
 
@@ -26,6 +25,7 @@ WORKDIR /root
 
 COPY --from=builder /root/thirdparties-src.zip /root/thirdparties-src.zip
 
+ARG GITHUB_BRANCH=master
 ARG GITHUB_REPOSITORY_URL=https://github.com/apache/incubator-pegasus.git
 RUN git clone --depth=1 --branch=${GITHUB_BRANCH} ${GITHUB_REPOSITORY_URL} \
     && cd incubator-pegasus/thirdparty \

--- a/docker/thirdparties-bin/Dockerfile
+++ b/docker/thirdparties-bin/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG OS_VERSION=centos7
-FROM apache/pegasus:thirdparties-src as builder
+FROM apache/pegasus:thirdparties-src-${GITHUB_BRANCH} as builder
 
 ARG OS_VERSION=centos7
 FROM apache/pegasus:build-env-${OS_VERSION}


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1113

Now different branches of apache repo will push docker images to DockerHub, this will introduce conflicts if they are not compatiable(e.g. thirdparty changes and not compatiable).
This patch is aim to push differnet name of docker images to DockerHub and will use different images according to the target branch name.