### PR TITLE
refactor(log): adjust log level and rename for d*_f macros

### DIFF
--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -84,11 +84,11 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
                           aio_ctx.file_offset + buffer_offset);
         if (dsn_unlikely(ret < 0)) {
             if (errno == EINTR) {
-                dwarn_f("write failed with errno={} and will retry it.", strerror(errno));
+                LOG_WARNING_F("write failed with errno={} and will retry it.", strerror(errno));
                 continue;
             }
             resp = ERR_FILE_OPERATION_FAILED;
-            derror_f("write failed with errno={}, return {}.", strerror(errno), resp);
+            LOG_ERROR_F("write failed with errno={}, return {}.", strerror(errno), resp);
             return resp;
         }
 
@@ -101,11 +101,12 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
 
         buffer_offset += ret;
         if (dsn_unlikely(buffer_offset != aio_ctx.buffer_size)) {
-            dwarn_f("write incomplete, request_size={}, total_write_size={}, this_write_size={}, "
-                    "and will retry it.",
-                    aio_ctx.buffer_size,
-                    buffer_offset,
-                    ret);
+            LOG_WARNING_F(
+                "write incomplete, request_size={}, total_write_size={}, this_write_size={}, "
+                "and will retry it.",
+                aio_ctx.buffer_size,
+                buffer_offset,
+                ret);
         }
     } while (dsn_unlikely(buffer_offset < aio_ctx.buffer_size));
 

--- a/src/base/pegasus_value_schema.h
+++ b/src/base/pegasus_value_schema.h
@@ -115,7 +115,7 @@ inline void pegasus_update_expire_ts(uint32_t version, std::string &value, uint3
         new_expire_ts = dsn::endian::hton(new_expire_ts);
         memcpy(const_cast<char *>(value.data()), &new_expire_ts, sizeof(uint32_t));
     } else {
-        dfatal_f("unsupported value schema version: {}", version);
+        LOG_FATAL_F("unsupported value schema version: {}", version);
         __builtin_unreachable();
     }
 }
@@ -156,7 +156,7 @@ public:
         } else if (value_schema_version == 1) {
             return generate_value_v1(expire_ts, timetag, user_data);
         } else {
-            dfatal_f("unsupported value schema version: {}", value_schema_version);
+            LOG_FATAL_F("unsupported value schema version: {}", value_schema_version);
             __builtin_unreachable();
         }
     }

--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -72,9 +72,9 @@ block_filesystem *block_service_manager::get_or_create_block_filesystem(const st
     block_filesystem *fs =
         utils::factory_store<block_filesystem>::create(provider_type, PROVIDER_TYPE_MAIN);
     if (fs == nullptr) {
-        derror_f("acquire block filesystem failed, provider = {}, provider_type = {}",
-                 provider,
-                 std::string(provider_type));
+        LOG_ERROR_F("acquire block filesystem failed, provider = {}, provider_type = {}",
+                    provider,
+                    std::string(provider_type));
         return nullptr;
     }
 
@@ -86,12 +86,12 @@ block_filesystem *block_service_manager::get_or_create_block_filesystem(const st
     dsn::error_code err = fs->initialize(args);
 
     if (dsn::ERR_OK == err) {
-        ddebug_f("create block filesystem ok for provider {}", provider);
+        LOG_INFO_F("create block filesystem ok for provider {}", provider);
         _fs_map.emplace(provider, std::unique_ptr<block_filesystem>(fs));
     } else {
-        derror_f("create block file system err {} for provider {}",
-                 std::string(err.to_string()),
-                 provider);
+        LOG_ERROR_F("create block file system err {} for provider {}",
+                    std::string(err.to_string()),
+                    provider);
         delete fs;
         fs = nullptr;
     }
@@ -145,7 +145,7 @@ error_code block_service_manager::download_file(const std::string &remote_dir,
     // local file exists
     const std::string local_file_name = utils::filesystem::path_combine(local_dir, file_name);
     if (utils::filesystem::file_exists(local_file_name)) {
-        ddebug_f("local file({}) exists", local_file_name);
+        LOG_INFO_F("local file({}) exists", local_file_name);
         return ERR_PATH_ALREADY_EXIST;
     }
 
@@ -157,7 +157,7 @@ error_code block_service_manager::download_file(const std::string &remote_dir,
         create_block_file_sync(remote_file_name, false /*ignore file meta*/, fs, &tracker);
     error_code err = create_resp.err;
     if (err != ERR_OK) {
-        derror_f("create file({}) failed with error({})", remote_file_name, err.to_string());
+        LOG_ERROR_F("create file({}) failed with error({})", remote_file_name, err.to_string());
         return err;
     }
     block_file_ptr bf = create_resp.file_handle;
@@ -168,17 +168,17 @@ error_code block_service_manager::download_file(const std::string &remote_dir,
         // error, however, if file damaged on remote file provider, bulk load should stop,
         // return ERR_CORRUPTION instead
         if (resp.err == ERR_OBJECT_NOT_FOUND) {
-            derror_f("download file({}) failed, file on remote file provider is damaged",
-                     local_file_name);
+            LOG_ERROR_F("download file({}) failed, file on remote file provider is damaged",
+                        local_file_name);
             return ERR_CORRUPTION;
         }
         return resp.err;
     }
 
-    ddebug_f("download file({}) succeed, file_size = {}, md5 = {}",
-             local_file_name.c_str(),
-             resp.downloaded_size,
-             resp.file_md5);
+    LOG_INFO_F("download file({}) succeed, file_size = {}, md5 = {}",
+               local_file_name.c_str(),
+               resp.downloaded_size,
+               resp.file_md5);
     download_file_size = resp.downloaded_size;
     download_file_md5 = resp.file_md5;
     return ERR_OK;

--- a/src/block_service/directio_writable_file.cpp
+++ b/src/block_service/directio_writable_file.cpp
@@ -72,7 +72,7 @@ direct_io_writable_file::~direct_io_writable_file()
 bool direct_io_writable_file::initialize()
 {
     if (posix_memalign(&_buffer, g_page_size, _buffer_size) != 0) {
-        derror_f("Allocate memaligned buffer failed, errno = {}", errno);
+        LOG_ERROR_F("Allocate memaligned buffer failed, errno = {}", errno);
         return false;
     }
 
@@ -82,7 +82,7 @@ bool direct_io_writable_file::initialize()
 #endif
     _fd = open(_file_path.c_str(), flag, S_IRUSR | S_IWUSR | S_IRGRP);
     if (_fd < 0) {
-        derror_f("Failed to open {} with flag {}, errno = {}", _file_path, flag, errno);
+        LOG_ERROR_F("Failed to open {} with flag {}, errno = {}", _file_path, flag, errno);
         free(_buffer);
         _buffer = nullptr;
         return false;
@@ -96,7 +96,8 @@ bool direct_io_writable_file::finalize()
 
     if (_offset > 0) {
         if (::write(_fd, _buffer, _buffer_size) != _buffer_size) {
-            derror_f("Failed to write last chunk, filie_path = {}, errno = {}", _file_path, errno);
+            LOG_ERROR_F(
+                "Failed to write last chunk, filie_path = {}, errno = {}", _file_path, errno);
             return false;
         }
         _offset = 0;
@@ -119,7 +120,7 @@ bool direct_io_writable_file::write(const char *s, size_t n)
         // buffer is full, flush to file
         if (_offset == _buffer_size) {
             if (::write(_fd, _buffer, _buffer_size) != _buffer_size) {
-                derror_f("Failed to write to direct_io_writable_file, errno = {}", errno);
+                LOG_ERROR_F("Failed to write to direct_io_writable_file, errno = {}", errno);
                 return false;
             }
             // reset offset

--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -84,7 +84,7 @@ error_code hdfs_service::initialize(const std::vector<std::string> &args)
     // If no path was configured, just use "/" as default root path.
     _hdfs_name_node = args[0];
     _hdfs_path = args.size() >= 2 ? args[1] : "/";
-    ddebug_f("hdfs backup root path is initialized to {}.", _hdfs_path);
+    LOG_INFO_F("hdfs backup root path is initialized to {}.", _hdfs_path);
 
     return create_fs();
 }
@@ -93,18 +93,18 @@ error_code hdfs_service::create_fs()
 {
     hdfsBuilder *builder = hdfsNewBuilder();
     if (!builder) {
-        derror_f("Fail to create an HDFS builder, error: {}.", utils::safe_strerror(errno));
+        LOG_ERROR_F("Fail to create an HDFS builder, error: {}.", utils::safe_strerror(errno));
         return ERR_FS_INTERNAL;
     }
     hdfsBuilderSetNameNode(builder, _hdfs_name_node.c_str());
     _fs = hdfsBuilderConnect(builder);
     if (!_fs) {
-        derror_f("Fail to connect hdfs name node {}, error: {}.",
-                 _hdfs_name_node,
-                 utils::safe_strerror(errno));
+        LOG_ERROR_F("Fail to connect hdfs name node {}, error: {}.",
+                    _hdfs_name_node,
+                    utils::safe_strerror(errno));
         return ERR_FS_INTERNAL;
     }
-    ddebug_f("Succeed to connect hdfs name node {}.", _hdfs_name_node);
+    LOG_INFO_F("Succeed to connect hdfs name node {}.", _hdfs_name_node);
     return ERR_OK;
 }
 
@@ -116,8 +116,8 @@ void hdfs_service::close()
     LOG_INFO("Try to disconnect hdfs.");
     int result = hdfsDisconnect(_fs);
     if (result == -1) {
-        derror_f("Fail to disconnect from the hdfs file system, error: {}.",
-                 utils::safe_strerror(errno));
+        LOG_ERROR_F("Fail to disconnect from the hdfs file system, error: {}.",
+                    utils::safe_strerror(errno));
     }
     // Even if there is an error, the resources associated with the hdfsFS will be freed.
     _fs = nullptr;
@@ -143,7 +143,7 @@ dsn::task_ptr hdfs_service::list_dir(const ls_request &req,
         ls_response resp;
 
         if (hdfsExists(_fs, path.c_str()) == -1) {
-            derror_f("HDFS list directory failed: path {} not found.", path);
+            LOG_ERROR_F("HDFS list directory failed: path {} not found.", path);
             resp.err = ERR_OBJECT_NOT_FOUND;
             tsk->enqueue_with(resp);
             return;
@@ -151,20 +151,20 @@ dsn::task_ptr hdfs_service::list_dir(const ls_request &req,
 
         hdfsFileInfo *dir_info = hdfsGetPathInfo(_fs, path.c_str());
         if (dir_info == nullptr) {
-            derror_f("HDFS get path {} failed.", path);
+            LOG_ERROR_F("HDFS get path {} failed.", path);
             resp.err = ERR_FS_INTERNAL;
             tsk->enqueue_with(resp);
             return;
         }
 
         if (dir_info->mKind == kObjectKindFile) {
-            derror_f("HDFS list directory failed, {} is not a directory", path);
+            LOG_ERROR_F("HDFS list directory failed, {} is not a directory", path);
             resp.err = ERR_INVALID_PARAMETERS;
         } else {
             int entries = 0;
             hdfsFileInfo *info = hdfsListDirectory(_fs, path.c_str(), &entries);
             if (info == nullptr) {
-                derror_f("HDFS list directory {} failed.", path);
+                LOG_ERROR_F("HDFS list directory {} failed.", path);
                 resp.err = ERR_FS_INTERNAL;
             } else {
                 for (int i = 0; i < entries; i++) {
@@ -211,7 +211,7 @@ dsn::task_ptr hdfs_service::create_file(const create_file_request &req,
             // immediately after this call.
             resp.err = ERR_OK;
             resp.file_handle = f;
-            ddebug_f("create remote file {} succeed", hdfs_file);
+            LOG_INFO_F("create remote file {} succeed", hdfs_file);
         }
         tsk->enqueue_with(resp);
     };
@@ -234,7 +234,7 @@ dsn::task_ptr hdfs_service::remove_path(const remove_path_request &req,
 
         // Check if path exists.
         if (hdfsExists(_fs, path.c_str()) == -1) {
-            derror_f("HDFS remove_path failed: path {} not found.", path);
+            LOG_ERROR_F("HDFS remove_path failed: path {} not found.", path);
             resp.err = ERR_OBJECT_NOT_FOUND;
             tsk->enqueue_with(resp);
             return;
@@ -244,7 +244,7 @@ dsn::task_ptr hdfs_service::remove_path(const remove_path_request &req,
         hdfsFileInfo *info = hdfsListDirectory(_fs, path.c_str(), &entries);
         hdfsFreeFileInfo(info, entries);
         if (entries > 0 && !req.recursive) {
-            derror_f("HDFS remove_path failed: directory {} is not empty.", path);
+            LOG_ERROR_F("HDFS remove_path failed: directory {} is not empty.", path);
             resp.err = ERR_DIR_NOT_EMPTY;
             tsk->enqueue_with(resp);
             return;
@@ -252,7 +252,7 @@ dsn::task_ptr hdfs_service::remove_path(const remove_path_request &req,
 
         // Remove directory now.
         if (hdfsDelete(_fs, path.c_str(), req.recursive) == -1) {
-            derror_f("HDFS remove_path {} failed.", path);
+            LOG_ERROR_F("HDFS remove_path {} failed.", path);
             resp.err = ERR_FS_INTERNAL;
         } else {
             resp.err = ERR_OK;
@@ -272,12 +272,12 @@ hdfs_file_object::hdfs_file_object(hdfs_service *s, const std::string &name)
 error_code hdfs_file_object::get_file_meta()
 {
     if (hdfsExists(_service->get_fs(), file_name().c_str()) == -1) {
-        dwarn_f("HDFS file {} does not exist.", file_name());
+        LOG_WARNING_F("HDFS file {} does not exist.", file_name());
         return ERR_OBJECT_NOT_FOUND;
     }
     hdfsFileInfo *info = hdfsGetPathInfo(_service->get_fs(), file_name().c_str());
     if (info == nullptr) {
-        derror_f("HDFS get file info failed, file: {}.", file_name());
+        LOG_ERROR_F("HDFS get file info failed, file: {}.", file_name());
         return ERR_FS_INTERNAL;
     }
     _size = info->mSize;
@@ -296,9 +296,9 @@ error_code hdfs_file_object::write_data_in_batches(const char *data,
     hdfsFile write_file =
         hdfsOpenFile(_service->get_fs(), file_name().c_str(), O_WRONLY | O_CREAT, 0, 0, 0);
     if (!write_file) {
-        derror_f("Failed to open hdfs file {} for writting, error: {}.",
-                 file_name(),
-                 utils::safe_strerror(errno));
+        LOG_ERROR_F("Failed to open hdfs file {} for writting, error: {}.",
+                    file_name(),
+                    utils::safe_strerror(errno));
         return ERR_FS_INTERNAL;
     }
     uint64_t cur_pos = 0;
@@ -314,23 +314,23 @@ error_code hdfs_file_object::write_data_in_batches(const char *data,
                                             (void *)(data + cur_pos),
                                             static_cast<tSize>(write_len));
         if (num_written_bytes == -1) {
-            derror_f("Failed to write hdfs file {}, error: {}.",
-                     file_name(),
-                     utils::safe_strerror(errno));
+            LOG_ERROR_F("Failed to write hdfs file {}, error: {}.",
+                        file_name(),
+                        utils::safe_strerror(errno));
             hdfsCloseFile(_service->get_fs(), write_file);
             return ERR_FS_INTERNAL;
         }
         cur_pos += num_written_bytes;
     }
     if (hdfsHFlush(_service->get_fs(), write_file) != 0) {
-        derror_f(
+        LOG_ERROR_F(
             "Failed to flush hdfs file {}, error: {}.", file_name(), utils::safe_strerror(errno));
         hdfsCloseFile(_service->get_fs(), write_file);
         return ERR_FS_INTERNAL;
     }
     written_size = cur_pos;
     if (hdfsCloseFile(_service->get_fs(), write_file) != 0) {
-        derror_f(
+        LOG_ERROR_F(
             "Failed to close hdfs file {}, error: {}", file_name(), utils::safe_strerror(errno));
         return ERR_FS_INTERNAL;
     }
@@ -378,10 +378,11 @@ dsn::task_ptr hdfs_file_object::upload(const upload_request &req,
             is.close();
             resp.err = write_data_in_batches(buffer.get(), file_sz, resp.uploaded_size);
         } else {
-            derror_f("HDFS upload failed: open local file {} failed when upload to {}, error: {}",
-                     req.input_local_name,
-                     file_name(),
-                     utils::safe_strerror(errno));
+            LOG_ERROR_F(
+                "HDFS upload failed: open local file {} failed when upload to {}, error: {}",
+                req.input_local_name,
+                file_name(),
+                utils::safe_strerror(errno));
             resp.err = dsn::ERR_FILE_OPERATION_FAILED;
         }
         t->enqueue_with(resp);
@@ -401,16 +402,16 @@ error_code hdfs_file_object::read_data_in_batches(uint64_t start_pos,
     if (!_has_meta_synced) {
         error_code err = get_file_meta();
         if (err != ERR_OK) {
-            derror_f("Failed to read remote file {}", file_name());
+            LOG_ERROR_F("Failed to read remote file {}", file_name());
             return err;
         }
     }
 
     hdfsFile read_file = hdfsOpenFile(_service->get_fs(), file_name().c_str(), O_RDONLY, 0, 0, 0);
     if (!read_file) {
-        derror_f("Failed to open hdfs file {} for reading, error: {}.",
-                 file_name(),
-                 utils::safe_strerror(errno));
+        LOG_ERROR_F("Failed to open hdfs file {} for reading, error: {}.",
+                    file_name(),
+                    utils::safe_strerror(errno));
         return ERR_FS_INTERNAL;
     }
     std::unique_ptr<char[]> raw_buf(new char[_size]);
@@ -437,15 +438,15 @@ error_code hdfs_file_object::read_data_in_batches(uint64_t start_pos,
             cur_pos += num_read_bytes;
             dst_buf += num_read_bytes;
         } else if (num_read_bytes == -1) {
-            derror_f("Failed to read hdfs file {}, error: {}.",
-                     file_name(),
-                     utils::safe_strerror(errno));
+            LOG_ERROR_F("Failed to read hdfs file {}, error: {}.",
+                        file_name(),
+                        utils::safe_strerror(errno));
             read_success = false;
             break;
         }
     }
     if (hdfsCloseFile(_service->get_fs(), read_file) != 0) {
-        derror_f(
+        LOG_ERROR_F(
             "Failed to close hdfs file {}, error: {}.", file_name(), utils::safe_strerror(errno));
         return ERR_FS_INTERNAL;
     }
@@ -529,11 +530,11 @@ dsn::task_ptr hdfs_file_object::download(const download_request &req,
                 }
             }
             if (!write_succ) {
-                derror_f("HDFS download failed: fail to open localfile {} when download {}, "
-                         "error: {}",
-                         req.output_local_name,
-                         file_name(),
-                         utils::safe_strerror(errno));
+                LOG_ERROR_F("HDFS download failed: fail to open localfile {} when download {}, "
+                            "error: {}",
+                            req.output_local_name,
+                            file_name(),
+                            utils::safe_strerror(errno));
                 resp.err = ERR_FILE_OPERATION_FAILED;
                 resp.downloaded_size = 0;
             }

--- a/src/block_service/local/local_service.cpp
+++ b/src/block_service/local/local_service.cpp
@@ -53,7 +53,7 @@ bool file_metadata_from_json(std::ifstream &fin, file_metadata &fmeta) noexcept
         nlohmann::json::parse(data).get_to(fmeta);
         return true;
     } catch (nlohmann::json::exception &exp) {
-        dwarn_f("decode meta data from json failed: {} [{}]", exp.what(), data);
+        LOG_WARNING_F("decode meta data from json failed: {} [{}]", exp.what(), data);
         return false;
     }
 }

--- a/src/client/partition_resolver_simple.cpp
+++ b/src/client/partition_resolver_simple.cpp
@@ -83,16 +83,16 @@ void partition_resolver_simple::on_access_failure(int partition_index, error_cod
 
     zauto_write_lock l(_config_lock);
     if (err == ERR_PARENT_PARTITION_MISUSED) {
-        ddebug_f("clear all partition configuration cache due to access failure {} at {}.{}",
-                 err,
-                 _app_id,
-                 partition_index);
+        LOG_INFO_F("clear all partition configuration cache due to access failure {} at {}.{}",
+                   err,
+                   _app_id,
+                   partition_index);
         _app_partition_count = -1;
     } else {
-        ddebug_f("clear partition configuration cache {}.{} due to access failure {}",
-                 _app_id,
-                 partition_index,
-                 err);
+        LOG_INFO_F("clear partition configuration cache {}.{} due to access failure {}",
+                   _app_id,
+                   partition_index,
+                   err);
         _config_cache.erase(partition_index);
     }
 }
@@ -270,18 +270,20 @@ void partition_resolver_simple::query_config_reply(error_code err,
             zauto_write_lock l(_config_lock);
 
             if (_app_id != -1 && _app_id != resp.app_id) {
-                dwarn_f("app id is changed (mostly the app was removed and created with the same "
-                        "name), local Vs remote: {} vs {} ",
-                        _app_id,
-                        resp.app_id);
+                LOG_WARNING_F(
+                    "app id is changed (mostly the app was removed and created with the same "
+                    "name), local Vs remote: {} vs {} ",
+                    _app_id,
+                    resp.app_id);
             }
             if (_app_partition_count != -1 && _app_partition_count != resp.partition_count &&
                 _app_partition_count * 2 != resp.partition_count &&
                 _app_partition_count != resp.partition_count * 2) {
-                dwarn_f("partition count is changed (mostly the app was removed and created with "
-                        "the same name), local Vs remote: %u vs %u ",
-                        _app_partition_count,
-                        resp.partition_count);
+                LOG_WARNING_F(
+                    "partition count is changed (mostly the app was removed and created with "
+                    "the same name), local Vs remote: %u vs %u ",
+                    _app_partition_count,
+                    resp.partition_count);
             }
             _app_id = resp.app_id;
             _app_partition_count = resp.partition_count;

--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -89,7 +89,7 @@ bool dir_node::update_disk_stat(const bool update_disk_status)
     FAIL_POINT_INJECT_F("update_disk_stat", [](string_view) { return false; });
     dsn::utils::filesystem::disk_space_info info;
     if (!dsn::utils::filesystem::get_disk_space_info(full_dir, info)) {
-        derror_f("update disk space failed: dir = {}", full_dir);
+        LOG_ERROR_F("update disk space failed: dir = {}", full_dir);
         return false;
     }
     // update disk space info
@@ -99,12 +99,12 @@ bool dir_node::update_disk_stat(const bool update_disk_status)
         disk_capacity_mb == 0 ? 0 : std::round(disk_available_mb * 100.0 / disk_capacity_mb));
 
     if (!update_disk_status) {
-        ddebug_f("update disk space succeed: dir = {}, capacity_mb = {}, available_mb = {}, "
-                 "available_ratio = {}%",
-                 full_dir,
-                 disk_capacity_mb,
-                 disk_available_mb,
-                 disk_available_ratio);
+        LOG_INFO_F("update disk space succeed: dir = {}, capacity_mb = {}, available_mb = {}, "
+                   "available_ratio = {}%",
+                   full_dir,
+                   disk_capacity_mb,
+                   disk_available_mb,
+                   disk_available_ratio);
         return false;
     }
     auto old_status = status;
@@ -114,13 +114,13 @@ bool dir_node::update_disk_stat(const bool update_disk_status)
     if (old_status != new_status) {
         status = new_status;
     }
-    ddebug_f("update disk space succeed: dir = {}, capacity_mb = {}, available_mb = {}, "
-             "available_ratio = {}%, disk_status = {}",
-             full_dir,
-             disk_capacity_mb,
-             disk_available_mb,
-             disk_available_ratio,
-             enum_to_string(status));
+    LOG_INFO_F("update disk space succeed: dir = {}, capacity_mb = {}, available_mb = {}, "
+               "available_ratio = {}%, disk_status = {}",
+               full_dir,
+               disk_capacity_mb,
+               disk_available_mb,
+               disk_available_ratio,
+               enum_to_string(status));
     return (old_status != new_status);
 }
 
@@ -322,15 +322,15 @@ void fs_manager::update_disk_stat(bool check_status_changed)
     _total_available_ratio = static_cast<int>(
         _total_capacity_mb == 0 ? 0 : std::round(_total_available_mb * 100.0 / _total_capacity_mb));
 
-    ddebug_f("update disk space succeed: disk_count = {}, total_capacity_mb = {}, "
-             "total_available_mb = {}, total_available_ratio = {}%, min_available_ratio = {}%, "
-             "max_available_ratio = {}%",
-             _dir_nodes.size(),
-             _total_capacity_mb,
-             _total_available_mb,
-             _total_available_ratio,
-             _min_available_ratio,
-             _max_available_ratio);
+    LOG_INFO_F("update disk space succeed: disk_count = {}, total_capacity_mb = {}, "
+               "total_available_mb = {}, total_available_ratio = {}%, min_available_ratio = {}%, "
+               "max_available_ratio = {}%",
+               _dir_nodes.size(),
+               _total_capacity_mb,
+               _total_available_mb,
+               _total_available_ratio,
+               _min_available_ratio,
+               _max_available_ratio);
     _counter_total_capacity_mb->set(_total_capacity_mb);
     _counter_total_available_mb->set(_total_available_mb);
     _counter_total_available_ratio->set(_total_available_ratio);
@@ -346,7 +346,8 @@ void fs_manager::add_new_dir_node(const std::string &data_dir, const std::string
     dir_node *n = new dir_node(tag, norm_path);
     _dir_nodes.emplace_back(n);
     _available_data_dirs.emplace_back(data_dir);
-    ddebug_f("{}: mark data dir({}) as tag({})", dsn_primary_address().to_string(), norm_path, tag);
+    LOG_INFO_F(
+        "{}: mark data dir({}) as tag({})", dsn_primary_address().to_string(), norm_path, tag);
 }
 
 bool fs_manager::is_dir_node_available(const std::string &data_dir, const std::string &tag) const

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -494,13 +494,13 @@ bool replica_helper::load_meta_servers(/*out*/ std::vector<dsn::rpc_address> &se
         if (0 != (ip = ::dsn::rpc_address::ipv4_from_host(hostname_port[0].c_str()))) {
             addr.assign_ipv4(ip, static_cast<uint16_t>(port_num));
         } else if (!addr.from_string_ipv4(s.c_str())) {
-            derror_f("invalid address '{}' specified in config [{}].{}", s, section, key);
+            LOG_ERROR_F("invalid address '{}' specified in config [{}].{}", s, section, key);
             return false;
         }
         servers.push_back(addr);
     }
     if (servers.empty()) {
-        derror_f("no meta server specified in config [{}].{}", section, key);
+        LOG_ERROR_F("no meta server specified in config [{}].{}", section, key);
         return false;
     }
     return true;
@@ -562,7 +562,7 @@ replication_options::get_data_dir_and_tag(const std::string &config_dirs_str,
 
     for (unsigned i = 0; i < dirs.size(); ++i) {
         const std::string &dir = dirs[i];
-        ddebug_f("data_dirs[{}] = {}, tag = {}", i + 1, dir, dir_tags[i]);
+        LOG_INFO_F("data_dirs[{}] = {}, tag = {}", i + 1, dir, dir_tags[i]);
         data_dirs.push_back(utils::filesystem::path_combine(dir, "reps"));
         data_dir_tags.push_back(dir_tags[i]);
     }
@@ -574,11 +574,11 @@ replication_options::get_data_dirs_in_black_list(const std::string &fname,
                                                  /*out*/ std::vector<std::string> &dirs)
 {
     if (fname.empty() || !utils::filesystem::file_exists(fname)) {
-        ddebug_f("data_dirs_black_list_file[{}] not found, ignore it", fname);
+        LOG_INFO_F("data_dirs_black_list_file[{}] not found, ignore it", fname);
         return;
     }
 
-    ddebug_f("data_dirs_black_list_file[{}] found, apply it", fname);
+    LOG_INFO_F("data_dirs_black_list_file[{}] found, apply it", fname);
     std::ifstream file(fname);
     if (!file) {
         dassert_f(false, "open data_dirs_black_list_file failed: {}", fname);
@@ -596,7 +596,7 @@ replication_options::get_data_dirs_in_black_list(const std::string &fname,
         }
         dirs.push_back(str2);
         count++;
-        ddebug_f("black_list[{}] = [{}]", count, str2);
+        LOG_INFO_F("black_list[{}] = [{}]", count, str2);
     }
 }
 

--- a/src/geo/lib/geo_client.cpp
+++ b/src/geo/lib/geo_client.cpp
@@ -120,10 +120,10 @@ int geo_client::set(const std::string &hash_key,
     dsn::utils::notify_event set_completed;
     auto async_set_callback = [&](int ec_, pegasus_client::internal_info &&info_) {
         if (ec_ != PERR_OK) {
-            derror_f("set data failed. hash_key={}, sort_key={}, error={}",
-                     hash_key,
-                     sort_key,
-                     get_error_string(ec_));
+            LOG_ERROR_F("set data failed. hash_key={}, sort_key={}, error={}",
+                        hash_key,
+                        sort_key,
+                        get_error_string(ec_));
             ret = ec_;
         }
         if (info != nullptr) {
@@ -167,11 +167,11 @@ void geo_client::async_set(const std::string &hash_key,
                     }
 
                     if (ec_ != PERR_OK) {
-                        derror_f("set {} data failed. hash_key={}, sort_key={}, error={}",
-                                 data_type_ == DataType::common ? "common" : "geo",
-                                 hash_key,
-                                 sort_key,
-                                 get_error_string(ec_));
+                        LOG_ERROR_F("set {} data failed. hash_key={}, sort_key={}, error={}",
+                                    data_type_ == DataType::common ? "common" : "geo",
+                                    hash_key,
+                                    sort_key,
+                                    get_error_string(ec_));
                         *ret = ec_;
                     }
 
@@ -220,10 +220,10 @@ int geo_client::get(const std::string &hash_key,
             lat_degrees = lat_degrees_;
             lng_degrees = lng_degrees_;
         } else {
-            dwarn_f("get data failed. hash_key={}, sort_key={}, error={}",
-                    hash_key,
-                    sort_key,
-                    get_error_string(ec_));
+            LOG_WARNING_F("get data failed. hash_key={}, sort_key={}, error={}",
+                          hash_key,
+                          sort_key,
+                          get_error_string(ec_));
         }
         ret = ec_;
         get_completed.notify();
@@ -251,10 +251,10 @@ void geo_client::async_get(const std::string &hash_key,
             }
             S2LatLng latlng;
             if (!_codec.decode_from_value(value_, latlng)) {
-                derror_f("decode_from_value failed. hash_key={}, sort_key={}, value={}",
-                         hash_key,
-                         sort_key,
-                         value_);
+                LOG_ERROR_F("decode_from_value failed. hash_key={}, sort_key={}, value={}",
+                            hash_key,
+                            sort_key,
+                            value_);
                 cb(PERR_GEO_DECODE_VALUE_ERROR, id, 0, 0);
                 return;
             }
@@ -272,10 +272,10 @@ int geo_client::del(const std::string &hash_key,
     dsn::utils::notify_event del_completed;
     auto async_del_callback = [&](int ec_, pegasus_client::internal_info &&info_) {
         if (ec_ != PERR_OK) {
-            derror_f("del data failed. hash_key={}, sort_key={}, error={}",
-                     hash_key,
-                     sort_key,
-                     get_error_string(ec_));
+            LOG_ERROR_F("del data failed. hash_key={}, sort_key={}, error={}",
+                        hash_key,
+                        sort_key,
+                        get_error_string(ec_));
             ret = ec_;
         }
         if (info != nullptr) {
@@ -319,7 +319,7 @@ void geo_client::async_del(const std::string &hash_key,
             std::string geo_sort_key;
             if (!generate_geo_keys(hash_key, sort_key, value_, geo_hash_key, geo_sort_key)) {
                 keep_geo_data = true;
-                dwarn_f("generate_geo_keys failed");
+                LOG_WARNING_F("generate_geo_keys failed");
             }
 
             std::shared_ptr<int> ret = std::make_shared<int>(PERR_OK);
@@ -339,11 +339,11 @@ void geo_client::async_del(const std::string &hash_key,
             auto async_del_callback =
                 [=](int ec__, pegasus_client::internal_info &&, DataType data_type_) mutable {
                     if (ec__ != PERR_OK) {
-                        derror_f("del {} data failed. hash_key={}, sort_key={}, error={}",
-                                 data_type_ == DataType::common ? "common" : "geo",
-                                 hash_key,
-                                 sort_key,
-                                 get_error_string(ec_));
+                        LOG_ERROR_F("del {} data failed. hash_key={}, sort_key={}, error={}",
+                                    data_type_ == DataType::common ? "common" : "geo",
+                                    hash_key,
+                                    sort_key,
+                                    get_error_string(ec_));
                         *ret = ec__;
                     }
 
@@ -373,10 +373,10 @@ int geo_client::set_geo_data(const std::string &hash_key,
     auto async_set_callback = [&](int ec_, pegasus_client::internal_info &&info_) {
         if (ec_ != PERR_OK) {
             ret = ec_;
-            derror_f("set geo data failed. hash_key={}, sort_key={}, error={}",
-                     hash_key,
-                     sort_key,
-                     get_error_string(ec_));
+            LOG_ERROR_F("set geo data failed. hash_key={}, sort_key={}, error={}",
+                        hash_key,
+                        sort_key,
+                        get_error_string(ec_));
         }
         set_completed.notify();
     };
@@ -416,7 +416,7 @@ int geo_client::search_radial(double lat_degrees,
     int ret = PERR_OK;
     S2LatLng latlng = S2LatLng::FromDegrees(lat_degrees, lng_degrees);
     if (!latlng.is_valid()) {
-        derror_f("latlng is invalid. lat_degrees={}, lng_degrees={}", lat_degrees, lng_degrees);
+        LOG_ERROR_F("latlng is invalid. lat_degrees={}, lng_degrees={}", lat_degrees, lng_degrees);
         return PERR_GEO_INVALID_LATLNG_ERROR;
     }
     dsn::utils::notify_event search_completed;
@@ -446,7 +446,7 @@ void geo_client::async_search_radial(double lat_degrees,
 {
     S2LatLng latlng = S2LatLng::FromDegrees(lat_degrees, lng_degrees);
     if (!latlng.is_valid()) {
-        derror_f("latlng is invalid. lat_degrees={}, lng_degrees={}", lat_degrees, lng_degrees);
+        LOG_ERROR_F("latlng is invalid. lat_degrees={}, lng_degrees={}", lat_degrees, lng_degrees);
         callback(PERR_GEO_INVALID_LATLNG_ERROR, {});
     }
 
@@ -503,20 +503,20 @@ void geo_client::async_search_radial(const std::string &hash_key,
           cb = std::move(callback)
         ](int ec_, std::string &&value_, pegasus_client::internal_info &&) mutable {
             if (ec_ != PERR_OK) {
-                derror_f("get failed. hash_key={}, sort_key={}, error={}",
-                         hash_key,
-                         sort_key,
-                         get_error_string(ec_));
+                LOG_ERROR_F("get failed. hash_key={}, sort_key={}, error={}",
+                            hash_key,
+                            sort_key,
+                            get_error_string(ec_));
                 cb(ec_, {});
                 return;
             }
 
             S2LatLng latlng;
             if (!_codec.decode_from_value(value_, latlng)) {
-                derror_f("decode_from_value failed. hash_key={}, sort_key={}, value={}",
-                         hash_key,
-                         sort_key,
-                         value_);
+                LOG_ERROR_F("decode_from_value failed. hash_key={}, sort_key={}, value={}",
+                            hash_key,
+                            sort_key,
+                            value_);
                 cb(ec_, {});
                 return;
             }
@@ -705,10 +705,10 @@ bool geo_client::generate_geo_keys(const std::string &hash_key,
     // extract latitude and longitude from value
     S2LatLng latlng;
     if (!_codec.decode_from_value(value, latlng)) {
-        derror_f("decode_from_value failed. hash_key={}, sort_key={}, value={}",
-                 hash_key,
-                 sort_key,
-                 value);
+        LOG_ERROR_F("decode_from_value failed. hash_key={}, sort_key={}, value={}",
+                    hash_key,
+                    sort_key,
+                    value);
         return false;
     }
 
@@ -883,14 +883,14 @@ void geo_client::do_scan(pegasus_client::pegasus_scanner_wrapper scanner_wrapper
             }
 
             if (ret != PERR_OK) {
-                derror_f("async_next failed. error={}", get_error_string(ret));
+                LOG_ERROR_F("async_next failed. error={}", get_error_string(ret));
                 cb();
                 return;
             }
 
             S2LatLng latlng;
             if (!_codec.decode_from_value(value, latlng)) {
-                derror_f("decode_from_value failed. value={}", value);
+                LOG_ERROR_F("decode_from_value failed. value={}", value);
                 cb();
                 return;
             }
@@ -899,7 +899,7 @@ void geo_client::do_scan(pegasus_client::pegasus_scanner_wrapper scanner_wrapper
             if (distance <= S2Earth::ToMeters(cap_ptr->radius())) {
                 std::string origin_hash_key, origin_sort_key;
                 if (!restore_origin_keys(geo_sort_key, origin_hash_key, origin_sort_key)) {
-                    derror_f("restore_origin_keys failed. geo_sort_key={}", geo_sort_key);
+                    LOG_ERROR_F("restore_origin_keys failed. geo_sort_key={}", geo_sort_key);
                     cb();
                     return;
                 }
@@ -932,13 +932,14 @@ int geo_client::distance(const std::string &hash_key1,
     dsn::utils::notify_event get_completed;
     auto async_calculate_callback = [&](int ec_, double &&distance_) {
         if (ec_ != PERR_OK) {
-            derror_f("get distance failed. hash_key1={}, sort_key1={}, hash_key2={}, sort_key2={}, "
-                     "error={}",
-                     hash_key1,
-                     sort_key1,
-                     hash_key2,
-                     sort_key2,
-                     get_error_string(ec_));
+            LOG_ERROR_F(
+                "get distance failed. hash_key1={}, sort_key1={}, hash_key2={}, sort_key2={}, "
+                "error={}",
+                hash_key1,
+                sort_key1,
+                hash_key2,
+                sort_key2,
+                get_error_string(ec_));
             ret = ec_;
         }
         distance = distance_;
@@ -965,19 +966,19 @@ void geo_client::async_distance(const std::string &hash_key1,
         int ec_, std::string &&value_, pegasus_client::internal_info &&)
     {
         if (ec_ != PERR_OK) {
-            derror_f("get data failed. hash_key1={}, sort_key1={}, hash_key2={}, sort_key2={}, "
-                     "error={}",
-                     hash_key1,
-                     sort_key1,
-                     hash_key2,
-                     sort_key2,
-                     get_error_string(ec_));
+            LOG_ERROR_F("get data failed. hash_key1={}, sort_key1={}, hash_key2={}, sort_key2={}, "
+                        "error={}",
+                        hash_key1,
+                        sort_key1,
+                        hash_key2,
+                        sort_key2,
+                        get_error_string(ec_));
             *ret = ec_;
         }
 
         S2LatLng latlng;
         if (!_codec.decode_from_value(value_, latlng)) {
-            derror_f("decode_from_value failed. value={}", value_);
+            LOG_ERROR_F("decode_from_value failed. value={}", value_);
             *ret = PERR_GEO_DECODE_VALUE_ERROR;
         }
 

--- a/src/geo/lib/latlng_codec.cpp
+++ b/src/geo/lib/latlng_codec.cpp
@@ -95,7 +95,7 @@ bool latlng_codec::encode_to_value(double lat_degrees, double lng_degrees, std::
     dcheck_eq(_sorted_indices.size(), 2);
     S2LatLng latlng = S2LatLng::FromDegrees(lat_degrees, lng_degrees);
     if (!latlng.is_valid()) {
-        derror_f("latlng is invalid. lat_degrees={}, lng_degrees={}", lat_degrees, lng_degrees);
+        LOG_ERROR_F("latlng is invalid. lat_degrees={}, lng_degrees={}", lat_degrees, lng_degrees);
         return false;
     }
 

--- a/src/http/pprof_http_service.cpp
+++ b/src/http/pprof_http_service.cpp
@@ -328,7 +328,7 @@ void pprof_http_service::heap_handler(const http_request &req, http_response &re
 {
     bool in_pprof = false;
     if (!_in_pprof_action.compare_exchange_strong(in_pprof, true)) {
-        dwarn_f("node is already exectuting pprof action, please wait and retry");
+        LOG_WARNING_F("node is already exectuting pprof action, please wait and retry");
         resp.status_code = http_status_code::internal_server_error;
         return;
     }
@@ -425,7 +425,7 @@ void pprof_http_service::growth_handler(const http_request &req, http_response &
 {
     bool in_pprof = false;
     if (!_in_pprof_action.compare_exchange_strong(in_pprof, true)) {
-        dwarn_f("node is already exectuting pprof action, please wait and retry");
+        LOG_WARNING_F("node is already exectuting pprof action, please wait and retry");
         resp.status_code = http_status_code::internal_server_error;
         return;
     }
@@ -468,7 +468,7 @@ void pprof_http_service::profile_handler(const http_request &req, http_response 
 {
     bool in_pprof = false;
     if (!_in_pprof_action.compare_exchange_strong(in_pprof, true)) {
-        dwarn_f("node is already exectuting pprof action, please wait and retry");
+        LOG_WARNING_F("node is already exectuting pprof action, please wait and retry");
         resp.status_code = http_status_code::internal_server_error;
         return;
     }

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -156,7 +156,7 @@ bool copy_secondary_operation::can_continue()
     int id_max = *_ordered_address_ids.rbegin();
     if (_partition_counts[id_max] <= _replicas_low ||
         _partition_counts[id_max] - _partition_counts[id_min] <= 1) {
-        ddebug_f("{}: stop copy secondary coz it will be balanced later", _app->get_logname());
+        LOG_INFO_F("{}: stop copy secondary coz it will be balanced later", _app->get_logname());
         return false;
     }
     return true;
@@ -172,29 +172,29 @@ bool copy_secondary_operation::can_select(gpid pid, migration_list *result)
     int id_max = *_ordered_address_ids.rbegin();
     const node_state &max_ns = _nodes.at(_address_vec[id_max]);
     if (max_ns.served_as(pid) == partition_status::PS_PRIMARY) {
-        dinfo_f("{}: skip gpid({}.{}) coz it is primary",
-                _app->get_logname(),
-                pid.get_app_id(),
-                pid.get_partition_index());
+        LOG_DEBUG_F("{}: skip gpid({}.{}) coz it is primary",
+                    _app->get_logname(),
+                    pid.get_app_id(),
+                    pid.get_partition_index());
         return false;
     }
 
     // if the pid have been used
     if (result->find(pid) != result->end()) {
-        dinfo_f("{}: skip gpid({}.{}) coz it is already copyed",
-                _app->get_logname(),
-                pid.get_app_id(),
-                pid.get_partition_index());
+        LOG_DEBUG_F("{}: skip gpid({}.{}) coz it is already copyed",
+                    _app->get_logname(),
+                    pid.get_app_id(),
+                    pid.get_partition_index());
         return false;
     }
 
     int id_min = *_ordered_address_ids.begin();
     const node_state &min_ns = _nodes.at(_address_vec[id_min]);
     if (min_ns.served_as(pid) != partition_status::PS_INACTIVE) {
-        dinfo_f("{}: skip gpid({}.{}) coz it is already a member on the target node",
-                _app->get_logname(),
-                pid.get_app_id(),
-                pid.get_partition_index());
+        LOG_DEBUG_F("{}: skip gpid({}.{}) coz it is already a member on the target node",
+                    _app->get_logname(),
+                    pid.get_app_id(),
+                    pid.get_partition_index());
         return false;
     }
     return true;

--- a/src/meta/app_env_validator.cpp
+++ b/src/meta/app_env_validator.cpp
@@ -154,7 +154,7 @@ bool app_env_validator::validate_app_env(const std::string &env_name,
     if (func_iter != _validator_funcs.end()) {
         // check function == nullptr means no check
         if (nullptr != func_iter->second && !func_iter->second(env_value, hint_message)) {
-            dwarn_f("{}={} is invalid.", env_name, env_value);
+            LOG_WARNING_F("{}={} is invalid.", env_name, env_value);
             return false;
         }
 

--- a/src/meta/backup_engine.cpp
+++ b/src/meta/backup_engine.cpp
@@ -41,7 +41,7 @@ error_code backup_engine::init_backup(int32_t app_id)
         _backup_service->get_state()->lock_read(l);
         std::shared_ptr<app_state> app = _backup_service->get_state()->get_app(app_id);
         if (app == nullptr || app->status != app_status::AS_AVAILABLE) {
-            derror_f("app {} is not available, couldn't do backup now.", app_id);
+            LOG_ERROR_F("app {} is not available, couldn't do backup now.", app_id);
             return ERR_INVALID_STATE;
         }
         app_name = app->app_name;
@@ -77,7 +77,7 @@ error_code backup_engine::set_backup_path(const std::string &path)
     if (_block_service && _block_service->is_root_path_set()) {
         return ERR_INVALID_PARAMETERS;
     }
-    ddebug_f("backup path is set to {}.", path);
+    LOG_INFO_F("backup path is set to {}.", path);
     _backup_path = path;
     return ERR_OK;
 }
@@ -100,7 +100,7 @@ error_code backup_engine::write_backup_file(const std::string &file_name,
                       })
         ->wait();
     if (err != dsn::ERR_OK) {
-        ddebug_f("create file {} failed", file_name);
+        LOG_INFO_F("create file {} failed", file_name);
         return err;
     }
     dassert_f(remote_file != nullptr,
@@ -122,7 +122,7 @@ error_code backup_engine::backup_app_meta()
         _backup_service->get_state()->lock_read(l);
         std::shared_ptr<app_state> app = _backup_service->get_state()->get_app(_cur_backup.app_id);
         if (app == nullptr || app->status != app_status::AS_AVAILABLE) {
-            derror_f("app {} is not available, couldn't do backup now.", _cur_backup.app_id);
+            LOG_ERROR_F("app {} is not available, couldn't do backup now.", _cur_backup.app_id);
             return ERR_INVALID_STATE;
         }
         app_state tmp = *app;
@@ -147,7 +147,7 @@ void backup_engine::backup_app_partition(const gpid &pid)
         _backup_service->get_state()->lock_read(l);
         std::shared_ptr<app_state> app = _backup_service->get_state()->get_app(pid.get_app_id());
         if (app == nullptr || app->status != app_status::AS_AVAILABLE) {
-            derror_f("app {} is not available, couldn't do backup now.", pid.get_app_id());
+            LOG_ERROR_F("app {} is not available, couldn't do backup now.", pid.get_app_id());
 
             zauto_lock lock(_lock);
             _is_backup_failed = true;
@@ -157,9 +157,10 @@ void backup_engine::backup_app_partition(const gpid &pid)
     }
 
     if (partition_primary.is_invalid()) {
-        dwarn_f("backup_id({}): partition {} doesn't have a primary now, retry to backup it later.",
-                _cur_backup.backup_id,
-                pid.to_string());
+        LOG_WARNING_F(
+            "backup_id({}): partition {} doesn't have a primary now, retry to backup it later.",
+            _cur_backup.backup_id,
+            pid.to_string());
         tasking::enqueue(LPC_DEFAULT_CALLBACK,
                          &_tracker,
                          [this, pid]() { backup_app_partition(pid); },
@@ -180,10 +181,10 @@ void backup_engine::backup_app_partition(const gpid &pid)
         req->__set_backup_path(_backup_path);
     }
 
-    ddebug_f("backup_id({}): send backup request to partition {}, target_addr = {}",
-             _cur_backup.backup_id,
-             pid.to_string(),
-             partition_primary.to_string());
+    LOG_INFO_F("backup_id({}): send backup request to partition {}, target_addr = {}",
+               _cur_backup.backup_id,
+               pid.to_string(),
+               partition_primary.to_string());
     backup_rpc rpc(std::move(req), RPC_COLD_BACKUP, 10000_ms, 0, pid.thread_hash());
     rpc.call(
         partition_primary, &_tracker, [this, rpc, pid, partition_primary](error_code err) mutable {
@@ -200,10 +201,10 @@ inline void backup_engine::handle_replica_backup_failed(const backup_response &r
     dcheck_eq(response.pid, pid);
     dcheck_eq(response.backup_id, _cur_backup.backup_id);
 
-    derror_f("backup_id({}): backup for partition {} failed, response.err: {}",
-             _cur_backup.backup_id,
-             pid.to_string(),
-             response.err.to_string());
+    LOG_ERROR_F("backup_id({}): backup for partition {} failed, response.err: {}",
+                _cur_backup.backup_id,
+                pid.to_string(),
+                response.err.to_string());
     zauto_lock l(_lock);
     // if one partition fail, the whole backup plan fail.
     _is_backup_failed = true;
@@ -246,11 +247,11 @@ void backup_engine::on_backup_reply(const error_code err,
     }
 
     if (rep_error != ERR_OK) {
-        derror_f("backup_id({}): backup request to server {} failed, error: {}, retry to "
-                 "send backup request.",
-                 _cur_backup.backup_id,
-                 primary.to_string(),
-                 rep_error.to_string());
+        LOG_ERROR_F("backup_id({}): backup request to server {} failed, error: {}, retry to "
+                    "send backup request.",
+                    _cur_backup.backup_id,
+                    primary.to_string(),
+                    rep_error.to_string());
         retry_backup(pid);
         return;
     };
@@ -258,9 +259,9 @@ void backup_engine::on_backup_reply(const error_code err,
     if (response.progress == cold_backup_constant::PROGRESS_FINISHED) {
         dcheck_eq(response.pid, pid);
         dcheck_eq(response.backup_id, _cur_backup.backup_id);
-        ddebug_f("backup_id({}): backup for partition {} completed.",
-                 _cur_backup.backup_id,
-                 pid.to_string());
+        LOG_INFO_F("backup_id({}): backup for partition {} completed.",
+                   _cur_backup.backup_id,
+                   pid.to_string());
         {
             zauto_lock l(_lock);
             _backup_status[pid.get_partition_index()] = backup_status::COMPLETED;
@@ -270,12 +271,12 @@ void backup_engine::on_backup_reply(const error_code err,
     }
 
     // backup is not finished, meta polling to send request
-    ddebug_f("backup_id({}): receive backup response for partition {} from server {}, now "
-             "progress {}, retry to send backup request.",
-             _cur_backup.backup_id,
-             pid.to_string(),
-             primary.to_string(),
-             response.progress);
+    LOG_INFO_F("backup_id({}): receive backup response for partition {} from server {}, now "
+               "progress {}, retry to send backup request.",
+               _cur_backup.backup_id,
+               pid.to_string(),
+               primary.to_string(),
+               response.progress);
 
     retry_backup(pid);
 }
@@ -288,7 +289,7 @@ void backup_engine::write_backup_info()
     blob buf = dsn::json::json_forwarder<app_backup_info>::encode(_cur_backup);
     error_code err = write_backup_file(file_name, buf);
     if (err == ERR_FS_INTERNAL) {
-        derror_f(
+        LOG_ERROR_F(
             "backup_id({}): write backup info failed, error {}, do not try again for this error.",
             _cur_backup.backup_id,
             err.to_string());
@@ -297,7 +298,8 @@ void backup_engine::write_backup_info()
         return;
     }
     if (err != ERR_OK) {
-        dwarn_f("backup_id({}): write backup info failed, retry it later.", _cur_backup.backup_id);
+        LOG_WARNING_F("backup_id({}): write backup info failed, retry it later.",
+                      _cur_backup.backup_id);
         tasking::enqueue(LPC_DEFAULT_CALLBACK,
                          &_tracker,
                          [this]() { write_backup_info(); },
@@ -305,9 +307,9 @@ void backup_engine::write_backup_info()
                          std::chrono::seconds(1));
         return;
     }
-    ddebug_f("backup_id({}): successfully wrote backup info, backup for app {} completed.",
-             _cur_backup.backup_id,
-             _cur_backup.app_id);
+    LOG_INFO_F("backup_id({}): successfully wrote backup info, backup for app {} completed.",
+               _cur_backup.backup_id,
+               _cur_backup.app_id);
     zauto_lock l(_lock);
     _cur_backup.end_time_ms = dsn_now_ms();
 }
@@ -331,10 +333,10 @@ error_code backup_engine::start()
 {
     error_code err = backup_app_meta();
     if (err != ERR_OK) {
-        derror_f("backup_id({}): backup meta data for app {} failed, error {}",
-                 _cur_backup.backup_id,
-                 _cur_backup.app_id,
-                 err.to_string());
+        LOG_ERROR_F("backup_id({}): backup meta data for app {} failed, error {}",
+                    _cur_backup.backup_id,
+                    _cur_backup.app_id,
+                    err.to_string());
         return err;
     }
     for (int i = 0; i < _backup_status.size(); ++i) {

--- a/src/meta/cluster_balance_policy.cpp
+++ b/src/meta/cluster_balance_policy.cpp
@@ -120,7 +120,7 @@ bool cluster_balance_policy::cluster_replica_balance(const meta_view *global_vie
         return false;
     }
     if (!list.empty()) {
-        ddebug_f("migration count of {} = {}", enum_to_string(type), list.size());
+        LOG_INFO_F("migration count of {} = {}", enum_to_string(type), list.size());
         return false;
     }
     return true;
@@ -165,11 +165,11 @@ bool cluster_balance_policy::get_cluster_migration_info(
         const std::shared_ptr<app_state> &app = kv.second;
         auto ignored = is_ignored_app(app->app_id);
         if (ignored || app->is_bulk_loading || app->splitting()) {
-            ddebug_f("skip to balance app({}), ignored={}, bulk loading={}, splitting={}",
-                     app->app_name,
-                     ignored,
-                     app->is_bulk_loading,
-                     app->splitting());
+            LOG_INFO_F("skip to balance app({}), ignored={}, bulk loading={}, splitting={}",
+                       app->app_name,
+                       ignored,
+                       app->is_bulk_loading,
+                       app->splitting());
             continue;
         }
         if (app->status == app_status::AS_AVAILABLE) {
@@ -263,13 +263,13 @@ bool cluster_balance_policy::get_next_move(const cluster_migration_info &cluster
     std::multimap<uint32_t, int32_t> app_skew_multimap = utils::flip_map(cluster_info.apps_skew);
     auto max_app_skew = app_skew_multimap.rbegin()->first;
     if (max_app_skew == 0) {
-        ddebug_f("every app is balanced and any move will unbalance a app");
+        LOG_INFO_F("every app is balanced and any move will unbalance a app");
         return false;
     }
 
     auto server_skew = get_skew(cluster_info.replicas_count);
     if (max_app_skew <= 1 && server_skew <= 1) {
-        ddebug_f("every app is balanced and the cluster as a whole is balanced");
+        LOG_INFO_F("every app is balanced and the cluster as a whole is balanced");
         return false;
     }
 
@@ -314,10 +314,10 @@ bool cluster_balance_policy::get_next_move(const cluster_migration_info &cluster
         std::multimap<uint32_t, rpc_address> app_count_multimap = utils::flip_map(app_map);
         if (app_count_multimap.rbegin()->first <= app_count_multimap.begin()->first + 1 &&
             (app_cluster_min_set.empty() || app_cluster_max_set.empty())) {
-            ddebug_f("do not move replicas of a balanced app({}) if the least (most) loaded "
-                     "servers overall do not intersect the servers hosting the least (most) "
-                     "replicas of the app",
-                     app_id);
+            LOG_INFO_F("do not move replicas of a balanced app({}) if the least (most) loaded "
+                       "servers overall do not intersect the servers hosting the least (most) "
+                       "replicas of the app",
+                       app_id);
             continue;
         }
 
@@ -357,10 +357,10 @@ bool cluster_balance_policy::pick_up_move(const cluster_migration_info &cluster_
     }
     auto index = rand() % max_load_disk_set.size();
     auto max_load_disk = *select_random(max_load_disk_set, index);
-    ddebug_f("most load disk({}) on node({}) is picked, has {} partition",
-             max_load_disk.node.to_string(),
-             max_load_disk.disk_tag,
-             max_load_disk.partitions.size());
+    LOG_INFO_F("most load disk({}) on node({}) is picked, has {} partition",
+               max_load_disk.node.to_string(),
+               max_load_disk.disk_tag,
+               max_load_disk.partitions.size());
     for (const auto &node_addr : min_nodes) {
         gpid picked_pid;
         if (pick_up_partition(
@@ -370,17 +370,17 @@ bool cluster_balance_policy::pick_up_move(const cluster_migration_info &cluster_
             move_info.source_disk_tag = max_load_disk.disk_tag;
             move_info.target_node = node_addr;
             move_info.type = cluster_info.type;
-            ddebug_f("partition[{}] will migrate from {} to {}",
-                     picked_pid,
-                     max_load_disk.node.to_string(),
-                     node_addr.to_string());
+            LOG_INFO_F("partition[{}] will migrate from {} to {}",
+                       picked_pid,
+                       max_load_disk.node.to_string(),
+                       node_addr.to_string());
             return true;
         }
     }
-    ddebug_f("can not find a partition(app_id={}) from random max load disk(node={}, disk={})",
-             app_id,
-             max_load_disk.node.to_string(),
-             max_load_disk.disk_tag);
+    LOG_INFO_F("can not find a partition(app_id={}) from random max load disk(node={}, disk={})",
+               app_id,
+               max_load_disk.node.to_string(),
+               max_load_disk.disk_tag);
     return false;
 }
 

--- a/src/meta/duplication/duplication_info.cpp
+++ b/src/meta/duplication/duplication_info.cpp
@@ -48,7 +48,7 @@ namespace replication {
         s = it->second;
         return true;
     }
-    derror_f("unexpected duplication_status name: {}", name);
+    LOG_ERROR_F("unexpected duplication_status name: {}", name);
 
     // for forward compatibility issue, duplication of unexpected status
     // will be marked as invisible.
@@ -77,7 +77,7 @@ namespace replication {
         fmode = it->second;
         return true;
     }
-    derror_f("unexpected duplication_fail_mode name: {}", name);
+    LOG_ERROR_F("unexpected duplication_fail_mode name: {}", name);
     // marked as default value.
     fmode = duplication_fail_mode::FAIL_SLOW;
     return false;
@@ -197,7 +197,7 @@ void duplication_info::report_progress_if_time_up()
     // progress report is not supposed to be too frequent.
     if (dsn_now_ms() > _last_progress_report_ms + PROGRESS_REPORT_PERIOD_MS) {
         _last_progress_report_ms = dsn_now_ms();
-        ddebug_f("duplication report: {}", to_string());
+        LOG_INFO_F("duplication report: {}", to_string());
     }
 }
 

--- a/src/meta/duplication/duplication_info.h
+++ b/src/meta/duplication/duplication_info.h
@@ -74,10 +74,10 @@ public:
         if (is_duplicating_checkpoint) {
             return alter_status(duplication_status::DS_PREPARE);
         }
-        dwarn_f("you now create duplication[{}[{}.{}]] without duplicating checkpoint",
-                id,
-                follower_cluster_name,
-                app_name);
+        LOG_WARNING_F("you now create duplication[{}[{}.{}]] without duplicating checkpoint",
+                      id,
+                      follower_cluster_name,
+                      app_name);
         return alter_status(duplication_status::DS_LOG);
     }
 
@@ -168,7 +168,7 @@ public:
                             return item.second.checkpoint_prepared;
                         });
         if (!completed) {
-            dwarn_f("replica checkpoint still running: {}/{}", prepared, _progress.size());
+            LOG_WARNING_F("replica checkpoint still running: {}/{}", prepared, _progress.size());
         }
         return completed;
     }
@@ -249,13 +249,13 @@ extern bool json_decode(const dsn::json::JsonObject &in, duplication_fail_mode::
 
 // Macros for writing log message prefixed by appid and dupid.
 #define ddebug_dup(_dup_, ...)                                                                     \
-    ddebug_f("[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
+    LOG_INFO_F("[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
 #define dwarn_dup(_dup_, ...)                                                                      \
-    dwarn_f("[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
+    LOG_WARNING_F("[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
 #define derror_dup(_dup_, ...)                                                                     \
-    derror_f("[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
+    LOG_ERROR_F("[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
 #define dfatal_dup(_dup_, ...)                                                                     \
-    dfatal_f("[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
+    LOG_FATAL_F("[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
 #define dassert_dup(_pred_, _dup_, ...)                                                            \
     dassert_f(_pred_, "[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
 

--- a/src/meta/meta_bulk_load_ingestion_context.cpp
+++ b/src/meta/meta_bulk_load_ingestion_context.cpp
@@ -80,20 +80,20 @@ bool ingestion_context::node_context::check_if_add(const std::string &disk_tag)
 {
     auto max_node_ingestion_count = FLAGS_bulk_load_node_max_ingesting_count;
     if (node_ingesting_count >= max_node_ingestion_count) {
-        dwarn_f("node[{}] has {} partition executing ingestion, max_count = {}",
-                address.to_string(),
-                node_ingesting_count,
-                max_node_ingestion_count);
+        LOG_WARNING_F("node[{}] has {} partition executing ingestion, max_count = {}",
+                      address.to_string(),
+                      node_ingesting_count,
+                      max_node_ingestion_count);
         return false;
     }
 
     auto max_disk_ingestion_count = get_max_disk_ingestion_count(max_node_ingestion_count);
     if (disk_ingesting_counts[disk_tag] >= max_disk_ingestion_count) {
-        dwarn_f("node[{}] disk[{}] has {} partition executing ingestion, max_count = {}",
-                address.to_string(),
-                disk_tag,
-                disk_ingesting_counts[disk_tag],
-                max_disk_ingestion_count);
+        LOG_WARNING_F("node[{}] disk[{}] has {} partition executing ingestion, max_count = {}",
+                      address.to_string(),
+                      disk_tag,
+                      disk_ingesting_counts[disk_tag],
+                      max_disk_ingestion_count);
         return false;
     }
     return true;

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -191,19 +191,19 @@ bool meta_service::try_lock_meta_op_status(meta_op_status op_status)
 {
     meta_op_status expected = meta_op_status::FREE;
     if (!_meta_op_status.compare_exchange_strong(expected, op_status)) {
-        derror_f("LOCK meta op status failed, meta "
-                 "server is busy, current op status is {}",
-                 enum_to_string(expected));
+        LOG_ERROR_F("LOCK meta op status failed, meta "
+                    "server is busy, current op status is {}",
+                    enum_to_string(expected));
         return false;
     }
 
-    ddebug_f("LOCK meta op status to {}", enum_to_string(op_status));
+    LOG_INFO_F("LOCK meta op status to {}", enum_to_string(op_status));
     return true;
 }
 
 void meta_service::unlock_meta_op_status()
 {
-    ddebug_f("UNLOCK meta op status from {}", enum_to_string(_meta_op_status.load()));
+    LOG_INFO_F("UNLOCK meta op status from {}", enum_to_string(_meta_op_status.load()));
     _meta_op_status.store(meta_op_status::FREE);
 }
 
@@ -647,10 +647,10 @@ void meta_service::on_query_configuration_by_index(configuration_query_by_index_
 
     _state->query_configuration_by_index(rpc.request(), response);
     if (ERR_OK == response.err) {
-        ddebug_f("client {} queried an available app {} with appid {}",
-                 rpc.dsn_request()->header->from_address.to_string(),
-                 rpc.request().app_name,
-                 response.app_id);
+        LOG_INFO_F("client {} queried an available app {} with appid {}",
+                   rpc.dsn_request()->header->from_address.to_string(),
+                   rpc.request().app_name,
+                   response.app_id);
     }
 }
 
@@ -1001,7 +1001,7 @@ void meta_service::on_start_partition_split(start_split_rpc rpc)
         return;
     }
     if (_split_svc == nullptr) {
-        derror_f("meta doesn't support partition split");
+        LOG_ERROR_F("meta doesn't support partition split");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }
@@ -1018,7 +1018,7 @@ void meta_service::on_control_partition_split(control_split_rpc rpc)
     }
 
     if (_split_svc == nullptr) {
-        derror_f("meta doesn't support partition split");
+        LOG_ERROR_F("meta doesn't support partition split");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }
@@ -1035,7 +1035,7 @@ void meta_service::on_query_partition_split(query_split_rpc rpc)
     }
 
     if (_split_svc == nullptr) {
-        derror_f("meta doesn't support partition split");
+        LOG_ERROR_F("meta doesn't support partition split");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }
@@ -1060,7 +1060,7 @@ void meta_service::on_notify_stop_split(notify_stop_split_rpc rpc)
         return;
     }
     if (_split_svc == nullptr) {
-        derror_f("meta doesn't support partition split");
+        LOG_ERROR_F("meta doesn't support partition split");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }
@@ -1076,7 +1076,7 @@ void meta_service::on_query_child_state(query_child_state_rpc rpc)
         return;
     }
     if (_split_svc == nullptr) {
-        derror_f("meta doesn't support partition split");
+        LOG_ERROR_F("meta doesn't support partition split");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }
@@ -1090,7 +1090,7 @@ void meta_service::on_start_bulk_load(start_bulk_load_rpc rpc)
     }
 
     if (_bulk_load_svc == nullptr) {
-        derror_f("meta doesn't support bulk load");
+        LOG_ERROR_F("meta doesn't support bulk load");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }
@@ -1104,7 +1104,7 @@ void meta_service::on_control_bulk_load(control_bulk_load_rpc rpc)
     }
 
     if (_bulk_load_svc == nullptr) {
-        derror_f("meta doesn't support bulk load");
+        LOG_ERROR_F("meta doesn't support bulk load");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }
@@ -1121,7 +1121,7 @@ void meta_service::on_query_bulk_load_status(query_bulk_load_rpc rpc)
     }
 
     if (_bulk_load_svc == nullptr) {
-        derror_f("meta doesn't support bulk load");
+        LOG_ERROR_F("meta doesn't support bulk load");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }
@@ -1135,7 +1135,7 @@ void meta_service::on_clear_bulk_load(clear_bulk_load_rpc rpc)
     }
 
     if (_bulk_load_svc == nullptr) {
-        derror_f("meta doesn't support bulk load");
+        LOG_ERROR_F("meta doesn't support bulk load");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }
@@ -1151,7 +1151,7 @@ void meta_service::on_start_backup_app(start_backup_app_rpc rpc)
         return;
     }
     if (_backup_handler == nullptr) {
-        derror_f("meta doesn't enable backup service");
+        LOG_ERROR_F("meta doesn't enable backup service");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }
@@ -1164,7 +1164,7 @@ void meta_service::on_query_backup_status(query_backup_status_rpc rpc)
         return;
     }
     if (_backup_handler == nullptr) {
-        derror_f("meta doesn't enable backup service");
+        LOG_ERROR_F("meta doesn't enable backup service");
         rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         return;
     }

--- a/src/meta/meta_state_service_utils_impl.h
+++ b/src/meta/meta_state_service_utils_impl.h
@@ -75,9 +75,9 @@ struct operation : pipeline::environment
     void on_error(T *this_instance, op_type::type type, error_code ec, const std::string &path)
     {
         if (ec == ERR_TIMEOUT) {
-            dwarn_f("request({}) on path({}) was timeout, retry after 1 second",
-                    op_type::to_string(type),
-                    path);
+            LOG_WARNING_F("request({}) on path({}) was timeout, retry after 1 second",
+                          op_type::to_string(type),
+                          path);
             pipeline::repeat(std::move(*this_instance), 1_s);
             return;
         }

--- a/src/meta/server_state_restore.cpp
+++ b/src/meta/server_state_restore.cpp
@@ -59,7 +59,7 @@ void server_state::sync_app_from_backup_media(
 
     error_code err = ERR_OK;
     block_file_ptr file_handle = nullptr;
-    ddebug_f("start to create metadata file {}", app_metadata);
+    LOG_INFO_F("start to create metadata file {}", app_metadata);
     blk_fs
         ->create_file(create_file_request{app_metadata, true},
                       TASK_CODE_EXEC_INLINED,
@@ -70,7 +70,7 @@ void server_state::sync_app_from_backup_media(
         ->wait();
 
     if (err != ERR_OK) {
-        derror_f("create metadata file {} failed.", app_metadata);
+        LOG_ERROR_F("create metadata file {} failed.", app_metadata);
         callback_tsk->enqueue_with(err, dsn::blob());
         return;
     }
@@ -89,7 +89,7 @@ std::pair<dsn::error_code, std::shared_ptr<app_state>> server_state::restore_app
     dsn::app_info info;
     if (!::dsn::json::json_forwarder<dsn::app_info>::decode(app_info, info)) {
         std::string b_str(app_info.data(), app_info.length());
-        derror_f("decode app_info '{}' failed", b_str);
+        LOG_ERROR_F("decode app_info '{}' failed", b_str);
         // NOTICE : maybe find a better error_code to replace err_corruption
         res.first = ERR_CORRUPTION;
         return res;

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -134,7 +134,7 @@ public:
 
     void mock_partition_bulk_load(const std::string &app_name, const gpid &pid)
     {
-        ddebug_f("mock function, app({}), pid({})", app_name, pid);
+        LOG_INFO_F("mock function, app({}), pid({})", app_name, pid);
     }
 
     gpid before_check_partition_status(bulk_load_status::type status)
@@ -373,11 +373,11 @@ public:
             std::move(app_path),
             std::move(value),
             [this, app_path, &ainfo, &partition_bulk_load_info_map]() {
-                ddebug_f("create app({}) app_id={} bulk load dir({}), bulk_load_status={}",
-                         ainfo.app_name,
-                         ainfo.app_id,
-                         app_path,
-                         dsn::enum_to_string(ainfo.status));
+                LOG_INFO_F("create app({}) app_id={} bulk load dir({}), bulk_load_status={}",
+                           ainfo.app_name,
+                           ainfo.app_id,
+                           app_path,
+                           dsn::enum_to_string(ainfo.status));
                 for (const auto &kv : partition_bulk_load_info_map) {
                     mock_partition_bulk_load_info_on_remote_storage(gpid(ainfo.app_id, kv.first),
                                                                     kv.second);
@@ -392,10 +392,10 @@ public:
         blob value = json::json_forwarder<partition_bulk_load_info>::encode(pinfo);
         _ms->get_meta_storage()->create_node(
             std::move(partition_path), std::move(value), [partition_path, pid, &pinfo]() {
-                ddebug_f("create partition[{}] bulk load dir({}), bulk_load_status={}",
-                         pid,
-                         partition_path,
-                         dsn::enum_to_string(pinfo.status));
+                LOG_INFO_F("create partition[{}] bulk load dir({}), bulk_load_status={}",
+                           pid,
+                           partition_path,
+                           dsn::enum_to_string(pinfo.status));
             });
     }
 
@@ -407,7 +407,7 @@ public:
 
         _ms->get_meta_storage()->create_node(
             std::move(path), blob(lock_state, 0, strlen(lock_state)), [this]() {
-                ddebug_f("create app root {}", _app_root);
+                LOG_INFO_F("create app root {}", _app_root);
             });
         wait_all();
 
@@ -416,7 +416,7 @@ public:
             _app_root + "/" + boost::lexical_cast<std::string>(info.app_id),
             std::move(value),
             [this, &info]() {
-                ddebug_f("create app({}) app_id={}, dir succeed", info.app_name, info.app_id);
+                LOG_INFO_F("create app({}) app_id={}, dir succeed", info.app_name, info.app_id);
                 for (int i = 0; i < info.partition_count; ++i) {
                     partition_configuration config;
                     config.max_replica_count = 3;
@@ -428,10 +428,10 @@ public:
                             boost::lexical_cast<std::string>(i),
                         std::move(v),
                         [info, i]() {
-                            ddebug_f("create app({}), partition({}.{}) dir succeed",
-                                     info.app_name,
-                                     info.app_id,
-                                     i);
+                            LOG_INFO_F("create app({}), partition({}.{}) dir succeed",
+                                       info.app_name,
+                                       info.app_id,
+                                       i);
                         });
                 }
             });

--- a/src/meta/test/meta_split_service_test.cpp
+++ b/src/meta/test/meta_split_service_test.cpp
@@ -289,7 +289,7 @@ public:
 
         _ms->get_meta_storage()->create_node(
             std::move(path), blob(lock_state, 0, strlen(lock_state)), [&app_root]() {
-                ddebug_f("create app root {}", app_root);
+                LOG_INFO_F("create app root {}", app_root);
             });
         wait_all();
 
@@ -309,7 +309,7 @@ public:
             app_root + "/" + boost::lexical_cast<std::string>(ainfo.app_id),
             std::move(value),
             [this, &app_root, &ainfo]() {
-                ddebug_f("create app({}) app_id={}, dir succeed", ainfo.app_name, ainfo.app_id);
+                LOG_INFO_F("create app({}) app_id={}, dir succeed", ainfo.app_name, ainfo.app_id);
                 for (int i = 0; i < ainfo.init_partition_count; ++i) {
                     create_partition_configuration_on_remote_storage(app_root, ainfo.app_id, i);
                 }
@@ -338,7 +338,7 @@ public:
                 boost::lexical_cast<std::string>(pidx),
             std::move(value),
             [app_id, pidx, this]() {
-                ddebug_f("create app({}), partition({}.{}) dir succeed", NAME, app_id, pidx);
+                LOG_INFO_F("create app({}), partition({}.{}) dir succeed", NAME, app_id, pidx);
             });
     }
 

--- a/src/meta/test/meta_test_base.cpp
+++ b/src/meta/test/meta_test_base.cpp
@@ -127,9 +127,9 @@ std::vector<rpc_address> meta_test_base::ensure_enough_alive_nodes(int min_node_
                   min_node_count,
                   node_count);
 
-        dinfo_f("already exists {} alive nodes: ", nodes.size());
+        LOG_DEBUG_F("already exists {} alive nodes: ", nodes.size());
         for (const auto &node : nodes) {
-            dinfo_f("    {}", node.to_string());
+            LOG_DEBUG_F("    {}", node.to_string());
         }
 
         // ensure that _ms->_alive_set is identical with _ss->_nodes
@@ -151,9 +151,9 @@ std::vector<rpc_address> meta_test_base::ensure_enough_alive_nodes(int min_node_
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
 
-    dinfo_f("created {} alive nodes: ", nodes.size());
+    LOG_DEBUG_F("created {} alive nodes: ", nodes.size());
     for (const auto &node : nodes) {
-        dinfo_f("    {}", node.to_string());
+        LOG_DEBUG_F("    {}", node.to_string());
     }
     return nodes;
 }

--- a/src/replica/backup/replica_backup_manager.cpp
+++ b/src/replica/backup/replica_backup_manager.cpp
@@ -46,7 +46,7 @@ static bool get_policy_checkpoint_dirs(const std::string &dir,
     // list sub dirs
     std::vector<std::string> sub_dirs;
     if (!utils::filesystem::get_subdirectories(dir, sub_dirs, false)) {
-        derror_f("list sub dirs of dir {} failed", dir.c_str());
+        LOG_ERROR_F("list sub dirs of dir {} failed", dir.c_str());
         return false;
     }
 

--- a/src/replica/backup/replica_backup_server.cpp
+++ b/src/replica/backup/replica_backup_server.cpp
@@ -72,9 +72,9 @@ void replica_backup_server::on_cold_backup(backup_rpc rpc)
 
 void replica_backup_server::on_clear_cold_backup(const backup_clear_request &request)
 {
-    ddebug_f("receive clear cold backup request: backup({}.{})",
-             request.pid.to_string(),
-             request.policy_name.c_str());
+    LOG_INFO_F("receive clear cold backup request: backup({}.{})",
+               request.pid.to_string(),
+               request.policy_name.c_str());
 
     replica_ptr rep = _stub->get_replica(request.pid);
     if (rep != nullptr) {

--- a/src/replica/disk_cleaner.cpp
+++ b/src/replica/disk_cleaner.cpp
@@ -68,7 +68,7 @@ error_s disk_remove_useless_dirs(const std::vector<std::string> &data_dirs,
     for (auto &dir : data_dirs) {
         std::vector<std::string> tmp_list;
         if (!dsn::utils::filesystem::get_subdirectories(dir, tmp_list, false)) {
-            dwarn_f("gc_disk: failed to get subdirectories in {}", dir);
+            LOG_WARNING_F("gc_disk: failed to get subdirectories in {}", dir);
             return error_s::make(ERR_OBJECT_NOT_FOUND, "failed to get subdirectories");
         }
         sub_list.insert(sub_list.end(), tmp_list.begin(), tmp_list.end());
@@ -82,7 +82,7 @@ error_s disk_remove_useless_dirs(const std::vector<std::string> &data_dirs,
 
         time_t mt;
         if (!dsn::utils::filesystem::last_write_time(fpath, mt)) {
-            dwarn_f("gc_disk: failed to get last write time of {}", fpath);
+            LOG_WARNING_F("gc_disk: failed to get last write time of {}", fpath);
             continue;
         }
 
@@ -107,20 +107,20 @@ error_s disk_remove_useless_dirs(const std::vector<std::string> &data_dirs,
 
         if (last_write_time + remove_interval_seconds <= current_time_ms / 1000) {
             if (!dsn::utils::filesystem::remove_path(fpath)) {
-                dwarn_f("gc_disk: failed to delete directory '{}', time_used_ms = {}",
-                        fpath,
-                        dsn_now_ms() - current_time_ms);
+                LOG_WARNING_F("gc_disk: failed to delete directory '{}', time_used_ms = {}",
+                              fpath,
+                              dsn_now_ms() - current_time_ms);
             } else {
-                dwarn_f("gc_disk: replica_dir_op succeed to delete directory '{}'"
-                        ", time_used_ms = {}",
-                        fpath,
-                        dsn_now_ms() - current_time_ms);
+                LOG_WARNING_F("gc_disk: replica_dir_op succeed to delete directory '{}'"
+                              ", time_used_ms = {}",
+                              fpath,
+                              dsn_now_ms() - current_time_ms);
                 report.remove_dir_count++;
             }
         } else {
-            ddebug_f("gc_disk: reserve directory '{}', wait_seconds = {}",
-                     fpath,
-                     last_write_time + remove_interval_seconds - current_time_ms / 1000);
+            LOG_INFO_F("gc_disk: reserve directory '{}', wait_seconds = {}",
+                       fpath,
+                       last_write_time + remove_interval_seconds - current_time_ms / 1000);
         }
     }
     return error_s::ok();

--- a/src/replica/duplication/duplication_sync_timer.cpp
+++ b/src/replica/duplication/duplication_sync_timer.cpp
@@ -35,15 +35,16 @@ void duplication_sync_timer::run()
 {
     // ensure duplication sync never be concurrent
     if (_rpc_task) {
-        ddebug_f("a duplication sync is already ongoing");
+        LOG_INFO_F("a duplication sync is already ongoing");
         return;
     }
 
     {
         zauto_lock l(_stub->_state_lock);
         if (_stub->_state == replica_stub::NS_Disconnected) {
-            ddebug_f("stop this round of duplication sync because this server is disconnected from "
-                     "meta server");
+            LOG_INFO_F(
+                "stop this round of duplication sync because this server is disconnected from "
+                "meta server");
             return;
         }
     }
@@ -64,7 +65,7 @@ void duplication_sync_timer::run()
 
     duplication_sync_rpc rpc(std::move(req), RPC_CM_DUPLICATION_SYNC, 3_s);
     rpc_address meta_server_address(_stub->get_meta_server_address());
-    ddebug_f("duplication_sync to meta({})", meta_server_address.to_string());
+    LOG_INFO_F("duplication_sync to meta({})", meta_server_address.to_string());
 
     zauto_lock l(_lock);
     _rpc_task =
@@ -80,7 +81,7 @@ void duplication_sync_timer::on_duplication_sync_reply(error_code err,
         err = resp.err;
     }
     if (err != ERR_OK) {
-        derror_f("on_duplication_sync_reply: err({})", err.to_string());
+        LOG_ERROR_F("on_duplication_sync_reply: err({})", err.to_string());
     } else {
         update_duplication_map(resp.dup_map);
     }
@@ -156,7 +157,7 @@ void duplication_sync_timer::close()
 
 void duplication_sync_timer::start()
 {
-    ddebug_f("run duplication sync periodically in {}s", DUPLICATION_SYNC_PERIOD_SECOND);
+    LOG_INFO_F("run duplication sync periodically in {}s", DUPLICATION_SYNC_PERIOD_SECOND);
 
     _timer_task = tasking::enqueue_timer(LPC_DUPLICATION_SYNC_TIMER,
                                          &_stub->_tracker,

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -59,7 +59,7 @@ bool load_from_private_log::switch_to_next_log_file()
         start_from_log_file(file);
         return true;
     } else {
-        ddebug_f("no next log file (log.{}) is found", _current->index() + 1);
+        LOG_INFO_F("no next log file (log.{}) is found", _current->index() + 1);
         _current = nullptr;
         return false;
     }

--- a/src/replica/duplication/test/load_from_private_log_test.cpp
+++ b/src/replica/duplication/test/load_from_private_log_test.cpp
@@ -223,7 +223,7 @@ public:
             if (err == ERR_OK) {
                 break;
             }
-            derror_f("mlog open failed, encountered error: {}", err);
+            LOG_ERROR_F("mlog open failed, encountered error: {}", err);
         }
         return mlog;
     }

--- a/src/replica/mutation_log_replay.cpp
+++ b/src/replica/mutation_log_replay.cpp
@@ -155,7 +155,7 @@ namespace replication {
 
     error_s error = log_utils::check_log_files_continuity(logs);
     if (!error.is_ok()) {
-        derror_f("check_log_files_continuity failed: {}", error);
+        LOG_ERROR_F("check_log_files_continuity failed: {}", error);
         return error.code();
     }
 

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -82,10 +82,10 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
 
     task_spec *spec = task_spec::get(request->rpc_code());
     if (dsn_unlikely(nullptr == spec || request->rpc_code() == TASK_CODE_INVALID)) {
-        derror_f("recv message with unhandled rpc name {} from {}, trace_id = {}",
-                 request->rpc_code().to_string(),
-                 request->header->from_address.to_string(),
-                 request->header->trace_id);
+        LOG_ERROR_F("recv message with unhandled rpc name {} from {}, trace_id = {}",
+                    request->rpc_code().to_string(),
+                    request->header->from_address.to_string(),
+                    request->header->trace_id);
         response_client_write(request, ERR_HANDLER_NOT_FOUND);
         return;
     }

--- a/src/replica/replica_context.cpp
+++ b/src/replica/replica_context.cpp
@@ -182,9 +182,9 @@ bool primary_context::secondary_disk_space_insufficient() const
 {
     for (const auto &kv : secondary_disk_status) {
         if (kv.second == disk_status::SPACE_INSUFFICIENT) {
-            ddebug_f("partition[{}] secondary[{}] disk space is insufficient",
-                     membership.pid,
-                     kv.first.to_string());
+            LOG_INFO_F("partition[{}] secondary[{}] disk space is insufficient",
+                       membership.pid,
+                       kv.first.to_string());
             return true;
         }
     }

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -83,25 +83,25 @@ error_code replica::initialize_on_new()
         new replica(stub, gpid, app, dir.c_str(), restore_if_necessary, is_duplication_follower);
     error_code err;
     if (restore_if_necessary && (err = rep->restore_checkpoint()) != dsn::ERR_OK) {
-        derror_f("{}: try to restore replica failed, error({})", rep->name(), err.to_string());
+        LOG_ERROR_F("{}: try to restore replica failed, error({})", rep->name(), err.to_string());
         return clear_on_failure(stub, rep, dir, gpid);
     }
 
     if (is_duplication_follower &&
         (err = rep->get_replica_follower()->duplicate_checkpoint()) != dsn::ERR_OK) {
-        derror_f("{}: try to duplicate replica checkpoint failed, error({}) and please check "
-                 "previous detail error log",
-                 rep->name(),
-                 err.to_string());
+        LOG_ERROR_F("{}: try to duplicate replica checkpoint failed, error({}) and please check "
+                    "previous detail error log",
+                    rep->name(),
+                    err.to_string());
         return clear_on_failure(stub, rep, dir, gpid);
     }
 
     err = rep->initialize_on_new();
     if (err == ERR_OK) {
-        dinfo_f("{}: new replica succeed", rep->name());
+        LOG_DEBUG_F("{}: new replica succeed", rep->name());
         return rep;
     } else {
-        derror_f("{}: new replica failed, err = {}", rep->name(), err.to_string());
+        LOG_ERROR_F("{}: new replica failed, err = {}", rep->name(), err.to_string());
         return clear_on_failure(stub, rep, dir, gpid);
     }
 }
@@ -172,10 +172,11 @@ error_code replica::initialize_on_load()
     }
 
     if (info.partition_count < pidx) {
-        derror_f("partition[{}], count={}, this replica may be partition split garbage partition, "
-                 "ignore it",
-                 pid,
-                 info.partition_count);
+        LOG_ERROR_F(
+            "partition[{}], count={}, this replica may be partition split garbage partition, "
+            "ignore it",
+            pid,
+            info.partition_count);
         return nullptr;
     }
 

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -98,7 +98,7 @@ error_code replica_init_info::load(const std::string &dir)
     dassert_f(utils::filesystem::path_exists(info_path), "file({}) not exist", info_path);
     ERR_LOG_AND_RETURN_NOT_OK(
         load_json(info_path), "load replica_init_info from {} failed", info_path);
-    ddebug_f("load replica_init_info from {} succeed: {}", info_path, to_string());
+    LOG_INFO_F("load replica_init_info from {} succeed: {}", info_path, to_string());
     return ERR_OK;
 }
 
@@ -110,10 +110,10 @@ error_code replica_init_info::store(const std::string &dir)
                               "store replica_init_info to {} failed, time_used_ns = {}",
                               info_path,
                               dsn_now_ns() - start);
-    ddebug_f("store replica_init_info to {} succeed, time_used_ns = {}: {}",
-             info_path,
-             dsn_now_ns() - start,
-             to_string());
+    LOG_INFO_F("store replica_init_info to {} succeed, time_used_ns = {}: {}",
+               info_path,
+               dsn_now_ns() - start,
+               to_string());
     return ERR_OK;
 }
 

--- a/src/replica/test/mutation_log_test.cpp
+++ b/src/replica/test/mutation_log_test.cpp
@@ -344,7 +344,7 @@ public:
             if (err == ERR_OK) {
                 break;
             }
-            derror_f("mlog open failed, encountered error: {}", err);
+            LOG_ERROR_F("mlog open failed, encountered error: {}", err);
         }
         EXPECT_NE(mlog, nullptr);
         return mlog;

--- a/src/replica/test/replica_disk_test.cpp
+++ b/src/replica/test/replica_disk_test.cpp
@@ -51,7 +51,7 @@ public:
         stub->on_add_new_disk(rpc);
         error_code err = rpc.response().err;
         if (err != ERR_OK) {
-            ddebug_f("error msg: {}", rpc.response().err_hint);
+            LOG_INFO_F("error msg: {}", rpc.response().err_hint);
         }
         return err;
     }

--- a/src/reporter/pegasus_counter_reporter.cpp
+++ b/src/reporter/pegasus_counter_reporter.cpp
@@ -108,7 +108,7 @@ void pegasus_counter_reporter::prometheus_initialize()
         dsn::make_unique<prometheus::Exposer>(fmt::format("0.0.0.0:{}", FLAGS_prometheus_port));
     _exposer->RegisterCollectable(_registry);
 
-    ddebug_f("prometheus exposer [0.0.0.0:{}] started", FLAGS_prometheus_port);
+    LOG_INFO_F("prometheus exposer [0.0.0.0:{}] started", FLAGS_prometheus_port);
 }
 
 void pegasus_counter_reporter::falcon_initialize()

--- a/src/runtime/security/client_negotiation.cpp
+++ b/src/runtime/security/client_negotiation.cpp
@@ -36,7 +36,7 @@ client_negotiation::client_negotiation(rpc_session_ptr session) : negotiation(se
 
 void client_negotiation::start()
 {
-    ddebug_f("{}: start negotiation", _name);
+    LOG_INFO_F("{}: start negotiation", _name);
     list_mechanisms();
 }
 
@@ -51,9 +51,9 @@ void client_negotiation::handle_response(error_code err, const negotiation_respo
     if (err != ERR_OK) {
         // ERR_HANDLER_NOT_FOUND means server is old version, which doesn't support authentication
         if (ERR_HANDLER_NOT_FOUND == err) {
-            ddebug_f("{}: treat negotiation succeed because server is old version, which doesn't "
-                     "support authentication",
-                     _name);
+            LOG_INFO_F("{}: treat negotiation succeed because server is old version, which doesn't "
+                       "support authentication",
+                       _name);
             succ_negotiation();
         } else {
             fail_negotiation();
@@ -63,7 +63,7 @@ void client_negotiation::handle_response(error_code err, const negotiation_respo
 
     // make the negotiation succeed if server doesn't enable auth
     if (negotiation_status::type::SASL_AUTH_DISABLE == response.status) {
-        ddebug_f("{}: treat negotiation succeed as server doesn't enable it", _name);
+        LOG_INFO_F("{}: treat negotiation succeed as server doesn't enable it", _name);
         succ_negotiation();
         return;
     }
@@ -104,9 +104,9 @@ void client_negotiation::on_recv_mechanisms(const negotiation_response &resp)
     }
 
     if (match_mechanism.empty()) {
-        dwarn_f("server only support mechanisms of ({}), can't find expected ({})",
-                boost::join(supported_mechanisms, ","),
-                resp_string);
+        LOG_WARNING_F("server only support mechanisms of ({}), can't find expected ({})",
+                      boost::join(supported_mechanisms, ","),
+                      resp_string);
         fail_negotiation();
         return;
     }
@@ -124,10 +124,10 @@ void client_negotiation::on_mechanism_selected(const negotiation_response &resp)
     // init client sasl
     auto err_s = _sasl->init();
     if (!err_s.is_ok()) {
-        dwarn_f("{}: initialize sasl client failed, error = {}, reason = {}",
-                _name,
-                err_s.code().to_string(),
-                err_s.description());
+        LOG_WARNING_F("{}: initialize sasl client failed, error = {}, reason = {}",
+                      _name,
+                      err_s.code().to_string(),
+                      err_s.description());
         fail_negotiation();
         return;
     }
@@ -139,10 +139,10 @@ void client_negotiation::on_mechanism_selected(const negotiation_response &resp)
         _status = negotiation_status::type::SASL_INITIATE;
         send(_status, std::move(start_output));
     } else {
-        dwarn_f("{}: start sasl client failed, error = {}, reason = {}",
-                _name,
-                err_s.code().to_string(),
-                err_s.description());
+        LOG_WARNING_F("{}: start sasl client failed, error = {}, reason = {}",
+                      _name,
+                      err_s.code().to_string(),
+                      err_s.description());
         fail_negotiation();
     }
 }
@@ -153,7 +153,7 @@ void client_negotiation::on_challenge(const negotiation_response &challenge)
         blob response_msg;
         auto err = _sasl->step(challenge.msg, response_msg);
         if (!err.is_ok() && err.code() != ERR_SASL_INCOMPLETE) {
-            dwarn_f("{}: negotiation failed, reason = {}", _name, err.description());
+            LOG_WARNING_F("{}: negotiation failed, reason = {}", _name, err.description());
             fail_negotiation();
             return;
         }
@@ -168,7 +168,8 @@ void client_negotiation::on_challenge(const negotiation_response &challenge)
         return;
     }
 
-    dwarn_f("{}: recv wrong negotiation msg type: {}", _name, enum_to_string(challenge.status));
+    LOG_WARNING_F(
+        "{}: recv wrong negotiation msg type: {}", _name, enum_to_string(challenge.status));
     fail_negotiation();
 }
 
@@ -196,7 +197,7 @@ void client_negotiation::succ_negotiation()
 {
     _status = negotiation_status::type::SASL_SUCC;
     _session->set_negotiation_succeed();
-    ddebug_f("{}: negotiation succeed", _name);
+    LOG_INFO_F("{}: negotiation succeed", _name);
 }
 } // namespace security
 } // namespace dsn

--- a/src/runtime/security/init.cpp
+++ b/src/runtime/security/init.cpp
@@ -52,14 +52,14 @@ bool init(bool is_server)
 {
     error_s err = init_kerberos(is_server);
     if (!err.is_ok()) {
-        derror_f("initialize kerberos failed, with err = {}", err.description());
+        LOG_ERROR_F("initialize kerberos failed, with err = {}", err.description());
         return false;
     }
     LOG_INFO("initialize kerberos succeed");
 
     err = init_sasl(is_server);
     if (!err.is_ok()) {
-        derror_f("initialize sasl failed, with err = {}", err.description());
+        LOG_ERROR_F("initialize sasl failed, with err = {}", err.description());
         return false;
     }
     LOG_INFO("initialize sasl succeed");
@@ -72,14 +72,14 @@ bool init_for_zookeeper_client()
 {
     error_s err = run_kinit();
     if (!err.is_ok()) {
-        derror_f("initialize kerberos failed, with err = {}", err.description());
+        LOG_ERROR_F("initialize kerberos failed, with err = {}", err.description());
         return false;
     }
     LOG_INFO("initialize kerberos for zookeeper client succeed");
 
     err = init_sasl(false);
     if (!err.is_ok()) {
-        derror_f("initialize sasl failed, with err = {}", err.description());
+        LOG_ERROR_F("initialize sasl failed, with err = {}", err.description());
         return false;
     }
     LOG_INFO("initialize sasl for zookeeper client succeed");

--- a/src/runtime/security/kinit_context.cpp
+++ b/src/runtime/security/kinit_context.cpp
@@ -226,9 +226,9 @@ error_s kinit_context::get_credentials()
                                                    _opt),
                         "get_init_cred");
     if (!err.is_ok()) {
-        dwarn_f("get credentials of {} from KDC failed, reason({})",
-                FLAGS_krb5_principal,
-                err.description());
+        LOG_WARNING_F("get credentials of {} from KDC failed, reason({})",
+                      FLAGS_krb5_principal,
+                      err.description());
         return err;
     }
     auto cleanup = dsn::defer([&]() { krb5_free_cred_contents(_krb5_context, &creds); });
@@ -236,23 +236,23 @@ error_s kinit_context::get_credentials()
     // store credentials into _ccache.
     err = wrap_krb5_err(krb5_cc_store_cred(_krb5_context, _ccache, &creds), "store_cred");
     if (!err.is_ok()) {
-        dwarn_f("store credentials of {} to cache failed, err({})",
-                FLAGS_krb5_principal,
-                err.description());
+        LOG_WARNING_F("store credentials of {} to cache failed, err({})",
+                      FLAGS_krb5_principal,
+                      err.description());
         return err;
     }
 
     _cred_expire_timestamp = creds.times.endtime;
-    ddebug_f("get credentials of {} from KDC ok, expires at {}",
-             FLAGS_krb5_principal,
-             utils::time_s_to_date_time(_cred_expire_timestamp));
+    LOG_INFO_F("get credentials of {} from KDC ok, expires at {}",
+               FLAGS_krb5_principal,
+               utils::time_s_to_date_time(_cred_expire_timestamp));
     return err;
 }
 
 void kinit_context::schedule_renew_credentials()
 {
     int64_t renew_gap = get_next_renew_interval();
-    ddebug_f("schedule to renew credentials in {} seconds later", renew_gap);
+    LOG_INFO_F("schedule to renew credentials in {} seconds later", renew_gap);
 
     // why don't we use timers in rDSN framework?
     //  1. currently the rdsn framework may not started yet.

--- a/src/runtime/security/negotiation.cpp
+++ b/src/runtime/security/negotiation.cpp
@@ -59,10 +59,10 @@ bool negotiation::check_status(negotiation_status::type status,
                                negotiation_status::type expected_status)
 {
     if (status != expected_status) {
-        dwarn_f("{}: get message({}) while expect({})",
-                _name,
-                enum_to_string(status),
-                enum_to_string(expected_status));
+        LOG_WARNING_F("{}: get message({}) while expect({})",
+                      _name,
+                      enum_to_string(status),
+                      enum_to_string(expected_status));
         return false;
     }
 

--- a/src/runtime/security/negotiation_manager.cpp
+++ b/src/runtime/security/negotiation_manager.cpp
@@ -132,9 +132,9 @@ std::shared_ptr<negotiation> negotiation_manager::get_negotiation(negotiation_rp
     utils::auto_read_lock l(_lock);
     auto it = _negotiations.find(rpc.dsn_request()->io_session);
     if (it == _negotiations.end()) {
-        ddebug_f("negotiation was removed for msg: {}, {}",
-                 rpc.dsn_request()->rpc_code().to_string(),
-                 rpc.remote_address().to_string());
+        LOG_INFO_F("negotiation was removed for msg: {}, {}",
+                   rpc.dsn_request()->rpc_code().to_string(),
+                   rpc.remote_address().to_string());
         return nullptr;
     }
 

--- a/src/runtime/security/replica_access_controller.cpp
+++ b/src/runtime/security/replica_access_controller.cpp
@@ -39,7 +39,7 @@ bool replica_access_controller::allowed(message_ex *msg)
         // they are finally ensured to be fully upgraded, they can specify some usernames to ACL and
         // the table will be truly protected.
         if (!_users.empty() && _users.find(user_name) == _users.end()) {
-            ddebug_f("{}: user_name {} doesn't exist in acls map", _name, user_name);
+            LOG_INFO_F("{}: user_name {} doesn't exist in acls map", _name, user_name);
             return false;
         }
         return true;

--- a/src/runtime/security/server_negotiation.cpp
+++ b/src/runtime/security/server_negotiation.cpp
@@ -37,7 +37,7 @@ server_negotiation::server_negotiation(rpc_session_ptr session) : negotiation(se
 void server_negotiation::start()
 {
     _status = negotiation_status::type::SASL_LIST_MECHANISMS;
-    ddebug_f("{}: start negotiation", _name);
+    LOG_INFO_F("{}: start negotiation", _name);
 }
 
 void server_negotiation::handle_request(negotiation_rpc rpc)
@@ -83,17 +83,17 @@ void server_negotiation::on_select_mechanism(negotiation_rpc rpc)
 
     _selected_mechanism = request.msg.to_string();
     if (supported_mechanisms.find(_selected_mechanism) == supported_mechanisms.end()) {
-        dwarn_f("the mechanism of {} is not supported", _selected_mechanism);
+        LOG_WARNING_F("the mechanism of {} is not supported", _selected_mechanism);
         fail_negotiation();
         return;
     }
 
     error_s err_s = _sasl->init();
     if (!err_s.is_ok()) {
-        dwarn_f("{}: server initialize sasl failed, error = {}, msg = {}",
-                _name,
-                err_s.code().to_string(),
-                err_s.description());
+        LOG_WARNING_F("{}: server initialize sasl failed, error = {}, msg = {}",
+                      _name,
+                      err_s.code().to_string(),
+                      err_s.description());
         fail_negotiation();
         return;
     }
@@ -131,10 +131,10 @@ void server_negotiation::on_challenge_resp(negotiation_rpc rpc)
 void server_negotiation::do_challenge(negotiation_rpc rpc, error_s err_s, const blob &resp_msg)
 {
     if (!err_s.is_ok() && err_s.code() != ERR_SASL_INCOMPLETE) {
-        dwarn_f("{}: negotiation failed, with err = {}, msg = {}",
-                _name,
-                err_s.code().to_string(),
-                err_s.description());
+        LOG_WARNING_F("{}: negotiation failed, with err = {}, msg = {}",
+                      _name,
+                      err_s.code().to_string(),
+                      err_s.description());
         fail_negotiation();
         return;
     }
@@ -145,10 +145,10 @@ void server_negotiation::do_challenge(negotiation_rpc rpc, error_s err_s, const 
         if (retrive_err.is_ok()) {
             succ_negotiation(rpc, user_name);
         } else {
-            dwarn_f("{}: retrive user name failed: with err = {}, msg = {}",
-                    _name,
-                    retrive_err.code().to_string(),
-                    retrive_err.description());
+            LOG_WARNING_F("{}: retrive user name failed: with err = {}, msg = {}",
+                          _name,
+                          retrive_err.code().to_string(),
+                          retrive_err.description());
             fail_negotiation();
         }
     } else {
@@ -164,7 +164,7 @@ void server_negotiation::succ_negotiation(negotiation_rpc rpc, const std::string
     _status = response.status = negotiation_status::type::SASL_SUCC;
     _session->set_client_username(user_name);
     _session->set_negotiation_succeed();
-    ddebug_f("{}: negotiation succeed", _name);
+    LOG_INFO_F("{}: negotiation succeed", _name);
 }
 } // namespace security
 } // namespace dsn

--- a/src/runtime/task/task_engine.cpp
+++ b/src/runtime/task/task_engine.cpp
@@ -89,7 +89,7 @@ void task_worker_pool::start()
         wk->start();
     }
 
-    ddebug_f(
+    LOG_INFO_F(
         "[{}]: thread pool [{}] started, pool_code = {}, worker_count = {}, worker_share_core = "
         "{}, partitioned = {}, ...",
         _node->full_name(),
@@ -115,7 +115,7 @@ void task_worker_pool::stop()
         wk->stop();
     }
     _is_running = false;
-    ddebug_f("[{}]: thread pool {} stopped", _node->full_name(), _spec.name);
+    LOG_INFO_F("[{}]: thread pool {} stopped", _node->full_name(), _spec.name);
 }
 
 void task_worker_pool::add_timer(task *t)
@@ -239,7 +239,7 @@ void task_engine::start()
             pl->start();
     }
     _is_running = true;
-    ddebug_f("[{}]: task engine started", _node->full_name());
+    LOG_INFO_F("[{}]: task engine started", _node->full_name());
 }
 
 void task_engine::stop()
@@ -253,7 +253,7 @@ void task_engine::stop()
             pl->stop();
     }
     _is_running = false;
-    ddebug_f("[{}]: task engine stopped", _node->full_name());
+    LOG_INFO_F("[{}]: task engine stopped", _node->full_name());
 }
 
 volatile int *task_engine::get_task_queue_virtual_length_ptr(dsn::task_code code, int hash)

--- a/src/server/compaction_filter_rule.cpp
+++ b/src/server/compaction_filter_rule.cpp
@@ -46,7 +46,7 @@ bool string_pattern_match(dsn::string_view value,
                       filter_pattern.data(),
                       filter_pattern.length()) == 0;
     default:
-        derror_f("invalid match type {}", type);
+        LOG_ERROR_F("invalid match type {}", type);
         return false;
     }
 }

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -174,10 +174,10 @@ void hotspot_partition_calculator::detect_hotkey_in_hotpartition(int data_type)
     for (int index = 0; index < _hot_points.size(); index++) {
         if (_hot_points[index][data_type].get()->get_value() >= now_hot_partition_threshold) {
             if (++_hotpartition_counter[index][data_type] >= now_occurrence_threshold) {
-                derror_f("Find a {} hot partition {}.{}",
-                         (data_type == partition_qps_type::READ_HOTSPOT_DATA ? "read" : "write"),
-                         _app_name,
-                         index);
+                LOG_ERROR_F("Find a {} hot partition {}.{}",
+                            (data_type == partition_qps_type::READ_HOTSPOT_DATA ? "read" : "write"),
+                            _app_name,
+                            index);
                 send_detect_hotkey_request(_app_name,
                                            index,
                                            (data_type == dsn::replication::hotkey_type::type::READ)
@@ -213,26 +213,26 @@ void hotspot_partition_calculator::send_detect_hotkey_request(
     req.pid = dsn::gpid(app_id, partition_index);
     auto error = _shell_context->ddl_client->detect_hotkey(target_address, req, resp);
 
-    ddebug_f("{} {} hotkey detection in {}.{}, server address: {}",
-             (action == dsn::replication::detect_action::STOP) ? "Stop" : "Start",
-             (hotkey_type == dsn::replication::hotkey_type::WRITE) ? "write" : "read",
-             app_name,
-             partition_index,
-             target_address.to_string());
+    LOG_INFO_F("{} {} hotkey detection in {}.{}, server address: {}",
+               (action == dsn::replication::detect_action::STOP) ? "Stop" : "Start",
+               (hotkey_type == dsn::replication::hotkey_type::WRITE) ? "write" : "read",
+               app_name,
+               partition_index,
+               target_address.to_string());
 
     if (error != dsn::ERR_OK) {
-        derror_f("Hotkey detect rpc sending failed, in {}.{}, error_hint:{}",
-                 app_name,
-                 partition_index,
-                 error.to_string());
+        LOG_ERROR_F("Hotkey detect rpc sending failed, in {}.{}, error_hint:{}",
+                    app_name,
+                    partition_index,
+                    error.to_string());
     }
 
     if (resp.err != dsn::ERR_OK) {
-        derror_f("Hotkey detect rpc executing failed, in {}.{}, error_hint:{} {}",
-                 app_name,
-                 partition_index,
-                 resp.err,
-                 resp.err_hint);
+        LOG_ERROR_F("Hotkey detect rpc executing failed, in {}.{}, error_hint:{} {}",
+                    app_name,
+                    partition_index,
+                    resp.err,
+                    resp.err_hint);
     }
 }
 

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -170,10 +170,10 @@ void info_collector::on_app_stat()
     }
     get_app_counters(all_stats.row_name)->set(all_stats);
 
-    ddebug_f("stat apps succeed, app_count = {}, total_read_qps = {}, total_write_qps = {}",
-             all_rows.size(),
-             all_stats.get_total_read_qps(),
-             all_stats.get_total_write_qps());
+    LOG_INFO_F("stat apps succeed, app_count = {}, total_read_qps = {}, total_write_qps = {}",
+               all_rows.size(),
+               all_stats.get_total_read_qps(),
+               all_stats.get_total_write_qps());
 }
 
 info_collector::app_stat_counters *info_collector::get_app_counters(const std::string &app_name)

--- a/src/server/logging_utils.h
+++ b/src/server/logging_utils.h
@@ -24,14 +24,14 @@
 /// Utilities for logging the operation on rocksdb.
 
 #define derror_rocksdb(op, error, ...)                                                             \
-    derror_f("{}: rocksdb {} failed: error = {} [{}]",                                             \
-             replica_name(),                                                                       \
-             op,                                                                                   \
-             error,                                                                                \
-             fmt::format(__VA_ARGS__))
+    LOG_ERROR_F("{}: rocksdb {} failed: error = {} [{}]",                                          \
+                replica_name(),                                                                    \
+                op,                                                                                \
+                error,                                                                             \
+                fmt::format(__VA_ARGS__))
 
 #define ddebug_rocksdb(op, ...)                                                                    \
-    ddebug_f("{}: rocksdb {}: [{}]", replica_name(), op, fmt::format(__VA_ARGS__))
+    LOG_INFO_F("{}: rocksdb {}: [{}]", replica_name(), op, fmt::format(__VA_ARGS__))
 
 #define dwarn_rocksdb(op, ...)                                                                     \
-    dwarn_f("{}: rocksdb {}: [{}]", replica_name(), op, fmt::format(__VA_ARGS__))
+    LOG_WARNING_F("{}: rocksdb {}: [{}]", replica_name(), op, fmt::format(__VA_ARGS__))

--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -103,9 +103,9 @@ int pegasus_server_write::on_batched_writes(dsn::message_ex **requests, int coun
                 } else {
                     if (_non_batch_write_handlers.find(rpc_code) !=
                         _non_batch_write_handlers.end()) {
-                        dfatal_f("rpc code not allow batch: {}", rpc_code.to_string());
+                        LOG_FATAL_F("rpc code not allow batch: {}", rpc_code.to_string());
                     } else {
-                        dfatal_f("rpc code not handled: {}", rpc_code.to_string());
+                        LOG_FATAL_F("rpc code not handled: {}", rpc_code.to_string());
                     }
                 }
             } catch (TTransportException &ex) {

--- a/src/test/function_test/base_api_test/test_copy.cpp
+++ b/src/test/function_test/base_api_test/test_copy.cpp
@@ -166,14 +166,14 @@ const char copy_data_test::CCH[] =
 
 TEST_F(copy_data_test, EMPTY_HASH_KEY_COPY)
 {
-    ddebug_f("TESTING_COPY_DATA, EMPTY HASH_KEY COPY ....");
+    LOG_INFO_F("TESTING_COPY_DATA, EMPTY HASH_KEY COPY ....");
 
     pegasus_client::scan_options options;
     options.return_expire_ts = true;
     vector<pegasus::pegasus_client::pegasus_scanner *> raw_scanners;
     ASSERT_EQ(PERR_OK, srouce_client_->get_unordered_scanners(INT_MAX, options, raw_scanners));
 
-    ddebug_f("open source app scanner succeed, partition_count = {}", raw_scanners.size());
+    LOG_INFO_F("open source app scanner succeed, partition_count = {}", raw_scanners.size());
 
     vector<pegasus::pegasus_client::pegasus_scanner_wrapper> scanners;
     for (auto raw_scanner : raw_scanners) {
@@ -183,7 +183,7 @@ TEST_F(copy_data_test, EMPTY_HASH_KEY_COPY)
     raw_scanners.clear();
 
     int split_count = scanners.size();
-    ddebug_f("prepare scanners succeed, split_count = {}", split_count);
+    LOG_INFO_F("prepare scanners succeed, split_count = {}", split_count);
 
     std::atomic_bool error_occurred(false);
     vector<std::unique_ptr<scan_data_context>> contexts;

--- a/src/test/function_test/base_api_test/test_scan.cpp
+++ b/src/test/function_test/base_api_test/test_scan.cpp
@@ -138,7 +138,7 @@ public:
         }
         // 1000 + 5000 + 5000 kvs
 
-        ddebug_f("Database filled with kv count {}.", i);
+        LOG_INFO_F("Database filled with kv count {}.", i);
     }
 
 protected:
@@ -176,7 +176,7 @@ TEST_F(scan_test, OVERALL_COUNT_ONLY)
                                            << client_->get_error_string(ret);
         delete scanner;
     }
-    ddebug_f("scan count {}", i);
+    LOG_INFO_F("scan count {}", i);
     int base_data_count = 0;
     for (auto &m : expect_kvs_) {
         base_data_count += m.second.size();

--- a/src/utils/filesystem.cpp
+++ b/src/utils/filesystem.cpp
@@ -789,20 +789,20 @@ std::pair<error_code, bool> is_directory_empty(const std::string &dirname)
 error_code read_file(const std::string &fname, std::string &buf)
 {
     if (!file_exists(fname)) {
-        derror_f("file({}) doesn't exist", fname);
+        LOG_ERROR_F("file({}) doesn't exist", fname);
         return ERR_FILE_OPERATION_FAILED;
     }
 
     int64_t file_sz = 0;
     if (!file_size(fname, file_sz)) {
-        derror_f("get file({}) size failed", fname);
+        LOG_ERROR_F("get file({}) size failed", fname);
         return ERR_FILE_OPERATION_FAILED;
     }
 
     buf.resize(file_sz);
     std::ifstream fin(fname, std::ifstream::in);
     if (!fin.is_open()) {
-        derror_f("open file({}) failed", fname);
+        LOG_ERROR_F("open file({}) failed", fname);
         return ERR_FILE_OPERATION_FAILED;
     }
     fin.read(&buf[0], file_sz);
@@ -820,26 +820,26 @@ bool verify_file(const std::string &fname,
                  const int64_t &expected_fsize)
 {
     if (!file_exists(fname)) {
-        derror_f("file({}) is not existed", fname);
+        LOG_ERROR_F("file({}) is not existed", fname);
         return false;
     }
     int64_t f_size = 0;
     if (!file_size(fname, f_size)) {
-        derror_f("verify file({}) failed, becaused failed to get file size", fname);
+        LOG_ERROR_F("verify file({}) failed, becaused failed to get file size", fname);
         return false;
     }
     std::string md5;
     if (md5sum(fname, md5) != ERR_OK) {
-        derror_f("verify file({}) failed, becaused failed to get file md5", fname);
+        LOG_ERROR_F("verify file({}) failed, becaused failed to get file md5", fname);
         return false;
     }
     if (f_size != expected_fsize || md5 != expected_md5) {
-        derror_f("verify file({}) failed, because file damaged, size: {} VS {}, md5: {} VS {}",
-                 fname,
-                 f_size,
-                 expected_fsize,
-                 md5,
-                 expected_md5);
+        LOG_ERROR_F("verify file({}) failed, because file damaged, size: {} VS {}, md5: {} VS {}",
+                    fname,
+                    f_size,
+                    expected_fsize,
+                    md5,
+                    expected_md5);
         return false;
     }
     return true;
@@ -848,19 +848,19 @@ bool verify_file(const std::string &fname,
 bool verify_file_size(const std::string &fname, const int64_t &expected_fsize)
 {
     if (!file_exists(fname)) {
-        derror_f("file({}) is not existed", fname);
+        LOG_ERROR_F("file({}) is not existed", fname);
         return false;
     }
     int64_t f_size = 0;
     if (!file_size(fname, f_size)) {
-        derror_f("verify file({}) size failed, becaused failed to get file size", fname);
+        LOG_ERROR_F("verify file({}) size failed, becaused failed to get file size", fname);
         return false;
     }
     if (f_size != expected_fsize) {
-        derror_f("verify file({}) size failed, because file damaged, size: {} VS {}",
-                 fname,
-                 f_size,
-                 expected_fsize);
+        LOG_ERROR_F("verify file({}) size failed, because file damaged, size: {} VS {}",
+                    fname,
+                    f_size,
+                    expected_fsize);
         return false;
     }
     return true;
@@ -873,10 +873,10 @@ bool verify_data_md5(const std::string &fname,
 {
     std::string md5 = string_md5(data, data_size);
     if (md5 != expected_md5) {
-        derror_f("verify data({}) failed, because data damaged, size: md5: {} VS {}",
-                 fname,
-                 md5,
-                 expected_md5);
+        LOG_ERROR_F("verify data({}) failed, because data damaged, size: md5: {} VS {}",
+                    fname,
+                    md5,
+                    expected_md5);
         return false;
     }
     return true;
@@ -906,7 +906,7 @@ bool create_directory(const std::string &path, std::string &absolute_path, std::
 bool write_file(const std::string &fname, std::string &buf)
 {
     if (!file_exists(fname)) {
-        derror_f("file({}) doesn't exist", fname);
+        LOG_ERROR_F("file({}) doesn't exist", fname);
         return false;
     }
 

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -31,13 +31,12 @@
             dsn_log(                                                                               \
                 __FILENAME__, __FUNCTION__, __LINE__, level, fmt::format(__VA_ARGS__).c_str());    \
     } while (false)
-// TODO(yingchun): to reduce the changes in one patch, now log levels using 'fmt' are left and will
-// be refactored in a follow up patch.
-#define dinfo_f(...) dlog_f(LOG_LEVEL_DEBUG, __VA_ARGS__)
-#define ddebug_f(...) dlog_f(LOG_LEVEL_INFO, __VA_ARGS__)
-#define dwarn_f(...) dlog_f(LOG_LEVEL_WARNING, __VA_ARGS__)
-#define derror_f(...) dlog_f(LOG_LEVEL_ERROR, __VA_ARGS__)
-#define dfatal_f(...) dlog_f(LOG_LEVEL_FATAL, __VA_ARGS__)
+
+#define LOG_DEBUG_F(...) dlog_f(LOG_LEVEL_DEBUG, __VA_ARGS__)
+#define LOG_INFO_F(...) dlog_f(LOG_LEVEL_INFO, __VA_ARGS__)
+#define LOG_WARNING_F(...) dlog_f(LOG_LEVEL_WARNING, __VA_ARGS__)
+#define LOG_ERROR_F(...) dlog_f(LOG_LEVEL_ERROR, __VA_ARGS__)
+#define LOG_FATAL_F(...) dlog_f(LOG_LEVEL_FATAL, __VA_ARGS__)
 #define dassert_f(x, ...)                                                                          \
     do {                                                                                           \
         if (dsn_unlikely(!(x))) {                                                                  \
@@ -48,11 +47,11 @@
     } while (false)
 
 // Macros for writing log message prefixed by gpid and address.
-#define dinfo_replica(...) dinfo_f("[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
-#define ddebug_replica(...) ddebug_f("[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
-#define dwarn_replica(...) dwarn_f("[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
-#define derror_replica(...) derror_f("[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
-#define dfatal_replica(...) dfatal_f("[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
+#define dinfo_replica(...) LOG_DEBUG_F("[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
+#define ddebug_replica(...) LOG_INFO_F("[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
+#define dwarn_replica(...) LOG_WARNING_F("[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
+#define derror_replica(...) LOG_ERROR_F("[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
+#define dfatal_replica(...) LOG_FATAL_F("[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
 #define dassert_replica(x, ...) dassert_f(x, "[{}] {}", replica_name(), fmt::format(__VA_ARGS__))
 
 // Macros to check expected condition. It will abort the application
@@ -73,7 +72,7 @@
 #define ERR_LOG_AND_RETURN_NOT_TRUE(s, err, ...)                                                   \
     do {                                                                                           \
         if (dsn_unlikely(!(s))) {                                                                  \
-            derror_f("{}: {}", err, fmt::format(__VA_ARGS__));                                     \
+            LOG_ERROR_F("{}: {}", err, fmt::format(__VA_ARGS__));                                  \
             return err;                                                                            \
         }                                                                                          \
     } while (0)

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -204,7 +204,7 @@ std::shared_ptr<latency_tracer> latency_tracer::sub_tracer(const std::string &na
     if (iter != _sub_tracers.end()) {
         return iter->second;
     }
-    dwarn_f("can't find the [{}] sub tracer of {}", name, _name);
+    LOG_WARNING_F("can't find the [{}] sub tracer of {}", name, _name);
     return nullptr;
 }
 
@@ -276,7 +276,7 @@ void latency_tracer::dump_trace_points(/*out*/ std::string &traces)
     }
 
     if (!_is_sub && total_time_used >= _threshold) {
-        dwarn_f("TRACE:the traces as fallow:\n{}", traces);
+        LOG_WARNING_F("TRACE:the traces as fallow:\n{}", traces);
         return;
     }
 }


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1199

This patch continue to refactor logging macros, including:
- rename `d*_f` macros as following:
  - `dinfo_f` -> `LOG_DEBUG_F` (yes, adjust from info to debug)
  - `ddebug_f` -> `LOG_INFO_F` (yes, adjust from debug to info)
  - `dwarn_f` -> `LOG_WARNING_F`
  - `derror_f` -> `LOG_ERROR_F`
  - `dfatal_f` -> `LOG_FATAL_F`
- update all the places where use `d*_f` macros

There are too many files changed, reviewers could pay more attend on files:
- src/utils/fmt_logging.h
- src/meta/duplication/duplication_info.h
- src/server/logging_utils.h

**TODO**:
1. `d*_replica` macros are left (e.g. `dinfo_replica`, `ddebug_replica`)
2. `d*_rocksdb` macros are left
3. `d*_dup` macros are left
