### PR TITLE
fix: update app_name on 'on_config_sync'

### DIFF
--- a/src/rdsn/src/replica/replica.h
+++ b/src/rdsn/src/replica/replica.h
@@ -496,6 +496,7 @@ private:
     clear_on_failure(replica_stub *stub, replica *rep, const std::string &path, const gpid &pid);
 
     void update_app_max_replica_count(int32_t max_replica_count);
+    void update_app_name(std::string app_name);
 
 private:
     friend class ::dsn::replication::test::test_checker;

--- a/src/rdsn/src/replica/replica_config.cpp
+++ b/src/rdsn/src/replica/replica_config.cpp
@@ -1103,6 +1103,7 @@ void replica::on_config_sync(const app_info &info,
         return;
 
     update_app_max_replica_count(info.max_replica_count);
+    update_app_name(info.app_name);
     update_app_envs(info.envs);
     _is_duplication_master = info.duplicating;
 
@@ -1141,6 +1142,23 @@ void replica::on_config_sync(const app_info &info,
             }
         }
     }
+}
+
+void replica::update_app_name(std::string app_name)
+{
+    if (app_name == _app_info.app_name) {
+        return;
+    }
+
+    auto old_app_name = _app_info.app_name;
+    _app_info.app_name = app_name;
+
+    auto ec = store_app_info(_app_info);
+    dassert_replica(ec == ERR_OK,
+                    "store_app_info for app_name failed: error_code={}, app_name={}, app_id={}",
+                    ec.to_string(),
+                    _app_info.app_name,
+                    _app_info.app_id);
 }
 
 void replica::update_app_max_replica_count(int32_t max_replica_count)


### PR DESCRIPTION
### What problem does this PR solve? 

https://github.com/apache/incubator-pegasus/issues/1183

### What is changed and how does it work?

 I want to add `update_app_name` on `on_config_sync`. 

`app_name` on data_dirs file `.app_info` will be changed when execute `recall`.
