### PR TITLE
fix: update pegasus regular ci docker version base branch

### DIFF
--- a/.github/workflows/pegasus-regular-build.yml
+++ b/.github/workflows/pegasus-regular-build.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/apache/incubator-pegasus.git
           cd incubator-pegasus
+          git checkout ${{ github.ref_name }}
       - name: Unpack prebuilt third-parties
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Compilation pegasus on GCC


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1125

When pegasus run regular ci, it will clone `master` code, but use the current branch docker images, this will cause ci falied.

### What is changed and how does it work?
clone code and checkout the current branch
Note: 
need merge v2.4 https://github.com/apache/incubator-pegasus/issues/1032
### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test

##### Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

##### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
