### PR TITLE
ci: download hadoop-2.8.4.tar.gz during release building for unit tests once third-parties have changed

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -173,7 +173,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          source ./scripts/config_hdfs.sh
+          . ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_ASAN:
@@ -285,7 +285,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          source ./scripts/config_hdfs.sh
+          . ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_UBSAN:
@@ -397,7 +397,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          source ./scripts/config_hdfs.sh
+          . ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_with_jemalloc:
@@ -483,7 +483,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          source ./scripts/config_hdfs.sh
+          . ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_pegasus_on_macos:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -93,6 +93,7 @@ jobs:
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
           cmake --build build/ -j $(nproc)
+          ./scripts/download_hadoop.sh hadoop-bin
       - name: Compilation
         run: |
           ccache -p
@@ -105,8 +106,9 @@ jobs:
         run: ./run.sh pack_tools
       - name: Tar files
         run: |
+          mv thirdparty/hadoop-bin ./
           rm -rf thirdparty
-          tar -zcvhf release__builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini --exclude='*CMakeFiles*'
+          tar -zcvhf release__builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini hadoop-bin --exclude='*CMakeFiles*'
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -207,6 +209,7 @@ jobs:
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
           cmake --build build/ -j $(nproc)
+          ./scripts/download_hadoop.sh hadoop-bin
       - name: Compilation
         run: |
           ccache -p
@@ -215,8 +218,9 @@ jobs:
           ccache -s
       - name: Tar files
         run: |
+          mv thirdparty/hadoop-bin ./
           rm -rf thirdparty
-          tar -zcvhf release_address_builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini --exclude='*CMakeFiles*'
+          tar -zcvhf release_address_builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini hadoop-bin --exclude='*CMakeFiles*'
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -317,6 +321,7 @@ jobs:
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
           cmake --build build/ -j $(nproc)
+          ./scripts/download_hadoop.sh hadoop-bin
       - name: Compilation
         run: |
           ccache -p
@@ -325,8 +330,9 @@ jobs:
           ccache -s
       - name: Tar files
         run: |
+          mv thirdparty/hadoop-bin ./
           rm -rf thirdparty
-          tar -zcvhf release_undefined_builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini --exclude='*CMakeFiles*'
+          tar -zcvhf release_undefined_builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini hadoop-bin --exclude='*CMakeFiles*'
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -173,7 +173,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          ./scripts/config_hdfs.sh
+          source ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_ASAN:
@@ -285,7 +285,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          ./scripts/config_hdfs.sh
+          source ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_UBSAN:
@@ -397,7 +397,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          ./scripts/config_hdfs.sh
+          source ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_with_jemalloc:
@@ -433,6 +433,7 @@ jobs:
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -DUSE_JEMALLOC=ON -B build/
           cmake --build build/ -j $(nproc)
+          ./scripts/download_hadoop.sh hadoop-bin
       - name: Compilation
         run: |
           ccache -p
@@ -445,8 +446,9 @@ jobs:
         run: ./run.sh pack_tools -j
       - name: Tar files
         run: |
+          mv thirdparty/hadoop-bin ./
           rm -rf thirdparty
-          tar -zcvhf release_jemalloc_builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini --exclude='*CMakeFiles*'
+          tar -zcvhf release_jemalloc_builder.tar DSN_ROOT/ src/builder/bin src/builder/src/server/test/config.ini hadoop-bin --exclude='*CMakeFiles*'
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -481,7 +483,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          ./scripts/config_hdfs.sh
+          source ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_pegasus_on_macos:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -173,7 +173,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          . ./scripts/config_hdfs.sh
+          . scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_ASAN:
@@ -285,7 +285,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          . ./scripts/config_hdfs.sh
+          . scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_UBSAN:
@@ -397,7 +397,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          . ./scripts/config_hdfs.sh
+          . scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_with_jemalloc:
@@ -483,7 +483,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          . ./scripts/config_hdfs.sh
+          . scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_pegasus_on_macos:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -173,7 +173,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          . scripts/config_hdfs.sh
+          . ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_ASAN:
@@ -285,7 +285,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          . scripts/config_hdfs.sh
+          . ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_UBSAN:
@@ -397,7 +397,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          . scripts/config_hdfs.sh
+          . ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_with_jemalloc:
@@ -483,7 +483,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
-          . scripts/config_hdfs.sh
+          . ./scripts/config_hdfs.sh
           ./run.sh test -m ${{ matrix.test_module }}
 
   build_pegasus_on_macos:

--- a/scripts/config_hdfs.sh
+++ b/scripts/config_hdfs.sh
@@ -39,35 +39,9 @@ fi
 JAVA_JVM_LIBRARY_DIR=$(dirname $(find "${JAVA_HOME}/" -name libjvm.so  | head -1))
 export LD_LIBRARY_PATH=${JAVA_JVM_LIBRARY_DIR}:$LD_LIBRARY_PATH
 
-# download hdfs for unit test
-HDFS_ROOT=hadoop-2.8.4
-HDFS_TAR_NAME=${HDFS_ROOT}.tar.gz
-HDFS_TAR_MD5_VALUE="b30b409bb69185003b3babd1504ba224"
-if [ ! -f $HDFS_ROOT ]; then
-    echo "Downloading hadoop..."
-    download_url="https://pegasus-thirdparty-package.oss-cn-beijing.aliyuncs.com/hadoop-2.8.4.tar.gz"
-    if ! wget -T 10 -t 5 $download_url; then
-        echo "ERROR: download hadoop failed"
-        exit 1
-    fi
-    if [ `md5sum $HDFS_TAR_NAME | awk '{print$1}'` != $HDFS_TAR_MD5_VALUE ]; then
-        echo "check file $HDFS_TAR_NAME md5sum failed!"
-        exit 1
-    fi
-fi
-
-if [ ! -d $HDFS_ROOT ]; then
-    echo "Decompressing HDFS..."
-    if ! tar xf $HDFS_TAR_NAME; then
-        echo "ERROR: decompress hadoop failed"
-        exit 1
-    fi
-    rm -f $HDFS_TAR_NAME
-fi
-
 # Set CLASSPATH to all the Hadoop jars needed to run Hadoop itself as well as
 # the right configuration directory containing core-site.xml or hdfs-site.xml.
-PEGASUS_HADOOP_HOME=`pwd`/${HDFS_ROOT}
+PEGASUS_HADOOP_HOME=`pwd`/hadoop-bin
 # Prefer the HADOOP_HOME set in the environment, but use the pegasus's hadoop dir otherwise.
 export HADOOP_HOME="${HADOOP_HOME:-${PEGASUS_HADOOP_HOME}}"
 if [ ! -d "$HADOOP_HOME/etc/hadoop" ] || [ ! -d "$HADOOP_HOME/share/hadoop" ]; then


### PR DESCRIPTION
This PR is to fix https://github.com/apache/incubator-pegasus/issues/1164. Once third-parties have changed, image will not be used thus hadoop-2.8.4.tar.gz should be downloaded.

On the other hand, an error was reported as:

![image](https://user-images.githubusercontent.com/743379/191884213-119e1c3f-30f2-4f9d-8486-a5dc75d5a611.png)

This told that `source` should be used since it will quit from `return` rather than `exit`, as following code in [config_hdfs.sh](https://github.com/apache/incubator-pegasus/blob/master/scripts/config_hdfs.sh):

```bash
export HADOOP_HOME="${HADOOP_HOME:-${PEGASUS_HADOOP_HOME}}"
if [ ! -d "$HADOOP_HOME/etc/hadoop" ] || [ ! -d "$HADOOP_HOME/share/hadoop" ]; then
  echo "HADOOP_HOME must be set to the location of your Hadoop jars and core-site.xml."
  return 1
fi
```

Thus in [lint_and_test_cpp.yaml](https://github.com/apache/incubator-pegasus/blob/master/.github/workflows/lint_and_test_cpp.yaml), `. ./scripts/config_hdfs.sh` should be used instead of `./scripts/config_hdfs.sh`. The reason for using `.` rather than `source` is that the shell is not bash for github workflow: once `source` is used the workflow will fail with `source: not found`.