### PR TITLE
fix(workflow): drop --on_travis option for unit tests of jemalloc

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -476,7 +476,7 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
           ./scripts/config_hdfs.sh
-          ./run.sh test --on_travis -m ${{ matrix.test_module }}
+          ./run.sh test -m ${{ matrix.test_module }}
 
   build_pegasus_on_macos:
     name: macOS

--- a/run.sh
+++ b/run.sh
@@ -365,7 +365,7 @@ function run_test()
                 enable_gcov="yes"
                 ;;
             *)
-                echo "Error: unknow option \"$key\""
+                echo "Error: unknown option \"$key\""
                 echo
                 usage_test
                 exit 1


### PR DESCRIPTION
This PR is to fix https://github.com/apache/incubator-pegasus/issues/1160.