### PR TITLE
fix: fix bad links and bad image names

### DIFF
--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -18,14 +18,14 @@
 name: Lint and build regularly
 
 on:
-  pull_request:
-    types: [ synchronize, opened, reopened ]
-    paths:
-      - '.github/workflows/regular-build.yml'
-
   push:
     paths:
       - '.github/workflows/regular-build.yml'
+    branches:
+      - master
+      - 'v[0-9]+.*' # release branch
+      - ci-test # testing branch for github action
+      - '*dev' # developing branch
 
   # for manually triggering workflow
   workflow_dispatch:
@@ -70,7 +70,7 @@ jobs:
             compiler: "clang-9,clang++-9"
             os: ubuntu1804
     container:
-      image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-master
+      image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-${{ github.ref_name }}
     defaults:
       run:
         working-directory: /root/incubator-pegasus

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -70,7 +70,7 @@ jobs:
             compiler: "clang-9,clang++-9"
             os: ubuntu1804
     container:
-      image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-${{ github.ref }}
+      image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-master
     defaults:
       run:
         working-directory: /root/incubator-pegasus

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -71,9 +71,6 @@ jobs:
             os: ubuntu1804
     container:
       image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-master
-    defaults:
-      run:
-        working-directory: /root/incubator-pegasus
     steps:
       - name: Clone Apache Pegasus Source
         uses: actions/checkout@v2

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -70,16 +70,15 @@ jobs:
             compiler: "clang-9,clang++-9"
             os: ubuntu1804
     container:
-      image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-${{ github.ref }}
     defaults:
       run:
         working-directory: /root/incubator-pegasus
     steps:
       - name: Clone Apache Pegasus Source
-        working-directory: /root
-        run: |
-          git clone -b ${{ github.base_ref }} --depth=1 https://github.com/apache/incubator-pegasus.git
-          cd incubator-pegasus
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
       - name: Unpack prebuilt third-parties
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Compilation Pegasus on GCC

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -71,11 +71,14 @@ jobs:
             os: ubuntu1804
     container:
       image: apache/pegasus:thirdparties-bin-${{ matrix.os }}-master
+    defaults:
+      run:
+        working-directory: /root/incubator-pegasus
     steps:
       - name: Clone Apache Pegasus Source
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+        working-directory: /root
+        run: |
+          git clone -b ${{ github.ref_name }} --depth=1 https://github.com/apache/incubator-pegasus.git
       - name: Unpack prebuilt third-parties
         run: unzip /root/thirdparties-bin.zip -d ./thirdparty
       - name: Compilation Pegasus on GCC

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ under the License.
 
 ![pegasus-logo](https://github.com/apache/incubator-pegasus-website/blob/master/assets/images/pegasus-logo-inv.png)
 
-[![BuildPegasusRegularly - build pegasus and rdsn on different env every day](https://github.com/apache/incubator-pegasus/actions/workflows/pegasus-regular-build.yml/badge.svg)](https://github.com/apache/incubator-pegasus/actions/workflows/pegasus-regular-build.yml)
+[![Lint and build regularly](https://github.com/apache/incubator-pegasus/actions/workflows/regular-build.yml/badge.svg)](https://github.com/apache/incubator-pegasus/actions/workflows/regular-build.yml)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![Releases](https://img.shields.io/github/release/apache/incubator-pegasus.svg)][github-release]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,7 +27,7 @@ to deploying a standalone cluster of Pegasus containers on your local machine.
 
 [![BuildThirdpartyDockerRegularly - build and publish thirdparty every week](https://github.com/apache/incubator-pegasus/actions/workflows/thirdparty-regular-push.yml/badge.svg)](https://github.com/apache/incubator-pegasus/actions/workflows/thirdparty-regular-push.yml)
 
-[![BuildPegasusRegularly - build pegasus and rdsn on different env every day](https://github.com/apache/incubator-pegasus/actions/workflows/pegasus-regular-build.yml/badge.svg)](https://github.com/apache/incubator-pegasus/actions/workflows/pegasus-regular-build.yml)
+[![Lint and build regularly](https://github.com/apache/incubator-pegasus/actions/workflows/regular-build.yml/badge.svg)](https://github.com/apache/incubator-pegasus/actions/workflows/regular-build.yml)
 
 ## pegasus-build-env
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1053

Revert changes on `.github/workflows/regular-build.yml`, since context `github.base_ref` is not valid when workflow triggered by push.
Of course, this workflow will not be triggered by pull_request event, which is the same behavior as before, we have to run it mannually.

manual test passed: https://github.com/apache/incubator-pegasus/actions/runs/3019576718