### PR TITLE
build(images): download hadoop-2.8.4.tar.gz during third-parties image building for unit tests

### DIFF
--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -122,6 +122,7 @@ jobs:
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
             ROCKSDB_PORTABLE=ON
+            HADOOP_BIN_PATH=hadoop-bin
       - name: Build and push for test with jemalloc
         uses: docker/build-push-action@v2.10.0
         with:
@@ -135,5 +136,6 @@ jobs:
             OS_VERSION=${{ matrix.osversion }}
             ROCKSDB_PORTABLE=ON
             USE_JEMALLOC=ON
+            HADOOP_BIN_PATH=hadoop-bin
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/docker/thirdparties-bin/Dockerfile
+++ b/docker/thirdparties-bin/Dockerfile
@@ -28,11 +28,13 @@ ARG GITHUB_BRANCH=master
 ARG GITHUB_REPOSITORY_URL=https://github.com/apache/incubator-pegasus.git
 ARG ROCKSDB_PORTABLE=OFF
 ARG USE_JEMALLOC=OFF
+ARG HADOOP_BIN_PATH
 RUN git clone --depth=1 --branch=${GITHUB_BRANCH} ${GITHUB_REPOSITORY_URL} \
     && cd incubator-pegasus/thirdparty \
     && unzip /root/thirdparties-src.zip -d . \
     && cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=${ROCKSDB_PORTABLE} -DUSE_JEMALLOC=${USE_JEMALLOC} -B build/ . \
     && cmake --build build/ -j $(($(nproc)/2+1)) \
-    && zip -r ~/thirdparties-bin.zip output/ build/Source/rocksdb/cmake build/Source/http-parser build/Source/hadoop build/Download/zookeeper \
+    && ../scripts/download_hadoop.sh ${HADOOP_BIN_PATH} \
+    && zip -r ~/thirdparties-bin.zip output/ build/Source/rocksdb/cmake build/Source/http-parser build/Source/hadoop build/Download/zookeeper ${HADOOP_BIN_PATH} \
     && cd ~ \
     && rm -rf incubator-pegasus;

--- a/scripts/download_hadoop.sh
+++ b/scripts/download_hadoop.sh
@@ -65,4 +65,4 @@ if [ ! -d ${HADOOP_DIR_NAME} ]; then
     exit 1
 fi
 
-mv ${HADOOP_PACKAGE_NAME} ${HADOOP_BIN_PATH}
+mv ${HADOOP_DIR_NAME} ${HADOOP_BIN_PATH}

--- a/scripts/download_hadoop.sh
+++ b/scripts/download_hadoop.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+if [ $# -lt 1 ]; then
+    exit 0
+fi
+
+HADOOP_BIN_PATH=$1
+if [ -d ${HADOOP_BIN_PATH} ]; then
+    exit 0
+fi
+
+HADOOP_VERSION=2.8.4
+HADOOP_DIR_NAME=hadoop-${HADOOP_VERSION}
+HADOOP_PACKAGE_NAME=${HADOOP_DIR_NAME}.tar.gz
+if [ ! -f ${HADOOP_PACKAGE_NAME} ]; then
+    echo "Downloading hadoop..."
+
+    DOWNLOAD_URL="https://pegasus-thirdparty-package.oss-cn-beijing.aliyuncs.com/${HADOOP_PACKAGE_NAME}"
+    if ! wget -T 10 -t 5 ${DOWNLOAD_URL}; then
+        echo "ERROR: download hadoop failed"
+        exit 1
+    fi
+
+    HADOOP_PACKAGE_MD5="b30b409bb69185003b3babd1504ba224"
+    if [ `md5sum ${HADOOP_PACKAGE_NAME} | awk '{print$1}'` != ${HADOOP_PACKAGE_MD5} ]; then
+        echo "Check file ${HADOOP_PACKAGE_NAME} md5sum failed!"
+        exit 1
+    fi
+fi
+
+rm -rf ${HADOOP_DIR_NAME}
+
+echo "Decompressing HDFS..."
+if ! tar xf ${HADOOP_PACKAGE_NAME}; then
+    echo "ERROR: decompress hadoop failed"
+    rm -f ${HADOOP_PACKAGE_NAME}
+    exit 1
+fi
+
+rm -f ${HADOOP_PACKAGE_NAME}
+
+if [ ! -d ${HADOOP_DIR_NAME} ]; then
+    echo "ERROR: ${HADOOP_DIR_NAME} does not exist"
+    exit 1
+fi
+
+mv ${HADOOP_PACKAGE_NAME} ${HADOOP_BIN_PATH}

--- a/scripts/download_hadoop.sh
+++ b/scripts/download_hadoop.sh
@@ -18,15 +18,15 @@
 # under the License.
 
 set -e
-set -x
 
 if [ $# -lt 1 ]; then
-    echo "parameterNumber is less than 1"
+    echo "Target HADOOP_BIN_PATH is not provided, thus do not try to download hadoop"
     exit 0
 fi
 
 HADOOP_BIN_PATH=$1
 if [ -d ${HADOOP_BIN_PATH} ]; then
+    echo "Target HADOOP_BIN_PATH ${HADOOP_BIN_PATH} has existed, thus do not try to download hadoop"
     exit 0
 fi
 
@@ -51,7 +51,7 @@ fi
 
 rm -rf ${HADOOP_DIR_NAME}
 
-echo "Decompressing HDFS..."
+echo "Decompressing hadoop..."
 if ! tar xf ${HADOOP_PACKAGE_NAME}; then
     echo "ERROR: decompress hadoop failed"
     rm -f ${HADOOP_PACKAGE_NAME}

--- a/scripts/download_hadoop.sh
+++ b/scripts/download_hadoop.sh
@@ -18,8 +18,10 @@
 # under the License.
 
 set -e
+set -x
 
 if [ $# -lt 1 ]; then
+    echo "parameterNumber is less than 1"
     exit 0
 fi
 


### PR DESCRIPTION
This PR is to fix https://github.com/apache/incubator-pegasus/issues/1164. This has been tested by manually running BuildThirdpartyDockerRegularly as https://github.com/apache/incubator-pegasus/actions/runs/3094818838.