### PR TITLE
fix(github): fix the conditions for file changes that trigger workflows

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -32,6 +32,13 @@ on:
       - 'v[0-9]+.*' # release branch
       - ci-test # testing branch for github action
       - '*dev'
+    paths:
+      - '.github/workflows/lint_and_test_cpp.yaml'
+      - 'CMakeLists.txt'
+      - 'run.sh'
+      - 'cmake_modules/**'
+      - 'src/**'
+      - 'thirdparty/**'
 
   # for manually triggering workflow
   workflow_dispatch:
@@ -68,13 +75,6 @@ jobs:
         id: changes
         with:
           filters: |
-            base:
-              - 'cmake_modules/**'
-              - 'CMakeLists.txt'
-              - 'run.sh'
-              - '.github/workflows/lint_and_test_cpp.yaml'
-            src:
-              - 'src/**'
             thirdparty:
               - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
@@ -88,22 +88,19 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Release -B build/
           cmake --build build/ -j $(nproc)
       - name: Compilation
-        if: steps.changes.outputs.base == 'true' || steps.changes.outputs.src == 'true' || steps.changes.outputs.thirdparty == 'true'
         run: |
           ccache -p
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release
           ccache -s
       - name: Pack Server
-        if: steps.changes.outputs.base == 'true' || steps.changes.outputs.src == 'true' || steps.changes.outputs.thirdparty == 'true'
         run: ./run.sh pack_server
       - name: Pack Tools
-        if: steps.changes.outputs.base == 'true' || steps.changes.outputs.src == 'true' || steps.changes.outputs.thirdparty == 'true'
         run: ./run.sh pack_tools
       - name: Tar files
         run: |
           rm -rf thirdparty
-          tar -zcvhf release__builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini  --exclude='*CMakeFiles*'
+          tar -zcvhf release__builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini --exclude='*CMakeFiles*'
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -182,13 +179,6 @@ jobs:
         id: changes
         with:
           filters: |
-            base:
-              - 'cmake_modules/**'
-              - 'CMakeLists.txt'
-              - 'run.sh'
-              - '.github/workflows/lint_and_test_cpp.yaml'
-            src:
-              - 'src/**'
             thirdparty:
               - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
@@ -202,7 +192,6 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Release -B build/
           cmake --build build/ -j $(nproc)
       - name: Compilation
-        if: steps.changes.outputs.base == 'true' || steps.changes.outputs.src == 'true' || steps.changes.outputs.thirdparty == 'true'
         run: |
           ccache -p
           ccache -z
@@ -211,7 +200,7 @@ jobs:
       - name: Tar files
         run: |
           rm -rf thirdparty
-          tar -zcvhf release_address_builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini  --exclude='*CMakeFiles*'
+          tar -zcvhf release_address_builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini --exclude='*CMakeFiles*'
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -290,13 +279,6 @@ jobs:
         id: changes
         with:
           filters: |
-            base:
-              - 'cmake_modules/**'
-              - 'CMakeLists.txt'
-              - 'run.sh'
-              - '.github/workflows/lint_and_test_cpp.yaml'
-            src:
-              - 'src/**'
             thirdparty:
               - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
@@ -310,7 +292,6 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Release -B build/
           cmake --build build/ -j $(nproc)
       - name: Compilation
-        if: steps.changes.outputs.base == 'true' || steps.changes.outputs.src == 'true' || steps.changes.outputs.thirdparty == 'true'
         run: |
           ccache -p
           ccache -z
@@ -319,7 +300,7 @@ jobs:
       - name: Tar files
         run: |
           rm -rf thirdparty
-          tar -zcvhf release_undefined_builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini  --exclude='*CMakeFiles*'
+          tar -zcvhf release_undefined_builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini --exclude='*CMakeFiles*'
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -412,16 +393,7 @@ jobs:
           mkdir -p build
           cmake -DCMAKE_BUILD_TYPE=Release -B build/ -DMACOS_OPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}
           cmake --build build/ -j $(sysctl -n hw.physicalcpu)
-      - uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          filters: |
-            src:
-              - 'src/**'
-            thirdparty:
-              - 'thirdparty/**'
       - name: Compilation
-        if: steps.changes.outputs.src == 'true' || steps.changes.outputs.thirdparty == 'true'
         run: |
           ccache -p
           ccache -z


### PR DESCRIPTION
This PR is to solve https://github.com/apache/incubator-pegasus/issues/1122.

To filter all the file changes that should trigger actions for github, at beginning of CI all of the path patterns are listed, which means workflows for build and test will never be run for the files that are irrelevant. 