### PR TITLE
fix(actinos): use portable thirdparties-bin-test-* as the base image to build and run unit tests for CI on github

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -65,7 +65,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache
@@ -146,7 +146,7 @@ jobs:
     needs: build_Release
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2
@@ -172,7 +172,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache
@@ -249,7 +249,7 @@ jobs:
     needs: build_ASAN
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2
@@ -275,7 +275,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache
@@ -352,7 +352,7 @@ jobs:
     needs: build_UBSAN
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR is to resolve https://github.com/apache/incubator-pegasus/issues/1135.

Since `thirdparties-bin-test-*` images had been committed to be built in https://github.com/apache/incubator-pegasus/pull/1136, first portable image of third-parties for master branch such as [apache/pegasus/thirdparties-bin-test-ubuntu1804-master](https://hub.docker.com/layers/pegasus/apache/pegasus/thirdparties-bin-test-ubuntu1804-master/images/sha256-d35457046181cb8575b2c30912f478cdea5c84b54b035be8ffce77a5a81df7ee?context=explore) was already pushed to [dockerhub](https://hub.docker.com).

To run unit tests on github `thirdparties-bin-test-*` image should be added to C++ workflow. This is the purpose of this PR.