### PR TITLE
feat(backup): 9. replica handle backup clear context and invalid status

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -27,7 +27,7 @@ to deploying a standalone cluster of Pegasus containers on your local machine.
 
 [![BuildThirdpartyDockerRegularly - build and publish thirdparty every week](https://github.com/apache/incubator-pegasus/actions/workflows/thirdparty-regular-push.yml/badge.svg)](https://github.com/apache/incubator-pegasus/actions/workflows/thirdparty-regular-push.yml)
 
-[![BuildPegasusRegularly - build pegasus and rdsn on different env every day](https://github.com/apache/incubator-pegasus/actions/workflows/pegasus-regular-build.yml/badge.svg)](https://github.com/apache/incubator-pegasus/actions/workflows/pegasus-regular-build.yml)
+[![BuildPegasusRegularly - build pegasus and rdsn on different env every day](https://github.com/apache/incubator-pegasus/actions/workflows/regular-build.yml/badge.svg)](https://github.com/apache/incubator-pegasus/actions/workflows/regular-build.yml)
 
 ## pegasus-build-env
 

--- a/src/rdsn/src/common/backup_restore_common.cpp
+++ b/src/rdsn/src/common/backup_restore_common.cpp
@@ -27,6 +27,10 @@ DSN_DEFINE_string("replication",
                   cold_backup_root,
                   "",
                   "cold backup remote block service storage path prefix");
+DSN_DEFINE_uint32("replication",
+                  cold_backup_checkpoint_reserve_minutes,
+                  10,
+                  "reserve minutes of cold backup checkpoint");
 
 const std::string backup_constant::APP_METADATA("app_metadata");
 const std::string backup_constant::APP_BACKUP_STATUS("app_backup_status");

--- a/src/rdsn/src/common/backup_restore_common.h
+++ b/src/rdsn/src/common/backup_restore_common.h
@@ -29,6 +29,7 @@ namespace dsn {
 namespace replication {
 
 DSN_DECLARE_string(cold_backup_root);
+DSN_DECLARE_uint32(cold_backup_checkpoint_reserve_minutes);
 
 class backup_constant
 {

--- a/src/rdsn/src/common/backup_restore_common.h
+++ b/src/rdsn/src/common/backup_restore_common.h
@@ -29,7 +29,6 @@ namespace dsn {
 namespace replication {
 
 DSN_DECLARE_string(cold_backup_root);
-DSN_DECLARE_uint32(cold_backup_checkpoint_reserve_minutes);
 
 class backup_constant
 {

--- a/src/rdsn/src/common/replication_common.cpp
+++ b/src/rdsn/src/common/replication_common.cpp
@@ -110,8 +110,6 @@ replication_options::replication_options()
     lb_interval_ms = 10000;
 
     learn_app_max_concurrent_count = 5;
-
-    cold_backup_checkpoint_reserve_minutes = 10;
 }
 
 replication_options::~replication_options() {}
@@ -397,12 +395,6 @@ void replication_options::initialize()
                                          "learn_app_max_concurrent_count",
                                          learn_app_max_concurrent_count,
                                          "max count of learning app concurrently");
-
-    cold_backup_checkpoint_reserve_minutes =
-        (int)dsn_config_get_value_uint64("replication",
-                                         "cold_backup_checkpoint_reserve_minutes",
-                                         cold_backup_checkpoint_reserve_minutes,
-                                         "reserve minutes of cold backup checkpoint");
 
     max_concurrent_bulk_load_downloading_count = FLAGS_max_concurrent_bulk_load_downloading_count;
 

--- a/src/rdsn/src/common/replication_common.h
+++ b/src/rdsn/src/common/replication_common.h
@@ -109,8 +109,6 @@ public:
 
     int32_t learn_app_max_concurrent_count;
 
-    int32_t cold_backup_checkpoint_reserve_minutes;
-
     int32_t max_concurrent_bulk_load_downloading_count;
 
 public:

--- a/src/rdsn/src/replica/backup/replica_backup_manager.cpp
+++ b/src/rdsn/src/replica/backup/replica_backup_manager.cpp
@@ -23,6 +23,8 @@
 namespace dsn {
 namespace replication {
 
+DSN_DECLARE_uint32(cold_backup_checkpoint_reserve_minutes);
+
 replica_backup_manager::replica_backup_manager(replica *r)
     : replica_base(r), _replica(r), _stub(r->get_replica_stub())
 {

--- a/src/rdsn/src/replica/backup/replica_backup_manager.cpp
+++ b/src/rdsn/src/replica/backup/replica_backup_manager.cpp
@@ -429,7 +429,7 @@ void replica_backup_manager::clear_context()
     }
     ddebug_replica("start to clear backup context, old status = {}", enum_to_string(_status));
 
-    for (auto &kv : _upload_files_task) {
+    for (const auto &kv : _upload_files_task) {
         cleanup_backup_task(kv.second);
     }
     cleanup_backup_task(_uploading_task);

--- a/src/rdsn/src/replica/backup/replica_backup_manager.h
+++ b/src/rdsn/src/replica/backup/replica_backup_manager.h
@@ -93,6 +93,9 @@ private:
     int32_t calc_upload_progress();
 
     void clear_context();
+    void background_clear_backup_checkpoint(int64_t backup_id);
+    void clear_backup_checkpoint(int64_t backup_id);
+    bool cleanup_backup_task(task_ptr task_);
 
     task_tracker *tracker() { return _replica->tracker(); }
 

--- a/src/rdsn/src/replica/backup/test/replica_backup_manager_test.cpp
+++ b/src/rdsn/src/replica/backup/test/replica_backup_manager_test.cpp
@@ -42,6 +42,23 @@ public:
         fail::teardown();
     }
 
+    error_code on_backup(backup_status::type local_status, backup_status::type request_status)
+    {
+        mock_local_backup_states(local_status);
+
+        backup_request req;
+        req.pid = _replica->get_gpid();
+        req.app_name = APP_NAME;
+        req.backup_id = dsn_now_ms();
+        req.status = request_status;
+        req.backup_provider_type = PROVIDER;
+        req.__set_backup_root_path(PATH);
+
+        backup_response resp;
+        _backup_mgr->on_backup(req, resp);
+        return resp.err;
+    }
+
     void generate_checkpoint() { _backup_mgr->generate_checkpoint(); }
 
     bool set_backup_metadata()
@@ -64,6 +81,12 @@ public:
     }
 
     void report_uploading(backup_response &response) { _backup_mgr->report_uploading(response); }
+
+    void clear_context()
+    {
+        _backup_mgr->clear_context();
+        _backup_mgr->tracker()->wait_outstanding_tasks();
+    }
 
     void mock_local_backup_states(backup_status::type status,
                                   error_code checkpoint_err = ERR_OK,
@@ -120,7 +143,178 @@ protected:
     std::unique_ptr<replica_backup_manager> _backup_mgr;
 };
 
-// TODO(heyuchen): add unit test for on_backup after implement all status
+TEST_F(replica_backup_manager_test, on_backup_test)
+{
+    fail::cfg("replica_backup_start_checkpointing", "return()");
+    fail::cfg("replica_backup_start_uploading", "return()");
+    fail::cfg("replica_backup_upload_completed", "return()");
+    fail::cfg("replica_backup_clear_context", "return()");
+
+    struct test_struct
+    {
+        backup_status::type local_status;
+        backup_status::type request_status;
+        error_code expected_err;
+        backup_status::type expected_status;
+    } tests[]{
+        // request_status = UNINITIALIZED
+        {backup_status::UNINITIALIZED,
+         backup_status::UNINITIALIZED,
+         ERR_INVALID_STATE,
+         backup_status::UNINITIALIZED},
+        {backup_status::CHECKPOINTING,
+         backup_status::UNINITIALIZED,
+         ERR_INVALID_STATE,
+         backup_status::CHECKPOINTING},
+        {backup_status::CHECKPOINTED,
+         backup_status::UNINITIALIZED,
+         ERR_INVALID_STATE,
+         backup_status::CHECKPOINTED},
+        {backup_status::UPLOADING,
+         backup_status::UNINITIALIZED,
+         ERR_INVALID_STATE,
+         backup_status::UPLOADING},
+        {backup_status::SUCCEED,
+         backup_status::UNINITIALIZED,
+         ERR_INVALID_STATE,
+         backup_status::SUCCEED},
+        {backup_status::FAILED,
+         backup_status::UNINITIALIZED,
+         ERR_INVALID_STATE,
+         backup_status::FAILED},
+        {backup_status::CANCELED,
+         backup_status::UNINITIALIZED,
+         ERR_INVALID_STATE,
+         backup_status::CANCELED},
+        // request_status = CHECKPOINTING
+        {backup_status::UNINITIALIZED,
+         backup_status::CHECKPOINTING,
+         ERR_OK,
+         backup_status::CHECKPOINTING},
+        {backup_status::CHECKPOINTING,
+         backup_status::CHECKPOINTING,
+         ERR_OK,
+         backup_status::CHECKPOINTING},
+        {backup_status::CHECKPOINTED,
+         backup_status::CHECKPOINTING,
+         ERR_OK,
+         backup_status::CHECKPOINTED},
+        {backup_status::UPLOADING,
+         backup_status::CHECKPOINTING,
+         ERR_INVALID_STATE,
+         backup_status::UPLOADING},
+        {backup_status::SUCCEED,
+         backup_status::CHECKPOINTING,
+         ERR_INVALID_STATE,
+         backup_status::SUCCEED},
+        {backup_status::FAILED,
+         backup_status::CHECKPOINTING,
+         ERR_INVALID_STATE,
+         backup_status::FAILED},
+        {backup_status::CANCELED,
+         backup_status::CHECKPOINTING,
+         ERR_INVALID_STATE,
+         backup_status::CANCELED},
+        // request_status = CHECKPOINTED
+        {backup_status::UNINITIALIZED,
+         backup_status::CHECKPOINTED,
+         ERR_INVALID_STATE,
+         backup_status::UNINITIALIZED},
+        {backup_status::CHECKPOINTING,
+         backup_status::CHECKPOINTED,
+         ERR_INVALID_STATE,
+         backup_status::CHECKPOINTING},
+        {backup_status::CHECKPOINTED,
+         backup_status::CHECKPOINTED,
+         ERR_INVALID_STATE,
+         backup_status::CHECKPOINTED},
+        {backup_status::UPLOADING,
+         backup_status::CHECKPOINTED,
+         ERR_INVALID_STATE,
+         backup_status::UPLOADING},
+        {backup_status::SUCCEED,
+         backup_status::CHECKPOINTED,
+         ERR_INVALID_STATE,
+         backup_status::SUCCEED},
+        {backup_status::FAILED,
+         backup_status::CHECKPOINTED,
+         ERR_INVALID_STATE,
+         backup_status::FAILED},
+        {backup_status::CANCELED,
+         backup_status::CHECKPOINTED,
+         ERR_INVALID_STATE,
+         backup_status::CANCELED},
+        // request_status = UPLOADING
+        {backup_status::UNINITIALIZED,
+         backup_status::UPLOADING,
+         ERR_INVALID_STATE,
+         backup_status::UNINITIALIZED},
+        {backup_status::CHECKPOINTING,
+         backup_status::UPLOADING,
+         ERR_INVALID_STATE,
+         backup_status::CHECKPOINTING},
+        {backup_status::CHECKPOINTED, backup_status::UPLOADING, ERR_OK, backup_status::UPLOADING},
+        {backup_status::UPLOADING, backup_status::UPLOADING, ERR_OK, backup_status::UPLOADING},
+        {backup_status::SUCCEED, backup_status::UPLOADING, ERR_OK, backup_status::SUCCEED},
+        {backup_status::FAILED, backup_status::UPLOADING, ERR_INVALID_STATE, backup_status::FAILED},
+        {backup_status::CANCELED,
+         backup_status::UPLOADING,
+         ERR_INVALID_STATE,
+         backup_status::CANCELED},
+        // request_status = SUCCEED
+        {backup_status::UNINITIALIZED,
+         backup_status::SUCCEED,
+         ERR_INVALID_STATE,
+         backup_status::UNINITIALIZED},
+        {backup_status::CHECKPOINTING,
+         backup_status::SUCCEED,
+         ERR_INVALID_STATE,
+         backup_status::CHECKPOINTING},
+        {backup_status::CHECKPOINTED,
+         backup_status::SUCCEED,
+         ERR_INVALID_STATE,
+         backup_status::CHECKPOINTED},
+        {backup_status::UPLOADING,
+         backup_status::SUCCEED,
+         ERR_INVALID_STATE,
+         backup_status::UPLOADING},
+        {backup_status::SUCCEED, backup_status::SUCCEED, ERR_INVALID_STATE, backup_status::SUCCEED},
+        {backup_status::FAILED, backup_status::SUCCEED, ERR_INVALID_STATE, backup_status::FAILED},
+        {backup_status::CANCELED,
+         backup_status::SUCCEED,
+         ERR_INVALID_STATE,
+         backup_status::CANCELED},
+        // request_status = FAILED
+        {backup_status::UNINITIALIZED, backup_status::FAILED, ERR_OK, backup_status::UNINITIALIZED},
+        {backup_status::CHECKPOINTING, backup_status::FAILED, ERR_OK, backup_status::UNINITIALIZED},
+        {backup_status::CHECKPOINTED, backup_status::FAILED, ERR_OK, backup_status::UNINITIALIZED},
+        {backup_status::UPLOADING, backup_status::FAILED, ERR_OK, backup_status::UNINITIALIZED},
+        {backup_status::SUCCEED, backup_status::FAILED, ERR_OK, backup_status::UNINITIALIZED},
+        {backup_status::FAILED, backup_status::FAILED, ERR_OK, backup_status::UNINITIALIZED},
+        {backup_status::CANCELED, backup_status::FAILED, ERR_OK, backup_status::UNINITIALIZED},
+        // request_status = CANCELED
+        {backup_status::UNINITIALIZED,
+         backup_status::CANCELED,
+         ERR_OK,
+         backup_status::UNINITIALIZED},
+        {backup_status::CHECKPOINTING,
+         backup_status::CANCELED,
+         ERR_OK,
+         backup_status::UNINITIALIZED},
+        {backup_status::CHECKPOINTED,
+         backup_status::CANCELED,
+         ERR_OK,
+         backup_status::UNINITIALIZED},
+        {backup_status::UPLOADING, backup_status::CANCELED, ERR_OK, backup_status::UNINITIALIZED},
+        {backup_status::SUCCEED, backup_status::CANCELED, ERR_OK, backup_status::UNINITIALIZED},
+        {backup_status::FAILED, backup_status::CANCELED, ERR_OK, backup_status::UNINITIALIZED},
+        {backup_status::CANCELED, backup_status::CANCELED, ERR_OK, backup_status::UNINITIALIZED}};
+
+    for (const auto &test : tests) {
+        ASSERT_EQ(on_backup(test.local_status, test.request_status), test.expected_err);
+        ASSERT_EQ(get_status(), test.expected_status);
+    }
+}
 
 TEST_F(replica_backup_manager_test, generate_checkpoint_test)
 {
@@ -211,6 +405,21 @@ TEST_F(replica_backup_manager_test, report_uploading_test)
         }
         ASSERT_EQ(resp.upload_progress, test.expected_upload_progress);
     }
+}
+
+TEST_F(replica_backup_manager_test, clear_context_test)
+{
+    FLAGS_cold_backup_checkpoint_reserve_minutes = 0;
+    mock_local_backup_states(backup_status::SUCCEED, ERR_OK, ERR_OK, 100);
+    auto dir_name = create_local_backup_checkpoint_dir();
+    create_local_backup_file(dir_name, FILE_NAME1);
+
+    clear_context();
+
+    ASSERT_EQ(get_status(), backup_status::UNINITIALIZED);
+    ASSERT_EQ(get_checkpoint_err(), ERR_OK);
+    ASSERT_EQ(get_upload_err(), ERR_OK);
+    ASSERT_FALSE(utils::filesystem::directory_exists(dir_name));
 }
 
 } // namespace replication

--- a/src/rdsn/src/replica/backup/test/replica_backup_manager_test.cpp
+++ b/src/rdsn/src/replica/backup/test/replica_backup_manager_test.cpp
@@ -24,6 +24,8 @@
 namespace dsn {
 namespace replication {
 
+DSN_DECLARE_uint32(cold_backup_checkpoint_reserve_minutes);
+
 class replica_backup_manager_test : public replica_test_base
 {
 public:

--- a/src/rdsn/src/replica/replica_config.cpp
+++ b/src/rdsn/src/replica/replica_config.cpp
@@ -38,6 +38,7 @@
 #include "mutation.h"
 #include "mutation_log.h"
 #include "replica_stub.h"
+#include "backup/replica_backup_manager.h"
 #include "bulk_load/replica_bulk_loader.h"
 #include "runtime/security/access_controller.h"
 #include "split/replica_split_manager.h"
@@ -849,6 +850,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
     switch (old_status) {
     case partition_status::PS_PRIMARY:
         cleanup_preparing_mutations(false);
+        _backup_mgr->clear_context();
         switch (config.status) {
         case partition_status::PS_PRIMARY:
             replay_prepare_list();


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1081

This pr is about replica handle clear after backup succeed or failed, and add invalid status check, including:
- add backup_status check in function `on_backup`
- implement function `clear_context` to clear backup context
- implement function `background_clear_backup_checkpoint` and `clear_backup_checkpoint` to delete replica checkpoint directory created by backup
- when replica configuration changed, call clear_context to stop possible backup, in `replica_config.cpp`
- add related unit tests