### PR TITLE
refactor(function_test): use test_util to reduce duplicate code

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -765,7 +765,6 @@ function run_start_onebox()
         cd meta$i
         ln -s -f ${SERVER_PATH}/pegasus_server pegasus_server
         sed "s/@META_PORT@/$meta_port/;s/@REPLICA_PORT@/34800/;s/@PROMETHEUS_PORT@/$prometheus_port/" ${ROOT}/config-server.ini >config.ini
-        echo "cd `pwd` && $PWD/pegasus_server config.ini -app_list meta &>result &"
         $PWD/pegasus_server config.ini -app_list meta &>result &
         PID=$!
         ps -ef | grep '/pegasus_server config.ini' | grep "\<$PID\>"
@@ -779,7 +778,6 @@ function run_start_onebox()
         cd replica$j
         ln -s -f ${SERVER_PATH}/pegasus_server pegasus_server
         sed "s/@META_PORT@/34600/;s/@REPLICA_PORT@/$replica_port/;s/@PROMETHEUS_PORT@/$prometheus_port/" ${ROOT}/config-server.ini >config.ini
-        echo "cd `pwd` && $PWD/pegasus_server config.ini -app_list replica &>result &"
         $PWD/pegasus_server config.ini -app_list replica &>result &
         PID=$!
         ps -ef | grep '/pegasus_server config.ini' | grep "\<$PID\>"
@@ -791,7 +789,6 @@ function run_start_onebox()
         cd collector
         ln -s -f ${SERVER_PATH}/pegasus_server pegasus_server
         sed "s/@META_PORT@/34600/;s/@REPLICA_PORT@/34800/;s/@PROMETHEUS_PORT@/9091/" ${ROOT}/config-server.ini >config.ini
-        echo "cd `pwd` && $PWD/pegasus_server config.ini -app_list collector &>result &"
         $PWD/pegasus_server config.ini -app_list collector &>result &
         PID=$!
         ps -ef | grep '/pegasus_server config.ini' | grep "\<$PID\>"
@@ -967,7 +964,6 @@ function run_start_onebox_instance()
             exit 1
         fi
         cd $dir
-        echo "cd `pwd` && $PWD/pegasus_server config.ini -app_list meta &>result &"
         $PWD/pegasus_server config.ini -app_list meta &>result &
         PID=$!
         ps -ef | grep '/pegasus_server config.ini' | grep "\<$PID\>"
@@ -985,7 +981,6 @@ function run_start_onebox_instance()
             exit 1
         fi
         cd $dir
-        echo "cd `pwd` && $PWD/pegasus_server config.ini -app_list replica &>result &"
         $PWD/pegasus_server config.ini -app_list replica &>result &
         PID=$!
         ps -ef | grep '/pegasus_server config.ini' | grep "\<$PID\>"
@@ -1003,7 +998,6 @@ function run_start_onebox_instance()
             exit 1
         fi
         cd $dir
-        echo "cd `pwd` && $PWD/pegasus_server config.ini -app_list collector &>result &"
         $PWD/pegasus_server config.ini -app_list collector &>result &
         PID=$!
         ps -ef | grep '/pegasus_server config.ini' | grep "\<$PID\>"

--- a/src/test/function_test/backup_restore_test/test_backup_and_restore.cpp
+++ b/src/test/function_test/backup_restore_test/test_backup_and_restore.cpp
@@ -30,6 +30,8 @@ using namespace dsn;
 using namespace dsn::replication;
 using namespace pegasus;
 
+// TODO(yingchun): backup & restore festure is on refactoring, we can refactor the related function
+// test later.
 class backup_restore_test : public testing::Test
 {
 public:

--- a/src/test/function_test/base_api_test/test_batch_get.cpp
+++ b/src/test/function_test/base_api_test/test_batch_get.cpp
@@ -42,17 +42,14 @@ class batch_get : public test_util
 
 TEST_F(batch_get, set_and_then_batch_get)
 {
-    std::vector<rpc_address> meta_list;
-    ASSERT_TRUE(replica_helper::load_meta_servers(
-        meta_list, PEGASUS_CLUSTER_SECTION_NAME.c_str(), "mycluster"));
-    auto rrdb_client = new ::dsn::apps::rrdb_client("mycluster", meta_list, client->get_app_name());
+    auto rrdb_client =
+        new ::dsn::apps::rrdb_client(cluster_name_.c_str(), meta_list_, app_name_.c_str());
 
     int test_data_count = 100;
     int test_timeout_milliseconds = 3000;
     uint64_t test_partition_hash = 0;
 
     apps::batch_get_request batch_request;
-
     std::vector<std::string> test_data_hash_keys(test_data_count);
     std::vector<std::string> test_data_sort_keys(test_data_count);
     std::vector<std::string> test_data_values(test_data_count);

--- a/src/test/function_test/base_api_test/test_check_and_mutate.cpp
+++ b/src/test/function_test/base_api_test/test_check_and_mutate.cpp
@@ -41,8 +41,7 @@ TEST_F(check_and_mutate, value_not_exist)
     std::string hash_key("check_and_mutate_test_value_not_exist");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -51,62 +50,57 @@ TEST_F(check_and_mutate, value_not_exist)
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = false;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_FALSE(results.check_value_returned);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->del(hash_key, "k2");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k2"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -115,48 +109,43 @@ TEST_F(check_and_mutate, value_not_exist)
 
         options.return_check_value = true;
         mutations.set("k2", "");
-        ret = client->check_and_mutate(hash_key,
-                                       "k2",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k2",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k2", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k2", value));
         ASSERT_EQ("", value);
 
         options.return_check_value = true;
         mutations.set("k2", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k2",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k2",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k2", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k2", value));
         ASSERT_EQ("", value);
 
-        ret = client->del(hash_key, "k2");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k2"));
     }
 
     {
-        int ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -165,25 +154,22 @@ TEST_F(check_and_mutate, value_not_exist)
 
         options.return_check_value = true;
         mutations.set("k4", "v4");
-        ret = client->check_and_mutate(hash_key,
-                                       "k3",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k3",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 
@@ -192,8 +178,7 @@ TEST_F(check_and_mutate, value_exist)
     std::string hash_key("check_and_mutate_test_value_exist");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -202,68 +187,60 @@ TEST_F(check_and_mutate, value_exist)
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
-
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v3");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -272,26 +249,23 @@ TEST_F(check_and_mutate, value_exist)
 
         options.return_check_value = true;
         mutations.set("k4", "v4");
-        ret = client->check_and_mutate(hash_key,
-                                       "k3",
-                                       pegasus_client::cas_check_type::CT_VALUE_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k3",
+                                            pegasus_client::cas_check_type::CT_VALUE_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v3", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 
@@ -300,8 +274,7 @@ TEST_F(check_and_mutate, value_not_empty)
     std::string hash_key("check_and_mutate_test_value_not_empty");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -310,71 +283,62 @@ TEST_F(check_and_mutate, value_not_empty)
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
-
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("", value);
 
-        ret = client->set(hash_key, "k1", "v1");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", "v1"));
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v3");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -383,26 +347,23 @@ TEST_F(check_and_mutate, value_not_empty)
 
         options.return_check_value = true;
         mutations.set("k4", "v4");
-        ret = client->check_and_mutate(hash_key,
-                                       "k3",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k3",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v3", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 TEST_F(check_and_mutate, value_match_anywhere)
@@ -410,8 +371,7 @@ TEST_F(check_and_mutate, value_match_anywhere)
     std::string hash_key("check_and_mutate_test_value_match_anywhere");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -420,176 +380,162 @@ TEST_F(check_and_mutate, value_match_anywhere)
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                       "v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                            "v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
-
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                       "v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                            "v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v111v");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                       "2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                            "2",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v111v", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                       "111",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                            "111",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v111v", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                       "y",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                            "y",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                       "v2v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                            "v2v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                       "v2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                            "v2",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v3", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v333v");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v333v"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -598,26 +544,23 @@ TEST_F(check_and_mutate, value_match_anywhere)
 
         options.return_check_value = true;
         mutations.set("k4", "v4");
-        ret = client->check_and_mutate(hash_key,
-                                       "k3",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                       "333",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k3",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                            "333",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v333v", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 
@@ -626,8 +569,7 @@ TEST_F(check_and_mutate, value_match_prefix)
     std::string hash_key("check_and_mutate_test_value_match_prefix");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -636,212 +578,197 @@ TEST_F(check_and_mutate, value_match_prefix)
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v111v");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v111v", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "111",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "111",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v111v", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v111v", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "v111",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "v111",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v111v", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "y",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "y",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "v2v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "v2v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "2",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "v2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "v2",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v3", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v333v");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v333v"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -850,26 +777,23 @@ TEST_F(check_and_mutate, value_match_prefix)
 
         options.return_check_value = true;
         mutations.set("k4", "v4");
-        ret = client->check_and_mutate(hash_key,
-                                       "k3",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                       "v333",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k3",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                            "v333",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v333v", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 
@@ -878,8 +802,7 @@ TEST_F(check_and_mutate, value_match_postfix)
     std::string hash_key("check_and_mutate_test_value_match_postfix");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -888,212 +811,197 @@ TEST_F(check_and_mutate, value_match_postfix)
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v111v");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "2",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v111v", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "111",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "111",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v111v", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v111v", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "111v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "111v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v111v", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "y",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "y",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "2v2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "2v2",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "v2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "v2",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v3", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v333v");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v333v"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -1102,26 +1010,23 @@ TEST_F(check_and_mutate, value_match_postfix)
 
         options.return_check_value = true;
         mutations.set("k4", "v4");
-        ret = client->check_and_mutate(hash_key,
-                                       "k3",
-                                       pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                       "333v",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k3",
+                                            pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                            "333v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v333v", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 
@@ -1130,8 +1035,7 @@ TEST_F(check_and_mutate, value_bytes_compare)
     std::string hash_key("check_and_mutate_test_value_bytes_compare");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -1140,86 +1044,78 @@ TEST_F(check_and_mutate, value_bytes_compare)
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
         mutations.set("k1", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                       "v1",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
+                                            "v1",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v3");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -1228,31 +1124,27 @@ TEST_F(check_and_mutate, value_bytes_compare)
 
         options.return_check_value = true;
         mutations.set("k4", "v4");
-        ret = client->check_and_mutate(hash_key,
-                                       "k3",
-                                       pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                       "v3",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k3",
+                                            pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
+                                            "v3",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v3", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 
     {
-        int ret = client->set(hash_key, "k5", "v1");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k5", "v1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -1262,121 +1154,116 @@ TEST_F(check_and_mutate, value_bytes_compare)
         // v1 < v2
         options.return_check_value = true;
         mutations.set("k5", "v2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k5",
-                                       pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS,
-                                       "v2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k5",
+                                            pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS,
+                                            "v2",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v2", value);
 
         // v2 <= v2
         options.return_check_value = true;
         mutations.set("k5", "v3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k5",
-                                       pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS_OR_EQUAL,
-                                       "v2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_mutate(hash_key,
+                                      "k5",
+                                      pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS_OR_EQUAL,
+                                      "v2",
+                                      mutations,
+                                      options,
+                                      results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v3", value);
 
         // v3 <= v4
         options.return_check_value = true;
         mutations.set("k5", "v4");
-        ret = client->check_and_mutate(hash_key,
-                                       "k5",
-                                       pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS_OR_EQUAL,
-                                       "v4",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_mutate(hash_key,
+                                      "k5",
+                                      pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS_OR_EQUAL,
+                                      "v4",
+                                      mutations,
+                                      options,
+                                      results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v3", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v4", value);
 
         // v4 >= v4
         options.return_check_value = true;
         mutations.set("k5", "v5");
-        ret = client->check_and_mutate(
-            hash_key,
-            "k5",
-            pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER_OR_EQUAL,
-            "v4",
-            mutations,
-            options,
-            results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(
+                      hash_key,
+                      "k5",
+                      pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER_OR_EQUAL,
+                      "v4",
+                      mutations,
+                      options,
+                      results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v4", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v5", value);
 
         // v5 >= v4
         options.return_check_value = true;
         mutations.set("k5", "v6");
-        ret = client->check_and_mutate(
-            hash_key,
-            "k5",
-            pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER_OR_EQUAL,
-            "v4",
-            mutations,
-            options,
-            results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(
+                      hash_key,
+                      "k5",
+                      pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER_OR_EQUAL,
+                      "v4",
+                      mutations,
+                      options,
+                      results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v5", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v6", value);
 
         // v6 > v5
         options.return_check_value = true;
         mutations.set("k5", "v7");
-        ret = client->check_and_mutate(hash_key,
-                                       "k5",
-                                       pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER,
-                                       "v5",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k5",
+                                            pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER,
+                                            "v5",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v6", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v7", value);
 
-        ret = client->del(hash_key, "k5");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k5"));
     }
 }
 
@@ -1385,8 +1272,7 @@ TEST_F(check_and_mutate, value_int_compare)
     std::string hash_key("check_and_mutate_test_value_int_compare");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -1395,164 +1281,150 @@ TEST_F(check_and_mutate, value_int_compare)
 
         options.return_check_value = true;
         mutations.set("k1", "2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                       "1",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                            "1",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
         mutations.set("k1", "2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                       "1",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+        ASSERT_EQ(PERR_INVALID_ARGUMENT,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                            "1",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("", value);
 
-        ret = client->set(hash_key, "k1", "1");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", "1"));
 
         options.return_check_value = true;
         mutations.set("k1", "2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                       "1",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                            "1",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+        ASSERT_EQ(PERR_INVALID_ARGUMENT,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                       "v1",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+        ASSERT_EQ(PERR_INVALID_ARGUMENT,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                            "v1",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("2", value);
 
         options.return_check_value = true;
         mutations.set("k1", "3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                       "88888888888888888888888888888888888888888888888",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+        ASSERT_EQ(PERR_INVALID_ARGUMENT,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                            "88888888888888888888888888888888888888888888888",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("2", value);
 
-        ret = client->set(hash_key, "k1", "0");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", "0"));
 
         options.return_check_value = true;
         mutations.set("k1", "-1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                       "0",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                            "0",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("0", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("-1", value);
 
         options.return_check_value = true;
         mutations.set("k1", "-2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                       "-1",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                            "-1",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("-1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("-2", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "3");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -1561,31 +1433,27 @@ TEST_F(check_and_mutate, value_int_compare)
 
         options.return_check_value = true;
         mutations.set("k4", "4");
-        ret = client->check_and_mutate(hash_key,
-                                       "k3",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                       "3",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k3",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                            "3",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("3", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 
     {
-        int ret = client->set(hash_key, "k5", "1");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k5", "1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -1595,121 +1463,116 @@ TEST_F(check_and_mutate, value_int_compare)
         // 1 < 2
         options.return_check_value = true;
         mutations.set("k5", "2");
-        ret = client->check_and_mutate(hash_key,
-                                       "k5",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_LESS,
-                                       "2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k5",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_LESS,
+                                            "2",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("1", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("2", value);
 
         // 2 <= 2
         options.return_check_value = true;
         mutations.set("k5", "3");
-        ret = client->check_and_mutate(hash_key,
-                                       "k5",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_LESS_OR_EQUAL,
-                                       "2",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_mutate(hash_key,
+                                      "k5",
+                                      pegasus_client::cas_check_type::CT_VALUE_INT_LESS_OR_EQUAL,
+                                      "2",
+                                      mutations,
+                                      options,
+                                      results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("2", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("3", value);
 
         // 3 <= 4
         options.return_check_value = true;
         mutations.set("k5", "4");
-        ret = client->check_and_mutate(hash_key,
-                                       "k5",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_LESS_OR_EQUAL,
-                                       "4",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_mutate(hash_key,
+                                      "k5",
+                                      pegasus_client::cas_check_type::CT_VALUE_INT_LESS_OR_EQUAL,
+                                      "4",
+                                      mutations,
+                                      options,
+                                      results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("3", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("4", value);
 
         // 4 >= 4
         options.return_check_value = true;
         mutations.set("k5", "5");
-        ret =
-            client->check_and_mutate(hash_key,
-                                     "k5",
-                                     pegasus_client::cas_check_type::CT_VALUE_INT_GREATER_OR_EQUAL,
-                                     "4",
-                                     mutations,
-                                     options,
-                                     results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_mutate(hash_key,
+                                      "k5",
+                                      pegasus_client::cas_check_type::CT_VALUE_INT_GREATER_OR_EQUAL,
+                                      "4",
+                                      mutations,
+                                      options,
+                                      results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("4", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("5", value);
 
         // 5 >= 4
         options.return_check_value = true;
         mutations.set("k5", "6");
-        ret =
-            client->check_and_mutate(hash_key,
-                                     "k5",
-                                     pegasus_client::cas_check_type::CT_VALUE_INT_GREATER_OR_EQUAL,
-                                     "4",
-                                     mutations,
-                                     options,
-                                     results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_mutate(hash_key,
+                                      "k5",
+                                      pegasus_client::cas_check_type::CT_VALUE_INT_GREATER_OR_EQUAL,
+                                      "4",
+                                      mutations,
+                                      options,
+                                      results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("5", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("6", value);
 
         // 6 > 5
         options.return_check_value = true;
         mutations.set("k5", "7");
-        ret = client->check_and_mutate(hash_key,
-                                       "k5",
-                                       pegasus_client::cas_check_type::CT_VALUE_INT_GREATER,
-                                       "5",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k5",
+                                            pegasus_client::cas_check_type::CT_VALUE_INT_GREATER,
+                                            "5",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("6", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("7", value);
 
-        ret = client->del(hash_key, "k5");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k5"));
     }
 }
 
@@ -1718,16 +1581,20 @@ TEST_F(check_and_mutate, invalid_type)
     std::string hash_key("check_and_mutate_test_value_invalid_type");
 
     {
-        int ret = 0;
         pegasus_client::mutations mutations;
         pegasus_client::check_and_mutate_options options;
         pegasus_client::check_and_mutate_results results;
 
         options.return_check_value = true;
         mutations.set("k1", "v1");
-        ret = client->check_and_mutate(
-            hash_key, "k1", (pegasus_client::cas_check_type)100, "v", mutations, options, results);
-        ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+        ASSERT_EQ(PERR_INVALID_ARGUMENT,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            (pegasus_client::cas_check_type)100,
+                                            "v",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_FALSE(results.mutate_succeed);
         ASSERT_FALSE(results.check_value_returned);
     }
@@ -1738,9 +1605,7 @@ TEST_F(check_and_mutate, set_del)
     std::string hash_key("check_and_mutate_test_set_del");
 
     {
-        int ret = 0;
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -1750,20 +1615,19 @@ TEST_F(check_and_mutate, set_del)
         options.return_check_value = true;
         mutations.set("k1", "v1");
         mutations.del("k1");
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
 
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
     }
 }
 
@@ -1772,9 +1636,7 @@ TEST_F(check_and_mutate, multi_get_mutations)
     std::string hash_key("check_and_mutate_test_multi_get_mutations");
 
     {
-        int ret = 0;
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -1783,36 +1645,34 @@ TEST_F(check_and_mutate, multi_get_mutations)
 
         options.return_check_value = true;
         mutations.set("k1", "v1", 10);
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
 
         ::sleep(12);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
 
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
     }
 }
@@ -1822,9 +1682,7 @@ TEST_F(check_and_mutate, expire_seconds)
     std::string hash_key("check_and_mutate_test_expire_seconds");
 
     {
-        int ret = 0;
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::mutations mutations;
@@ -1835,19 +1693,18 @@ TEST_F(check_and_mutate, expire_seconds)
         mutations.set("k1", "v1", 10);
         ::sleep(12);
         mutations.set("k2", "v2", 10);
-        ret = client->check_and_mutate(hash_key,
-                                       "k1",
-                                       pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                       "",
-                                       mutations,
-                                       options,
-                                       results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_mutate(hash_key,
+                                            "k1",
+                                            pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                            "",
+                                            mutations,
+                                            options,
+                                            results));
         ASSERT_TRUE(results.mutate_succeed);
         ASSERT_TRUE(results.check_value_returned);
 
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
     }
 }

--- a/src/test/function_test/base_api_test/test_check_and_set.cpp
+++ b/src/test/function_test/base_api_test/test_check_and_set.cpp
@@ -41,146 +41,132 @@ TEST_F(check_and_set, value_not_exist)
     std::string hash_key("check_and_set_test_value_not_exist");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                    "",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                         "",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = false;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_FALSE(results.check_value_returned);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->del(hash_key, "k2");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k2"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k2",
-                                    pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                    "",
-                                    "k2",
-                                    "",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k2",
+                                         pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                         "",
+                                         "k2",
+                                         "",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k2", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k2", value));
         ASSERT_EQ("", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k2",
-                                    pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                    "",
-                                    "k2",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k2",
+                                         pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                         "",
+                                         "k2",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k2", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k2", value));
         ASSERT_EQ("", value);
 
-        ret = client->del(hash_key, "k2");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k2"));
     }
 
     {
-        int ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k3",
-                                    pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
-                                    "",
-                                    "k4",
-                                    "v4",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k3",
+                                         pegasus_client::cas_check_type::CT_VALUE_NOT_EXIST,
+                                         "",
+                                         "k4",
+                                         "v4",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 
@@ -189,104 +175,93 @@ TEST_F(check_and_set, value_exist)
     std::string hash_key("check_and_set_test_value_exist");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_EXIST,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_EXIST,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_EXIST,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_EXIST,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_EXIST,
-                                    "",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_EXIST,
+                                         "",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v3");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k3",
-                                    pegasus_client::cas_check_type::CT_VALUE_EXIST,
-                                    "",
-                                    "k4",
-                                    "v4",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k3",
+                                         pegasus_client::cas_check_type::CT_VALUE_EXIST,
+                                         "",
+                                         "k4",
+                                         "v4",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v3", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 
@@ -295,107 +270,95 @@ TEST_F(check_and_set, value_not_empty)
     std::string hash_key("check_and_set_test_value_not_empty");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("", value);
 
-        ret = client->set(hash_key, "k1", "v1");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", "v1"));
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
-                                    "",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
+                                         "",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v3");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k3",
-                                    pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
-                                    "",
-                                    "k4",
-                                    "v4",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k3",
+                                         pegasus_client::cas_check_type::CT_VALUE_NOT_EMPTY,
+                                         "",
+                                         "k4",
+                                         "v4",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v3", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 TEST_F(check_and_set, value_match_anywhere)
@@ -403,212 +366,195 @@ TEST_F(check_and_set, value_match_anywhere)
     std::string hash_key("check_and_set_test_value_match_anywhere");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                    "v",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                         "v",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                    "v",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                         "v",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                    "",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                         "",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                    "2",
-                                    "k1",
-                                    "v111v",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                         "2",
+                                         "k1",
+                                         "v111v",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v111v", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                    "111",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                         "111",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v111v", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                    "y",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                         "y",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                    "v2v",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                         "v2v",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                    "v2",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                         "v2",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v3", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v333v");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v333v"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k3",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
-                                    "333",
-                                    "k4",
-                                    "v4",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k3",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_ANYWHERE,
+                                         "333",
+                                         "k4",
+                                         "v4",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v333v", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 
@@ -617,248 +563,229 @@ TEST_F(check_and_set, value_match_prefix)
     std::string hash_key("check_and_set_test_value_match_prefix");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "v",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "v",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "v",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "v",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "v",
-                                    "k1",
-                                    "v111v",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "v",
+                                         "k1",
+                                         "v111v",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v111v", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "111",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "111",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v111v", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v111v", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "v111",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "v111",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v111v", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "y",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "y",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "v2v",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "v2v",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "2",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "2",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "v2",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "v2",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v3", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v333v");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v333v"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k3",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
-                                    "v333",
-                                    "k4",
-                                    "v4",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k3",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_PREFIX,
+                                         "v333",
+                                         "k4",
+                                         "v4",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v333v", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 
@@ -867,248 +794,229 @@ TEST_F(check_and_set, value_match_postfix)
     std::string hash_key("check_and_set_test_value_match_postfix");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "v",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "v",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "v",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "v",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "2",
-                                    "k1",
-                                    "v111v",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "2",
+                                         "k1",
+                                         "v111v",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v111v", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "111",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "111",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v111v", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v111v", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "111v",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "111v",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v111v", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "y",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "y",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "2v2",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "2v2",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "v",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "v",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "v2",
-                                    "k1",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "v2",
+                                         "k1",
+                                         "v3",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v3", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v333v");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v333v"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k3",
-                                    pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
-                                    "333v",
-                                    "k4",
-                                    "v4",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k3",
+                                         pegasus_client::cas_check_type::CT_VALUE_MATCH_POSTFIX,
+                                         "333v",
+                                         "k4",
+                                         "v4",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v333v", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 }
 
@@ -1117,127 +1025,114 @@ TEST_F(check_and_set, value_bytes_compare)
     std::string hash_key("check_and_set_test_value_bytes_compare");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                    "",
-                                    "k1",
-                                    "v1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
+                                         "",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                    "",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
+                                         "",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v1", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                    "v1",
-                                    "k1",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
+                                         "v1",
+                                         "k1",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("v2", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "v3");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "v3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k3",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
-                                    "v3",
-                                    "k4",
-                                    "v4",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k3",
+                                         pegasus_client::cas_check_type::CT_VALUE_BYTES_EQUAL,
+                                         "v3",
+                                         "k4",
+                                         "v4",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v3", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("v4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 
     {
-        int ret = client->set(hash_key, "k5", "v1");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k5", "v1"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
@@ -1245,120 +1140,117 @@ TEST_F(check_and_set, value_bytes_compare)
 
         // v1 < v2
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS,
-                                    "v2",
-                                    "k5",
-                                    "v2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k5",
+                                         pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS,
+                                         "v2",
+                                         "k5",
+                                         "v2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v1", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v2", value);
 
         // v2 <= v2
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS_OR_EQUAL,
-                                    "v2",
-                                    "k5",
-                                    "v3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_set(hash_key,
+                                   "k5",
+                                   pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS_OR_EQUAL,
+                                   "v2",
+                                   "k5",
+                                   "v3",
+                                   options,
+                                   results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v2", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v3", value);
 
         // v3 <= v4
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS_OR_EQUAL,
-                                    "v4",
-                                    "k5",
-                                    "v4",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_set(hash_key,
+                                   "k5",
+                                   pegasus_client::cas_check_type::CT_VALUE_BYTES_LESS_OR_EQUAL,
+                                   "v4",
+                                   "k5",
+                                   "v4",
+                                   options,
+                                   results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v3", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v4", value);
 
         // v4 >= v4
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER_OR_EQUAL,
-                                    "v4",
-                                    "k5",
-                                    "v5",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_set(hash_key,
+                                   "k5",
+                                   pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER_OR_EQUAL,
+                                   "v4",
+                                   "k5",
+                                   "v5",
+                                   options,
+                                   results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v4", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v5", value);
 
         // v5 >= v4
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER_OR_EQUAL,
-                                    "v4",
-                                    "k5",
-                                    "v6",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_set(hash_key,
+                                   "k5",
+                                   pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER_OR_EQUAL,
+                                   "v4",
+                                   "k5",
+                                   "v6",
+                                   options,
+                                   results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v5", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v6", value);
 
         // v6 > v5
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER,
-                                    "v5",
-                                    "k5",
-                                    "v7",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k5",
+                                         pegasus_client::cas_check_type::CT_VALUE_BYTES_GREATER,
+                                         "v5",
+                                         "k5",
+                                         "v7",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("v6", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("v7", value);
 
-        ret = client->del(hash_key, "k5");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k5"));
     }
 }
 
@@ -1367,205 +1259,186 @@ TEST_F(check_and_set, value_int_compare)
     std::string hash_key("check_and_set_test_value_int_compare");
 
     {
-        int ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                    "1",
-                                    "k1",
-                                    "2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                         "1",
+                                         "k1",
+                                         "2",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_FALSE(results.check_value_exist);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_NOT_FOUND, ret);
+        ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, "k1", value));
 
-        ret = client->set(hash_key, "k1", "");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", ""));
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                    "1",
-                                    "k1",
-                                    "2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+        ASSERT_EQ(PERR_INVALID_ARGUMENT,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                         "1",
+                                         "k1",
+                                         "2",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("", value);
 
-        ret = client->set(hash_key, "k1", "1");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", "1"));
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                    "1",
-                                    "k1",
-                                    "2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                         "1",
+                                         "k1",
+                                         "2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                    "",
-                                    "k1",
-                                    "3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+        ASSERT_EQ(PERR_INVALID_ARGUMENT,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                         "",
+                                         "k1",
+                                         "3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                    "v1",
-                                    "k1",
-                                    "3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+        ASSERT_EQ(PERR_INVALID_ARGUMENT,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                         "v1",
+                                         "k1",
+                                         "3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("2", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                    "88888888888888888888888888888888888888888888888",
-                                    "k1",
-                                    "3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+        ASSERT_EQ(PERR_INVALID_ARGUMENT,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                         "88888888888888888888888888888888888888888888888",
+                                         "k1",
+                                         "3",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("2", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("2", value);
 
-        ret = client->set(hash_key, "k1", "0");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k1", "0"));
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                    "0",
-                                    "k1",
-                                    "-1",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                         "0",
+                                         "k1",
+                                         "-1",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("0", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("-1", value);
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k1",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                    "-1",
-                                    "k1",
-                                    "-2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                         "-1",
+                                         "k1",
+                                         "-2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("-1", results.check_value);
-        ret = client->get(hash_key, "k1", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k1", value));
         ASSERT_EQ("-2", value);
 
-        ret = client->del(hash_key, "k1");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k1"));
     }
 
     {
-        int ret = client->set(hash_key, "k3", "3");
-        ASSERT_EQ(PERR_OK, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k3", "3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k3",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
-                                    "3",
-                                    "k4",
-                                    "4",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k3",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_EQUAL,
+                                         "3",
+                                         "k4",
+                                         "4",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("3", results.check_value);
-        ret = client->get(hash_key, "k4", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k4", value));
         ASSERT_EQ("4", value);
 
-        ret = client->del(hash_key, "k3");
-        ASSERT_EQ(0, ret);
-        ret = client->del(hash_key, "k4");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k3"));
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k4"));
     }
 
     {
-        int ret = client->set(hash_key, "k5", "1");
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->set(hash_key, "k5", "1"));
 
         std::string value;
         pegasus_client::check_and_set_options options;
@@ -1573,120 +1446,115 @@ TEST_F(check_and_set, value_int_compare)
 
         // 1 < 2
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_LESS,
-                                    "2",
-                                    "k5",
-                                    "2",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k5",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_LESS,
+                                         "2",
+                                         "k5",
+                                         "2",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("1", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("2", value);
 
         // 2 <= 2
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_LESS_OR_EQUAL,
-                                    "2",
-                                    "k5",
-                                    "3",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k5",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_LESS_OR_EQUAL,
+                                         "2",
+                                         "k5",
+                                         "3",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("2", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("3", value);
 
         // 3 <= 4
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_LESS_OR_EQUAL,
-                                    "4",
-                                    "k5",
-                                    "4",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k5",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_LESS_OR_EQUAL,
+                                         "4",
+                                         "k5",
+                                         "4",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("3", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("4", value);
 
         // 4 >= 4
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_GREATER_OR_EQUAL,
-                                    "4",
-                                    "k5",
-                                    "5",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_set(hash_key,
+                                   "k5",
+                                   pegasus_client::cas_check_type::CT_VALUE_INT_GREATER_OR_EQUAL,
+                                   "4",
+                                   "k5",
+                                   "5",
+                                   options,
+                                   results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("4", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("5", value);
 
         // 5 >= 4
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_GREATER_OR_EQUAL,
-                                    "4",
-                                    "k5",
-                                    "6",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(
+            PERR_OK,
+            client_->check_and_set(hash_key,
+                                   "k5",
+                                   pegasus_client::cas_check_type::CT_VALUE_INT_GREATER_OR_EQUAL,
+                                   "4",
+                                   "k5",
+                                   "6",
+                                   options,
+                                   results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("5", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("6", value);
 
         // 6 > 5
         options.return_check_value = true;
-        ret = client->check_and_set(hash_key,
-                                    "k5",
-                                    pegasus_client::cas_check_type::CT_VALUE_INT_GREATER,
-                                    "5",
-                                    "k5",
-                                    "7",
-                                    options,
-                                    results);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK,
+                  client_->check_and_set(hash_key,
+                                         "k5",
+                                         pegasus_client::cas_check_type::CT_VALUE_INT_GREATER,
+                                         "5",
+                                         "k5",
+                                         "7",
+                                         options,
+                                         results));
         ASSERT_TRUE(results.set_succeed);
         ASSERT_TRUE(results.check_value_returned);
         ASSERT_TRUE(results.check_value_exist);
         ASSERT_EQ("6", results.check_value);
-        ret = client->get(hash_key, "k5", value);
-        ASSERT_EQ(PERR_OK, ret);
+        ASSERT_EQ(PERR_OK, client_->get(hash_key, "k5", value));
         ASSERT_EQ("7", value);
 
-        ret = client->del(hash_key, "k5");
-        ASSERT_EQ(0, ret);
+        ASSERT_EQ(PERR_OK, client_->del(hash_key, "k5"));
     }
 }
 
@@ -1695,14 +1563,19 @@ TEST_F(check_and_set, invalid_type)
     std::string hash_key("check_and_set_test_value_invalid_type");
 
     {
-        int ret = 0;
         pegasus_client::check_and_set_options options;
         pegasus_client::check_and_set_results results;
 
         options.return_check_value = true;
-        ret = client->check_and_set(
-            hash_key, "k1", (pegasus_client::cas_check_type)100, "v", "k1", "v1", options, results);
-        ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+        ASSERT_EQ(PERR_INVALID_ARGUMENT,
+                  client_->check_and_set(hash_key,
+                                         "k1",
+                                         (pegasus_client::cas_check_type)100,
+                                         "v",
+                                         "k1",
+                                         "v1",
+                                         options,
+                                         results));
         ASSERT_FALSE(results.set_succeed);
         ASSERT_FALSE(results.check_value_returned);
     }

--- a/src/test/function_test/base_api_test/test_incr.cpp
+++ b/src/test/function_test/base_api_test/test_incr.cpp
@@ -38,267 +38,215 @@ class incr : public test_util
 
 TEST_F(incr, unexist_key)
 {
-    int ret = client->del("incr_test_unexist_key", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_unexist_key", ""));
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_unexist_key", "", 100, new_value_int);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->incr("incr_test_unexist_key", "", 100, new_value_int));
     ASSERT_EQ(100, new_value_int);
 
     std::string new_value_str;
-    ret = client->get("incr_test_unexist_key", "", new_value_str);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->get("incr_test_unexist_key", "", new_value_str));
     ASSERT_EQ("100", new_value_str);
 
-    ret = client->del("incr_test_unexist_key", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_unexist_key", ""));
 }
 
 TEST_F(incr, empty_key)
 {
-    int ret = client->set("incr_test_empty_key", "", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_empty_key", "", ""));
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_empty_key", "", 100, new_value_int);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->incr("incr_test_empty_key", "", 100, new_value_int));
     ASSERT_EQ(100, new_value_int);
 
     std::string new_value_str;
-    ret = client->get("incr_test_empty_key", "", new_value_str);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->get("incr_test_empty_key", "", new_value_str));
     ASSERT_EQ("100", new_value_str);
 
-    ret = client->del("incr_test_empty_key", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_empty_key", ""));
 }
 
 TEST_F(incr, negative_value)
 {
-    int ret = client->set("incr_test_negative_value", "", "-100");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_negative_value", "", "-100"));
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_negative_value", "", -1, new_value_int);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->incr("incr_test_negative_value", "", -1, new_value_int));
     ASSERT_EQ(-101, new_value_int);
 
     std::string new_value_str;
-    ret = client->get("incr_test_negative_value", "", new_value_str);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->get("incr_test_negative_value", "", new_value_str));
     ASSERT_EQ("-101", new_value_str);
 
-    ret = client->del("incr_test_negative_value", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_negative_value", ""));
 }
 
 TEST_F(incr, increase_zero)
 {
-    int ret = client->set("incr_test_increase_zero", "", "100");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_increase_zero", "", "100"));
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_increase_zero", "", 0, new_value_int);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->incr("incr_test_increase_zero", "", 0, new_value_int));
     ASSERT_EQ(100, new_value_int);
 
     std::string new_value_str;
-    ret = client->get("incr_test_increase_zero", "", new_value_str);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->get("incr_test_increase_zero", "", new_value_str));
     ASSERT_EQ("100", new_value_str);
 
-    ret = client->del("incr_test_increase_zero", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_increase_zero", ""));
 }
 
 TEST_F(incr, multiple_increment)
 {
-    int ret = client->set("incr_test_multiple_increment", "", "100");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_multiple_increment", "", "100"));
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_multiple_increment", "", 1, new_value_int);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->incr("incr_test_multiple_increment", "", 1, new_value_int));
     ASSERT_EQ(101, new_value_int);
 
     std::string new_value_str;
-    ret = client->get("incr_test_multiple_increment", "", new_value_str);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->get("incr_test_multiple_increment", "", new_value_str));
     ASSERT_EQ("101", new_value_str);
 
-    ret = client->incr("incr_test_multiple_increment", "", 2, new_value_int);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->incr("incr_test_multiple_increment", "", 2, new_value_int));
     ASSERT_EQ(103, new_value_int);
 
-    ret = client->get("incr_test_multiple_increment", "", new_value_str);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->get("incr_test_multiple_increment", "", new_value_str));
     ASSERT_EQ("103", new_value_str);
 
-    ret = client->del("incr_test_multiple_increment", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_multiple_increment", ""));
 }
 
 TEST_F(incr, invalid_old_data)
 {
-    int ret = client->set("incr_test_invalid_old_data", "", "aaa");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_invalid_old_data", "", "aaa"));
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_invalid_old_data", "", 1, new_value_int);
-    ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+    ASSERT_EQ(PERR_INVALID_ARGUMENT,
+              client_->incr("incr_test_invalid_old_data", "", 1, new_value_int));
     ASSERT_EQ(0, new_value_int);
 
     std::string new_value_str;
-    ret = client->get("incr_test_invalid_old_data", "", new_value_str);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->get("incr_test_invalid_old_data", "", new_value_str));
     ASSERT_EQ("aaa", new_value_str);
 
-    ret = client->del("incr_test_invalid_old_data", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_invalid_old_data", ""));
 }
 
 TEST_F(incr, out_of_range_old_data)
 {
-    int ret = client->set(
-        "incr_test_out_of_range_old_data", "", "10000000000000000000000000000000000000");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK,
+              client_->set(
+                  "incr_test_out_of_range_old_data", "", "10000000000000000000000000000000000000"));
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_out_of_range_old_data", "", 1, new_value_int);
-    ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+    ASSERT_EQ(PERR_INVALID_ARGUMENT,
+              client_->incr("incr_test_out_of_range_old_data", "", 1, new_value_int));
     ASSERT_EQ(0, new_value_int);
 
     std::string new_value_str;
-    ret = client->get("incr_test_out_of_range_old_data", "", new_value_str);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->get("incr_test_out_of_range_old_data", "", new_value_str));
     ASSERT_EQ("10000000000000000000000000000000000000", new_value_str);
 
-    ret = client->del("incr_test_out_of_range_old_data", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_out_of_range_old_data", ""));
 }
 
 TEST_F(incr, up_overflow)
 {
-    int ret = client->set("incr_test_up_overflow", "", "1");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_up_overflow", "", "1"));
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_up_overflow", "", LLONG_MAX, new_value_int);
-    ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+    ASSERT_EQ(PERR_INVALID_ARGUMENT,
+              client_->incr("incr_test_up_overflow", "", LLONG_MAX, new_value_int));
     ASSERT_EQ(1, new_value_int);
 
     std::string new_value_str;
-    ret = client->get("incr_test_up_overflow", "", new_value_str);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->get("incr_test_up_overflow", "", new_value_str));
     ASSERT_EQ("1", new_value_str);
 
-    ret = client->del("incr_test_up_overflow", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_up_overflow", ""));
 }
 
 TEST_F(incr, down_overflow)
 {
-    int ret = client->set("incr_test_down_overflow", "", "-1");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_down_overflow", "", "-1"));
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_down_overflow", "", LLONG_MIN, new_value_int);
-    ASSERT_EQ(PERR_INVALID_ARGUMENT, ret);
+    ASSERT_EQ(PERR_INVALID_ARGUMENT,
+              client_->incr("incr_test_down_overflow", "", LLONG_MIN, new_value_int));
     ASSERT_EQ(-1, new_value_int);
 
     std::string new_value_str;
-    ret = client->get("incr_test_down_overflow", "", new_value_str);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->get("incr_test_down_overflow", "", new_value_str));
     ASSERT_EQ("-1", new_value_str);
 
-    ret = client->del("incr_test_down_overflow", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_down_overflow", ""));
 }
 
 TEST_F(incr, preserve_ttl)
 {
-    int ret = client->set("incr_test_preserve_ttl", "", "100", 5000, 3);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_preserve_ttl", "", "100", 5000, 3));
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_preserve_ttl", "", 1, new_value_int);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->incr("incr_test_preserve_ttl", "", 1, new_value_int));
     ASSERT_EQ(101, new_value_int);
 
     int ttl_seconds;
-    ret = client->ttl("incr_test_preserve_ttl", "", ttl_seconds);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->ttl("incr_test_preserve_ttl", "", ttl_seconds));
     ASSERT_GE(3, ttl_seconds);
 
     sleep(4);
 
     std::string new_value_str;
-    ret = client->get("incr_test_preserve_ttl", "", new_value_str);
-    ASSERT_EQ(PERR_NOT_FOUND, ret);
+    ASSERT_EQ(PERR_NOT_FOUND, client_->get("incr_test_preserve_ttl", "", new_value_str));
 
-    ret = client->del("incr_test_preserve_ttl", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_preserve_ttl", ""));
 }
 
 TEST_F(incr, reset_ttl)
 {
     /// reset after old value ttl timeout
-    int ret = client->set("incr_test_reset_ttl", "", "100", 5000, 3);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_reset_ttl", "", "100", 5000, 3));
 
     sleep(4);
 
     int64_t new_value_int;
-    ret = client->incr("incr_test_reset_ttl", "", 1, new_value_int);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->incr("incr_test_reset_ttl", "", 1, new_value_int));
     ASSERT_EQ(1, new_value_int);
 
     int ttl_seconds;
-    ret = client->ttl("incr_test_reset_ttl", "", ttl_seconds);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->ttl("incr_test_reset_ttl", "", ttl_seconds));
     ASSERT_GE(-1, ttl_seconds);
 
-    ret = client->del("incr_test_reset_ttl", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_reset_ttl", ""));
 
     /// reset with new ttl
-    ret = client->set("incr_test_reset_ttl", "", "100");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_reset_ttl", "", "100"));
 
-    ret = client->ttl("incr_test_reset_ttl", "", ttl_seconds);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->ttl("incr_test_reset_ttl", "", ttl_seconds));
     ASSERT_GE(-1, ttl_seconds);
 
-    ret = client->incr("incr_test_reset_ttl", "", 1, new_value_int, 5000, 10);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->incr("incr_test_reset_ttl", "", 1, new_value_int, 5000, 10));
     ASSERT_EQ(101, new_value_int);
 
-    ret = client->ttl("incr_test_reset_ttl", "", ttl_seconds);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->ttl("incr_test_reset_ttl", "", ttl_seconds));
     ASSERT_LT(0, ttl_seconds);
     ASSERT_GE(10, ttl_seconds);
 
-    ret = client->del("incr_test_reset_ttl", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_reset_ttl", ""));
 
     /// reset with no ttl
-    ret = client->set("incr_test_reset_ttl", "", "200", 5000, 10);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->set("incr_test_reset_ttl", "", "200", 5000, 10));
 
-    ret = client->ttl("incr_test_reset_ttl", "", ttl_seconds);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->ttl("incr_test_reset_ttl", "", ttl_seconds));
     ASSERT_LT(0, ttl_seconds);
     ASSERT_GE(10, ttl_seconds);
 
-    ret = client->incr("incr_test_reset_ttl", "", 1, new_value_int, 5000, -1);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->incr("incr_test_reset_ttl", "", 1, new_value_int, 5000, -1));
     ASSERT_EQ(201, new_value_int);
 
-    ret = client->ttl("incr_test_reset_ttl", "", ttl_seconds);
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->ttl("incr_test_reset_ttl", "", ttl_seconds));
     ASSERT_GE(-1, ttl_seconds);
 
-    ret = client->del("incr_test_reset_ttl", "");
-    ASSERT_EQ(0, ret);
+    ASSERT_EQ(PERR_OK, client_->del("incr_test_reset_ttl", ""));
 }

--- a/src/test/function_test/base_api_test/test_scan.cpp
+++ b/src/test/function_test/base_api_test/test_scan.cpp
@@ -35,117 +35,100 @@
 
 using namespace ::pegasus;
 
-static const char CCH[] = "_0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-static char buffer[256];
-static constexpr int ttl_seconds = 24 * 60 * 60;
-
-class scan : public test_util
+class scan_test : public test_util
 {
 public:
     void SetUp() override
     {
         test_util::SetUp();
-        // TODO(yingchun): can be removed?
-        ASSERT_EQ(dsn::ERR_OK, ddl_client->drop_app(app_name_, 0));
-        ASSERT_EQ(dsn::ERR_OK, ddl_client->create_app(app_name_, "pegasus", 8, 3, {}, false));
-        client = pegasus_client_factory::get_client(cluster_name_.c_str(), app_name_.c_str());
-        ASSERT_TRUE(client != nullptr);
+        ASSERT_EQ(dsn::ERR_OK, ddl_client_->drop_app(app_name_, 0));
+        ASSERT_EQ(dsn::ERR_OK, ddl_client_->create_app(app_name_, "pegasus", 8, 3, {}, false));
+        client_ = pegasus_client_factory::get_client(cluster_name_.c_str(), app_name_.c_str());
+        ASSERT_TRUE(client_ != nullptr);
         ASSERT_NO_FATAL_FAILURE(fill_database());
     }
 
-    void TearDown() override
-    {
-        // TODO(yingchun): can be removed too?
-        ASSERT_EQ(dsn::ERR_OK, ddl_client->drop_app(app_name_, 0));
-    }
+    void TearDown() override { ASSERT_EQ(dsn::ERR_OK, ddl_client_->drop_app(app_name_, 0)); }
 
-    // REQUIRED: 'buffer' has been filled with random chars.
-    static const std::string random_string()
+    // REQUIRED: 'buffer_' has been filled with random chars.
+    const std::string random_string() const
     {
-        int pos = random() % sizeof(buffer);
-        unsigned int length = random() % sizeof(buffer) + 1;
-        if (pos + length < sizeof(buffer)) {
-            return std::string(buffer + pos, length);
+        int pos = random() % sizeof(buffer_);
+        unsigned int length = random() % sizeof(buffer_) + 1;
+        if (pos + length < sizeof(buffer_)) {
+            return std::string(buffer_ + pos, length);
         } else {
-            return std::string(buffer + pos, sizeof(buffer) - pos) +
-                   std::string(buffer, length + pos - sizeof(buffer));
+            return std::string(buffer_ + pos, sizeof(buffer_) - pos) +
+                   std::string(buffer_, length + pos - sizeof(buffer_));
         }
     }
 
-    // REQUIRED: 'base' is empty
+    // REQUIRED: 'expect_kvs_' is empty
     void fill_database()
     {
-        ddebug("FILLING_DATABASE...");
-
         srandom((unsigned int)time(nullptr));
-        for (auto &c : buffer) {
+        for (auto &c : buffer_) {
             c = CCH[random() % strlen(CCH)];
         }
 
         int i = 0;
-        // Fill data with <expected_hash_key> : <sort_key> -> <value>, there are 1000 sort keys in
-        // the unique <expected_hash_key>.
-        expected_hash_key = random_string();
+        // Fill data with <expected_hash_key_> : <sort_key> -> <value>, there are 1000 sort keys in
+        // the unique <expected_hash_key_>.
+        expected_hash_key_ = random_string();
         std::string sort_key;
         std::string value;
-        while (base[expected_hash_key].size() < 1000) {
+        while (expect_kvs_[expected_hash_key_].size() < 1000) {
             sort_key = random_string();
             value = random_string();
-            int ret = client->set(expected_hash_key, sort_key, value);
-            ASSERT_EQ(PERR_OK, ret) << "Error occurred when set, hash_key=" << expected_hash_key
-                                    << ", sort_key=" << sort_key
-                                    << ", error=" << client->get_error_string(ret);
+            ASSERT_EQ(PERR_OK, client_->set(expected_hash_key_, sort_key, value))
+                << "hash_key=" << expected_hash_key_ << ", sort_key=" << sort_key;
             i++;
-            base[expected_hash_key][sort_key] = value;
+            expect_kvs_[expected_hash_key_][sort_key] = value;
         }
         // 1000 kvs
 
         std::string hash_key;
-        // Fill data with <hash_key> : <sort_key> -> <value>, except <expected_hash_key>, there are
+        // Fill data with <hash_key> : <sort_key> -> <value>, except <expected_hash_key_>, there are
         // total 499 hash keys and 10 sortkeys in each <hash_key>.
-        while (base.size() < 501) {
+        while (expect_kvs_.size() < 501) {
             hash_key = random_string();
-            if (base.count(hash_key) != 0) {
+            if (expect_kvs_.count(hash_key) != 0) {
                 continue;
             }
-            while (base[hash_key].size() < 10) {
+            while (expect_kvs_[hash_key].size() < 10) {
                 sort_key = random_string();
-                if (base[hash_key].count(sort_key) != 0) {
+                if (expect_kvs_[hash_key].count(sort_key) != 0) {
                     continue;
                 }
                 value = random_string();
-                int ret = client->set(hash_key, sort_key, value);
-                ASSERT_EQ(PERR_OK, ret) << "Error occurred when set, hash_key=" << hash_key
-                                        << ", sort_key=" << sort_key
-                                        << ", error=" << client->get_error_string(ret);
+                ASSERT_EQ(PERR_OK, client_->set(hash_key, sort_key, value))
+                    << "hash_key=" << hash_key << ", sort_key=" << sort_key;
                 i++;
-                base[hash_key][sort_key] = value;
+                expect_kvs_[hash_key][sort_key] = value;
             }
         }
         // 1000 + 5000 kvs
 
-        // Fill data with <hash_key> : <sort_key> -> <value> with TTL, except <expected_hash_key>
+        // Fill data with <hash_key> : <sort_key> -> <value> with TTL, except <expected_hash_key_>
         // and normal kvs, there are total 500 hash keys and 10 sortkeys in each <hash_key>.
-        while (base.size() < 1001) {
+        while (expect_kvs_.size() < 1001) {
             hash_key = random_string();
-            if (base.count(hash_key) != 0) {
+            if (expect_kvs_.count(hash_key) != 0) {
                 continue;
             }
-            while (base[hash_key].size() < 10) {
+            while (expect_kvs_[hash_key].size() < 10) {
                 sort_key = random_string();
-                if (base[hash_key].count(sort_key) != 0) {
+                if (expect_kvs_[hash_key].count(sort_key) != 0) {
                     continue;
                 }
                 value = random_string();
                 auto expire_ts_seconds = static_cast<uint32_t>(ttl_seconds) + utils::epoch_now();
-                int ret = client->set(hash_key, sort_key, value, 5000, ttl_seconds, nullptr);
-                i++;
-                ASSERT_EQ(PERR_OK, ret) << "Error occurred when set, hash_key=" << hash_key
-                                        << ", sort_key=" << sort_key
-                                        << ", error=" << client->get_error_string(ret);
-                i++;
-                base[hash_key][sort_key] = value;
-                ttl_base[hash_key][sort_key] =
+                ASSERT_EQ(PERR_OK,
+                          client_->set(hash_key, sort_key, value, 5000, ttl_seconds, nullptr))
+                    << "hash_key=" << hash_key << ", sort_key=" << sort_key;
+                i += 2;
+                expect_kvs_[hash_key][sort_key] = value;
+                expect_kvs_with_ttl_[hash_key][sort_key] =
                     std::pair<std::string, uint32_t>(value, expire_ts_seconds);
             }
         }
@@ -154,21 +137,25 @@ public:
         ddebug_f("Database filled with kv count {}.", i);
     }
 
-public:
-    std::string expected_hash_key;
-    std::map<std::string, std::map<std::string, std::string>> base;
-    std::map<std::string, std::map<std::string, std::pair<std::string, uint32_t>>> ttl_base;
-};
+protected:
+    static const char CCH[];
+    static constexpr int ttl_seconds = 24 * 60 * 60;
 
-TEST_F(scan, OVERALL_COUNT_ONLY)
+    char buffer_[256];
+
+    std::string expected_hash_key_;
+    std::map<std::string, std::map<std::string, std::string>> expect_kvs_;
+    std::map<std::string, std::map<std::string, std::pair<std::string, uint32_t>>>
+        expect_kvs_with_ttl_;
+};
+const char scan_test::CCH[] = "_0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+TEST_F(scan_test, OVERALL_COUNT_ONLY)
 {
-    ddebug("TEST OVERALL_SCAN_COUNT_ONLY...");
     pegasus_client::scan_options options;
     options.only_return_count = true;
     std::vector<pegasus_client::pegasus_scanner *> scanners;
-    int ret = client->get_unordered_scanners(3, options, scanners);
-    ASSERT_EQ(0, ret) << "Error occurred when getting scanner. error="
-                      << client->get_error_string(ret);
+    ASSERT_EQ(PERR_OK, client_->get_unordered_scanners(3, options, scanners));
     ASSERT_LE(scanners.size(), 3);
 
     int i = 0;
@@ -176,50 +163,48 @@ TEST_F(scan, OVERALL_COUNT_ONLY)
     for (auto scanner : scanners) {
         ASSERT_NE(nullptr, scanner);
         int32_t kv_count;
+        int ret;
         while (PERR_OK == (ret = (scanner->next(kv_count)))) {
             data_count += kv_count;
             i++;
         }
         ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="
-                                           << client->get_error_string(ret);
+                                           << client_->get_error_string(ret);
         delete scanner;
     }
     ddebug_f("scan count {}", i);
     int base_data_count = 0;
-    for (auto &m : base) {
+    for (auto &m : expect_kvs_) {
         base_data_count += m.second.size();
     }
     ASSERT_EQ(base_data_count, data_count);
 }
 
-TEST_F(scan, ALL_SORT_KEY)
+TEST_F(scan_test, ALL_SORT_KEY)
 {
-    ddebug("TESTING_HASH_SCAN, ALL SORT_KEYS ....");
     pegasus_client::scan_options options;
     std::map<std::string, std::string> data;
     pegasus_client::pegasus_scanner *scanner = nullptr;
-    int ret = client->get_scanner(expected_hash_key, "", "", options, scanner);
-    ASSERT_EQ(PERR_OK, ret) << "Error occurred when getting scanner. error="
-                            << client->get_error_string(ret);
+    ASSERT_EQ(PERR_OK, client_->get_scanner(expected_hash_key_, "", "", options, scanner));
     ASSERT_NE(nullptr, scanner);
 
     std::string hash_key;
     std::string sort_key;
     std::string value;
+    int ret;
     while (PERR_OK == (ret = (scanner->next(hash_key, sort_key, value)))) {
-        ASSERT_EQ(expected_hash_key, hash_key);
-        check_and_put(data, expected_hash_key, sort_key, value);
+        ASSERT_EQ(expected_hash_key_, hash_key);
+        check_and_put(data, expected_hash_key_, sort_key, value);
     }
     delete scanner;
     ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="
-                                       << client->get_error_string(ret);
-    ASSERT_NO_FATAL_FAILURE(compare(base[expected_hash_key], data, expected_hash_key));
+                                       << client_->get_error_string(ret);
+    ASSERT_NO_FATAL_FAILURE(compare(expect_kvs_[expected_hash_key_], data, expected_hash_key_));
 }
 
-TEST_F(scan, BOUND_INCLUSIVE)
+TEST_F(scan_test, BOUND_INCLUSIVE)
 {
-    ddebug("TESTING_HASH_SCAN, [start, stop]...");
-    auto it1 = base[expected_hash_key].begin();
+    auto it1 = expect_kvs_[expected_hash_key_].begin();
     std::advance(it1, random() % 500); // [0,499]
     std::string start = it1->first;
 
@@ -232,30 +217,27 @@ TEST_F(scan, BOUND_INCLUSIVE)
     options.stop_inclusive = true;
     std::map<std::string, std::string> data;
     pegasus_client::pegasus_scanner *scanner = nullptr;
-    int ret = client->get_scanner(expected_hash_key, start, stop, options, scanner);
-    ASSERT_EQ(PERR_OK, ret) << "Error occurred when getting scanner. error="
-                            << client->get_error_string(ret);
+    ASSERT_EQ(PERR_OK, client_->get_scanner(expected_hash_key_, start, stop, options, scanner));
     ASSERT_NE(nullptr, scanner);
 
     std::string hash_key;
     std::string sort_key;
     std::string value;
+    int ret;
     while (PERR_OK == (ret = (scanner->next(hash_key, sort_key, value)))) {
-        ASSERT_EQ(expected_hash_key, hash_key);
-        check_and_put(data, expected_hash_key, sort_key, value);
+        ASSERT_EQ(expected_hash_key_, hash_key);
+        check_and_put(data, expected_hash_key_, sort_key, value);
     }
     delete scanner;
-    ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="
-                                       << client->get_error_string(ret);
+    ASSERT_EQ(PERR_SCAN_COMPLETE, ret);
     ++it2; // to be the 'end' iterator
     ASSERT_NO_FATAL_FAILURE(
-        compare(data, std::map<std::string, std::string>(it1, it2), expected_hash_key));
+        compare(data, std::map<std::string, std::string>(it1, it2), expected_hash_key_));
 }
 
-TEST_F(scan, BOUND_EXCLUSIVE)
+TEST_F(scan_test, BOUND_EXCLUSIVE)
 {
-    ddebug("TESTING_HASH_SCAN, (start, stop)...");
-    auto it1 = base[expected_hash_key].begin();
+    auto it1 = expect_kvs_[expected_hash_key_].begin();
     std::advance(it1, random() % 500); // [0,499]
     std::string start = it1->first;
 
@@ -268,30 +250,28 @@ TEST_F(scan, BOUND_EXCLUSIVE)
     options.stop_inclusive = false;
     std::map<std::string, std::string> data;
     pegasus_client::pegasus_scanner *scanner = nullptr;
-    int ret = client->get_scanner(expected_hash_key, start, stop, options, scanner);
-    ASSERT_EQ(PERR_OK, ret) << "Error occurred when getting scanner. error="
-                            << client->get_error_string(ret);
+    ASSERT_EQ(PERR_OK, client_->get_scanner(expected_hash_key_, start, stop, options, scanner));
     ASSERT_NE(nullptr, scanner);
 
     std::string hash_key;
     std::string sort_key;
     std::string value;
+    int ret;
     while (PERR_OK == (ret = (scanner->next(hash_key, sort_key, value)))) {
-        ASSERT_EQ(expected_hash_key, hash_key);
-        check_and_put(data, expected_hash_key, sort_key, value);
+        ASSERT_EQ(expected_hash_key_, hash_key);
+        check_and_put(data, expected_hash_key_, sort_key, value);
     }
     delete scanner;
     ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="
-                                       << client->get_error_string(ret);
+                                       << client_->get_error_string(ret);
     ++it1;
     ASSERT_NO_FATAL_FAILURE(
-        compare(data, std::map<std::string, std::string>(it1, it2), expected_hash_key));
+        compare(data, std::map<std::string, std::string>(it1, it2), expected_hash_key_));
 }
 
-TEST_F(scan, ONE_POINT)
+TEST_F(scan_test, ONE_POINT)
 {
-    ddebug("TESTING_HASH_SCAN, [start, start]...");
-    auto it1 = base[expected_hash_key].begin();
+    auto it1 = expect_kvs_[expected_hash_key_].begin();
     std::advance(it1, random() % 800); // [0,799]
     std::string start = it1->first;
 
@@ -299,29 +279,23 @@ TEST_F(scan, ONE_POINT)
     options.start_inclusive = true;
     options.stop_inclusive = true;
     pegasus_client::pegasus_scanner *scanner = nullptr;
-    int ret = client->get_scanner(expected_hash_key, start, start, options, scanner);
-    ASSERT_EQ(PERR_OK, ret) << "Error occurred when getting scanner. error="
-                            << client->get_error_string(ret);
+    ASSERT_EQ(PERR_OK, client_->get_scanner(expected_hash_key_, start, start, options, scanner));
     ASSERT_NE(nullptr, scanner);
 
     std::string hash_key;
     std::string sort_key;
     std::string value;
-    ret = scanner->next(hash_key, sort_key, value);
-    ASSERT_EQ(PERR_OK, ret) << "Error occurred when scan. error=" << client->get_error_string(ret);
-    ASSERT_EQ(expected_hash_key, hash_key);
+    ASSERT_EQ(PERR_OK, scanner->next(hash_key, sort_key, value));
+    ASSERT_EQ(expected_hash_key_, hash_key);
     ASSERT_EQ(start, sort_key);
     ASSERT_EQ(it1->second, value);
-    ret = scanner->next(hash_key, sort_key, value);
-    ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="
-                                       << client->get_error_string(ret);
+    ASSERT_EQ(PERR_SCAN_COMPLETE, scanner->next(hash_key, sort_key, value));
     delete scanner;
 }
 
-TEST_F(scan, HALF_INCLUSIVE)
+TEST_F(scan_test, HALF_INCLUSIVE)
 {
-    ddebug("TESTING_HASH_SCAN, [start, start)...");
-    auto it1 = base[expected_hash_key].begin();
+    auto it1 = expect_kvs_[expected_hash_key_].begin();
     std::advance(it1, random() % 800); // [0,799]
     std::string start = it1->first;
 
@@ -329,24 +303,19 @@ TEST_F(scan, HALF_INCLUSIVE)
     options.start_inclusive = true;
     options.stop_inclusive = false;
     pegasus_client::pegasus_scanner *scanner = nullptr;
-    int ret = client->get_scanner(expected_hash_key, start, start, options, scanner);
-    ASSERT_EQ(PERR_OK, ret) << "Error occurred when getting scanner. error="
-                            << client->get_error_string(ret);
+    ASSERT_EQ(PERR_OK, client_->get_scanner(expected_hash_key_, start, start, options, scanner));
     ASSERT_NE(nullptr, scanner);
 
     std::string hash_key;
     std::string sort_key;
     std::string value;
-    ret = scanner->next(hash_key, sort_key, value);
-    ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="
-                                       << client->get_error_string(ret);
+    ASSERT_EQ(PERR_SCAN_COMPLETE, scanner->next(hash_key, sort_key, value));
     delete scanner;
 }
 
-TEST_F(scan, VOID_SPAN)
+TEST_F(scan_test, VOID_SPAN)
 {
-    ddebug("TESTING_HASH_SCAN, [stop, start]...");
-    auto it1 = base[expected_hash_key].begin();
+    auto it1 = expect_kvs_[expected_hash_key_].begin();
     std::advance(it1, random() % 500); // [0,499]
     std::string start = it1->first;
 
@@ -358,28 +327,21 @@ TEST_F(scan, VOID_SPAN)
     options.start_inclusive = true;
     options.stop_inclusive = true;
     pegasus_client::pegasus_scanner *scanner = nullptr;
-    int ret = client->get_scanner(expected_hash_key, stop, start, options, scanner);
-    ASSERT_EQ(PERR_OK, ret) << "Error occurred when getting scanner. error="
-                            << client->get_error_string(ret);
+    ASSERT_EQ(PERR_OK, client_->get_scanner(expected_hash_key_, stop, start, options, scanner));
     ASSERT_NE(nullptr, scanner);
 
     std::string hash_key;
     std::string sort_key;
     std::string value;
-    ret = scanner->next(hash_key, sort_key, value);
-    ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="
-                                       << client->get_error_string(ret);
+    ASSERT_EQ(PERR_SCAN_COMPLETE, scanner->next(hash_key, sort_key, value));
     delete scanner;
 }
 
-TEST_F(scan, OVERALL)
+TEST_F(scan_test, OVERALL)
 {
-    ddebug("TEST OVERALL_SCAN...");
     pegasus_client::scan_options options;
     std::vector<pegasus_client::pegasus_scanner *> scanners;
-    int ret = client->get_unordered_scanners(3, options, scanners);
-    ASSERT_EQ(0, ret) << "Error occurred when getting scanner. error="
-                      << client->get_error_string(ret);
+    ASSERT_EQ(PERR_OK, client_->get_unordered_scanners(3, options, scanners));
     ASSERT_LE(scanners.size(), 3);
 
     std::string hash_key;
@@ -388,24 +350,23 @@ TEST_F(scan, OVERALL)
     std::map<std::string, std::map<std::string, std::string>> data;
     for (auto scanner : scanners) {
         ASSERT_NE(nullptr, scanner);
+        int ret;
         while (PERR_OK == (ret = (scanner->next(hash_key, sort_key, value)))) {
             check_and_put(data, hash_key, sort_key, value);
         }
         ASSERT_EQ(PERR_SCAN_COMPLETE, ret) << "Error occurred when scan. error="
-                                           << client->get_error_string(ret);
+                                           << client_->get_error_string(ret);
         delete scanner;
     }
-    ASSERT_NO_FATAL_FAILURE(compare(base, data));
+    ASSERT_NO_FATAL_FAILURE(compare(expect_kvs_, data));
 }
 
-TEST_F(scan, REQUEST_EXPIRE_TS)
+TEST_F(scan_test, REQUEST_EXPIRE_TS)
 {
     pegasus_client::scan_options options;
     options.return_expire_ts = true;
     std::vector<pegasus_client::pegasus_scanner *> raw_scanners;
-    int ret = client->get_unordered_scanners(3, options, raw_scanners);
-    ASSERT_EQ(pegasus::PERR_OK, ret) << "Error occurred when getting scanner. error="
-                                     << client->get_error_string(ret);
+    ASSERT_EQ(PERR_OK, client_->get_unordered_scanners(3, options, raw_scanners));
 
     std::vector<pegasus::pegasus_client::pegasus_scanner_wrapper> scanners;
     for (auto raw_scanner : raw_scanners) {
@@ -437,7 +398,7 @@ TEST_F(scan, REQUEST_EXPIRE_TS)
                     split_completed.store(true);
                 } else {
                     ASSERT_TRUE(false) << "Error occurred when scan. error="
-                                       << client->get_error_string(err);
+                                       << client_->get_error_string(err);
                 }
                 op_completed.notify();
             });
@@ -445,15 +406,15 @@ TEST_F(scan, REQUEST_EXPIRE_TS)
         }
     }
 
-    ASSERT_NO_FATAL_FAILURE(compare(base, data));
-    ASSERT_NO_FATAL_FAILURE(compare(ttl_base, ttl_data));
+    ASSERT_NO_FATAL_FAILURE(compare(expect_kvs_, data));
+    ASSERT_NO_FATAL_FAILURE(compare(expect_kvs_with_ttl_, ttl_data));
 }
 
-TEST_F(scan, ITERATION_TIME_LIMIT)
+TEST_F(scan_test, ITERATION_TIME_LIMIT)
 {
     // update iteration threshold to 1ms
-    auto response = ddl_client->set_app_envs(
-        client->get_app_name(), {ROCKSDB_ITERATION_THRESHOLD_TIME_MS}, {std::to_string(1)});
+    auto response = ddl_client_->set_app_envs(
+        client_->get_app_name(), {ROCKSDB_ITERATION_THRESHOLD_TIME_MS}, {std::to_string(1)});
     ASSERT_EQ(true, response.is_ok());
     ASSERT_EQ(dsn::ERR_OK, response.get_value().err);
     // wait envs to be synced.
@@ -466,24 +427,19 @@ TEST_F(scan, ITERATION_TIME_LIMIT)
     while (i < 9000) {
         sort_key = random_string();
         value = random_string();
-        int ret = client->set(expected_hash_key, sort_key, value);
-        ASSERT_EQ(PERR_OK, ret) << "Error occurred when set, hash_key=" << expected_hash_key
-                                << ", sort_key=" << sort_key
-                                << ", error=" << client->get_error_string(ret);
+        ASSERT_EQ(PERR_OK, client_->set(expected_hash_key_, sort_key, value))
+            << "hash_key=" << expected_hash_key_ << ", sort_key=" << sort_key;
         i++;
     }
 
     // get sortkey count timeout
     int64_t count = 0;
-    int ret = client->sortkey_count(expected_hash_key, count);
-    ASSERT_EQ(0, ret);
-    ASSERT_EQ(count, -1);
+    ASSERT_EQ(PERR_OK, client_->sortkey_count(expected_hash_key_, count));
+    ASSERT_EQ(-1, count);
 
     // set iteration threshold to 100ms
-    response = ddl_client->set_app_envs(
-        client->get_app_name(), {ROCKSDB_ITERATION_THRESHOLD_TIME_MS}, {std::to_string(100)});
-    ASSERT_EQ(true, response.is_ok());
+    response = ddl_client_->set_app_envs(
+        client_->get_app_name(), {ROCKSDB_ITERATION_THRESHOLD_TIME_MS}, {std::to_string(100)});
+    ASSERT_TRUE(response.is_ok());
     ASSERT_EQ(dsn::ERR_OK, response.get_value().err);
-    // wait envs to be synced.
-    std::this_thread::sleep_for(std::chrono::seconds(30));
 }

--- a/src/test/function_test/base_api_test/test_ttl.cpp
+++ b/src/test/function_test/base_api_test/test_ttl.cpp
@@ -29,217 +29,187 @@
 using namespace ::dsn;
 using namespace ::pegasus;
 
-std::string ttl_hash_key = "ttl_test_hash_key";
-std::string ttl_test_sort_key_0 = "ttl_test_sort_key_0";
-std::string ttl_test_sort_key_1 = "ttl_test_sort_key_1";
-std::string ttl_test_sort_key_2 = "ttl_test_sort_key_2";
-std::string ttl_test_value_0 = "ttl_test_value_0";
-std::string ttl_test_value_1 = "ttl_test_value_1";
-std::string ttl_test_value_2 = "ttl_test_value_2";
-int default_ttl = 3600;
-int specify_ttl = 5;
-int sleep_for_expiring = 10;
-int sleep_for_envs_effect = 31;
-int error_allow = 2;
-int timeout = 5000;
-
-class ttl : public test_util
+class ttl_test : public test_util
 {
 public:
     void SetUp() override
     {
         test_util::SetUp();
-        set_default_ttl(0);
+        ASSERT_NO_FATAL_FAILURE(set_default_ttl_secs(0));
     }
 
-    void TearDown() override { ASSERT_EQ(dsn::ERR_OK, ddl_client->drop_app(app_name_, 0)); }
+    void TearDown() override { ASSERT_EQ(dsn::ERR_OK, ddl_client_->drop_app(app_name_, 0)); }
 
-    void set_default_ttl(int ttl)
+    void set_default_ttl_secs(int32_t ttl)
     {
         std::map<std::string, std::string> envs;
-        ddl_client->get_app_envs(client->get_app_name(), envs);
+        ASSERT_EQ(ERR_OK, ddl_client_->get_app_envs(client_->get_app_name(), envs));
 
         std::string env = envs[TABLE_LEVEL_DEFAULT_TTL];
         if ((env.empty() && ttl != 0) || env != std::to_string(ttl)) {
-            auto response = ddl_client->set_app_envs(
-                client->get_app_name(), {TABLE_LEVEL_DEFAULT_TTL}, {std::to_string(ttl)});
+            auto response = ddl_client_->set_app_envs(
+                client_->get_app_name(), {TABLE_LEVEL_DEFAULT_TTL}, {std::to_string(ttl)});
             ASSERT_EQ(true, response.is_ok());
             ASSERT_EQ(ERR_OK, response.get_value().err);
 
             // wait envs to be synced.
-            std::this_thread::sleep_for(std::chrono::seconds(sleep_for_envs_effect));
+            std::this_thread::sleep_for(std::chrono::seconds(sleep_secs_for_envs_effect));
         }
     }
+
+protected:
+    const std::string ttl_hash_key = "ttl_test_hash_key";
+    const std::string ttl_test_sort_key_0 = "ttl_test_sort_key_0";
+    const std::string ttl_test_sort_key_1 = "ttl_test_sort_key_1";
+    const std::string ttl_test_sort_key_2 = "ttl_test_sort_key_2";
+    const std::string ttl_test_value_0 = "ttl_test_value_0";
+    const std::string ttl_test_value_1 = "ttl_test_value_1";
+    const std::string ttl_test_value_2 = "ttl_test_value_2";
+
+    const int32_t default_ttl_secs = 3600;
+    const int32_t specify_ttl_secs = 5;
+    const int32_t sleep_for_expiring = 10;
+    const int32_t sleep_secs_for_envs_effect = 31;
+    const int32_t error_allow = 2;
+    const int32_t timeout_ms = 5000;
 };
 
-TEST_F(ttl, set_without_default_ttl)
+TEST_F(ttl_test, set_without_default_ttl)
 {
     // set with ttl
-    int ret =
-        client->set(ttl_hash_key, ttl_test_sort_key_1, ttl_test_value_1, timeout, specify_ttl);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(
+        PERR_OK,
+        client_->set(
+            ttl_hash_key, ttl_test_sort_key_1, ttl_test_value_1, timeout_ms, specify_ttl_secs));
 
     std::string value;
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_1, value);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(PERR_OK, client_->get(ttl_hash_key, ttl_test_sort_key_1, value));
     ASSERT_EQ(ttl_test_value_1, value);
 
-    int ttl_seconds;
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds);
-    ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(ttl_seconds > specify_ttl - error_allow && ttl_seconds <= specify_ttl)
-        << "ttl is " << ttl_seconds;
+    int32_t ttl_seconds;
+    ASSERT_EQ(PERR_OK, client_->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds));
+    ASSERT_GT(ttl_seconds, specify_ttl_secs - error_allow);
+    ASSERT_LE(ttl_seconds, specify_ttl_secs);
 
     // set without ttl
-    ret = client->set(ttl_hash_key, ttl_test_sort_key_2, ttl_test_value_2);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(PERR_OK, client_->set(ttl_hash_key, ttl_test_sort_key_2, ttl_test_value_2));
 
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_2, value);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(PERR_OK, client_->get(ttl_hash_key, ttl_test_sort_key_2, value));
     ASSERT_EQ(ttl_test_value_2, value);
 
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds);
-    ASSERT_EQ(PERR_OK, ret);
-    ASSERT_EQ(ttl_seconds, -1) << "ttl is " << ttl_seconds;
+    ASSERT_EQ(PERR_OK, client_->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds));
+    ASSERT_EQ(ttl_seconds, -1);
 
     // sleep a while
     std::this_thread::sleep_for(std::chrono::seconds(sleep_for_expiring));
 
     // check expired one
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds);
-    ASSERT_EQ(PERR_NOT_FOUND, ret);
-
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_1, value);
-    ASSERT_EQ(PERR_NOT_FOUND, ret);
+    ASSERT_EQ(PERR_NOT_FOUND, client_->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds));
+    ASSERT_EQ(PERR_NOT_FOUND, client_->get(ttl_hash_key, ttl_test_sort_key_1, value));
 
     // check exist one
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds);
-    ASSERT_EQ(PERR_OK, ret);
-    ASSERT_EQ(ttl_seconds, -1) << "ttl is " << ttl_seconds;
+    ASSERT_EQ(PERR_OK, client_->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds));
+    ASSERT_EQ(ttl_seconds, -1);
 
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_2, value);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(PERR_OK, client_->get(ttl_hash_key, ttl_test_sort_key_2, value));
     ASSERT_EQ(ttl_test_value_2, value);
 
     // trigger a manual compaction
-    auto response = ddl_client->set_app_envs(client->get_app_name(),
-                                             {MANUAL_COMPACT_ONCE_TRIGGER_TIME_KEY},
-                                             {std::to_string(time(nullptr))});
+    auto response = ddl_client_->set_app_envs(client_->get_app_name(),
+                                              {MANUAL_COMPACT_ONCE_TRIGGER_TIME_KEY},
+                                              {std::to_string(time(nullptr))});
     ASSERT_EQ(true, response.is_ok());
     ASSERT_EQ(ERR_OK, response.get_value().err);
 
     // wait envs to be synced, and manual lcompaction has been finished.
-    std::this_thread::sleep_for(std::chrono::seconds(sleep_for_envs_effect));
+    std::this_thread::sleep_for(std::chrono::seconds(sleep_secs_for_envs_effect));
 
     // check expired one
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds);
-    ASSERT_EQ(PERR_NOT_FOUND, ret);
-
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_1, value);
-    ASSERT_EQ(PERR_NOT_FOUND, ret);
+    ASSERT_EQ(PERR_NOT_FOUND, client_->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds));
+    ASSERT_EQ(PERR_NOT_FOUND, client_->get(ttl_hash_key, ttl_test_sort_key_1, value));
 
     // check exist one
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds);
-    ASSERT_EQ(PERR_OK, ret);
-    ASSERT_EQ(ttl_seconds, -1) << "ttl is " << ttl_seconds;
+    ASSERT_EQ(PERR_OK, client_->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds));
+    ASSERT_EQ(ttl_seconds, -1);
 
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_2, value);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(PERR_OK, client_->get(ttl_hash_key, ttl_test_sort_key_2, value));
     ASSERT_EQ(ttl_test_value_2, value);
 }
 
-TEST_F(ttl, set_with_default_ttl)
+TEST_F(ttl_test, set_with_default_ttl)
 {
     // set without ttl
-    int ret = client->set(ttl_hash_key, ttl_test_sort_key_0, ttl_test_value_0);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(PERR_OK, client_->set(ttl_hash_key, ttl_test_sort_key_0, ttl_test_value_0));
 
-    // set default_ttl
-    set_default_ttl(default_ttl);
+    // set default_ttl_secs
+    ASSERT_NO_FATAL_FAILURE(set_default_ttl_secs(default_ttl_secs));
 
     // set with ttl
-    ret = client->set(ttl_hash_key, ttl_test_sort_key_1, ttl_test_value_1, timeout, specify_ttl);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(
+        PERR_OK,
+        client_->set(
+            ttl_hash_key, ttl_test_sort_key_1, ttl_test_value_1, timeout_ms, specify_ttl_secs));
 
     std::string value;
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_1, value);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(PERR_OK, client_->get(ttl_hash_key, ttl_test_sort_key_1, value));
     ASSERT_EQ(ttl_test_value_1, value);
 
-    int ttl_seconds;
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds);
-    ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(ttl_seconds >= specify_ttl - error_allow && ttl_seconds <= specify_ttl)
-        << "ttl is " << ttl_seconds;
+    int32_t ttl_seconds;
+    ASSERT_EQ(PERR_OK, client_->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds));
+
+    ASSERT_GE(ttl_seconds, specify_ttl_secs - error_allow);
+    ASSERT_LE(ttl_seconds, specify_ttl_secs);
 
     // set without ttl
-    ret = client->set(ttl_hash_key, ttl_test_sort_key_2, ttl_test_value_2);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(PERR_OK, client_->set(ttl_hash_key, ttl_test_sort_key_2, ttl_test_value_2));
 
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_2, value);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(PERR_OK, client_->get(ttl_hash_key, ttl_test_sort_key_2, value));
     ASSERT_EQ(ttl_test_value_2, value);
 
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds);
-    ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(ttl_seconds >= default_ttl - error_allow && ttl_seconds <= default_ttl)
-        << "ttl is " << ttl_seconds;
+    ASSERT_EQ(PERR_OK, client_->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds));
+    ASSERT_GE(ttl_seconds, default_ttl_secs - error_allow);
+    ASSERT_LE(ttl_seconds, default_ttl_secs);
 
     // sleep a while
     std::this_thread::sleep_for(std::chrono::seconds(sleep_for_expiring));
 
     // check forever one
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_0, ttl_seconds);
-    ASSERT_EQ(PERR_OK, ret);
-    ASSERT_EQ(ttl_seconds, -1) << "ttl is " << ttl_seconds;
+    ASSERT_EQ(PERR_OK, client_->ttl(ttl_hash_key, ttl_test_sort_key_0, ttl_seconds));
+    ASSERT_EQ(ttl_seconds, -1);
 
     // check expired one
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds);
-    ASSERT_EQ(PERR_NOT_FOUND, ret);
-
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_1, value);
-    ASSERT_EQ(PERR_NOT_FOUND, ret);
+    ASSERT_EQ(PERR_NOT_FOUND, client_->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds));
+    ASSERT_EQ(PERR_NOT_FOUND, client_->get(ttl_hash_key, ttl_test_sort_key_1, value));
 
     // check exist one
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds);
-    ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(ttl_seconds >= default_ttl - sleep_for_expiring - error_allow &&
-                ttl_seconds <= default_ttl - sleep_for_expiring + error_allow)
-        << "ttl is " << ttl_seconds;
+    ASSERT_EQ(PERR_OK, client_->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds));
+    ASSERT_NEAR(ttl_seconds, default_ttl_secs - sleep_for_expiring, error_allow);
 
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_2, value);
-    ASSERT_EQ(PERR_OK, ret);
+    ASSERT_EQ(PERR_OK, client_->get(ttl_hash_key, ttl_test_sort_key_2, value));
     ASSERT_EQ(ttl_test_value_2, value);
 
     // trigger a manual compaction
-    auto response = ddl_client->set_app_envs(client->get_app_name(),
-                                             {MANUAL_COMPACT_ONCE_TRIGGER_TIME_KEY},
-                                             {std::to_string(time(nullptr))});
+    auto response = ddl_client_->set_app_envs(client_->get_app_name(),
+                                              {MANUAL_COMPACT_ONCE_TRIGGER_TIME_KEY},
+                                              {std::to_string(time(nullptr))});
     ASSERT_EQ(true, response.is_ok());
     ASSERT_EQ(ERR_OK, response.get_value().err);
 
     // wait envs to be synced, and manual compaction has been finished.
-    std::this_thread::sleep_for(std::chrono::seconds(sleep_for_envs_effect));
+    std::this_thread::sleep_for(std::chrono::seconds(sleep_secs_for_envs_effect));
 
     // check forever one
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_0, ttl_seconds);
-    ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(ttl_seconds >= default_ttl - sleep_for_envs_effect - error_allow &&
-                ttl_seconds <= default_ttl + error_allow)
-        << "ttl is " << ttl_seconds;
+    ASSERT_EQ(PERR_OK, client_->ttl(ttl_hash_key, ttl_test_sort_key_0, ttl_seconds));
+    ASSERT_GE(ttl_seconds, default_ttl_secs - sleep_secs_for_envs_effect - error_allow);
+    ASSERT_LE(ttl_seconds, default_ttl_secs + error_allow);
 
     // check expired one
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds);
-    ASSERT_EQ(PERR_NOT_FOUND, ret);
-
-    ret = client->get(ttl_hash_key, ttl_test_sort_key_1, value);
-    ASSERT_EQ(PERR_NOT_FOUND, ret);
+    ASSERT_EQ(PERR_NOT_FOUND, client_->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds));
+    ASSERT_EQ(PERR_NOT_FOUND, client_->get(ttl_hash_key, ttl_test_sort_key_1, value));
 
     // check exist one
-    ret = client->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds);
-    ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(
-        ttl_seconds >= default_ttl - sleep_for_expiring - sleep_for_envs_effect - error_allow &&
-        ttl_seconds <= default_ttl - sleep_for_expiring - sleep_for_envs_effect + error_allow)
-        << "ttl is " << ttl_seconds;
+    ASSERT_EQ(PERR_OK, client_->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds));
+    ASSERT_NEAR(ttl_seconds,
+                default_ttl_secs - sleep_for_expiring - sleep_secs_for_envs_effect,
+                error_allow);
 }

--- a/src/test/function_test/bulk_load_test/test_bulk_load.cpp
+++ b/src/test/function_test/bulk_load_test/test_bulk_load.cpp
@@ -15,20 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gtest/gtest.h>
+
 #include <dsn/service_api_c.h>
 #include <dsn/dist/replication/replication_ddl_client.h>
 #include <dsn/utility/filesystem.h>
 
 #include "include/pegasus/client.h"
 #include "include/pegasus/error.h"
-#include <gtest/gtest.h>
 
 #include "base/pegasus_const.h"
-#include "test/function_test/utils/global_env.h"
+#include "test/function_test/utils/test_util.h"
 
 using namespace ::dsn;
 using namespace ::dsn::replication;
 using namespace pegasus;
+using std::map;
 using std::string;
 
 ///
@@ -46,127 +48,74 @@ using std::string;
 /// hashkey: hashi sortkey: sorti value: newValue       i=[0, 1000]
 /// hashkey: hashkeyj sortkey: sortkeyj value: newValue j=[0, 1000]
 ///
-class bulk_load_test : public testing::Test
+class bulk_load_test : public test_util
 {
 protected:
-    static void SetUpTestCase() { ASSERT_TRUE(pegasus_client_factory::initialize("config.ini")); }
+    bulk_load_test() : test_util(map<string, string>({{"rocksdb.allow_ingest_behind", "true"}}))
+    {
+        TRICKY_CODE_TO_AVOID_LINK_ERROR;
+        bulk_load_local_root_ =
+            utils::filesystem::path_combine("onebox/block_service/local_service/", LOCAL_ROOT);
+    }
 
     void SetUp() override
     {
-        pegasus_root_dir = global_env::instance()._pegasus_root;
-        working_root_dir = global_env::instance()._working_dir;
-        bulk_load_local_root =
-            utils::filesystem::path_combine("onebox/block_service/local_service/", LOCAL_ROOT);
-
-        // initialize the clients
-        std::vector<rpc_address> meta_list;
-        ASSERT_TRUE(replica_helper::load_meta_servers(
-            meta_list, PEGASUS_CLUSTER_SECTION_NAME.c_str(), "mycluster"));
-        ASSERT_FALSE(meta_list.empty());
-
-        ddl_client = std::make_shared<replication_ddl_client>(meta_list);
-        ASSERT_TRUE(ddl_client != nullptr);
-
-        auto ret = ddl_client->drop_app(APP_NAME, 0);
-        ASSERT_EQ(ERR_OK, ret);
-
-        ret = ddl_client->create_app(
-            APP_NAME, "pegasus", 8, 3, {{"rocksdb.allow_ingest_behind", "true"}}, false);
-        ASSERT_EQ(ERR_OK, ret);
-        int32_t new_app_id;
-        int32_t partition_count;
-        std::vector<partition_configuration> partitions;
-        ret = ddl_client->list_app(APP_NAME, _app_id, partition_count, partitions);
-        ASSERT_EQ(ERR_OK, ret);
-        pg_client = pegasus::pegasus_client_factory::get_client("mycluster", APP_NAME.c_str());
-        ASSERT_TRUE(pg_client != nullptr);
-
-        // copy bulk_load files
-        copy_bulk_load_files();
+        test_util::SetUp();
+        ASSERT_NO_FATAL_FAILURE(copy_bulk_load_files());
     }
 
     void TearDown() override
     {
-        chdir(pegasus_root_dir.c_str());
-        string cmd = "rm -rf onebox/block_service";
-        std::stringstream ss;
-        int iret = dsn::utils::pipe_execute(cmd.c_str(), ss);
-        std::cout << cmd << " output: " << ss.str() << std::endl;
-        ASSERT_EQ(iret, 0);
+        ASSERT_EQ(ERR_OK, ddl_client_->drop_app(app_name_, 0));
+        ASSERT_NO_FATAL_FAILURE(run_cmd_from_project_root("rm -rf onebox/block_service"));
     }
 
-public:
-    std::shared_ptr<replication_ddl_client> ddl_client;
-    pegasus::pegasus_client *pg_client;
-    std::string pegasus_root_dir;
-    std::string working_root_dir;
-    std::string bulk_load_local_root;
-    enum operation
-    {
-        GET,
-        SET,
-        DEL,
-        NO_VALUE
-    };
-
-public:
     void copy_bulk_load_files()
     {
-        chdir(pegasus_root_dir.c_str());
-        system("mkdir onebox/block_service");
-        system("mkdir onebox/block_service/local_service");
-        std::string copy_file_cmd =
+        ASSERT_NO_FATAL_FAILURE(run_cmd_from_project_root("mkdir -p onebox/block_service"));
+        ASSERT_NO_FATAL_FAILURE(
+            run_cmd_from_project_root("mkdir -p onebox/block_service/local_service"));
+        ASSERT_NO_FATAL_FAILURE(run_cmd_from_project_root(
             "cp -r src/test/function_test/bulk_load_test/pegasus-bulk-load-function-test-files/" +
-            LOCAL_ROOT + " onebox/block_service/local_service";
-        system(copy_file_cmd.c_str());
-
-        std::stringstream cmd;
-        cmd << "echo '{\"app_id\":";
-        cmd << _app_id;
-        cmd << ",\"app_name\":\"temp\",\"partition_count\":8}' > "
-               "onebox/block_service/local_service/bulk_load_root/cluster/temp/bulk_load_info";
-        std::stringstream ss;
-        int ret = dsn::utils::pipe_execute(cmd.str().c_str(), ss);
-        std::cout << cmd.str() << " output: " << ss.str() << std::endl;
-        ASSERT_EQ(ret, 0);
+            LOCAL_ROOT + " onebox/block_service/local_service"));
+        string cmd = "echo '{\"app_id\":" + std::to_string(app_id_) +
+                     ",\"app_name\":\"temp\",\"partition_count\":8}' > "
+                     "onebox/block_service/local_service/bulk_load_root/cluster/temp/"
+                     "bulk_load_info";
+        ASSERT_NO_FATAL_FAILURE(run_cmd_from_project_root(cmd));
     }
 
     error_code start_bulk_load(bool ingest_behind = false)
     {
         auto err_resp =
-            ddl_client->start_bulk_load(APP_NAME, CLUSTER, PROVIDER, LOCAL_ROOT, ingest_behind);
+            ddl_client_->start_bulk_load(app_name_, CLUSTER, PROVIDER, LOCAL_ROOT, ingest_behind);
         return err_resp.get_value().err;
     }
 
-    void remove_file(const std::string &file_path)
+    void remove_file(const string &file_path)
     {
-        std::string cmd = "rm " + file_path;
-        system(cmd.c_str());
+        ASSERT_NO_FATAL_FAILURE(run_cmd_from_project_root("rm " + file_path));
     }
 
     void replace_bulk_load_info()
     {
-        chdir(pegasus_root_dir.c_str());
-        std::string cmd =
-            "cp -R "
-            "src/test/function_test/bulk_load_test/pegasus-bulk-load-function-test-files/"
-            "mock_bulk_load_info/. " +
-            bulk_load_local_root + "/" + CLUSTER + "/" + APP_NAME + "/";
-        system(cmd.c_str());
+        string cmd = "cp -R "
+                     "src/test/function_test/bulk_load_test/pegasus-bulk-load-function-test-files/"
+                     "mock_bulk_load_info/. " +
+                     bulk_load_local_root_ + "/" + CLUSTER + "/" + app_name_ + "/";
+        ASSERT_NO_FATAL_FAILURE(run_cmd_from_project_root(cmd));
     }
 
-    void update_allow_ingest_behind(const std::string &allow_ingest_behind)
+    void update_allow_ingest_behind(const string &allow_ingest_behind)
     {
         // update app envs
-        std::vector<std::string> keys;
+        std::vector<string> keys;
         keys.emplace_back(ROCKSDB_ALLOW_INGEST_BEHIND);
-        std::vector<std::string> values;
+        std::vector<string> values;
         values.emplace_back(allow_ingest_behind);
-        auto err_resp = ddl_client->set_app_envs(APP_NAME, keys, values);
-        ASSERT_EQ(err_resp.get_value().err, ERR_OK);
+        ASSERT_EQ(ERR_OK, ddl_client_->set_app_envs(app_name_, keys, values).get_value().err);
         std::cout << "sleep 31s to wait app_envs update" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(31));
-        chdir(working_root_dir.c_str());
     }
 
     bulk_load_status::type wait_bulk_load_finish(int64_t seconds)
@@ -182,7 +131,7 @@ public:
             std::cout << "sleep " << sleep_time << "s to query bulk status" << std::endl;
             std::this_thread::sleep_for(std::chrono::seconds(sleep_time));
 
-            auto resp = ddl_client->query_bulk_load(APP_NAME).get_value();
+            auto resp = ddl_client_->query_bulk_load(app_name_).get_value();
             err = resp.err;
             if (err == ERR_OK) {
                 last_status = resp.app_status;
@@ -197,45 +146,48 @@ public:
         ASSERT_NO_FATAL_FAILURE(verify_data(HASHKEY_PREFIX, SORTKEY_PREFIX));
     }
 
-    void verify_data(const std::string &hashkey_prefix, const std::string &sortkey_prefix)
+    void verify_data(const string &hashkey_prefix, const string &sortkey_prefix)
     {
-        const std::string &expected_value = VALUE;
+        const string &expected_value = VALUE;
         for (int i = 0; i < COUNT; ++i) {
-            std::string hash_key = hashkey_prefix + std::to_string(i);
+            string hash_key = hashkey_prefix + std::to_string(i);
             for (int j = 0; j < COUNT; ++j) {
-                std::string sort_key = sortkey_prefix + std::to_string(j);
-                std::string act_value;
-                int ret = pg_client->get(hash_key, sort_key, act_value);
-                ASSERT_EQ(PERR_OK, ret) << "Failed to get [" << hash_key << "," << sort_key
-                                        << "], error is " << ret << std::endl;
-                ASSERT_EQ(expected_value, act_value)
-                    << "get [" << hash_key << "," << sort_key << "], value = " << act_value
-                    << ", but expected_value = " << expected_value << std::endl;
+                string sort_key = sortkey_prefix + std::to_string(j);
+                string act_value;
+                ASSERT_EQ(PERR_OK, client_->get(hash_key, sort_key, act_value)) << hash_key << ","
+                                                                                << sort_key;
+                ASSERT_EQ(expected_value, act_value) << hash_key << "," << sort_key;
             }
         }
     }
 
-    void operate_data(bulk_load_test::operation op, const std::string &value, int count)
+    enum operation
+    {
+        GET,
+        SET,
+        DEL,
+        NO_VALUE
+    };
+    void operate_data(bulk_load_test::operation op, const string &value, int count)
     {
         for (int i = 0; i < count; ++i) {
-            std::string hash_key = HASHKEY_PREFIX + std::to_string(i);
-            std::string sort_key = SORTKEY_PREFIX + std::to_string(i);
+            string hash_key = HASHKEY_PREFIX + std::to_string(i);
+            string sort_key = SORTKEY_PREFIX + std::to_string(i);
             switch (op) {
             case bulk_load_test::operation::GET: {
-                std::string act_value;
-                int ret = pg_client->get(hash_key, sort_key, act_value);
-                ASSERT_EQ(ret, PERR_OK);
-                ASSERT_EQ(act_value, value);
+                string act_value;
+                ASSERT_EQ(PERR_OK, client_->get(hash_key, sort_key, act_value));
+                ASSERT_EQ(value, act_value);
             } break;
             case bulk_load_test::operation::DEL: {
-                ASSERT_EQ(pg_client->del(hash_key, sort_key), PERR_OK);
+                ASSERT_EQ(PERR_OK, client_->del(hash_key, sort_key));
             } break;
             case bulk_load_test::operation::SET: {
-                ASSERT_EQ(pg_client->set(hash_key, sort_key, value), PERR_OK);
+                ASSERT_EQ(PERR_OK, client_->set(hash_key, sort_key, value));
             } break;
             case bulk_load_test::operation::NO_VALUE: {
-                std::string act_value;
-                ASSERT_EQ(pg_client->get(hash_key, sort_key, act_value), PERR_NOT_FOUND);
+                string act_value;
+                ASSERT_EQ(PERR_NOT_FOUND, client_->get(hash_key, sort_key, act_value));
             } break;
             default:
                 ASSERT_TRUE(false);
@@ -244,17 +196,17 @@ public:
         }
     }
 
-    const std::string LOCAL_ROOT = "bulk_load_root";
-    const std::string CLUSTER = "cluster";
-    const std::string APP_NAME = "temp";
-    const std::string PROVIDER = "local_service";
+protected:
+    string bulk_load_local_root_;
 
-    const std::string HASHKEY_PREFIX = "hash";
-    const std::string SORTKEY_PREFIX = "sort";
-    const std::string VALUE = "newValue";
+    const string LOCAL_ROOT = "bulk_load_root";
+    const string CLUSTER = "cluster";
+    const string PROVIDER = "local_service";
+
+    const string HASHKEY_PREFIX = "hash";
+    const string SORTKEY_PREFIX = "sort";
+    const string VALUE = "newValue";
     const int32_t COUNT = 1000;
-
-    int32_t _app_id = 0;
 };
 
 ///
@@ -264,12 +216,13 @@ public:
 TEST_F(bulk_load_test, bulk_load_test_failed)
 {
     // bulk load failed because `bulk_load_info` file is missing
-    remove_file(bulk_load_local_root + "/" + CLUSTER + "/" + APP_NAME + "/bulk_load_info");
-    ASSERT_EQ(start_bulk_load(), ERR_OBJECT_NOT_FOUND);
+    ASSERT_NO_FATAL_FAILURE(
+        remove_file(bulk_load_local_root_ + "/" + CLUSTER + "/" + app_name_ + "/bulk_load_info"));
+    ASSERT_EQ(ERR_OBJECT_NOT_FOUND, start_bulk_load());
 
     // bulk load failed because `bulk_load_info` file inconsistent with current app_info
-    replace_bulk_load_info();
-    ASSERT_EQ(start_bulk_load(), ERR_INCONSISTENT_STATE);
+    ASSERT_NO_FATAL_FAILURE(replace_bulk_load_info());
+    ASSERT_EQ(ERR_INCONSISTENT_STATE, start_bulk_load());
 }
 
 ///
@@ -282,33 +235,34 @@ TEST_F(bulk_load_test, bulk_load_test_failed)
 TEST_F(bulk_load_test, bulk_load_tests)
 {
     // bulk load failed because partition[0] `bulk_load_metadata` file is missing
-    remove_file(bulk_load_local_root + "/" + CLUSTER + "/" + APP_NAME + "/0/bulk_load_metadata");
-    ASSERT_EQ(start_bulk_load(), ERR_OK);
+    ASSERT_NO_FATAL_FAILURE(remove_file(bulk_load_local_root_ + "/" + CLUSTER + "/" + app_name_ +
+                                        "/0/bulk_load_metadata"));
+    ASSERT_EQ(ERR_OK, start_bulk_load());
     // bulk load will get FAILED
-    ASSERT_EQ(wait_bulk_load_finish(300), bulk_load_status::BLS_FAILED);
+    ASSERT_EQ(bulk_load_status::BLS_FAILED, wait_bulk_load_finish(300));
 
     // recover complete files
-    copy_bulk_load_files();
+    ASSERT_NO_FATAL_FAILURE(copy_bulk_load_files());
 
     // write old data
-    operate_data(operation::SET, "oldValue", 10);
-    operate_data(operation::GET, "oldValue", 10);
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::SET, "oldValue", 10));
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::GET, "oldValue", 10));
 
-    ASSERT_EQ(start_bulk_load(), ERR_OK);
-    ASSERT_EQ(wait_bulk_load_finish(300), bulk_load_status::BLS_SUCCEED);
+    ASSERT_EQ(ERR_OK, start_bulk_load());
+    ASSERT_EQ(bulk_load_status::BLS_SUCCEED, wait_bulk_load_finish(300));
     std::cout << "Start to verify data..." << std::endl;
-    verify_bulk_load_data();
+    ASSERT_NO_FATAL_FAILURE(verify_bulk_load_data());
 
     // value overide by bulk_loaded_data
-    operate_data(operation::GET, VALUE, 10);
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::GET, VALUE, 10));
 
     // write data after bulk load succeed
-    operate_data(operation::SET, "valueAfterBulkLoad", 20);
-    operate_data(operation::GET, "valueAfterBulkLoad", 20);
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::SET, "valueAfterBulkLoad", 20));
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::GET, "valueAfterBulkLoad", 20));
 
     // del data after bulk load succeed
-    operate_data(operation::DEL, "", 15);
-    operate_data(operation::NO_VALUE, "", 15);
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::DEL, "", 15));
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::NO_VALUE, "", 15));
 }
 
 ///
@@ -320,30 +274,30 @@ TEST_F(bulk_load_test, bulk_load_tests)
 ///
 TEST_F(bulk_load_test, bulk_load_ingest_behind_tests)
 {
-    update_allow_ingest_behind("false");
+    ASSERT_NO_FATAL_FAILURE(update_allow_ingest_behind("false"));
 
     // app envs allow_ingest_behind = false, request ingest_behind = true
-    ASSERT_EQ(start_bulk_load(true), ERR_INCONSISTENT_STATE);
+    ASSERT_EQ(ERR_INCONSISTENT_STATE, start_bulk_load(true));
 
-    update_allow_ingest_behind("true");
+    ASSERT_NO_FATAL_FAILURE(update_allow_ingest_behind("true"));
 
     // write old data
-    operate_data(operation::SET, "oldValue", 10);
-    operate_data(operation::GET, "oldValue", 10);
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::SET, "oldValue", 10));
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::GET, "oldValue", 10));
 
-    ASSERT_EQ(start_bulk_load(true), ERR_OK);
-    ASSERT_EQ(wait_bulk_load_finish(300), bulk_load_status::BLS_SUCCEED);
+    ASSERT_EQ(ERR_OK, start_bulk_load(true));
+    ASSERT_EQ(bulk_load_status::BLS_SUCCEED, wait_bulk_load_finish(300));
 
     std::cout << "Start to verify data..." << std::endl;
     // value overide by bulk_loaded_data
-    operate_data(operation::GET, "oldValue", 10);
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::GET, "oldValue", 10));
     ASSERT_NO_FATAL_FAILURE(verify_data("hashkey", "sortkey"));
 
     // write data after bulk load succeed
-    operate_data(operation::SET, "valueAfterBulkLoad", 20);
-    operate_data(operation::GET, "valueAfterBulkLoad", 20);
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::SET, "valueAfterBulkLoad", 20));
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::GET, "valueAfterBulkLoad", 20));
 
     // del data after bulk load succeed
-    operate_data(operation::DEL, "", 15);
-    operate_data(operation::NO_VALUE, "", 15);
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::DEL, "", 15));
+    ASSERT_NO_FATAL_FAILURE(operate_data(operation::NO_VALUE, "", 15));
 }

--- a/src/test/function_test/partition_split_test/test_split.cpp
+++ b/src/test/function_test/partition_split_test/test_split.cpp
@@ -22,56 +22,43 @@
 #include <dsn/dist/replication/replication_ddl_client.h>
 
 #include "base/pegasus_const.h"
+#include "test/function_test/utils/test_util.h"
 
 using namespace dsn;
 using namespace dsn::replication;
 using namespace pegasus;
 
-class partition_split_test : public testing::Test
+class partition_split_test : public test_util
 {
 public:
-    static void SetUpTestCase() { ASSERT_TRUE(pegasus_client_factory::initialize("config.ini")); }
+    partition_split_test() : test_util()
+    {
+        TRICKY_CODE_TO_AVOID_LINK_ERROR;
+        static int32_t test_case = 0;
+        app_name_ = table_name_prefix + std::to_string(test_case++);
+    }
 
     void SetUp() override
     {
-        test_case++;
-        table_name = table_name_prefix + std::to_string(test_case);
-        std::vector<rpc_address> meta_list;
-        ASSERT_TRUE(replica_helper::load_meta_servers(
-            meta_list, PEGASUS_CLUSTER_SECTION_NAME.c_str(), "mycluster"));
-        ASSERT_FALSE(meta_list.empty());
-
-        ddl_client = std::make_shared<replication_ddl_client>(meta_list);
-        ASSERT_TRUE(ddl_client != nullptr);
-        error_code error =
-            ddl_client->create_app(table_name, "pegasus", partition_count, 3, {}, false);
-        ASSERT_EQ(ERR_OK, error);
-
-        pg_client = pegasus_client_factory::get_client("mycluster", table_name.c_str());
-        ASSERT_TRUE(pg_client != nullptr);
+        test_util::SetUp();
         ASSERT_NO_FATAL_FAILURE(write_data_before_split());
-
-        auto err_resp = ddl_client->start_partition_split(table_name, partition_count * 2);
-        ASSERT_EQ(ERR_OK, err_resp.get_value().err);
-        std::cout << "Table(" << table_name << ") start partition split succeed" << std::endl;
+        ASSERT_EQ(
+            ERR_OK,
+            ddl_client_->start_partition_split(app_name_, partition_count_ * 2).get_value().err);
     }
 
-    void TearDown() override
-    {
-        count_during_split = 0;
-        expected.clear();
-        ASSERT_EQ(ERR_OK, ddl_client->drop_app(table_name, 0));
-    }
+    void TearDown() override { ASSERT_EQ(ERR_OK, ddl_client_->drop_app(app_name_, 0)); }
 
     bool is_split_finished()
     {
-        auto err_resp = ddl_client->query_partition_split(table_name);
+        auto err_resp = ddl_client_->query_partition_split(app_name_);
+        auto status_map = err_resp.get_value().status;
         return err_resp.get_value().err == ERR_INVALID_STATE;
     }
 
     bool check_partition_split_status(int32_t target_pidx, split_status::type target_status)
     {
-        auto err_resp = ddl_client->query_partition_split(table_name);
+        auto err_resp = ddl_client_->query_partition_split(app_name_);
         auto status_map = err_resp.get_value().status;
         // is_single_partition
         if (target_pidx > 0) {
@@ -81,12 +68,12 @@ public:
 
         // all partitions
         int32_t finish_count = 0;
-        for (auto i = 0; i < partition_count; ++i) {
+        for (auto i = 0; i < partition_count_; ++i) {
             if (status_map.find(i) != status_map.end() && status_map[i] == target_status) {
                 finish_count++;
             }
         }
-        return finish_count == partition_count;
+        return finish_count == partition_count_;
     }
 
     error_code control_partition_split(split_control_type::type type,
@@ -94,19 +81,17 @@ public:
                                        int32_t old_partition_count = 0)
     {
         auto err_resp =
-            ddl_client->control_partition_split(table_name, type, parent_pidx, old_partition_count);
+            ddl_client_->control_partition_split(app_name_, type, parent_pidx, old_partition_count);
         return err_resp.get_value().err;
     }
 
     void write_data_before_split()
     {
-        std::cout << "Write data before partition split......" << std::endl;
         for (int32_t i = 0; i < dataset_count; ++i) {
             std::string hash_key = dataset_hashkey_prefix + std::to_string(i);
             std::string sort_key = dataset_sortkey_prefix + std::to_string(i);
-            auto ret = pg_client->set(hash_key, sort_key, data_value);
-            ASSERT_EQ(ret, PERR_OK) << ret;
-            expected[hash_key][sort_key] = data_value;
+            ASSERT_EQ(PERR_OK, client_->set(hash_key, sort_key, data_value));
+            expected_kvs_[hash_key][sort_key] = data_value;
         }
     }
 
@@ -117,13 +102,13 @@ public:
 
     void write_data_during_split()
     {
-        std::string hash = splitting_hashkey_prefix + std::to_string(count_during_split);
-        std::string sort = splitting_sortkey_prefix + std::to_string(count_during_split);
-        auto ret = pg_client->set(hash, sort, data_value);
+        std::string hash = splitting_hashkey_prefix + std::to_string(count_during_split_);
+        std::string sort = splitting_sortkey_prefix + std::to_string(count_during_split_);
+        auto ret = client_->set(hash, sort, data_value);
         ASSERT_TRUE(is_valid(ret)) << ret << ", " << hash << " : " << sort;
         if (ret == PERR_OK) {
-            expected[hash][sort] = data_value;
-            count_during_split++;
+            expected_kvs_[hash][sort] = data_value;
+            count_during_split_++;
         }
     }
 
@@ -132,22 +117,22 @@ public:
         auto index = rand() % dataset_count;
         std::string hash = dataset_hashkey_prefix + std::to_string(index);
         std::string sort = dataset_sortkey_prefix + std::to_string(index);
-        std::string expected_value;
-        auto ret = pg_client->get(hash, sort, expected_value);
-        dassert(is_valid(ret), "ret");
+        std::string actual_value;
+        auto ret = client_->get(hash, sort, actual_value);
+        ASSERT_TRUE(is_valid(ret)) << ret << ", " << hash << " : " << sort;
         if (ret == PERR_OK) {
-            ASSERT_EQ(expected_value, data_value);
+            ASSERT_EQ(data_value, actual_value);
         }
     }
 
     void verify_data_after_split()
     {
-        std::cout << "Verify data(count=" << dataset_count + count_during_split
+        std::cout << "Verify data(count=" << dataset_count + count_during_split_
                   << ") after partition split......" << std::endl;
         ASSERT_NO_FATAL_FAILURE(
             verify_data(dataset_hashkey_prefix, dataset_sortkey_prefix, dataset_count));
         ASSERT_NO_FATAL_FAILURE(
-            verify_data(splitting_hashkey_prefix, splitting_sortkey_prefix, count_during_split));
+            verify_data(splitting_hashkey_prefix, splitting_sortkey_prefix, count_during_split_));
     }
 
     void verify_data(const std::string &hashkey_prefix,
@@ -158,8 +143,8 @@ public:
             std::string hash_key = hashkey_prefix + std::to_string(i);
             std::string sort_key = sortkey_prefix + std::to_string(i);
             std::string value;
-            ASSERT_EQ(PERR_OK, pg_client->get(hash_key, sort_key, value));
-            ASSERT_EQ(expected[hash_key][sort_key], value);
+            ASSERT_EQ(PERR_OK, client_->get(hash_key, sort_key, value));
+            ASSERT_EQ(expected_kvs_[hash_key][sort_key], value);
         }
     }
 
@@ -171,15 +156,15 @@ public:
 
         pegasus_client::pegasus_scanner *scanner = nullptr;
         pegasus_client::scan_options options;
-        auto ret = pg_client->get_scanner(
+        auto ret = client_->get_scanner(
             dataset_hashkey_prefix + std::to_string(count), "", "", options, scanner);
-        ASSERT_TRUE(is_valid(ret));
+        ASSERT_TRUE(is_valid(ret)) << ret;
         if (ret == PERR_OK) {
             std::string hash_key;
             std::string sort_key;
-            std::string expected_value;
-            while (scanner->next(hash_key, sort_key, expected_value) == 0) {
-                ASSERT_EQ(expected[hash_key][sort_key], expected_value);
+            std::string actual_value;
+            while (scanner->next(hash_key, sort_key, actual_value) == 0) {
+                ASSERT_EQ(expected_kvs_[hash_key][sort_key], actual_value);
             }
         }
         delete scanner;
@@ -191,44 +176,38 @@ public:
         std::vector<pegasus_client::pegasus_scanner *> scanners;
         pegasus_client::scan_options options;
         options.timeout_ms = 30000;
-        auto ret = pg_client->get_unordered_scanners(10000, options, scanners);
-        ASSERT_EQ(ret, PERR_OK);
+        ASSERT_EQ(PERR_OK, client_->get_unordered_scanners(10000, options, scanners));
         int32_t count = 0;
         for (auto i = 0; i < scanners.size(); i++) {
             std::string hash_key;
             std::string sort_key;
-            std::string expected_value;
+            std::string actual_value;
             pegasus_client::internal_info info;
             pegasus_client::pegasus_scanner *scanner = scanners[i];
-            while (scanner->next(hash_key, sort_key, expected_value, &info) == 0) {
-                ASSERT_EQ(expected[hash_key][sort_key], expected_value);
+            while (scanner->next(hash_key, sort_key, actual_value, &info) == 0) {
+                ASSERT_EQ(expected_kvs_[hash_key][sort_key], actual_value);
                 count++;
             }
         }
-        ASSERT_EQ(count, dataset_count);
+        ASSERT_EQ(dataset_count, count);
         for (auto scanner : scanners) {
             delete scanner;
         }
     }
 
 public:
-    std::shared_ptr<replication_ddl_client> ddl_client;
-    pegasus_client *pg_client;
-    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> expected;
-    const int32_t partition_count = 4;
-    const int32_t dataset_count = 1000;
     const std::string table_name_prefix = "split_table_test_";
-    std::string table_name;
     const std::string dataset_hashkey_prefix = "hashkey";
     const std::string dataset_sortkey_prefix = "sortkey";
     const std::string splitting_hashkey_prefix = "keyh_";
     const std::string splitting_sortkey_prefix = "keys_";
     const std::string data_value = "vaule";
-    int32_t count_during_split = 0;
-    static int32_t test_case;
-};
 
-int32_t partition_split_test::test_case = 0;
+    const int32_t dataset_count = 1000;
+
+    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> expected_kvs_;
+    int32_t count_during_split_ = 0;
+};
 
 TEST_F(partition_split_test, split_with_write)
 {
@@ -272,22 +251,20 @@ TEST_F(partition_split_test, pause_split)
     bool already_pause = false, already_restart = false;
     int32_t target_partition = 2, count = 30;
     do {
-        write_data_during_split();
+        ASSERT_NO_FATAL_FAILURE(write_data_during_split());
         // pause target partition split
         if (!already_pause && check_partition_split_status(-1, split_status::SPLITTING)) {
-            error_code error = control_partition_split(split_control_type::PAUSE, target_partition);
-            ASSERT_EQ(ERR_OK, error);
-            std::cout << "Table(" << table_name << ") pause partition[" << target_partition
+            ASSERT_EQ(ERR_OK, control_partition_split(split_control_type::PAUSE, target_partition));
+            std::cout << "Table(" << app_name_ << ") pause partition[" << target_partition
                       << "] split succeed" << std::endl;
             already_pause = true;
         }
         // restart target partition split
-        if (!already_restart && count_during_split >= count &&
+        if (!already_restart && count_during_split_ >= count &&
             check_partition_split_status(target_partition, split_status::PAUSED)) {
-            error_code error =
-                control_partition_split(split_control_type::RESTART, target_partition);
-            ASSERT_EQ(ERR_OK, error);
-            std::cout << "Table(" << table_name << ") restart split partition[" << target_partition
+            ASSERT_EQ(ERR_OK,
+                      control_partition_split(split_control_type::RESTART, target_partition));
+            std::cout << "Table(" << app_name_ << ") restart split partition[" << target_partition
                       << "] succeed" << std::endl;
             already_restart = true;
         }
@@ -302,14 +279,12 @@ TEST_F(partition_split_test, cancel_split)
 {
     // pause partition split
     bool already_pause = false;
-    error_code error = ERR_OK;
     do {
-        write_data_during_split();
+        ASSERT_NO_FATAL_FAILURE(write_data_during_split());
         // pause all partition split
         if (!already_pause && check_partition_split_status(-1, split_status::SPLITTING)) {
-            error = control_partition_split(split_control_type::PAUSE, -1);
-            ASSERT_EQ(ERR_OK, error);
-            std::cout << "Table(" << table_name << ") pause all partitions split succeed"
+            ASSERT_EQ(ERR_OK, control_partition_split(split_control_type::PAUSE, -1));
+            std::cout << "Table(" << app_name_ << ") pause all partitions split succeed"
                       << std::endl;
             already_pause = true;
         }
@@ -317,14 +292,14 @@ TEST_F(partition_split_test, cancel_split)
     } while (!check_partition_split_status(-1, split_status::PAUSED));
 
     // cancel partition split
-    error = control_partition_split(split_control_type::CANCEL, -1, partition_count);
-    ASSERT_EQ(ERR_OK, error);
-    std::cout << "Table(" << table_name << ") cancel partitions split succeed" << std::endl;
+    ASSERT_EQ(ERR_OK, control_partition_split(split_control_type::CANCEL, -1, partition_count_));
+    std::cout << "Table(" << app_name_ << ") cancel partitions split succeed" << std::endl;
     // write data during cancel partition split
     do {
-        write_data_during_split();
+        ASSERT_NO_FATAL_FAILURE(write_data_during_split());
         std::this_thread::sleep_for(std::chrono::seconds(1));
     } while (!is_split_finished());
+    std::cout << "Partition split succeed" << std::endl;
 
     ASSERT_NO_FATAL_FAILURE(verify_data_after_split());
 }

--- a/src/test/function_test/recovery_test/test_recovery.cpp
+++ b/src/test/function_test/recovery_test/test_recovery.cpp
@@ -23,69 +23,47 @@
 #include <climits>
 #include <map>
 #include <memory>
-#include <boost/lexical_cast.hpp>
+
+#include <fmt/ostream.h>
+#include <gtest/gtest.h>
 
 #include <dsn/service_api_c.h>
 #include <dsn/dist/replication/replication_ddl_client.h>
 #include <dsn/utility/rand.h>
 
 #include "include/pegasus/client.h"
-#include <gtest/gtest.h>
 
 #include "base/pegasus_const.h"
 #include "test/function_test/utils/global_env.h"
+#include "test/function_test/utils/test_util.h"
 
 using namespace dsn::replication;
 using namespace pegasus;
 
-class recovery_test : public testing::Test
+// TODO(yingchun): add a check for it, get config by curl
+// NOTE: THREAD_POOL_META_SERVER worker count should be greater than 1
+// This function test update 'distributed_lock_service_type' to
+// 'distributed_lock_service_simple', which executes in threadpool THREAD_POOL_META_SERVER
+// As a result, failure detection lock executes in this pool
+// if worker count = 1, it will lead to ERR_TIMEOUT when execute 'ddl_client_->do_recovery'
+class recovery_test : public test_util
 {
 protected:
-    static void SetUpTestCase() { ASSERT_TRUE(pegasus_client_factory::initialize("config.ini")); }
-
     void SetUp() override
     {
-        // NOTE: THREAD_POOL_META_SERVER worker count should be greater than 1
-        // This function test update 'distributed_lock_service_type' to
-        // 'distributed_lock_service_simple', which executes in threadpool THREAD_POOL_META_SERVER
-        // As a result, failure detection lock executes in this pool
-        // if worker count = 1, it will lead to ERR_TIMEOUT when execute 'ddl_client->do_recovery'
-
-        // 2. initialize the clients
-        std::vector<dsn::rpc_address> meta_list;
-        ASSERT_TRUE(replica_helper::load_meta_servers(
-            meta_list, PEGASUS_CLUSTER_SECTION_NAME.c_str(), "single_master_cluster"));
-        ASSERT_FALSE(meta_list.empty());
-
-        ddl_client = std::make_shared<replication_ddl_client>(meta_list);
-        ASSERT_TRUE(ddl_client != nullptr);
-        pg_client = pegasus::pegasus_client_factory::get_client("single_master_cluster",
-                                                                table_name.c_str());
-        ASSERT_TRUE(pg_client != nullptr);
-
-        // 3. write some data to the app
-        dsn::error_code err;
-        // first create the app
-        err = ddl_client->create_app(table_name, "pegasus", default_partitions, 3, {}, false);
-        ASSERT_EQ(dsn::ERR_OK, err);
-
-        // then write keys
-        std::cerr << "write " << set_count << " keys" << std::endl;
-        for (int i = 0; i < set_count; ++i) {
-            std::string hash_key = key_prefix + boost::lexical_cast<std::string>(i);
+        TRICKY_CODE_TO_AVOID_LINK_ERROR;
+        test_util::SetUp();
+        for (int i = 0; i < dataset_count; ++i) {
+            std::string hash_key = key_prefix + std::to_string(i);
             std::string sort_key = hash_key;
-            std::string value = value_prefix + boost::lexical_cast<std::string>(i);
+            std::string value = value_prefix + std::to_string(i);
 
             pegasus::pegasus_client::internal_info info;
-            int ans = pg_client->set(hash_key, sort_key, value, 5000, 0, &info);
+            int ans = client_->set(hash_key, sort_key, value, 5000, 0, &info);
             ASSERT_EQ(0, ans);
-            ASSERT_TRUE(info.partition_index < default_partitions);
+            ASSERT_TRUE(info.partition_index < partition_count_);
         }
     }
-
-public:
-    std::shared_ptr<replication_ddl_client> ddl_client;
-    pegasus::pegasus_client *pg_client;
 
 public:
     std::vector<dsn::rpc_address> get_rpc_address_list(const std::vector<int> ports)
@@ -101,95 +79,55 @@ public:
 
     void stop_replica(int id)
     {
-        char command[512];
-        snprintf(command,
-                 512,
-                 "cd %s && ./run.sh stop_onebox_instance -r %d",
-                 global_env::instance()._pegasus_root.c_str(),
-                 id);
-        system(command);
+        ASSERT_NO_FATAL_FAILURE(
+            run_cmd_from_project_root("./run.sh stop_onebox_instance -r " + std::to_string(id)));
     }
 
     void stop_meta(int id)
     {
-        char command[512];
-        snprintf(command,
-                 512,
-                 "cd %s && ./run.sh stop_onebox_instance -m %d",
-                 global_env::instance()._pegasus_root.c_str(),
-                 id);
-        system(command);
+        ASSERT_NO_FATAL_FAILURE(
+            run_cmd_from_project_root("./run.sh stop_onebox_instance -m " + std::to_string(id)));
     }
 
     void start_meta(int id)
     {
-        char command[512];
-        snprintf(command,
-                 512,
-                 "cd %s && ./run.sh start_onebox_instance -m %d",
-                 global_env::instance()._pegasus_root.c_str(),
-                 id);
-        system(command);
+        ASSERT_NO_FATAL_FAILURE(
+            run_cmd_from_project_root("./run.sh start_onebox_instance -m " + std::to_string(id)));
     }
 
     void start_replica(int id)
     {
-        char command[512];
-        snprintf(command,
-                 512,
-                 "cd %s && ./run.sh start_onebox_instance -r %d",
-                 global_env::instance()._pegasus_root.c_str(),
-                 id);
-        system(command);
+        ASSERT_NO_FATAL_FAILURE(
+            run_cmd_from_project_root("./run.sh start_onebox_instance -r " + std::to_string(id)));
     }
 
     void clear_remote_storage()
     {
-        char command[512];
-        snprintf(command,
-                 512,
-                 "cd %s && rm -rf onebox/meta1/data/meta/meta_state_service.log",
-                 global_env::instance()._pegasus_root.c_str());
-        system(command);
+        ASSERT_NO_FATAL_FAILURE(
+            run_cmd_from_project_root("rm -rf onebox/meta1/data/meta/meta_state_service.log"));
     }
 
     void config_meta_to_do_cold_recovery()
     {
-        char command[512];
-        snprintf(
-            command,
-            512,
-            "cd %s && sed -i \"/^\\s*recover_from_replica_server/c recover_from_replica_server = "
-            "true\" onebox/meta1/config.ini",
-            global_env::instance()._pegasus_root.c_str());
-        system(command);
+        ASSERT_NO_FATAL_FAILURE(run_cmd_from_project_root(
+            "sed -i \"/^\\s*recover_from_replica_server/c recover_from_replica_server = true\" "
+            "onebox/meta1/config.ini"));
     }
 
     void delete_replica(int replica_id, int app_id, int partition_id)
     {
-        char command[512];
-        snprintf(command,
-                 512,
-                 "cd %s/onebox/replica%d/data/replica/reps && rm -rf %d.%d.pegasus",
-                 global_env::instance()._pegasus_root.c_str(),
-                 replica_id,
-                 app_id,
-                 partition_id);
-        std::cout << command << std::endl;
-        system(command);
+        std::string cmd = fmt::format("rm -rf onebox/replica{}/data/replica/reps/{}.{}.pegasus",
+                                      replica_id,
+                                      app_id,
+                                      partition_id);
+        ASSERT_NO_FATAL_FAILURE(run_cmd_from_project_root(cmd));
     }
 
     void delete_replicas_for_app_id(int replica_id, int app_id)
     {
-        char command[512];
-        snprintf(command,
-                 512,
-                 "cd %s/onebox/replica%d/data/replica/reps && rm -rf %d.*.pegasus",
-                 global_env::instance()._pegasus_root.c_str(),
-                 replica_id,
-                 app_id);
-        std::cout << command << std::endl;
-        system(command);
+        std::string cmd = fmt::format(
+            "rm -rf onebox/replica{}/data/replica/reps/{}.*.pegasus", replica_id, app_id);
+        ASSERT_NO_FATAL_FAILURE(run_cmd_from_project_root(cmd));
     }
 
     // 1. stop replicas
@@ -197,13 +135,13 @@ public:
     void prepare_recovery()
     {
         // then stop all jobs
-        stop_meta(1);
+        ASSERT_NO_FATAL_FAILURE(stop_meta(1));
         for (int i = 1; i <= 3; ++i) {
-            stop_replica(i);
+            ASSERT_NO_FATAL_FAILURE(stop_replica(i));
         }
 
-        clear_remote_storage();
-        config_meta_to_do_cold_recovery();
+        ASSERT_NO_FATAL_FAILURE(clear_remote_storage());
+        ASSERT_NO_FATAL_FAILURE(config_meta_to_do_cold_recovery());
         // sleep some time, in case that the socket is time-wait
         std::cout << "sleep for a while to wait the socket to destroy" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(10));
@@ -213,148 +151,135 @@ public:
     {
         // then check to read all keys
         for (int i = 0; i < count; ++i) {
-            std::string hash_key = key_prefix + boost::lexical_cast<std::string>(i);
+            std::string hash_key = key_prefix + std::to_string(i);
             std::string sort_key = hash_key;
-            std::string exp_value = value_prefix + boost::lexical_cast<std::string>(i);
+            std::string exp_value = value_prefix + std::to_string(i);
 
             std::string act_value;
-            int ans = pg_client->get(hash_key, sort_key, act_value);
-            ASSERT_EQ(0, ans);
+            ASSERT_EQ(PERR_OK, client_->get(hash_key, sort_key, act_value));
             ASSERT_EQ(exp_value, act_value);
         }
     }
 
-    static const std::string table_name;
-    static const std::string key_prefix;
-    static const std::string value_prefix;
-    static const int default_partitions = 4;
-    static const int set_count = 2048;
+    const std::string key_prefix = "hello_key";
+    const std::string value_prefix = "world_key";
+    static const int dataset_count = 2048;
 };
-
-const std::string recovery_test::table_name = "test_table";
-const std::string recovery_test::key_prefix = "hello_key";
-const std::string recovery_test::value_prefix = "world_key";
 
 TEST_F(recovery_test, recovery)
 {
-    dsn::error_code err;
-
     // first test the basic recovery
-    std::cout << ">>>>> test basic recovery <<<<<" << std::endl;
     {
-        prepare_recovery();
+        ASSERT_NO_FATAL_FAILURE(prepare_recovery());
         // start all jobs again
         for (int i = 1; i <= 3; ++i) {
-            start_replica(i);
+            ASSERT_NO_FATAL_FAILURE(start_replica(i));
         }
         std::cout << "sleep for a while to wait the replica to start" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(20));
-        start_meta(1);
+        ASSERT_NO_FATAL_FAILURE(start_meta(1));
 
         std::cout << "sleep for a while to wait the meta to come to alive" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(10));
 
         // then do recovery
         auto nodes = get_rpc_address_list({34801, 34802, 34803});
-        err = ddl_client->do_recovery(nodes, 30, false, false, std::string());
-        ASSERT_EQ(dsn::ERR_OK, err);
+        ASSERT_EQ(dsn::ERR_OK, ddl_client_->do_recovery(nodes, 30, false, false, std::string()));
 
         // send another recovery command
-        err = ddl_client->do_recovery(nodes, 30, false, false, std::string());
-        ASSERT_EQ(dsn::ERR_SERVICE_ALREADY_RUNNING, err);
+        ASSERT_EQ(dsn::ERR_SERVICE_ALREADY_RUNNING,
+                  ddl_client_->do_recovery(nodes, 30, false, false, std::string()));
 
         // then wait the apps to ready
-        err = ddl_client->create_app(table_name, "pegasus", default_partitions, 3, {}, false);
-        ASSERT_EQ(dsn::ERR_OK, err);
+        ASSERT_EQ(dsn::ERR_OK,
+                  ddl_client_->create_app(app_name_, "pegasus", partition_count_, 3, {}, false));
 
-        verify_data(set_count);
+        ASSERT_NO_FATAL_FAILURE(verify_data(dataset_count));
     }
 
     // recover from subset of all nodes
     std::cout << ">>>>> test recovery from subset of all nodes <<<<<" << std::endl;
     {
-        prepare_recovery();
-        for (int i = 1; i <= 3; ++i)
-            start_replica(i);
+        ASSERT_NO_FATAL_FAILURE(prepare_recovery());
+        for (int i = 1; i <= 3; ++i) {
+            ASSERT_NO_FATAL_FAILURE(start_replica(i));
+        }
         std::cout << "sleep for a while to wait the replica to start" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(20));
-        start_meta(1);
+        ASSERT_NO_FATAL_FAILURE(start_meta(1));
 
         std::cout << "sleep for a while to wait the meta to come to alive" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(10));
 
         // recovery only from 1 & 2
         std::vector<dsn::rpc_address> nodes = get_rpc_address_list({34801, 34802});
-        ddl_client->do_recovery(nodes, 30, false, false, std::string());
-        ASSERT_EQ(dsn::ERR_OK, err);
+        ASSERT_EQ(dsn::ERR_OK, ddl_client_->do_recovery(nodes, 30, false, false, std::string()));
 
         // then wait the app to ready
-        err = ddl_client->create_app(table_name, "pegasus", default_partitions, 3, {}, false);
-        ASSERT_EQ(dsn::ERR_OK, err);
+        ASSERT_EQ(dsn::ERR_OK,
+                  ddl_client_->create_app(app_name_, "pegasus", partition_count_, 3, {}, false));
 
-        verify_data(set_count);
+        ASSERT_NO_FATAL_FAILURE(verify_data(dataset_count));
     }
 
     // recovery from whole, but some partitions has been removed
     std::cout << ">>>>> test recovery, some partitions have been lost <<<<<" << std::endl;
     {
-        prepare_recovery();
-        for (int i = 0; i < default_partitions; ++i) {
+        ASSERT_NO_FATAL_FAILURE(prepare_recovery());
+        for (int i = 0; i < partition_count_; ++i) {
             int replica_id = dsn::rand::next_u32(1, 3);
             delete_replica(replica_id, 2, i);
         }
 
         // start all jobs again
         for (int i = 1; i <= 3; ++i) {
-            start_replica(i);
+            ASSERT_NO_FATAL_FAILURE(start_replica(i));
         }
         std::cout << "sleep for a while to wait the replica to start" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(20));
-        start_meta(1);
+        ASSERT_NO_FATAL_FAILURE(start_meta(1));
 
         std::cout << "sleep for a while to wait the meta to come to alive" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(10));
 
         // then do recovery
         auto nodes = get_rpc_address_list({34801, 34802, 34803});
-        err = ddl_client->do_recovery(nodes, 30, false, false, std::string());
-        ASSERT_EQ(dsn::ERR_OK, err);
+        ASSERT_EQ(dsn::ERR_OK, ddl_client_->do_recovery(nodes, 30, false, false, std::string()));
 
         // then wait the apps to ready
-        err = ddl_client->create_app(table_name, "pegasus", default_partitions, 3, {}, false);
-        ASSERT_EQ(dsn::ERR_OK, err);
+        ASSERT_EQ(dsn::ERR_OK,
+                  ddl_client_->create_app(app_name_, "pegasus", partition_count_, 3, {}, false));
 
-        verify_data(set_count);
+        ASSERT_NO_FATAL_FAILURE(verify_data(dataset_count));
     }
 
     // some apps has been totally removed
     std::cout << ">>>>> test recovery, app 1 is removed <<<<<" << std::endl;
     {
-        prepare_recovery();
+        ASSERT_NO_FATAL_FAILURE(prepare_recovery());
         for (int i = 1; i < 4; ++i) {
             delete_replicas_for_app_id(i, 1);
         }
 
         // start all jobs again
         for (int i = 1; i <= 3; ++i) {
-            start_replica(i);
+            ASSERT_NO_FATAL_FAILURE(start_replica(i));
         }
         std::cout << "sleep for a while to wait the replica to start" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(20));
-        start_meta(1);
+        ASSERT_NO_FATAL_FAILURE(start_meta(1));
 
         std::cout << "sleep for a while to wait the meta to come to alive" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(10));
 
         // then do recovery
         auto nodes = get_rpc_address_list({34801, 34802, 34803});
-        err = ddl_client->do_recovery(nodes, 30, false, false, std::string());
-        ASSERT_EQ(dsn::ERR_OK, err);
+        ASSERT_EQ(dsn::ERR_OK, ddl_client_->do_recovery(nodes, 30, false, false, std::string()));
 
         // then wait the apps to ready
-        err = ddl_client->create_app(table_name, "pegasus", default_partitions, 3, {}, false);
-        ASSERT_EQ(dsn::ERR_OK, err);
+        ASSERT_EQ(dsn::ERR_OK,
+                  ddl_client_->create_app(app_name_, "pegasus", partition_count_, 3, {}, false));
 
-        verify_data(set_count);
+        ASSERT_NO_FATAL_FAILURE(verify_data(dataset_count));
     }
 }

--- a/src/test/function_test/restore_test/test_restore.cpp
+++ b/src/test/function_test/restore_test/test_restore.cpp
@@ -33,6 +33,8 @@ using namespace ::dsn;
 using namespace ::dsn::replication;
 using namespace pegasus;
 
+// TODO(yingchun): backup & restore festure is on refactoring, we can refactor the related function
+// test later.
 class restore_test : public testing::Test
 {
 public:
@@ -288,42 +290,28 @@ public:
     int32_t old_app_id;
     int64_t time_stamp;
 
-    static const std::string policy_name;
-    static const std::string backup_provider_name;
-    static const int backup_interval_seconds;
-    static const int backup_history_count_to_keep;
-    static const std::string start_time;
+    const std::string policy_name = "policy_1";
+    const std::string backup_provider_name = "local_service";
+    // NOTICE: we enqueue a time task to check whether policy should start backup periodically, the
+    // period is 5min, so the time between two backup is at least 5min, but if we set the
+    // backup_interval_seconds smaller enough such as smaller than the time of finishing once
+    // backup, we
+    // can start next backup immediately when current backup is finished
+    // The backup interval must be greater than checkpoint reserve time, see
+    // backup_service::add_backup_policy() for details.
+    const int backup_interval_seconds = 700;
+    const int backup_history_count_to_keep = 6;
+    const std::string start_time = "24:0";
 
-    static const std::string app_name;
+    const std::string app_name = "backup_test";
 
-    static const std::string hash_key_prefix;
-    static const std::string sort_key_prefix;
-    static const std::string value_prefix;
+    const std::string hash_key_prefix = "hash_key";
+    const std::string sort_key_prefix = "sort_key";
+    const std::string value_prefix = "value";
 
-    static const int kv_pair_cnt;
-    static const int default_partition_cnt;
+    const int kv_pair_cnt = 10000;
+    const int default_partition_cnt = 8;
 };
-
-const std::string restore_test::policy_name = "policy_1";
-const std::string restore_test::backup_provider_name = "local_service";
-// NOTICE: we enqueue a time task to check whether policy should start backup periodically, the
-// period is 5min, so the time between two backup is at least 5min, but if we set the
-// backup_interval_seconds smaller enough such as smaller than the time of finishing once backup, we
-// can start next backup immediately when current backup is finished
-// The backup interval must be greater than checkpoint reserve time, see
-// backup_service::add_backup_policy() for details.
-const int restore_test::backup_interval_seconds = 700;
-const int restore_test::backup_history_count_to_keep = 6;
-const std::string restore_test::start_time = "24:0";
-
-const std::string restore_test::app_name = "backup_test";
-
-const std::string restore_test::hash_key_prefix = "hash_key";
-const std::string restore_test::sort_key_prefix = "sort_key";
-const std::string restore_test::value_prefix = "value";
-
-const int restore_test::kv_pair_cnt = 10000;
-const int restore_test::default_partition_cnt = 8;
 
 TEST_F(restore_test, restore)
 {

--- a/src/test/function_test/utils/CMakeLists.txt
+++ b/src/test/function_test/utils/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MY_PROJ_SRC "")
 set(MY_PROJ_LIBS
     dsn_client
     dsn_replication_common
+    pegasus_base
     pegasus_client_static
     gtest
     )

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -26,7 +26,10 @@
 #include "dsn/dist/replication/replication_other_types.h"
 #include "dsn/tool-api/rpc_address.h"
 #include "include/pegasus/client.h"
+#include "test/function_test/utils/global_env.h"
+#include "test/function_test/utils/utils.h"
 
+using dsn::partition_configuration;
 using dsn::replication::replica_helper;
 using dsn::replication::replication_ddl_client;
 using dsn::rpc_address;
@@ -34,7 +37,10 @@ using std::vector;
 
 namespace pegasus {
 
-test_util::test_util() : cluster_name_("mycluster"), app_name_("temp") {}
+test_util::test_util(std::map<std::string, std::string> create_envs)
+    : cluster_name_("mycluster"), app_name_("temp"), create_envs_(std::move(create_envs))
+{
+}
 
 test_util::~test_util() {}
 
@@ -42,16 +48,37 @@ void test_util::SetUpTestCase() { ASSERT_TRUE(pegasus_client_factory::initialize
 
 void test_util::SetUp()
 {
-    vector<rpc_address> meta_list;
     ASSERT_TRUE(replica_helper::load_meta_servers(
-        meta_list, PEGASUS_CLUSTER_SECTION_NAME.c_str(), cluster_name_.c_str()));
-    ASSERT_FALSE(meta_list.empty());
-    ddl_client = std::make_shared<replication_ddl_client>(meta_list);
-    ASSERT_TRUE(ddl_client != nullptr);
+        meta_list_, PEGASUS_CLUSTER_SECTION_NAME.c_str(), cluster_name_.c_str()));
+    ASSERT_FALSE(meta_list_.empty());
 
-    ASSERT_EQ(dsn::ERR_OK, ddl_client->create_app(app_name_, "pegasus", 8, 3, {}, false));
-    client = pegasus_client_factory::get_client(cluster_name_.c_str(), app_name_.c_str());
-    ASSERT_TRUE(client != nullptr);
+    ddl_client_ = std::make_shared<replication_ddl_client>(meta_list_);
+    ASSERT_TRUE(ddl_client_ != nullptr);
+
+    dsn::error_code ret =
+        ddl_client_->create_app(app_name_, "pegasus", partition_count_, 3, create_envs_, false);
+    if (ret == dsn::ERR_INVALID_PARAMETERS) {
+        ASSERT_EQ(dsn::ERR_OK, ddl_client_->drop_app(app_name_, 0));
+        ASSERT_EQ(dsn::ERR_OK,
+                  ddl_client_->create_app(
+                      app_name_, "pegasus", partition_count_, 3, create_envs_, false));
+    } else {
+        ASSERT_EQ(dsn::ERR_OK, ret);
+    }
+    client_ = pegasus_client_factory::get_client(cluster_name_.c_str(), app_name_.c_str());
+    ASSERT_TRUE(client_ != nullptr);
+
+    int32_t partition_count;
+    ASSERT_EQ(dsn::ERR_OK, ddl_client_->list_app(app_name_, app_id_, partition_count, partitions_));
+    ASSERT_NE(0, app_id_);
+    ASSERT_EQ(partition_count_, partition_count);
+    ASSERT_EQ(partition_count_, partitions_.size());
+}
+
+void test_util::run_cmd_from_project_root(const std::string &cmd)
+{
+    ASSERT_EQ(0, chdir(global_env::instance()._pegasus_root.c_str()));
+    ASSERT_NO_FATAL_FAILURE(run_cmd(cmd));
 }
 
 } // namespace pegasus

--- a/src/test/function_test/utils/test_util.h
+++ b/src/test/function_test/utils/test_util.h
@@ -19,11 +19,21 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
-
+#include <string>
 #include <gtest/gtest.h>
 
+// TODO(yingchun): it's too tricky, but I don't know how does it happen, we can fix it later.
+#define TRICKY_CODE_TO_AVOID_LINK_ERROR                                                            \
+    do {                                                                                           \
+        ddl_client_->create_app("", "pegasus", 0, 0, {}, false);                                   \
+        pegasus_client_factory::get_client("", "");                                                \
+    } while (false)
+
 namespace dsn {
+class partition_configuration;
+class rpc_address;
 namespace replication {
 class replication_ddl_client;
 } // namespace replication
@@ -35,17 +45,24 @@ class pegasus_client;
 class test_util : public ::testing::Test
 {
 public:
-    test_util();
+    test_util(std::map<std::string, std::string> create_envs = {});
     virtual ~test_util();
 
     static void SetUpTestCase();
 
     void SetUp() override;
 
+    void run_cmd_from_project_root(const std::string &cmd);
+
 protected:
-    std::string cluster_name_;
+    const std::string cluster_name_;
     std::string app_name_;
-    pegasus_client *client = nullptr;
-    std::shared_ptr<dsn::replication::replication_ddl_client> ddl_client;
+    const std::map<std::string, std::string> create_envs_;
+    int32_t app_id_;
+    int32_t partition_count_ = 8;
+    std::vector<dsn::partition_configuration> partitions_;
+    pegasus_client *client_ = nullptr;
+    std::vector<dsn::rpc_address> meta_list_;
+    std::shared_ptr<dsn::replication::replication_ddl_client> ddl_client_;
 };
 } // namespace pegasus


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1166

This is a flow up to https://github.com/apache/incubator-pegasus/pull/1149, now refactoring these function tests to inherit from test_util to reduce duplicate code.
And also include some other non-functional refactors.