### PR TITLE
build(images): parallelize images building for all binary third-parties and only build ubuntu1804 for test images

### DIFF
--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -98,6 +98,32 @@ jobs:
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  build_push_bin_jemalloc_docker_images:
+    runs-on: ubuntu-latest
+    needs: build_push_src_docker_images
+    strategy:
+      fail-fast: false
+      matrix:
+        osversion:
+          - ubuntu1604
+          - ubuntu1804
+          - ubuntu2004
+          - centos6
+          - centos7
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for production with jemalloc
         uses: docker/build-push-action@v2.10.0
         with:
@@ -110,6 +136,28 @@ jobs:
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
             USE_JEMALLOC=ON
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  build_push_bin_test_docker_images:
+    runs-on: ubuntu-latest
+    needs: build_push_src_docker_images
+    strategy:
+      fail-fast: false
+      matrix:
+        osversion:
+          - ubuntu1804
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for test
         uses: docker/build-push-action@v2.10.0
         with:
@@ -122,6 +170,28 @@ jobs:
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
             ROCKSDB_PORTABLE=ON
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  build_push_bin_test_jemalloc_docker_images:
+    runs-on: ubuntu-latest
+    needs: build_push_src_docker_images
+    strategy:
+      fail-fast: false
+      matrix:
+        osversion:
+          - ubuntu1804
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for test with jemalloc
         uses: docker/build-push-action@v2.10.0
         with:


### PR DESCRIPTION
This PR is to solve https://github.com/apache/incubator-pegasus/issues/1159.