### PR TITLE
feat(jemalloc): support building third-parties images for both production and test with jemalloc

### DIFF
--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -98,6 +98,18 @@ jobs:
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
+      - name: Build and push for production with jemalloc
+        uses: docker/build-push-action@v2.10.0
+        with:
+          context: .
+          file: ./docker/thirdparties-bin/Dockerfile
+          push: true
+          tags: |
+            apache/pegasus:thirdparties-bin-jemallc-${{ matrix.osversion }}-${{ github.ref_name }}
+          build-args: |
+            GITHUB_BRANCH=${{ github.ref_name }}
+            OS_VERSION=${{ matrix.osversion }}
+            USE_JEMALLOC=ON
       - name: Build and push for test
         uses: docker/build-push-action@v2.10.0
         with:
@@ -110,5 +122,18 @@ jobs:
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
             ROCKSDB_PORTABLE=ON
+      - name: Build and push for test with jemalloc
+        uses: docker/build-push-action@v2.10.0
+        with:
+          context: .
+          file: ./docker/thirdparties-bin/Dockerfile
+          push: true
+          tags: |
+            apache/pegasus:thirdparties-bin-test-jemallc-${{ matrix.osversion }}-${{ github.ref_name }}
+          build-args: |
+            GITHUB_BRANCH=${{ github.ref_name }}
+            OS_VERSION=${{ matrix.osversion }}
+            ROCKSDB_PORTABLE=ON
+            USE_JEMALLOC=ON
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/docker/thirdparties-bin/Dockerfile
+++ b/docker/thirdparties-bin/Dockerfile
@@ -27,10 +27,11 @@ COPY --from=builder /root/thirdparties-src.zip /root/thirdparties-src.zip
 ARG GITHUB_BRANCH=master
 ARG GITHUB_REPOSITORY_URL=https://github.com/apache/incubator-pegasus.git
 ARG ROCKSDB_PORTABLE=OFF
+ARG USE_JEMALLOC=OFF
 RUN git clone --depth=1 --branch=${GITHUB_BRANCH} ${GITHUB_REPOSITORY_URL} \
     && cd incubator-pegasus/thirdparty \
     && unzip /root/thirdparties-src.zip -d . \
-    && cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=${ROCKSDB_PORTABLE} -B build/ . \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=${ROCKSDB_PORTABLE} -DUSE_JEMALLOC=${USE_JEMALLOC} -B build/ . \
     && cmake --build build/ -j $(($(nproc)/2+1)) \
     && zip -r ~/thirdparties-bin.zip output/ build/Source/rocksdb/cmake build/Source/http-parser build/Source/hadoop build/Download/zookeeper \
     && cd ~ \


### PR DESCRIPTION
This PR is one of the sub-tasks of https://github.com/apache/incubator-pegasus/issues/1134. Third-parties images for both the purpose of production and test should be built firstly before they can be referenced by derived images.