### PR TITLE
fix(config): create stat table as required by cpp collector on bootstrap

### DIFF
--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -222,6 +222,13 @@
   enable_white_list = false
   replica_white_list = 
 
+[meta_server.apps.stat]
+app_name = stat
+app_type = pegasus
+partition_count = 4
+max_replica_count = 3
+stateful = true
+
 [replication]
   slog_dir = %{slog.dir}
   data_dirs = %{data.dirs}


### PR DESCRIPTION
This PR is to fix https://github.com/apache/incubator-pegasus/issues/1151.

The reason that table `stat` should be created by meta server on bootstrap is that once cpp collector is started it will report error if `stat` does not exist.

The configuration for `stat` is added in [src/server/config.ini](https://github.com/apache/incubator-pegasus/blob/master/src/server/config.ini), which is usually adopted by new users as their first configuration file.