### PR TITLE
feat(backup): 7. replica upload backup files

### DIFF
--- a/src/rdsn/src/common/backup_restore_common.cpp
+++ b/src/rdsn/src/common/backup_restore_common.cpp
@@ -34,6 +34,7 @@ const std::string backup_constant::CURRENT_CHECKPOINT("current_checkpoint");
 const std::string backup_constant::BACKUP_METADATA("backup_metadata");
 const std::string backup_constant::BACKUP_INFO("backup_info");
 const int32_t backup_constant::PROGRESS_FINISHED = 1000;
+const std::string backup_constant::DATA_VERSION("data_version");
 
 const std::string backup_restore_constant::FORCE_RESTORE("restore.force_restore");
 const std::string backup_restore_constant::BLOCK_SERVICE_PROVIDER("restore.block_service_provider");
@@ -76,6 +77,28 @@ std::string get_backup_meta_path(const std::string &root,
 {
     return fmt::format("{}/meta",
                        get_backup_path(root, app_name, app_id, backup_id, is_compatible));
+}
+
+std::string get_backup_partition_path(const std::string &root,
+                                      const std::string &app_name,
+                                      const int32_t app_id,
+                                      const int64_t backup_id,
+                                      const int32_t pidx,
+                                      const bool is_compatible)
+{
+    return fmt::format(
+        "{}/{}", get_backup_path(root, app_name, app_id, backup_id, is_compatible), pidx);
+}
+
+std::string get_checkpoint_str()
+{
+    auto node_address = dsn_primary_address();
+    return fmt::format("chkpt_{}_{}", node_address.ipv4_str(), node_address.port());
+}
+
+std::string get_backup_checkpoint_path(const std::string &partition_path)
+{
+    return fmt::format("{}/{}", partition_path, get_checkpoint_str());
 }
 
 } // namespace replication

--- a/src/rdsn/src/common/backup_restore_common.h
+++ b/src/rdsn/src/common/backup_restore_common.h
@@ -39,6 +39,7 @@ public:
     static const std::string BACKUP_METADATA;
     static const std::string BACKUP_INFO;
     static const int32_t PROGRESS_FINISHED;
+    static const std::string DATA_VERSION;
 };
 
 typedef rpc_holder<backup_request, backup_response> backup_rpc;
@@ -120,6 +121,29 @@ std::string get_backup_meta_path(const std::string &root,
                                  const int32_t app_id,
                                  const int64_t backup_id,
                                  const bool is_compatible = false);
+
+// This backup partition path on block service
+// if is_compatible = false (root is the return value of get_backup_root function)
+// - return <root>/<app_name>_<app_id>/<backup_id>/<pidx>
+// else (only used for restore compatible backup, root is the return value of
+// get_compatible_backup_root function)
+// - return <root>/<backup_id>/<app_name>_<app_id>/<pidx>
+std::string get_backup_partition_path(const std::string &root,
+                                      const std::string &app_name,
+                                      const int32_t app_id,
+                                      const int64_t backup_id,
+                                      const int32_t pidx,
+                                      const bool is_compatible = false);
+
+// Get replica node checkpoint directory string
+// return chkpt_<node_ip>_<node_port>
+std::string get_checkpoint_str();
+
+// This backup checkpoint path on block service
+// checkpoint_str is the return value of function get_checkpoint_str
+// partition_path should be the return value of function get_backup_partition_path
+// - return <partition_path>/<checkpoint_str>
+std::string get_backup_checkpoint_path(const std::string &partition_path);
 
 } // namespace replication
 } // namespace dsn

--- a/src/rdsn/src/replica/backup/replica_backup_manager.cpp
+++ b/src/rdsn/src/replica/backup/replica_backup_manager.cpp
@@ -42,6 +42,14 @@ void replica_backup_manager::on_backup(const backup_request &request,
         try_to_checkpoint(request.backup_id, response);
         return;
     }
+
+    if (request.status == backup_status::UPLOADING) {
+        try_to_upload(request.backup_provider_type,
+                      request.__isset.backup_root_path ? request.backup_root_path : "",
+                      request.app_name,
+                      response);
+        return;
+    }
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
@@ -95,6 +103,79 @@ void replica_backup_manager::report_checkpointing(/*out*/ backup_response &respo
         response.__set_checkpoint_upload_err(_checkpoint_err);
     }
     fill_response_unlock(response);
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica_backup_manager::try_to_upload(const std::string &provider_type,
+                                           const std::string &root_path,
+                                           const std::string app_name,
+                                           /*out*/ backup_response &response)
+{
+    switch (get_backup_status()) {
+    case backup_status::CHECKPOINTED:
+        start_uploading(provider_type, root_path, app_name, response);
+        break;
+    case backup_status::UPLOADING:
+        report_uploading(response);
+        break;
+    case backup_status::SUCCEED:
+        upload_completed(response);
+        break;
+    default:
+        response.err = ERR_INVALID_STATE;
+        derror_replica("invalid local status({}) while request status = {}",
+                       enum_to_string(_status),
+                       enum_to_string(backup_status::UPLOADING));
+        break;
+    }
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica_backup_manager::start_uploading(const std::string &provider_name,
+                                             const std::string &root_path,
+                                             const std::string &app_name,
+                                             /*out*/ backup_response &response)
+{
+    FAIL_POINT_INJECT_F("replica_backup_start_uploading", [&](dsn::string_view) {
+        _status = backup_status::UPLOADING;
+        response.err = ERR_OK;
+    });
+    zauto_write_lock l(_lock);
+    _uploading_task = tasking::enqueue(
+        LPC_BACKGROUND_COLD_BACKUP,
+        tracker(),
+        std::bind(
+            &replica_backup_manager::upload_checkpoint, this, provider_name, root_path, app_name));
+    _status = backup_status::UPLOADING;
+    fill_response_unlock(response);
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica_backup_manager::report_uploading(/*out*/ backup_response &response)
+{
+    zauto_read_lock l(_lock);
+    if (_upload_err == ERR_IO_PENDING || _upload_err == ERR_OK) {
+        response.__set_upload_progress(calc_upload_progress());
+    } else {
+        response.__set_checkpoint_upload_err(_upload_err);
+    }
+    fill_response_unlock(response);
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica_backup_manager::upload_completed(/*out*/ backup_response &response)
+{
+    FAIL_POINT_INJECT_F("replica_backup_upload_completed",
+                        [&](dsn::string_view) { response.err = ERR_OK; });
+
+    zauto_read_lock l(_lock);
+    fill_response_unlock(response);
+    response.__set_checkpoint_total_size(_backup_metadata.checkpoint_total_size);
+    tasking::enqueue(LPC_REPLICATION_COLD_BACKUP,
+                     tracker(),
+                     std::bind(&replica_backup_manager::clear_context, this),
+                     get_gpid().thread_hash(),
+                     std::chrono::seconds(5));
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
@@ -190,6 +271,149 @@ bool replica_backup_manager::set_backup_metadata_unlock(const std::string &local
                    _backup_metadata.checkpoint_total_size);
 
     return true;
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION_LONG
+void replica_backup_manager::upload_checkpoint(const std::string &provider_name,
+                                               const std::string &root_path,
+                                               const std::string &app_name)
+{
+    ddebug_replica("start to upload files");
+    dist::block_service::block_filesystem *fs =
+        _stub->_block_service_manager.get_or_create_block_filesystem(provider_name);
+
+    // get remote partition directory path
+    auto pid = get_gpid();
+    std::string remote_partition_dir =
+        get_backup_partition_path(get_backup_root(FLAGS_cold_backup_root, root_path),
+                                  app_name,
+                                  pid.get_app_id(),
+                                  _backup_id,
+                                  pid.get_partition_index());
+    {
+        zauto_write_lock l(_lock);
+        if (!_backup_metadata.files.empty()) {
+            const file_meta &f_meta = _backup_metadata.files[0];
+            _upload_files_task[f_meta.name] =
+                tasking::enqueue(LPC_BACKGROUND_COLD_BACKUP,
+                                 tracker(),
+                                 std::bind(&replica_backup_manager::upload_file,
+                                           this,
+                                           fs,
+                                           remote_partition_dir,
+                                           f_meta,
+                                           1));
+        }
+    }
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION_LONG
+void replica_backup_manager::upload_file(dist::block_service::block_filesystem *fs,
+                                         const std::string &remote_partition_dir,
+                                         const file_meta &f_meta,
+                                         int32_t next_index)
+{
+    const auto &local_checkpoint_dir = get_local_checkpoint_dir();
+    std::string remote_checkpoint_dir = get_backup_checkpoint_path(remote_partition_dir);
+    const auto &err = _stub->_block_service_manager.upload_file(
+        remote_checkpoint_dir, local_checkpoint_dir, f_meta.name, fs);
+    if (err != ERR_OK) {
+        derror_replica("upload file {} failed, error = {}", f_meta.name, err);
+        set_upload_err(err);
+        return;
+    }
+
+    std::vector<file_meta> files;
+    {
+        zauto_write_lock l(_lock);
+        _upload_file_size.fetch_add(f_meta.size);
+        files = _backup_metadata.files;
+    }
+    // update next file
+    if (next_index < files.size()) {
+        zauto_write_lock l(_lock);
+        const file_meta &f_meta = files[next_index];
+        _upload_files_task[f_meta.name] =
+            tasking::enqueue(LPC_BACKGROUND_COLD_BACKUP,
+                             tracker(),
+                             std::bind(&replica_backup_manager::upload_file,
+                                       this,
+                                       fs,
+                                       remote_partition_dir,
+                                       f_meta,
+                                       next_index + 1));
+    } else if (next_index == files.size()) {
+        upload_file_completed(fs, remote_partition_dir);
+    }
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION_LONG
+void replica_backup_manager::upload_file_completed(dist::block_service::block_filesystem *fs,
+                                                   const std::string &remote_partition_dir)
+{
+    auto checkpoint_str = get_checkpoint_str();
+    auto remote_checkpoint_dir = get_backup_checkpoint_path(remote_partition_dir);
+    auto data_version_str = std::to_string(_replica->query_data_version());
+    cold_backup_metadata metadata;
+    {
+        zauto_read_lock l(_lock);
+        metadata = _backup_metadata;
+    }
+
+    if (write_file_to_blockfs(fs,
+                              remote_checkpoint_dir,
+                              backup_constant::BACKUP_METADATA,
+                              json::json_forwarder<cold_backup_metadata>::encode(metadata)) !=
+            ERR_OK ||
+        write_file_to_blockfs(fs,
+                              remote_partition_dir,
+                              backup_constant::CURRENT_CHECKPOINT,
+                              blob::create_from_bytes(std::move(checkpoint_str))) != ERR_OK ||
+        write_file_to_blockfs(fs,
+                              remote_partition_dir,
+                              backup_constant::DATA_VERSION,
+                              blob::create_from_bytes(std::move(data_version_str))) != ERR_OK) {
+        return;
+    }
+
+    {
+        zauto_write_lock l(_lock);
+        _upload_err = ERR_OK;
+        _status = backup_status::SUCCEED;
+    }
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION_LONG
+error_code replica_backup_manager::write_file_to_blockfs(dist::block_service::block_filesystem *fs,
+                                                         const std::string &remote_dir,
+                                                         const std::string &file_name,
+                                                         const blob &buffer)
+{
+    const auto &err = _stub->_block_service_manager.write_file(remote_dir, file_name, buffer, fs);
+    if (err != ERR_OK) {
+        derror_replica("write {} failed, error = {}", file_name, err);
+        set_upload_err(err);
+    }
+    return err;
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+int32_t replica_backup_manager::calc_upload_progress()
+{
+    if (_backup_metadata.checkpoint_total_size <= 0) {
+        return 0;
+    }
+    auto total_size = static_cast<double>(_backup_metadata.checkpoint_total_size);
+    auto cur_upload_size = static_cast<double>(_upload_file_size.load());
+    return static_cast<int32_t>((cur_upload_size / total_size) * 100);
+}
+
+// ThreadPool: THREAD_POOL_REPLICATION
+void replica_backup_manager::clear_context()
+{
+    FAIL_POINT_INJECT_F("replica_backup_clear_context",
+                        [this](dsn::string_view) { _status = backup_status::UNINITIALIZED; });
+    // TODO(heyuchen): TBD
 }
 
 } // namespace replication

--- a/src/rdsn/src/replica/backup/replica_backup_manager.cpp
+++ b/src/rdsn/src/replica/backup/replica_backup_manager.cpp
@@ -108,7 +108,7 @@ void replica_backup_manager::report_checkpointing(/*out*/ backup_response &respo
 // ThreadPool: THREAD_POOL_REPLICATION
 void replica_backup_manager::try_to_upload(const std::string &provider_type,
                                            const std::string &root_path,
-                                           const std::string app_name,
+                                           const std::string &app_name,
                                            /*out*/ backup_response &response)
 {
     switch (get_backup_status()) {
@@ -141,6 +141,7 @@ void replica_backup_manager::start_uploading(const std::string &provider_name,
         response.err = ERR_OK;
     });
     zauto_write_lock l(_lock);
+    _upload_err = ERR_IO_PENDING;
     _uploading_task = tasking::enqueue(
         LPC_BACKGROUND_COLD_BACKUP,
         tracker(),

--- a/src/rdsn/src/replica/backup/replica_backup_manager.h
+++ b/src/rdsn/src/replica/backup/replica_backup_manager.h
@@ -61,7 +61,7 @@ private:
     void try_to_checkpoint(const int64_t &backup_id, /*out*/ backup_response &response);
     void try_to_upload(const std::string &provider_type,
                        const std::string &root_path,
-                       const std::string app_name,
+                       const std::string &app_name,
                        /*out*/ backup_response &response);
     void start_checkpointing(int64_t backup_id, /*out*/ backup_response &response);
     void report_checkpointing(/*out*/ backup_response &response);
@@ -134,7 +134,7 @@ private:
     backup_status::type _status{backup_status::UNINITIALIZED};
     int64_t _backup_id{0};
     error_code _checkpoint_err{ERR_OK};
-    error_code _upload_err{ERR_IO_PENDING};
+    error_code _upload_err{ERR_OK};
     cold_backup_metadata _backup_metadata;
     task_ptr _checkpointing_task;
     task_ptr _uploading_task;

--- a/src/rdsn/src/replica/backup/test/config-test.ini
+++ b/src/rdsn/src/replica/backup/test/config-test.ini
@@ -27,7 +27,7 @@ run = true
 
 [apps.replica]
 type = replica
-pools = THREAD_POOL_DEFAULT,THREAD_POOL_REPLICATION_LONG,THREAD_POOL_REPLICATION,THREAD_POOL_SLOG,THREAD_POOL_PLOG
+pools = THREAD_POOL_DEFAULT,THREAD_POOL_REPLICATION_LONG,THREAD_POOL_REPLICATION,THREAD_POOL_SLOG,THREAD_POOL_PLOG,THREAD_POOL_BLOCK_SERVICE
 
 [core]
 tool = nativerun
@@ -51,8 +51,8 @@ partitioned = true
 name = replica_long
 
 [replication]
-cluster_name = master-cluster
+cluster_name = cluster
 
-[duplication-group]
-master-cluster = 1
-slave-cluster  = 2
+[block_service.local_service]
+type = local_service
+args =

--- a/src/rdsn/src/replica/replica_stub.h
+++ b/src/rdsn/src/replica/replica_stub.h
@@ -321,6 +321,7 @@ private:
     friend class replica_bulk_loader;
     friend class replica_split_manager;
     friend class replica_disk_migrator;
+    friend class replica_backup_manager;
 
     friend class mock_replica_stub;
     friend class duplication_sync_timer;


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1081
This pr is about that replica server receive `backup_request` with uploading status, including:
- replica start to upload backup files, in function `start_uploading`, `upload_checkpoint` and `upload_file`, when replica upload all files, it will write some files onto remote block service, in function `upload_file_completed`.
- replica report upload process, in function `report_uploading`
- add related unit test