### PR TITLE
fix: update pegasus clone branch when regular ci docker

### DIFF
--- a/.github/workflows/pegasus-regular-build.yml
+++ b/.github/workflows/pegasus-regular-build.yml
@@ -59,9 +59,8 @@ jobs:
       - name: Clone Apache Pegasus Source
         working-directory: /root
         run: |
-          git clone --depth=1 https://github.com/apache/incubator-pegasus.git
+          git clone -b ${{ github.ref_name }} --depth=1 https://github.com/apache/incubator-pegasus.git
           cd incubator-pegasus
-          git checkout ${{ github.ref_name }}
       - name: Unpack prebuilt third-parties
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Compilation pegasus on GCC


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR is used for fixing https://github.com/apache/incubator-pegasus/pull/1124, which only clone master and cause checkout failed, the issue ref: https://github.com/apache/incubator-pegasus/issues/1125