### PR TITLE
refactor(macro): use CHECK_* to replace dassert_*

### DIFF
--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -125,7 +125,7 @@ aio_task *disk_file::on_write_completed(aio_task *wk, void *ctx, error_code err,
 
         if (err == ERR_OK) {
             size_t this_size = (size_t)wk->get_aio_context()->buffer_size;
-            dcheck_ge(size, this_size);
+            CHECK_GE(size, this_size);
             wk->enqueue(err, this_size);
             size -= this_size;
         } else {

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -422,7 +422,7 @@ void replication_options::sanity_check()
 
 int32_t replication_options::app_mutation_2pc_min_replica_count(int32_t app_max_replica_count) const
 {
-    dcheck_gt(app_max_replica_count, 0);
+    CHECK_GT(app_max_replica_count, 0);
     if (mutation_2pc_min_replica_count > 0) { //  >0 means use the user config
         return mutation_2pc_min_replica_count;
     } else { // otherwise, the value based on the table max_replica_count

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -95,7 +95,7 @@ void ship_mutation::update_progress()
 
     // committed decree never decreases
     decree last_committed_decree = _replica->last_committed_decree();
-    dcheck_ge_replica(last_committed_decree, _last_decree);
+    CHECK_GE_PREFIX(last_committed_decree, _last_decree);
 }
 
 ship_mutation::ship_mutation(replica_duplicator *duplicator)

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -78,7 +78,7 @@ void mutation_buffer::commit(decree d, commit_type ct)
             return;
         }
 
-        dcheck_ge_replica(next_committed_mutation->data.header.ballot, last_bt);
+        CHECK_GE_PREFIX(next_committed_mutation->data.header.ballot, last_bt);
         _last_committed_decree++;
         last_bt = next_committed_mutation->data.header.ballot;
         _committer(next_committed_mutation);

--- a/src/replica/log_file.cpp
+++ b/src/replica/log_file.cpp
@@ -263,7 +263,7 @@ aio_task_ptr log_file::commit_log_blocks(log_appender &pending,
                                          int hash)
 {
     dassert(!_is_read, "log file must be of write mode");
-    dcheck_gt(pending.size(), 0);
+    CHECK_GT(pending.size(), 0);
 
     zauto_lock lock(_write_lock);
     if (!_handle) {

--- a/src/replica/prepare_list.cpp
+++ b/src/replica/prepare_list.cpp
@@ -74,7 +74,7 @@ error_code prepare_list::prepare(mutation_ptr &mu,
                                  bool secondary_commit)
 {
     decree d = mu->data.header.decree;
-    dcheck_gt_replica(d, last_committed_decree());
+    CHECK_GT_PREFIX(d, last_committed_decree());
 
     ADD_POINT(mu->_tracer);
     error_code err;
@@ -156,7 +156,7 @@ void prepare_list::commit(decree d, commit_type ct)
 
             dassert_replica(
                 mu != nullptr && mu->is_logged(), "mutation {} is missing in prepare list", d0);
-            dcheck_ge_replica(mu->data.header.ballot, last_bt);
+            CHECK_GE_PREFIX(mu->data.header.ballot, last_bt);
 
             _last_committed_decree++;
             last_bt = mu->data.header.ballot;

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -267,7 +267,7 @@ decree replica::get_max_gced_decree_for_learn() const // on learner
 decree replica::get_learn_start_decree(const learn_request &request) // on primary
 {
     decree local_committed_decree = last_committed_decree();
-    dcheck_le_replica(request.last_committed_decree_in_app, local_committed_decree);
+    CHECK_LE_PREFIX(request.last_committed_decree_in_app, local_committed_decree);
 
     decree learn_start_decree_no_dup = request.last_committed_decree_in_app + 1;
     if (!is_duplication_master()) {
@@ -319,8 +319,8 @@ decree replica::get_learn_start_decree(const learn_request &request) // on prima
                             request.max_gced_decree);
         }
     }
-    dcheck_le_replica(learn_start_decree, local_committed_decree + 1);
-    dcheck_gt_replica(learn_start_decree, 0); // learn_start_decree can never be invalid_decree
+    CHECK_LE_PREFIX(learn_start_decree, local_committed_decree + 1);
+    CHECK_GT_PREFIX(learn_start_decree, 0); // learn_start_decree can never be invalid_decree
     return learn_start_decree;
 }
 

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -371,7 +371,7 @@ error_code replication_app_base::apply_mutation(const mutation *mu)
 
     CHECK_EQ_PREFIX(mu->data.header.decree, last_committed_decree() + 1);
     CHECK_EQ_PREFIX(mu->data.updates.size(), mu->client_requests.size());
-    dcheck_gt_replica(mu->data.updates.size(), 0);
+    CHECK_GT_PREFIX(mu->data.updates.size(), 0);
 
     if (_replica->status() == partition_status::PS_PRIMARY) {
         ADD_POINT(mu->_tracer);

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -239,8 +239,8 @@ void replica_split_manager::parent_prepare_states(const std::string &dir) // on 
     plist->truncate(last_committed_decree());
 
     CHECK_EQ(last_committed_decree(), checkpoint_decree);
-    dcheck_ge(mutation_list.size(), 0);
-    dcheck_ge(files.size(), 0);
+    CHECK_GE(mutation_list.size(), 0);
+    CHECK_GE(files.size(), 0);
     LOG_INFO_PREFIX("prepare state succeed: {} mutations, {} private log files, total file size = "
                     "{}, last_committed_decree = {}",
                     mutation_list.size(),
@@ -1037,7 +1037,7 @@ void replica_split_manager::on_register_child_on_meta_reply(
                     get_ballot(),
                     enum_to_string(status()));
 
-    dcheck_ge_replica(response.parent_config.ballot, get_ballot());
+    CHECK_GE_PREFIX(response.parent_config.ballot, get_ballot());
     CHECK_EQ_PREFIX(_replica->_app_info.partition_count * 2, response.app.partition_count);
 
     _stub->split_replica_exec(LPC_PARTITION_SPLIT,

--- a/src/reporter/pegasus_counter_reporter.cpp
+++ b/src/reporter/pegasus_counter_reporter.cpp
@@ -246,7 +246,7 @@ void pegasus_counter_reporter::update()
             if (lv.size() > 1) {
                 std::list<std::string> lv1;
                 ::dsn::utils::split_args(lv.back().c_str(), lv1, '.');
-                dcheck_le(lv1.size(), 3);
+                CHECK_LE(lv1.size(), 3);
                 int i = 0;
                 for (auto &v : lv1) {
                     app[i] = v;

--- a/src/runtime/task/task_spec.cpp
+++ b/src/runtime/task/task_spec.cpp
@@ -51,8 +51,8 @@ void task_spec::register_task_code(task_code code,
                                    dsn_task_priority_t pri,
                                    dsn::threadpool_code pool)
 {
-    dcheck_ge(code, 0);
-    dcheck_lt(code, TASK_SPEC_STORE_CAPACITY);
+    CHECK_GE(code, 0);
+    CHECK_LT(code, TASK_SPEC_STORE_CAPACITY);
     if (!s_task_spec_store[code]) {
         s_task_spec_store[code] = make_unique<task_spec>(code, code.to_string(), type, pri, pool);
         auto &spec = s_task_spec_store[code];
@@ -121,8 +121,8 @@ void task_spec::register_storage_task_code(task_code code,
 
 task_spec *task_spec::get(int code)
 {
-    dcheck_ge(code, 0);
-    dcheck_lt(code, TASK_SPEC_STORE_CAPACITY);
+    CHECK_GE(code, 0);
+    CHECK_LT(code, TASK_SPEC_STORE_CAPACITY);
     return s_task_spec_store[code].get();
 }
 

--- a/src/server/hotkey_collector.cpp
+++ b/src/server/hotkey_collector.cpp
@@ -71,7 +71,7 @@ DSN_TAG_VARIABLE(max_seconds_to_detect_hotkey, FT_MUTABLE);
 /*extern*/ bool
 find_outlier_index(const std::vector<uint64_t> &captured_keys, int threshold, int &hot_index)
 {
-    dcheck_gt(captured_keys.size(), 2);
+    CHECK_GT(captured_keys.size(), 2);
     int data_size = captured_keys.size();
     // empirical rule to calculate hot point of each partition
     // same algorithm as hotspot_partition_calculator::stat_histories_analyse

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1860,7 +1860,7 @@ private:
 
     int64_t last_durable = last_durable_decree();
     int64_t last_commit = last_committed_decree();
-    dcheck_le_replica(last_durable, last_commit);
+    CHECK_LE_PREFIX(last_durable, last_commit);
 
     // case 1: last_durable == last_commit
     // no need to do checkpoint
@@ -1911,11 +1911,11 @@ private:
 
     {
         ::dsn::utils::auto_lock<::dsn::utils::ex_lock_nr> l(_checkpoints_lock);
-        dcheck_gt_replica(last_commit, last_durable_decree());
+        CHECK_GT_PREFIX(last_commit, last_durable_decree());
         int64_t last_flushed = static_cast<int64_t>(_meta_store->get_last_flushed_decree());
         CHECK_EQ_PREFIX(last_commit, last_flushed);
         if (!_checkpoints.empty()) {
-            dcheck_gt_replica(last_commit, _checkpoints.back());
+            CHECK_GT_PREFIX(last_commit, _checkpoints.back());
         }
         _checkpoints.push_back(last_commit);
         set_last_durable_decree(_checkpoints.back());
@@ -1940,8 +1940,8 @@ private:
     int64_t last_flushed = static_cast<int64_t>(_meta_store->get_last_flushed_decree());
     int64_t last_commit = last_committed_decree();
 
-    dcheck_le_replica(last_durable, last_flushed);
-    dcheck_le_replica(last_flushed, last_commit);
+    CHECK_LE_PREFIX(last_durable, last_flushed);
+    CHECK_LE_PREFIX(last_flushed, last_commit);
 
     // case 1: last_durable == last_flushed == last_commit
     // no need to do checkpoint
@@ -1957,7 +1957,7 @@ private:
     // case 2: last_durable == last_flushed < last_commit
     // no need to do checkpoint, but need to flush memtable if required
     if (last_durable == last_flushed) {
-        dcheck_lt_replica(last_flushed, last_commit);
+        CHECK_LT_PREFIX(last_flushed, last_commit);
         if (!flush_memtable) {
             // no flush required
             return ::dsn::ERR_OK;
@@ -1975,7 +1975,7 @@ private:
 
     // case 3: last_durable < last_flushed <= last_commit
     // need to do checkpoint
-    dcheck_lt_replica(last_durable, last_flushed);
+    CHECK_LT_PREFIX(last_durable, last_flushed);
 
     std::string tmp_dir = ::dsn::utils::filesystem::path_combine(
         data_dir(), std::string("checkpoint.tmp.") + std::to_string(dsn_now_us()));
@@ -2020,9 +2020,9 @@ private:
 
     {
         ::dsn::utils::auto_lock<::dsn::utils::ex_lock_nr> l(_checkpoints_lock);
-        dcheck_gt_replica(checkpoint_decree, last_durable_decree());
+        CHECK_GT_PREFIX(checkpoint_decree, last_durable_decree());
         if (!_checkpoints.empty()) {
-            dcheck_gt_replica(checkpoint_decree, _checkpoints.back());
+            CHECK_GT_PREFIX(checkpoint_decree, _checkpoints.back());
         }
         _checkpoints.push_back(checkpoint_decree);
         set_last_durable_decree(_checkpoints.back());

--- a/src/utils/endians.h
+++ b/src/utils/endians.h
@@ -148,7 +148,7 @@ private:
         _size -= sz;
     }
 
-    void ensure(size_t sz) { dcheck_ge(_size, sz); }
+    void ensure(size_t sz) { CHECK_GE(_size, sz); }
 
 private:
     const char *_p{nullptr};

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -60,16 +60,16 @@
 // Macros to check expected condition. It will abort the application
 // and log a fatal message when the condition is not met.
 #define CHECK_EQ(var1, var2) CHECK(var1 == var2, "{} vs {}", var1, var2)
-#define dcheck_ge(var1, var2) CHECK(var1 >= var2, "{} vs {}", var1, var2)
-#define dcheck_le(var1, var2) CHECK(var1 <= var2, "{} vs {}", var1, var2)
-#define dcheck_gt(var1, var2) CHECK(var1 > var2, "{} vs {}", var1, var2)
-#define dcheck_lt(var1, var2) CHECK(var1 < var2, "{} vs {}", var1, var2)
+#define CHECK_GE(var1, var2) CHECK(var1 >= var2, "{} vs {}", var1, var2)
+#define CHECK_LE(var1, var2) CHECK(var1 <= var2, "{} vs {}", var1, var2)
+#define CHECK_GT(var1, var2) CHECK(var1 > var2, "{} vs {}", var1, var2)
+#define CHECK_LT(var1, var2) CHECK(var1 < var2, "{} vs {}", var1, var2)
 
 #define CHECK_EQ_PREFIX(var1, var2) dassert_replica(var1 == var2, "{} vs {}", var1, var2)
-#define dcheck_ge_replica(var1, var2) dassert_replica(var1 >= var2, "{} vs {}", var1, var2)
-#define dcheck_le_replica(var1, var2) dassert_replica(var1 <= var2, "{} vs {}", var1, var2)
-#define dcheck_gt_replica(var1, var2) dassert_replica(var1 > var2, "{} vs {}", var1, var2)
-#define dcheck_lt_replica(var1, var2) dassert_replica(var1 < var2, "{} vs {}", var1, var2)
+#define CHECK_GE_PREFIX(var1, var2) dassert_replica(var1 >= var2, "{} vs {}", var1, var2)
+#define CHECK_LE_PREFIX(var1, var2) dassert_replica(var1 <= var2, "{} vs {}", var1, var2)
+#define CHECK_GT_PREFIX(var1, var2) dassert_replica(var1 > var2, "{} vs {}", var1, var2)
+#define CHECK_LT_PREFIX(var1, var2) dassert_replica(var1 < var2, "{} vs {}", var1, var2)
 
 // Return the given status if condition is not true.
 #define ERR_LOG_AND_RETURN_NOT_TRUE(s, err, ...)                                                   \

--- a/src/utils/je_ctl.cpp
+++ b/src/utils/je_ctl.cpp
@@ -31,7 +31,7 @@
 #define RETURN_ARRAY_ELEM_BY_ENUM_TYPE(type, array)                                                \
     do {                                                                                           \
         const auto index = static_cast<size_t>(type);                                              \
-        dcheck_lt(index, sizeof(array) / sizeof(array[0]));                                        \
+        CHECK_LT(index, sizeof(array) / sizeof(array[0]));                                         \
         return array[index];                                                                       \
     } while (0);
 

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -179,7 +179,7 @@ closeable_metric::closeable_metric(const metric_prototype *prototype) : metric(p
 
 uint64_t percentile_timer::generate_initial_delay_ms(uint64_t interval_ms)
 {
-    dcheck_gt(interval_ms, 0);
+    CHECK_GT(interval_ms, 0);
 
     if (interval_ms < 1000) {
         return rand::next_u64() % interval_ms + 50;

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -660,7 +660,7 @@ public:
     bool get(kth_percentile_type type, value_type &val) const
     {
         const auto index = static_cast<size_t>(type);
-        dcheck_lt(index, static_cast<size_t>(kth_percentile_type::COUNT));
+        CHECK_LT(index, static_cast<size_t>(kth_percentile_type::COUNT));
 
         val = _full_nth_elements[index].load(std::memory_order_relaxed);
         return _kth_percentile_bitset.test(index);
@@ -712,7 +712,7 @@ protected:
             return;
         }
 #else
-        dcheck_gt(interval_ms, 0);
+        CHECK_GT(interval_ms, 0);
 #endif
 
         // Increment ref count of percentile, since it will be referenced by timer.


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1204

- `dcheck_ge` -> `CHECK_GE`
- `dcheck_le` -> `CHECK_LE`
- `dcheck_gt` -> `CHECK_GT`
- `dcheck_lt` -> `CHECK_LT`
- `dcheck_ge_replica` -> `CHECK_GE_PREFIX`
- `dcheck_le_replica` -> `CHECK_LE_PREFIX`
- `dcheck_gt_replica` -> `CHECK_GT_PREFIX`
- `dcheck_lt_replica` -> `CHECK_LT_PREFIX`