### PR TITLE
feat(config): Make the configs take effect for the FLAGS_* only used once

### DIFF
--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -102,7 +102,6 @@ replication_options::replication_options()
     log_shared_pending_size_throttling_delay_ms = 0;
 
     config_sync_disabled = false;
-    config_sync_interval_ms = 30000;
 
     mem_release_enabled = true;
     mem_release_check_interval_ms = 3600000;
@@ -361,11 +360,6 @@ void replication_options::initialize()
         "config_sync_disabled",
         config_sync_disabled,
         "whether to disable replica configuration periodical sync with the meta server");
-    config_sync_interval_ms = (int)dsn_config_get_value_uint64(
-        "replication",
-        "config_sync_interval_ms",
-        config_sync_interval_ms,
-        "every this period(ms) the replica syncs replica configuration with the meta server");
 
     mem_release_enabled = dsn_config_get_value_bool("replication",
                                                     "mem_release_enabled",

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -113,7 +113,6 @@ public:
     int32_t log_shared_pending_size_throttling_delay_ms;
 
     bool config_sync_disabled;
-    int32_t config_sync_interval_ms;
 
     bool mem_release_enabled;
     int32_t mem_release_check_interval_ms;

--- a/src/http/builtin_http_calls.cpp
+++ b/src/http/builtin_http_calls.cpp
@@ -92,11 +92,6 @@ namespace dsn {
         })
         .with_help("Gets the value of a perf counter");
 
-    register_http_call("updateConfig")
-        .with_callback(
-            [](const http_request &req, http_response &resp) { update_config(req, resp); })
-        .with_help("Updates the value of a config");
-
     register_http_call("config")
         .with_callback([](const http_request &req, http_response &resp) { get_config(req, resp); })
         .with_help("get the details of a specified config");

--- a/src/http/builtin_http_calls.h
+++ b/src/http/builtin_http_calls.h
@@ -40,8 +40,6 @@ extern void get_version_handler(const http_request &req, http_response &resp);
 
 extern void get_recent_start_time_handler(const http_request &req, http_response &resp);
 
-extern void update_config(const http_request &req, http_response &resp);
-
 extern void list_all_configs(const http_request &req, http_response &resp);
 
 extern void get_config(const http_request &req, http_response &resp);

--- a/src/http/config_http_service.cpp
+++ b/src/http/config_http_service.cpp
@@ -20,24 +20,6 @@
 #include "utils/output_utils.h"
 
 namespace dsn {
-void update_config(const http_request &req, http_response &resp)
-{
-    if (req.query_args.size() != 1) {
-        resp.status_code = http_status_code::bad_request;
-        return;
-    }
-
-    auto iter = req.query_args.begin();
-    auto res = update_flag(iter->first, iter->second);
-
-    utils::table_printer tp;
-    tp.add_row_name_and_data("update_status", res.description());
-    std::ostringstream out;
-    tp.output(out, dsn::utils::table_printer::output_format::kJsonCompact);
-    resp.body = out.str();
-    resp.status_code = http_status_code::ok;
-}
-
 void list_all_configs(const http_request &req, http_response &resp)
 {
     if (!req.query_args.empty()) {

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -88,11 +88,11 @@ void http_service::register_handler(std::string sub_path, http_callback cb, std:
         return;
     }
     auto call = make_unique<http_call>();
-    if (this->path().empty()) {
-        call->path = std::move(sub_path);
-    } else {
-        call->path = this->path() + "/" + std::move(sub_path);
+    call->path = this->path();
+    if (!call->path.empty()) {
+        call->path += '/';
     }
+    call->path += sub_path;
     call->callback = std::move(cb);
     call->help = std::move(help);
     http_call_registry::instance().add(std::move(call));

--- a/src/http/http_server.h
+++ b/src/http/http_server.h
@@ -100,7 +100,31 @@ public:
 
     virtual std::string path() const = 0;
 
-    void register_handler(std::string path, http_callback cb, std::string help);
+    void register_handler(std::string sub_path, http_callback cb, std::string help);
+};
+
+class http_server_base : public http_service
+{
+public:
+    explicit http_server_base()
+    {
+        static std::once_flag flag;
+        std::call_once(flag, [&]() {
+            register_handler("updateConfig",
+                             std::bind(&http_server_base::update_config_handler,
+                                       this,
+                                       std::placeholders::_1,
+                                       std::placeholders::_2),
+                             "ip:port/updateConfig?<key>=<value>");
+        });
+    }
+
+    std::string path() const override { return ""; }
+
+protected:
+    void update_config_handler(const http_request &req, http_response &resp);
+
+    virtual void update_config(const std::string &name) {}
 };
 
 // Example:
@@ -128,4 +152,5 @@ inline bool is_http_message(dsn::task_code code)
 {
     return code == RPC_HTTP_SERVICE || code == RPC_HTTP_SERVICE_ACK;
 }
+
 } // namespace dsn

--- a/src/meta/meta_http_service.h
+++ b/src/meta/meta_http_service.h
@@ -52,7 +52,7 @@ struct usage_scenario_info
 };
 
 class meta_service;
-class meta_http_service : public http_service
+class meta_http_service : public http_server_base
 {
 public:
     explicit meta_http_service(meta_service *s) : _service(s)

--- a/src/replica/duplication/test/dup_replica_http_service_test.cpp
+++ b/src/replica/duplication/test/dup_replica_http_service_test.cpp
@@ -21,11 +21,11 @@
 namespace dsn {
 namespace replication {
 
-class replica_http_service_test : public duplication_test_base
+class dup_replica_http_service_test : public duplication_test_base
 {
 };
 
-TEST_F(replica_http_service_test, query_duplication_handler)
+TEST_F(dup_replica_http_service_test, query_duplication_handler)
 {
     auto pri = stub->add_primary_replica(1, 1);
 
@@ -58,11 +58,8 @@ TEST_F(replica_http_service_test, query_duplication_handler)
     http_svc.query_duplication_handler(req, resp);
     ASSERT_EQ(resp.status_code, http_status_code::ok);
     ASSERT_EQ(
-        resp.body,
-        R"({)"
-        R"("1583306653":)"
-        R"({"1.1":{"duplicating":false,"fail_mode":"FAIL_SLOW","not_confirmed_mutations_num":100,"not_duplicated_mutations_num":50}})"
-        R"(})");
+        R"({"1583306653":{"1.1":{"duplicating":false,"fail_mode":"FAIL_SLOW","not_confirmed_mutations_num":100,"not_duplicated_mutations_num":50}}})",
+        resp.body);
 }
 
 } // namespace replication

--- a/src/replica/replica_http_service.cpp
+++ b/src/replica/replica_http_service.cpp
@@ -21,6 +21,7 @@
 #include <nlohmann/json.hpp>
 
 #include "duplication/duplication_sync_timer.h"
+#include "http/http_server.h"
 #include "utils/output_utils.h"
 #include "utils/string_conv.h"
 
@@ -154,6 +155,8 @@ void replica_http_service::query_manual_compaction_handler(const http_request &r
     resp.status_code = http_status_code::ok;
     resp.body = json.dump();
 }
+
+void replica_http_service::update_config(const std::string &name) { _stub->update_config(name); }
 
 } // namespace replication
 } // namespace dsn

--- a/src/replica/replica_http_service.h
+++ b/src/replica/replica_http_service.h
@@ -22,7 +22,7 @@
 namespace dsn {
 namespace replication {
 
-class replica_http_service : public http_service
+class replica_http_service : public http_server_base
 {
 public:
     explicit replica_http_service(replica_stub *stub) : _stub(stub)
@@ -71,6 +71,10 @@ public:
     }
 
 private:
+    friend class replica_http_service_test;
+
+    void update_config(const std::string &name) override;
+
     replica_stub *_stub;
 };
 

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -230,7 +230,7 @@ public:
     // query last checkpoint info for follower in duplication process
     void on_query_last_checkpoint(query_last_checkpoint_info_rpc rpc);
 
-    virtual void update_config(const std::string &name);
+    void update_config(const std::string &name);
 
 private:
     enum replica_node_state

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -230,6 +230,8 @@ public:
     // query last checkpoint info for follower in duplication process
     void on_query_last_checkpoint(query_last_checkpoint_info_rpc rpc);
 
+    virtual void update_config(const std::string &name);
+
 private:
     enum replica_node_state
     {
@@ -335,6 +337,7 @@ private:
     friend class open_replica_test;
     friend class replica_follower;
     friend class replica_follower_test;
+    friend class replica_http_service_test;
 
     typedef std::unordered_map<gpid, ::dsn::task_ptr> opening_replicas;
     typedef std::unordered_map<gpid, std::tuple<task_ptr, replica_ptr, app_info, replica_info>>
@@ -363,7 +366,7 @@ private:
 
     // temproal states
     ::dsn::task_ptr _config_query_task;
-    ::dsn::task_ptr _config_sync_timer_task;
+    ::dsn::timer_task_ptr _config_sync_timer_task;
     ::dsn::task_ptr _gc_timer_task;
     ::dsn::task_ptr _disk_stat_timer_task;
     ::dsn::task_ptr _mem_release_timer_task;

--- a/src/replica/test/replica_http_service_test.cpp
+++ b/src/replica/test/replica_http_service_test.cpp
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "http/builtin_http_calls.h"
+#include "http/http_call_registry.h"
+#include "replica/replica_http_service.h"
+#include "replica/test/replica_test_base.h"
+
+using std::map;
+using std::string;
+
+namespace dsn {
+namespace replication {
+
+DSN_DECLARE_uint32(config_sync_interval_ms);
+
+class replica_http_service_test : public replica_test_base
+{
+public:
+    replica_http_service_test()
+    {
+        // Disable unnecessary works before starting stub.
+        stub->_options.fd_disabled = true;
+        stub->_options.duplication_enabled = false;
+        stub->initialize_start();
+
+        http_call_registry::instance().clear_paths();
+        _http_svc = dsn::make_unique<replica_http_service>(stub.get());
+    }
+
+    void test_update_config(const map<string, string> &configs, const string &expect_resp)
+    {
+        http_request req;
+        for (const auto &config : configs) {
+            req.query_args[config.first] = config.second;
+        }
+
+        http_response resp;
+        _http_svc->update_config_handler(req, resp);
+        ASSERT_EQ(resp.status_code, http_status_code::ok);
+        ASSERT_EQ(expect_resp, resp.body);
+    }
+
+    void test_check_config(const string &config, const string &expect_value)
+    {
+        http_request req;
+        http_response resp;
+        req.query_args["name"] = config;
+        get_config(req, resp);
+        ASSERT_EQ(resp.status_code, http_status_code::ok);
+        const string unfilled_resp =
+            R"({{"name":"config_sync_interval_ms","section":"replication","type":"FV_UINT32","tags":"flag_tag::FT_MUTABLE","description":"The interval milliseconds of replica server to syncs replica configuration with meta server","value":"{}"}})"
+            "\n";
+        ASSERT_EQ(fmt::format(unfilled_resp, expect_value), resp.body);
+    }
+
+private:
+    std::unique_ptr<replica_http_service> _http_svc;
+};
+
+TEST_F(replica_http_service_test, update_config_handler)
+{
+    // Test the default value.
+    test_check_config("config_sync_interval_ms", "30000");
+    ASSERT_EQ(30000, FLAGS_config_sync_interval_ms);
+
+    // Update config failed and value not changed.
+    test_update_config(
+        {},
+        R"({"update_status":"ERR_INVALID_PARAMETERS: there should be exactly one config to be updated once"})"
+        "\n");
+    test_check_config("config_sync_interval_ms", "30000");
+    ASSERT_EQ(30000, FLAGS_config_sync_interval_ms);
+
+    // Update config failed and value not changed.
+    test_update_config(
+        {{"config_sync_interval_ms", "10"}, {"fds_write_limit_rate", "50"}},
+        R"({"update_status":"ERR_INVALID_PARAMETERS: there should be exactly one config to be updated once"})"
+        "\n");
+    test_check_config("config_sync_interval_ms", "30000");
+    ASSERT_EQ(30000, FLAGS_config_sync_interval_ms);
+
+    // Update config failed and value not changed.
+    test_update_config({{"config_sync_interval_ms", "-1"}},
+                       R"({"update_status":"ERR_INVALID_PARAMETERS: -1 is invalid"})"
+                       "\n");
+    test_check_config("config_sync_interval_ms", "30000");
+    ASSERT_EQ(30000, FLAGS_config_sync_interval_ms);
+
+    // Update config success and value changed.
+    test_update_config({{"config_sync_interval_ms", "10"}},
+                       R"({"update_status":"ERR_OK"})"
+                       "\n");
+    test_check_config("config_sync_interval_ms", "10");
+    ASSERT_EQ(10, FLAGS_config_sync_interval_ms);
+}
+
+} // namespace replication
+} // namespace dsn

--- a/src/runtime/task/async_calls.h
+++ b/src/runtime/task/async_calls.h
@@ -68,13 +68,13 @@ create_task(task_code code, task_tracker *tracker, task_handler &&callback, int 
     return t;
 }
 
-inline task_ptr create_timer_task(task_code code,
-                                  task_tracker *tracker,
-                                  task_handler &&callback,
-                                  std::chrono::milliseconds interval,
-                                  int hash = 0)
+inline timer_task_ptr create_timer_task(task_code code,
+                                        task_tracker *tracker,
+                                        task_handler &&callback,
+                                        std::chrono::milliseconds interval,
+                                        int hash = 0)
 {
-    task_ptr t(new timer_task(code, std::move(callback), interval.count(), hash, nullptr));
+    timer_task_ptr t(new timer_task(code, std::move(callback), interval.count(), hash, nullptr));
     t->set_tracker(tracker);
     t->spec().on_task_create.execute(task::get_current_task(), t);
     return t;
@@ -92,12 +92,12 @@ inline task_ptr enqueue(task_code code,
     return tsk;
 }
 
-inline task_ptr enqueue_timer(task_code evt,
-                              task_tracker *tracker,
-                              task_handler &&callback,
-                              std::chrono::milliseconds timer_interval,
-                              int hash = 0,
-                              std::chrono::milliseconds delay = std::chrono::milliseconds(0))
+inline timer_task_ptr enqueue_timer(task_code evt,
+                                    task_tracker *tracker,
+                                    task_handler &&callback,
+                                    std::chrono::milliseconds timer_interval,
+                                    int hash = 0,
+                                    std::chrono::milliseconds delay = std::chrono::milliseconds(0))
 {
     auto tsk = create_timer_task(evt, tracker, std::move(callback), timer_interval, hash);
     tsk->set_delay(static_cast<int>(delay.count()));

--- a/src/runtime/task/task.h
+++ b/src/runtime/task/task.h
@@ -359,15 +359,18 @@ public:
     void exec() override;
     void enqueue() override;
 
+    void update_interval(int interval_ms);
+
 protected:
     void clear_non_trivial_on_task_end() override { _cb = nullptr; }
 
 private:
-    // ATTENTION: if _interval_milliseconds <= 0, then timer task will just be executed once;
-    // otherwise, timer task will be executed periodically(period = _interval_milliseconds)
-    int _interval_milliseconds;
+    // ATTENTION: if _interval_ms == 0, then timer task will just be executed once;
+    // otherwise, timer task will be executed periodically(period = _interval_ms)
+    int _interval_ms;
     task_handler _cb;
 };
+typedef dsn::ref_ptr<dsn::timer_task> timer_task_ptr;
 
 template <typename First, typename... Remaining>
 class future_task : public task

--- a/src/server/info_collector_app.cpp
+++ b/src/server/info_collector_app.cpp
@@ -44,9 +44,14 @@
 namespace pegasus {
 namespace server {
 
+class collector_http_service : public ::dsn::http_server_base
+{
+};
+
 info_collector_app::info_collector_app(const dsn::service_app_info *info)
     : service_app(info), _updater_started(false)
 {
+    register_http_service(new collector_http_service());
     dsn::start_http_server();
 }
 

--- a/src/utils/flags.h
+++ b/src/utils/flags.h
@@ -121,6 +121,11 @@ struct hash<flag_tag>
     COMPILE_ASSERT(sizeof(decltype(FLAGS_##name)), exist_##name##_##tag);                          \
     static dsn::flag_tagger FLAGS_TAGGER_##name##_##tag(#name, flag_tag::tag)
 
+#define UPDATE_CONFIG(fn, flag, name)                                                              \
+    if (name == #flag) {                                                                           \
+        fn(FLAGS_##flag);                                                                          \
+    }
+
 namespace dsn {
 
 // An utility class that registers a flag upon initialization.


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1197

This patch implement a mechanism to make the configs take effect for the FLAGS_* only used once. They are used once to create some runtime objects, and then will never use the FLAGS_* again, which means update the config by HTTP is meanless.

This patch takes `config_sync_interval_ms` for example, showing how to update a config.