### PR TITLE
feat(backup): 8. meta handle backup_response during uploading and succeed

### DIFF
--- a/src/rdsn/src/meta/meta_backup_engine.cpp
+++ b/src/rdsn/src/meta/meta_backup_engine.cpp
@@ -296,10 +296,10 @@ void meta_backup_engine::complete_backup()
     backup_info.app_name = _cur_backup.app_name;
     backup_info.backup_id = _cur_backup.backup_id;
     backup_info.start_time_ms = _cur_backup.start_time_ms;
-    const auto end_time_ms = dsn_now_ms();
+    const auto end_time_ms = static_cast<int64_t>(dsn_now_ms());
     backup_info.end_time_ms = end_time_ms;
-    blob buf = json::json_forwarder<app_backup_info>::encode(backup_info);
-    error_code err = write_backup_file(remote_backup_dir, backup_constant::BACKUP_INFO, buf);
+    const auto &buf = json::json_forwarder<app_backup_info>::encode(backup_info);
+    const auto &err = write_backup_file(remote_backup_dir, backup_constant::BACKUP_INFO, buf);
     if (err == ERR_FS_INTERNAL) {
         derror_f(
             "backup_id({}): write backup info failed, error {}, do not try again for this error.",

--- a/src/rdsn/src/meta/meta_backup_engine.h
+++ b/src/rdsn/src/meta/meta_backup_engine.h
@@ -120,7 +120,7 @@ private:
                                  const std::string &file_name,
                                  const blob &write_buffer);
     error_code write_app_info();
-    void write_backup_info();
+    void complete_backup();
 
     void update_backup_item_on_remote_storage(backup_status::type new_status, int64_t end_time = 0);
 
@@ -161,13 +161,6 @@ private:
     backup_item _cur_backup;
     std::vector<backup_status::type> _backup_status;
     // }
-
-    // TODO(heyuchen): remove following functions and vars
-private:
-    void complete_current_backup();
-
-    backup_service *_backup_service;
-    std::string _backup_path;
 };
 
 } // namespace replication

--- a/src/rdsn/src/meta/test/meta_backup_engine_test.cpp
+++ b/src/rdsn/src/meta/test/meta_backup_engine_test.cpp
@@ -186,8 +186,9 @@ TEST_F(meta_backup_engine_test, on_backup_reply_succeed_test)
          true,
          backup_status::UPLOADING,
          true},
-        // TODO(heyuchen): add other status cases
-    };
+        {backup_status::UPLOADING, backup_status::UPLOADING, false, backup_status::UPLOADING, true},
+        {backup_status::SUCCEED, backup_status::UPLOADING, false, backup_status::UPLOADING, true},
+        {backup_status::SUCCEED, backup_status::UPLOADING, true, backup_status::SUCCEED, false}};
 
     for (const auto &test : tests) {
         init_backup(_app_id, test.old_status);


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1081

This pr is about meta server handle `backup_response` during uploading and succeed status:
- if partition status is uploading, continue to send request to replica server
- if all partitions succeed, write backup_info onto remote block service and update backup status on zk

Besides, this pr adds related unit test.