### PR TITLE
refactor(macro): use CHECK_* to replace dassert_* (part 2)

### DIFF
--- a/src/aio/aio_task.cpp
+++ b/src/aio/aio_task.cpp
@@ -32,9 +32,10 @@ aio_task::aio_task(dsn::task_code code, aio_handler &&cb, int hash, service_node
 {
     _is_null = (_cb == nullptr);
 
-    dassert_f(TASK_TYPE_AIO == spec().type,
-              "{} is not of AIO type, please use DEFINE_TASK_CODE_AIO to define the task code",
-              spec().name);
+    CHECK_EQ_MSG(TASK_TYPE_AIO,
+                 spec().type,
+                 "{} is not of AIO type, please use DEFINE_TASK_CODE_AIO to define the task code",
+                 spec().name);
     set_error_code(ERR_IO_PENDING);
 
     _aio_ctx = file::prepare_aio_context(this);

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -107,7 +107,7 @@ aio_task *disk_file::write(aio_task *tsk, void *ctx)
 
 aio_task *disk_file::on_read_completed(aio_task *wk, error_code err, size_t size)
 {
-    dassert(wk->next == nullptr, "");
+    CHECK(wk->next == nullptr, "");
     auto ret = _read_queue.on_work_completed(wk, nullptr);
     wk->enqueue(err, size);
     wk->release_ref(); // added in above read
@@ -138,7 +138,7 @@ aio_task *disk_file::on_write_completed(aio_task *wk, void *ctx, error_code err,
     }
 
     if (err == ERR_OK) {
-        dassert(size == 0, "written buffer size does not equal to input buffer's size");
+        CHECK_EQ_MSG(size, 0, "written buffer size does not equal to input buffer's size");
     }
 
     return ret;

--- a/src/base/pegasus_value_schema.h
+++ b/src/base/pegasus_value_schema.h
@@ -61,11 +61,7 @@ inline uint64_t extract_timestamp_from_timetag(uint64_t timetag)
 /// \return expire_ts in host endian
 inline uint32_t pegasus_extract_expire_ts(uint32_t version, dsn::string_view value)
 {
-    dassert_f(version <= PEGASUS_DATA_VERSION_MAX,
-              "data version({}) must be <= {}",
-              version,
-              PEGASUS_DATA_VERSION_MAX);
-
+    CHECK_LE(version, PEGASUS_DATA_VERSION_MAX);
     return dsn::data_input(value).read_u32();
 }
 
@@ -76,10 +72,7 @@ inline uint32_t pegasus_extract_expire_ts(uint32_t version, dsn::string_view val
 inline void
 pegasus_extract_user_data(uint32_t version, std::string &&raw_value, ::dsn::blob &user_data)
 {
-    dassert_f(version <= PEGASUS_DATA_VERSION_MAX,
-              "data version({}) must be <= {}",
-              version,
-              PEGASUS_DATA_VERSION_MAX);
+    CHECK_LE(version, PEGASUS_DATA_VERSION_MAX);
 
     auto *s = new std::string(std::move(raw_value));
     dsn::data_input input(*s);
@@ -110,7 +103,7 @@ inline uint64_t pegasus_extract_timetag(int version, dsn::string_view value)
 inline void pegasus_update_expire_ts(uint32_t version, std::string &value, uint32_t new_expire_ts)
 {
     if (version == 0 || version == 1) {
-        dassert_f(value.length() >= sizeof(uint32_t), "value must include 'expire_ts' header");
+        CHECK_GE_MSG(value.length(), sizeof(uint32_t), "value must include 'expire_ts' header");
 
         new_expire_ts = dsn::endian::hton(new_expire_ts);
         memcpy(const_cast<char *>(value.data()), &new_expire_ts, sizeof(uint32_t));

--- a/src/base/value_schema_v0.cpp
+++ b/src/base/value_schema_v0.cpp
@@ -86,7 +86,7 @@ std::unique_ptr<value_field> value_schema_v0::extract_timestamp(dsn::string_view
 
 void value_schema_v0::update_expire_ts(std::string &value, std::unique_ptr<value_field> field)
 {
-    dassert_f(value.length() >= sizeof(uint32_t), "value must include 'expire_ts' header");
+    CHECK_GE_MSG(value.length(), sizeof(uint32_t), "value must include 'expire_ts' header");
     auto expire_field = static_cast<expire_timestamp_field *>(field.get());
 
     auto new_expire_ts = dsn::endian::hton(expire_field->expire_ts);

--- a/src/base/value_schema_v1.cpp
+++ b/src/base/value_schema_v1.cpp
@@ -103,7 +103,7 @@ std::unique_ptr<value_field> value_schema_v1::extract_time_tag(dsn::string_view 
 
 void value_schema_v1::update_expire_ts(std::string &value, std::unique_ptr<value_field> field)
 {
-    dassert_f(value.length() >= sizeof(uint32_t), "value must include 'expire_ts' header");
+    CHECK_GE_MSG(value.length(), sizeof(uint32_t), "value must include 'expire_ts' header");
     auto expire_field = static_cast<expire_timestamp_field *>(field.get());
 
     auto new_expire_ts = dsn::endian::hton(expire_field->expire_ts);

--- a/src/base/value_schema_v2.cpp
+++ b/src/base/value_schema_v2.cpp
@@ -108,8 +108,9 @@ std::unique_ptr<value_field> value_schema_v2::extract_time_tag(dsn::string_view 
 
 void value_schema_v2::update_expire_ts(std::string &value, std::unique_ptr<value_field> field)
 {
-    dassert_f(value.length() >= sizeof(uint32_t) + sizeof(uint8_t),
-              "value must include 'expire_ts' header");
+    CHECK_GE_MSG(value.length(),
+                 sizeof(uint32_t) + sizeof(uint8_t),
+                 "value must include 'expire_ts' header");
     auto expire_field = static_cast<expire_timestamp_field *>(field.get());
 
     auto new_expire_ts = dsn::endian::hton(expire_field->expire_ts);

--- a/src/block_service/directio_writable_file.cpp
+++ b/src/block_service/directio_writable_file.cpp
@@ -63,7 +63,7 @@ direct_io_writable_file::~direct_io_writable_file()
         return;
     }
     // Here is an ensurance, users shuold call finalize manually
-    dassert(_offset == 0, "finalize() should be called before destructor");
+    CHECK_EQ_MSG(_offset, 0, "finalize() should be called before destructor");
 
     free(_buffer);
     close(_fd);
@@ -92,7 +92,7 @@ bool direct_io_writable_file::initialize()
 
 bool direct_io_writable_file::finalize()
 {
-    dassert(_buffer && _fd >= 0, "Initialize the instance first");
+    CHECK(_buffer && _fd >= 0, "Initialize the instance first");
 
     if (_offset > 0) {
         if (::write(_fd, _buffer, _buffer_size) != _buffer_size) {
@@ -108,7 +108,7 @@ bool direct_io_writable_file::finalize()
 
 bool direct_io_writable_file::write(const char *s, size_t n)
 {
-    dassert(_buffer && _fd >= 0, "Initialize the instance first");
+    CHECK(_buffer && _fd >= 0, "Initialize the instance first");
 
     uint32_t remaining = n;
     while (remaining > 0) {

--- a/src/client_lib/pegasus_client_impl.cpp
+++ b/src/client_lib/pegasus_client_impl.cpp
@@ -50,7 +50,7 @@ pegasus_client_impl::pegasus_client_impl(const char *cluster_name, const char *a
     std::vector<dsn::rpc_address> meta_servers;
     dsn::replication::replica_helper::load_meta_servers(
         meta_servers, PEGASUS_CLUSTER_SECTION_NAME.c_str(), cluster_name);
-    dassert(meta_servers.size() > 0, "");
+    CHECK_GT(meta_servers.size(), 0);
     _meta_server.assign_group("meta-servers");
     _meta_server.group_address()->add_list(meta_servers);
 

--- a/src/common/duplication_common.cpp
+++ b/src/common/duplication_common.cpp
@@ -99,7 +99,7 @@ private:
             CHECK(cluster_id < 128 && cluster_id > 0,
                   "cluster_id({}) for {} should be in [1, 127]",
                   cluster_id,
-                  cluster.data());
+                  cluster);
             _group.emplace(cluster, static_cast<uint8_t>(cluster_id));
         }
         CHECK_EQ_MSG(clusters.size(),

--- a/src/common/duplication_common.cpp
+++ b/src/common/duplication_common.cpp
@@ -96,20 +96,22 @@ private:
         for (std::string &cluster : clusters) {
             int64_t cluster_id =
                 dsn_config_get_value_int64("duplication-group", cluster.data(), 0, "");
-            dassert(cluster_id < 128 && cluster_id > 0,
-                    "cluster_id(%zd) for %s should be in [1, 127]",
-                    cluster_id,
-                    cluster.data());
+            CHECK(cluster_id < 128 && cluster_id > 0,
+                  "cluster_id({}) for {} should be in [1, 127]",
+                  cluster_id,
+                  cluster.data());
             _group.emplace(cluster, static_cast<uint8_t>(cluster_id));
         }
-        dassert_f(clusters.size() == _group.size(),
-                  "there might be duplicate cluster_name in configuration");
+        CHECK_EQ_MSG(clusters.size(),
+                     _group.size(),
+                     "there might be duplicate cluster_name in configuration");
 
         for (const auto &kv : _group) {
             _distinct_cids.insert(kv.second);
         }
-        dassert_f(_distinct_cids.size() == _group.size(),
-                  "there might be duplicate cluster_id in configuration");
+        CHECK_EQ_MSG(_distinct_cids.size(),
+                     _group.size(),
+                     "there might be duplicate cluster_id in configuration");
     }
     ~duplication_group_registry() = default;
 

--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -281,11 +281,11 @@ void fs_manager::remove_replica(const gpid &pid)
     unsigned remove_count = 0;
     for (auto &n : _dir_nodes) {
         unsigned r = n->remove(pid);
-        dassert(remove_count + r <= 1,
-                "gpid(%d.%d) found in dir(%s), which was removed before",
-                pid.get_app_id(),
-                pid.get_partition_index(),
-                n->tag.c_str());
+        CHECK_LE_MSG(remove_count + r,
+                     1,
+                     "gpid({}) found in dir({}), which was removed before",
+                     pid,
+                     n->tag);
         if (r != 0) {
             LOG_INFO("%s: remove gpid(%d.%d) from dir(%s)",
                      dsn_primary_address().to_string(),

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -414,10 +414,7 @@ void replication_options::initialize()
 
 void replication_options::sanity_check()
 {
-    dassert(max_mutation_count_in_prepare_list >= staleness_for_commit,
-            "%d VS %d",
-            max_mutation_count_in_prepare_list,
-            staleness_for_commit);
+    CHECK_GE(max_mutation_count_in_prepare_list, staleness_for_commit);
 }
 
 int32_t replication_options::app_mutation_2pc_min_replica_count(int32_t app_max_replica_count) const
@@ -478,11 +475,12 @@ bool replica_helper::load_meta_servers(/*out*/ std::vector<dsn::rpc_address> &se
         std::vector<std::string> hostname_port;
         uint32_t ip = 0;
         utils::split_args(s.c_str(), hostname_port, ':');
-        dassert_f(2 == hostname_port.size(),
-                  "invalid address '{}' specified in config [{}].{}",
-                  s.c_str(),
-                  section,
-                  key);
+        CHECK_EQ_MSG(2,
+                     hostname_port.size(),
+                     "invalid address '{}' specified in config [{}].{}",
+                     s,
+                     section,
+                     key);
         uint32_t port_num = 0;
         CHECK(dsn::internal::buf2unsigned(hostname_port[1], port_num) && port_num < UINT16_MAX,
               "invalid address '{}' specified in config [{}].{}",

--- a/src/common/serialization_helper/thrift_helper.h
+++ b/src/common/serialization_helper/thrift_helper.h
@@ -188,8 +188,8 @@ inline uint32_t rpc_address::read(apache::thrift::protocol::TProtocol *iprot)
     if (binary_proto != nullptr) {
         // the protocol is binary protocol
         auto r = iprot->readI64(reinterpret_cast<int64_t &>(_addr.value));
-        dassert(_addr.v4.type == HOST_TYPE_INVALID || _addr.v4.type == HOST_TYPE_IPV4,
-                "only invalid or ipv4 can be deserialized from binary");
+        CHECK(_addr.v4.type == HOST_TYPE_INVALID || _addr.v4.type == HOST_TYPE_IPV4,
+              "only invalid or ipv4 can be deserialized from binary");
         return r;
     } else {
         // the protocol is json protocol
@@ -247,8 +247,8 @@ inline uint32_t rpc_address::write(apache::thrift::protocol::TProtocol *oprot) c
         dynamic_cast<apache::thrift::protocol::TBinaryProtocol *>(oprot);
     if (binary_proto != nullptr) {
         // the protocol is binary protocol
-        dassert(_addr.v4.type == HOST_TYPE_INVALID || _addr.v4.type == HOST_TYPE_IPV4,
-                "only invalid or ipv4 can be serialized to binary");
+        CHECK(_addr.v4.type == HOST_TYPE_INVALID || _addr.v4.type == HOST_TYPE_IPV4,
+              "only invalid or ipv4 can be serialized to binary");
         return oprot->writeI64((int64_t)_addr.value);
     } else {
         // the protocol is json protocol

--- a/src/common/storage_serverlet.h
+++ b/src/common/storage_serverlet.h
@@ -107,7 +107,7 @@ protected:
         s_vhandlers.resize(rpc_code + 1);
         CHECK(s_vhandlers[rpc_code] == nullptr,
               "handler {}({}) has already been registered",
-              rpc_code.to_string(),
+              rpc_code,
               rpc_code.code());
         s_vhandlers[rpc_code] = h;
         return true;

--- a/src/common/storage_serverlet.h
+++ b/src/common/storage_serverlet.h
@@ -105,10 +105,10 @@ protected:
         dassert(s_handlers.emplace(name, h).second, "handler %s has already been registered", name);
 
         s_vhandlers.resize(rpc_code + 1);
-        dassert(s_vhandlers[rpc_code] == nullptr,
-                "handler %s(%d) has already been registered",
-                rpc_code.to_string(),
-                rpc_code.code());
+        CHECK(s_vhandlers[rpc_code] == nullptr,
+              "handler {}({}) has already been registered",
+              rpc_code.to_string(),
+              rpc_code.code());
         s_vhandlers[rpc_code] = h;
         return true;
     }

--- a/src/failure_detector/failure_detector_multimaster.cpp
+++ b/src/failure_detector/failure_detector_multimaster.cpp
@@ -85,10 +85,7 @@ void slave_failure_detector_with_multimaster::end_ping(::dsn::error_code err,
     if (!failure_detector::end_ping_internal(err, ack))
         return;
 
-    dassert(ack.this_node == _meta_servers.group_address()->leader(),
-            "ack.this_node[%s] vs meta_servers.leader[%s]",
-            ack.this_node.to_string(),
-            _meta_servers.group_address()->leader().to_string());
+    CHECK_EQ(ack.this_node, _meta_servers.group_address()->leader());
 
     if (ERR_OK != err) {
         rpc_address next = _meta_servers.group_address()->next(ack.this_node);

--- a/src/geo/lib/geo_client.cpp
+++ b/src/geo/lib/geo_client.cpp
@@ -81,10 +81,7 @@ geo_client::geo_client(const char *config_file,
     _max_level = (int32_t)dsn_config_get_value_uint64(
         "geo_client.lib", "max_level", 16, "max cell level for scan");
 
-    dassert_f(_min_level < _max_level,
-              "_min_level({}) must be less than _max_level({})",
-              _min_level,
-              _max_level);
+    CHECK_LT(_min_level, _max_level);
 
     uint32_t latitude_index = (uint32_t)dsn_config_get_value_uint64(
         "geo_client.lib", "latitude_index", 5, "latitude index in value");

--- a/src/http/http_message_parser.cpp
+++ b/src/http/http_message_parser.cpp
@@ -215,7 +215,7 @@ void http_message_parser::prepare_on_send(message_ex *msg)
     int dsn_buf_count = 0;
     while (dsn_size > 0 && dsn_buf_count < buffers.size()) {
         blob &buf = buffers[dsn_buf_count];
-        dassert(dsn_size >= buf.length(), "%u VS %u", dsn_size, buf.length());
+        CHECK_GE(dsn_size, buf.length());
         dsn_size -= buf.length();
         ++dsn_buf_count;
     }

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -172,8 +172,8 @@ bool greedy_load_balancer::all_replica_infos_collected(const node_state &ns)
 
 void greedy_load_balancer::greedy_balancer(const bool balance_checker)
 {
-    dassert(t_alive_nodes >= FLAGS_min_live_node_count_for_unfreeze,
-            "too few nodes will be freezed");
+    CHECK_GE_MSG(
+        t_alive_nodes, FLAGS_min_live_node_count_for_unfreeze, "too few nodes will be freezed");
 
     for (auto &kv : *(t_global_view->nodes)) {
         node_state &ns = kv.second;

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -191,8 +191,9 @@ void load_balance_policy::init(const meta_view *global_view, migration_list *lis
 bool load_balance_policy::primary_balance(const std::shared_ptr<app_state> &app,
                                           bool only_move_primary)
 {
-    dassert(_alive_nodes >= FLAGS_min_live_node_count_for_unfreeze,
-            "too few alive nodes will lead to freeze");
+    CHECK_GE_MSG(_alive_nodes,
+                 FLAGS_min_live_node_count_for_unfreeze,
+                 "too few alive nodes will lead to freeze");
     LOG_INFO_F("primary balancer for app({}:{})", app->app_name, app->app_id);
 
     auto graph = ford_fulkerson::builder(app, *_global_view->nodes, address_id).build();
@@ -278,12 +279,13 @@ void load_balance_policy::start_moving_primary(const std::shared_ptr<app_state> 
 {
     std::list<dsn::gpid> potential_moving = calc_potential_moving(app, from, to);
     auto potential_moving_size = potential_moving.size();
-    dassert_f(plan_moving <= potential_moving_size,
-              "from({}) to({}) plan({}), can_move({})",
-              from.to_string(),
-              to.to_string(),
-              plan_moving,
-              potential_moving_size);
+    CHECK_LE_MSG(plan_moving,
+                 potential_moving_size,
+                 "from({}) to({}) plan({}), can_move({})",
+                 from.to_string(),
+                 to.to_string(),
+                 plan_moving,
+                 potential_moving_size);
 
     while (plan_moving-- > 0) {
         dsn::gpid selected = select_moving(potential_moving, prev_load, current_load, from, to);

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -282,8 +282,8 @@ void load_balance_policy::start_moving_primary(const std::shared_ptr<app_state> 
     CHECK_LE_MSG(plan_moving,
                  potential_moving_size,
                  "from({}) to({}) plan({}), can_move({})",
-                 from.to_string(),
-                 to.to_string(),
+                 from,
+                 to,
                  plan_moving,
                  potential_moving_size);
 

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -494,17 +494,17 @@ void policy_context::on_backup_reply(error_code err,
                      _policy.policy_name,
                      "policy names don't match, pid({}), replica_server({})",
                      pid,
-                     primary.to_string());
+                     primary);
         CHECK_EQ_MSG(response.pid,
                      pid,
                      "{}: backup pids don't match, replica_server({})",
                      _policy.policy_name,
-                     primary.to_string());
+                     primary);
         CHECK_LE_MSG(response.backup_id,
                      _cur_backup.backup_id,
                      "{}: replica server({}) has bigger backup_id({}), gpid({})",
                      _backup_sig,
-                     primary.to_string(),
+                     primary,
                      response.backup_id,
                      pid);
 

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -118,9 +118,8 @@ void maintain_drops(std::vector<rpc_address> &drops, const rpc_address &node, co
                 drops.erase(it);
             }
         } else {
-            CHECK(it == drops.end(),
-                  "the node({}) cannot be in drops set before this update",
-                  node.to_string());
+            CHECK(
+                it == drops.end(), "the node({}) cannot be in drops set before this update", node);
             drops.push_back(node);
             if (drops.size() > 3) {
                 drops.erase(drops.begin());
@@ -135,7 +134,7 @@ bool construct_replica(meta_view view, const gpid &pid, int max_replica_count)
     partition_configuration &pc = *get_config(*view.apps, pid);
     config_context &cc = *get_config_context(*view.apps, pid);
 
-    CHECK_EQ(replica_count(pc), 0);
+    CHECK_EQ_MSG(replica_count(pc), 0, "replica count of gpid({}) must be 0", pid);
     CHECK_GT(max_replica_count, 0);
 
     std::vector<dropped_replica> &drop_list = cc.dropped;

--- a/src/meta/meta_http_service.cpp
+++ b/src/meta/meta_http_service.cpp
@@ -292,14 +292,8 @@ void meta_http_service::list_app_handler(const http_request &req, http_response 
             configuration_query_by_index_response response;
             request.app_name = info.app_name;
             _service->_state->query_configuration_by_index(request, response);
-            dassert(info.app_id == response.app_id,
-                    "invalid app_id, %d VS %d",
-                    info.app_id,
-                    response.app_id);
-            dassert(info.partition_count == response.partition_count,
-                    "invalid partition_count, %d VS %d",
-                    info.partition_count,
-                    response.partition_count);
+            CHECK_EQ(info.app_id, response.app_id);
+            CHECK_EQ(info.partition_count, response.partition_count);
             int fully_healthy = 0;
             int write_unhealthy = 0;
             int read_unhealthy = 0;
@@ -391,14 +385,8 @@ void meta_http_service::list_node_handler(const http_request &req, http_response
             configuration_query_by_index_response response_app;
             request_app.app_name = app.app_name;
             _service->_state->query_configuration_by_index(request_app, response_app);
-            dassert(app.app_id == response_app.app_id,
-                    "invalid app_id, %d VS %d",
-                    app.app_id,
-                    response_app.app_id);
-            dassert(app.partition_count == response_app.partition_count,
-                    "invalid partition_count, %d VS %d",
-                    app.partition_count,
-                    response_app.partition_count);
+            CHECK_EQ(app.app_id, response_app.app_id);
+            CHECK_EQ(app.partition_count, response_app.partition_count);
 
             for (int i = 0; i < response_app.partitions.size(); i++) {
                 const dsn::partition_configuration &p = response_app.partitions[i];

--- a/src/meta/meta_server_failure_detector.cpp
+++ b/src/meta/meta_server_failure_detector.cpp
@@ -58,7 +58,7 @@ meta_server_failure_detector::meta_server_failure_detector(meta_service *svc)
     _lock_svc = dsn::utils::factory_store<dist::distributed_lock_service>::create(
         _fd_opts->distributed_lock_service_type.c_str(), PROVIDER_TYPE_MAIN);
     error_code err = _lock_svc->initialize(_fd_opts->distributed_lock_service_args);
-    dassert(err == ERR_OK, "init distributed_lock_service failed, err = %s", err.to_string());
+    CHECK_EQ_MSG(err, ERR_OK, "init distributed_lock_service failed");
 }
 
 meta_server_failure_detector::~meta_server_failure_detector()
@@ -200,10 +200,7 @@ void meta_server_failure_detector::leader_initialize(const std::string &lock_ser
     CHECK(addr.from_string_ipv4(lock_service_owner.c_str()),
           "parse {} to rpc_address failed",
           lock_service_owner);
-    dassert(addr == dsn_primary_address(),
-            "acquire leader return success, but owner not match: %s vs %s",
-            addr.to_string(),
-            dsn_primary_address().to_string());
+    CHECK_EQ_MSG(addr, dsn_primary_address(), "acquire leader return success, but owner not match");
     _is_leader.store(true);
     _election_moment.store(dsn_now_ms());
 }

--- a/src/meta/meta_state_service_simple.cpp
+++ b/src/meta/meta_state_service_simple.cpp
@@ -157,7 +157,7 @@ error_code meta_state_service_simple::delete_node_internal(const std::string &no
         auto &node_pair = delete_stack.top();
         if (node_pair.node->children.end() == node_pair.next_child_to_delete) {
             auto delnum = _quick_map.erase(node_pair.path);
-            dassert(delnum == 1, "inconsistent state between quick map and tree");
+            CHECK_EQ_MSG(delnum, 1, "inconsistent state between quick map and tree");
             delete node_pair.node;
             delete_stack.pop();
         } else {
@@ -176,11 +176,11 @@ error_code meta_state_service_simple::delete_node_internal(const std::string &no
     }
 
     auto parent_it = _quick_map.find(parent);
-    dassert(parent_it != _quick_map.end(), "unable to find parent node");
+    CHECK(parent_it != _quick_map.end(), "unable to find parent node");
     // XXX we cannot delete root, right?
 
     auto erase_num = parent_it->second->children.erase(name);
-    dassert(erase_num == 1, "inconsistent state between quick map and tree");
+    CHECK_EQ_MSG(erase_num, 1, "inconsistent state between quick map and tree");
     return ERR_OK;
 }
 
@@ -218,7 +218,7 @@ error_code meta_state_service_simple::apply_transaction(
         default:
             CHECK(false, "unsupported operation");
         }
-        dassert(ec == ERR_OK, "unexpected error when applying, err=%s", ec.to_string());
+        CHECK_EQ_MSG(ec, ERR_OK, "unexpected error when applying");
     }
 
     return ERR_OK;
@@ -392,7 +392,7 @@ task_ptr meta_state_service_simple::submit_transaction(
             memcpy(dest, entry.data(), entry.length());
             dest += entry.length();
         });
-        dassert(dest - batch.get() == total_size, "memcpy error");
+        CHECK_EQ_MSG(dest - batch.get(), total_size, "memcpy error");
         task_ptr task(new error_code_future(cb_code, cb_transaction, 0));
         task->set_tracker(tracker);
         write_log(blob(batch, total_size),

--- a/src/meta/server_load_balancer.cpp
+++ b/src/meta/server_load_balancer.cpp
@@ -115,7 +115,7 @@ void newly_partitions::newly_remove_partition(int32_t app_id)
 {
     auto iter = partitions.find(app_id);
     CHECK(iter != partitions.end(), "invalid app_id, app_id = {}", app_id);
-    CHECK_GT_MSG(iter->second, 0, "invalid partition coun");
+    CHECK_GT_MSG(iter->second, 0, "invalid partition count");
     if ((--iter->second) == 0) {
         partitions.erase(iter);
     }

--- a/src/meta/server_load_balancer.cpp
+++ b/src/meta/server_load_balancer.cpp
@@ -97,13 +97,13 @@ void newly_partitions::newly_add_partition(int32_t app_id)
 void newly_partitions::newly_remove_primary(int32_t app_id, bool only_primary)
 {
     auto iter = primaries.find(app_id);
-    dassert(iter != primaries.end(), "invalid app_id, app_id = %d", app_id);
-    dassert(iter->second > 0, "invalid primary count, cnt = %d", iter->second);
+    CHECK(iter != primaries.end(), "invalid app_id, app_id = {}", app_id);
+    CHECK_GT_MSG(iter->second, 0, "invalid primary count");
     if (0 == (--iter->second)) {
         primaries.erase(iter);
     }
 
-    dassert(total_primaries > 0, "invalid total primaires = %d", total_primaries);
+    CHECK_GT_MSG(total_primaries, 0, "invalid total primaires");
     --total_primaries;
 
     if (!only_primary) {
@@ -114,13 +114,13 @@ void newly_partitions::newly_remove_primary(int32_t app_id, bool only_primary)
 void newly_partitions::newly_remove_partition(int32_t app_id)
 {
     auto iter = partitions.find(app_id);
-    dassert(iter != partitions.end(), "invalid app_id, app_id = %d", app_id);
-    dassert(iter->second > 0, "invalid partition count, cnt = %d", iter->second);
+    CHECK(iter != partitions.end(), "invalid app_id, app_id = {}", app_id);
+    CHECK_GT_MSG(iter->second, 0, "invalid partition coun");
     if ((--iter->second) == 0) {
         partitions.erase(iter);
     }
 
-    dassert(total_partitions > 0, "invalid total partitions = ", total_partitions);
+    CHECK_GT(total_partitions, 0);
     --total_partitions;
 }
 

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -3324,7 +3324,7 @@ void server_state::set_max_replica_count_env_updating(std::shared_ptr<app_state>
                          "An error that can't be handled occurs while updating remote env of "
                          "max_replica_count: error_code={}, app_name={}, app_id={}, "
                          "new_max_replica_count={}, {}={}",
-                         ec.to_string(),
+                         ec,
                          app->app_name,
                          app->app_id,
                          new_max_replica_count,
@@ -3451,7 +3451,7 @@ void server_state::update_app_max_replica_count(std::shared_ptr<app_state> &app,
                      "An error that can't be handled occurs while updating remote app-level "
                      "max_replica_count: error_code={}, app_name={}, app_id={}, "
                      "old_max_replica_count={}, new_max_replica_count={}, {}={}",
-                     ec.to_string(),
+                     ec,
                      app->app_name,
                      app->app_id,
                      old_max_replica_count,
@@ -3830,7 +3830,7 @@ void server_state::recover_all_partitions_max_replica_count(std::shared_ptr<app_
                              "partition-level max_replica_count: error_code={}, app_name={}, "
                              "app_id={}, partition_index={}, partition_count={}, "
                              "old_partition_config={}, new_partition_config={}",
-                             ec.to_string(),
+                             ec,
                              app->app_name,
                              app->app_id,
                              i,
@@ -3900,7 +3900,7 @@ void server_state::recover_app_max_replica_count(std::shared_ptr<app_state> &app
                          "An error that can't be handled occurs while recovering remote "
                          "app-level max_replica_count: error_code={}, app_name={}, app_id={}, "
                          "old_max_replica_count={}, new_max_replica_count={}",
-                         ec.to_string(),
+                         ec,
                          app->app_name,
                          app->app_id,
                          old_max_replica_count,

--- a/src/meta/server_state_restore.cpp
+++ b/src/meta/server_state_restore.cpp
@@ -96,11 +96,8 @@ std::pair<dsn::error_code, std::shared_ptr<app_state>> server_state::restore_app
     }
     int32_t old_app_id = info.app_id;
     std::string old_app_name = info.app_name;
-    dassert(old_app_id == req.app_id, "invalid app_id, %d VS %d", old_app_id, req.app_id);
-    dassert(old_app_name == req.app_name,
-            "invalid app_name, %s VS %s",
-            old_app_name.c_str(),
-            req.app_name.c_str());
+    CHECK_EQ_MSG(old_app_id, req.app_id, "invalid app id");
+    CHECK_EQ_MSG(old_app_name, req.app_name, "invalid app name");
     std::shared_ptr<app_state> app = nullptr;
 
     if (!req.new_app_name.empty()) {

--- a/src/meta/test/meta_app_operation_test.cpp
+++ b/src/meta/test/meta_app_operation_test.cpp
@@ -405,10 +405,7 @@ TEST_F(meta_app_operation_test, create_app)
 
         set_min_live_node_count_for_unfreeze(test.min_live_node_count_for_unfreeze);
 
-        dassert_f(total_node_count >= test.alive_node_count,
-                  "total_node_count({}) should be >= alive_node_count({})",
-                  total_node_count,
-                  test.alive_node_count);
+        CHECK_GE(total_node_count, test.alive_node_count);
         for (int i = 0; i < total_node_count - test.alive_node_count; i++) {
             _ms->set_node_state({nodes[i]}, false);
         }
@@ -749,10 +746,7 @@ TEST_F(meta_app_operation_test, set_max_replica_count)
         FLAGS_max_allowed_replica_count = test.max_allowed_replica_count;
 
         // set some nodes unalive to match the expected number of alive ndoes
-        dassert_f(total_node_count >= test.alive_node_count,
-                  "total_node_count({}) should be >= alive_node_count({})",
-                  total_node_count,
-                  test.alive_node_count);
+        CHECK_GE(total_node_count, test.alive_node_count);
         for (int i = 0; i < total_node_count - test.alive_node_count; i++) {
             _ms->set_node_state({nodes[i]}, false);
         }

--- a/src/meta/test/meta_state/meta_state_service.cpp
+++ b/src/meta/test/meta_state/meta_state_service.cpp
@@ -105,7 +105,7 @@ void provider_basic_test(const service_creator_func &service_creator,
                            dsn::binary_reader reader(value);
                            int read_value = 0;
                            reader.read(read_value);
-                           dassert(read_value == 0xdeadbeef, "get_value != create_value");
+                           CHECK_EQ(read_value, 0xdeadbeef);
                        })
             ->wait();
         writer = dsn::binary_writer();
@@ -122,7 +122,7 @@ void provider_basic_test(const service_creator_func &service_creator,
                            dsn::binary_reader reader(value);
                            int read_value = 0;
                            reader.read(read_value);
-                           dassert(read_value == 0xbeefdead, "get_value != create_value");
+                           CHECK_EQ(read_value, 0xbeefdead);
                        })
             ->wait();
     }

--- a/src/meta/test/meta_test_base.cpp
+++ b/src/meta/test/meta_test_base.cpp
@@ -122,10 +122,11 @@ std::vector<rpc_address> meta_test_base::ensure_enough_alive_nodes(int min_node_
     std::vector<dsn::rpc_address> nodes(get_alive_nodes());
     if (!nodes.empty()) {
         auto node_count = static_cast<int>(nodes.size());
-        dassert_f(node_count >= min_node_count,
-                  "there should be at least {} alive nodes, now we just have {} alive nodes",
-                  min_node_count,
-                  node_count);
+        CHECK_GE_MSG(node_count,
+                     min_node_count,
+                     "there should be at least {} alive nodes, now we just have {} alive nodes",
+                     min_node_count,
+                     node_count);
 
         LOG_DEBUG_F("already exists {} alive nodes: ", nodes.size());
         for (const auto &node : nodes) {

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -200,7 +200,8 @@ void nfs_client_impl::end_get_file_size(::dsn::error_code err,
             req_offset += req_size;
             size -= req_size;
             if (size <= 0) {
-                dassert(size == 0, "last request must read exactly the remaing size of the file");
+                CHECK_EQ_MSG(
+                    size, 0, "last request must read exactly the remaing size of the file");
                 break;
             }
 

--- a/src/nfs/nfs_client_impl.h
+++ b/src/nfs/nfs_client_impl.h
@@ -93,7 +93,7 @@ public:
         {
             if (file_handle != nullptr) {
                 auto err = file::close(file_handle);
-                dassert(err == ERR_OK, "file::close failed, err = %s", err.to_string());
+                CHECK_EQ_MSG(err, ERR_OK, "file::close failed");
             }
         }
     };

--- a/src/nfs/nfs_server_impl.h
+++ b/src/nfs/nfs_server_impl.h
@@ -113,7 +113,7 @@ private:
         ~file_handle_info_on_server()
         {
             error_code err = file::close(file_handle);
-            dassert(err == ERR_OK, "file::close failed, err = %s", err.to_string());
+            CHECK_EQ_MSG(err, ERR_OK, "file::close failed");
         }
     };
 

--- a/src/perf_counter/perf_counter_atomic.h
+++ b/src/perf_counter/perf_counter_atomic.h
@@ -275,7 +275,7 @@ public:
     virtual int get_latest_samples(int required_sample_count,
                                    /*out*/ samples_t &samples) const override
     {
-        dassert(required_sample_count <= MAX_QUEUE_LENGTH, "");
+        CHECK_LE(required_sample_count, MAX_QUEUE_LENGTH);
 
         uint64_t count = _tail.load();
         int return_count = count >= (uint64_t)required_sample_count ? required_sample_count : count;

--- a/src/perf_counter/perf_counters.cpp
+++ b/src/perf_counter/perf_counters.cpp
@@ -131,11 +131,10 @@ perf_counter_ptr perf_counters::get_global_counter(const char *app,
             _counters.emplace(full_name, counter_object{counter, 1});
             return counter;
         } else {
-            dassert(it->second.counter->type() == flags,
-                    "counters with the same name %s with differnt types, (%d) vs (%d)",
-                    full_name.c_str(),
-                    it->second.counter->type(),
-                    flags);
+            CHECK_EQ_MSG(it->second.counter->type(),
+                         flags,
+                         "counters with the same name {} with differnt types",
+                         full_name);
             ++it->second.user_reference;
             return it->second.counter;
         }

--- a/src/redis_protocol/proxy_lib/proxy_layer.cpp
+++ b/src/redis_protocol/proxy_lib/proxy_layer.cpp
@@ -110,9 +110,7 @@ proxy_session::proxy_session(proxy_stub *op, dsn::message_ex *first_msg)
     _backup_one_request->add_ref();
 
     _remote_address = _backup_one_request->header->from_address;
-    dassert(_remote_address.type() == HOST_TYPE_IPV4,
-            "invalid rpc_address type, type = %d",
-            (int)_remote_address.type());
+    CHECK_EQ_MSG(_remote_address.type(), HOST_TYPE_IPV4, "invalid rpc_address type");
 }
 
 proxy_session::~proxy_session()

--- a/src/redis_protocol/proxy_lib/redis_parser.cpp
+++ b/src/redis_protocol/proxy_lib/redis_parser.cpp
@@ -934,7 +934,7 @@ void redis_parser::decr_by(message_entry &entry) { counter_internal(entry); }
 void redis_parser::counter_internal(message_entry &entry)
 {
     CHECK(!entry.request.sub_requests.empty(), "");
-    dassert(entry.request.sub_requests[0].length > 0, "");
+    CHECK_GT(entry.request.sub_requests[0].length, 0);
     const char *command = entry.request.sub_requests[0].data.data();
     int64_t increment = 1;
     if (strcasecmp(command, "INCR") == 0 || strcasecmp(command, "DECR") == 0) {
@@ -1327,9 +1327,7 @@ void redis_parser::handle_command(std::unique_ptr<message_entry> &&entry)
               e.sequence_id);
     enqueue_pending_response(std::move(entry));
 
-    dassert(request.sub_request_count > 0,
-            "invalid request, request.length = %d",
-            request.sub_request_count);
+    CHECK_GT_MSG(request.sub_request_count, 0, "invalid request");
     ::dsn::blob &command = request.sub_requests[0].data;
     redis_call_handler handler = redis_parser::get_handler(command.data(), command.length());
     handler(this, e);

--- a/src/replica/backup/cold_backup_context.cpp
+++ b/src/replica/backup/cold_backup_context.cpp
@@ -1064,7 +1064,7 @@ void cold_backup_context::file_upload_uncomplete(const std::string &filename)
 {
     zauto_lock l(_lock);
 
-    dassert(_cur_upload_file_cnt >= 1, "cur_upload_file_cnt = %d", _cur_upload_file_cnt);
+    CHECK_GE(_cur_upload_file_cnt, 1);
     _cur_upload_file_cnt -= 1;
     _file_remain_cnt += 1;
     _file_status[filename] = file_status::FileUploadUncomplete;
@@ -1074,7 +1074,7 @@ void cold_backup_context::file_upload_complete(const std::string &filename)
 {
     zauto_lock l(_lock);
 
-    dassert(_cur_upload_file_cnt >= 1, "cur_upload_file_cnt = %d", _cur_upload_file_cnt);
+    CHECK_GE(_cur_upload_file_cnt, 1);
     _cur_upload_file_cnt -= 1;
     _file_status[filename] = file_status::FileUploadComplete;
 }

--- a/src/replica/backup/cold_backup_context.h
+++ b/src/replica/backup/cold_backup_context.h
@@ -17,11 +17,11 @@
 
 #pragma once
 
-#include "utils/zlocks.h"
-#include "common/json_helper.h"
 #include "block_service/block_service.h"
-
 #include "common/backup_common.h"
+#include "common/json_helper.h"
+#include "utils/fmt_logging.h"
+#include "utils/zlocks.h"
 
 class replication_service_test_app;
 
@@ -225,9 +225,9 @@ public:
     // Progress should be in range of [0, 1000].
     void update_progress(int progress)
     {
-        dassert(progress >= 0 && progress <= cold_backup_constant::PROGRESS_FINISHED,
-                "invalid progress %d",
-                progress);
+        CHECK(progress >= 0 && progress <= cold_backup_constant::PROGRESS_FINISHED,
+              "invalid progress {}",
+              progress);
         _progress.store(progress);
     }
 

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -215,13 +215,14 @@ void replica_duplicator::verify_start_decree(decree start_decree)
     decree confirmed_decree = progress().confirmed_decree;
     decree last_decree = progress().last_decree;
     decree max_gced_decree = get_max_gced_decree();
-    dassert_f(max_gced_decree < start_decree,
-              "the logs haven't yet duplicated were accidentally truncated "
-              "[max_gced_decree: {}, start_decree: {}, confirmed_decree: {}, last_decree: {}]",
-              max_gced_decree,
-              start_decree,
-              confirmed_decree,
-              last_decree);
+    CHECK_LT_MSG(max_gced_decree,
+                 start_decree,
+                 "the logs haven't yet duplicated were accidentally truncated "
+                 "[max_gced_decree: {}, start_decree: {}, confirmed_decree: {}, last_decree: {}]",
+                 max_gced_decree,
+                 start_decree,
+                 confirmed_decree,
+                 last_decree);
 }
 
 decree replica_duplicator::get_max_gced_decree() const

--- a/src/replica/log_file.cpp
+++ b/src/replica/log_file.cpp
@@ -179,7 +179,7 @@ void log_file::close()
     _stream.reset(nullptr);
     if (_handle) {
         error_code err = file::close(_handle);
-        dassert(err == ERR_OK, "file::close failed, err = %s", err.to_string());
+        CHECK_EQ_MSG(err, ERR_OK, "file::close failed");
 
         _handle = nullptr;
     }
@@ -192,7 +192,7 @@ void log_file::flush() const
 
     if (_handle) {
         error_code err = file::flush(_handle);
-        dassert(err == ERR_OK, "file::flush failed, err = %s", err.to_string());
+        CHECK_EQ_MSG(err, ERR_OK, "file::flush failed");
     }
 }
 
@@ -278,7 +278,7 @@ aio_task_ptr log_file::commit_log_blocks(log_appender &pending,
         int64_t local_offset = block.start_offset() - start_offset();
         auto hdr = reinterpret_cast<log_block_header *>(const_cast<char *>(block.front().data()));
 
-        dassert(hdr->magic == 0xdeadbeef, "");
+        CHECK_EQ(hdr->magic, 0xdeadbeef);
         hdr->local_offset = local_offset;
         hdr->length = static_cast<int32_t>(block.size() - sizeof(log_block_header));
         hdr->body_crc = _crc32;

--- a/src/replica/log_file_stream.h
+++ b/src/replica/log_file_stream.h
@@ -178,7 +178,7 @@ private:
                 _task->wait();
                 _have_ongoing_task = false;
                 _end += _task->get_transferred_size();
-                dassert(_end <= block_size_bytes, "invalid io_size.");
+                CHECK_LE_MSG(_end, block_size_bytes, "invalid io_size");
                 return _task->error();
             } else {
                 return ERR_OK;

--- a/src/replica/mutation.cpp
+++ b/src/replica/mutation.cpp
@@ -172,7 +172,7 @@ void mutation::add_client_request(task_code code, dsn::message_ex *request)
 
     client_requests.push_back(request);
 
-    dassert(client_requests.size() == data.updates.size(), "size must be equal");
+    CHECK_EQ(client_requests.size(), data.updates.size());
 }
 
 void mutation::write_to(const std::function<void(const blob &)> &inserter) const

--- a/src/replica/mutation_cache.cpp
+++ b/src/replica/mutation_cache.cpp
@@ -78,10 +78,7 @@ error_code mutation_cache::put(mutation_ptr &mu)
     int idx = ((decree - _end_decree) + _end_idx + _max_count) % _max_count;
     mutation_ptr &old = _array[idx];
     if (old != nullptr) {
-        dassert(old->data.header.ballot <= mu->data.header.ballot,
-                "%" PRId64 " VS %" PRId64 "",
-                old->data.header.ballot,
-                mu->data.header.ballot);
+        CHECK_LE(old->data.header.ballot, mu->data.header.ballot);
     }
 
     _array[idx] = mu;

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -781,8 +781,12 @@ error_code mutation_log::create_new_log_file()
                            },
                            0);
 
-    CHECK_EQ(_global_end_offset,
-             _current_log_file->start_offset() + sizeof(log_block_header) + header_len);
+    CHECK_EQ_MSG(_global_end_offset,
+                 _current_log_file->start_offset() + sizeof(log_block_header) + header_len,
+                 "current log file start offset: {}, log_block_header size: {}, header_len: {}",
+                 _current_log_file->start_offset(),
+                 sizeof(log_block_header),
+                 header_len);
     return ERR_OK;
 }
 

--- a/src/replica/mutation_log_replay.cpp
+++ b/src/replica/mutation_log_replay.cpp
@@ -191,10 +191,7 @@ namespace replication {
 
     if (err == ERR_OK || err == ERR_HANDLE_EOF) {
         // the log may still be written when used for learning
-        dassert(g_end_offset <= end_offset,
-                "make sure the global end offset is correct: %" PRId64 " vs %" PRId64,
-                g_end_offset,
-                end_offset);
+        CHECK_LE(g_end_offset, end_offset);
         err = ERR_OK;
     } else if (err == ERR_INCOMPLETE_DATA) {
         // ignore the last incomplate block

--- a/src/replica/prepare_list.cpp
+++ b/src/replica/prepare_list.cpp
@@ -109,7 +109,7 @@ error_code prepare_list::prepare(mutation_ptr &mu,
     //        err = mutation_cache::put(mu);
     //        if (err == ERR_CAPACITY_EXCEEDED)
     //        {
-    //            dassert(mu->data.header.last_committed_decree >= min_decree(), "");
+    //            CHECK_GE(mu->data.header.last_committed_decree, min_decree());
     //            commit (min_decree(), true);
     //            pop_min();
     //        }

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -535,10 +535,7 @@ void replica::trigger_async_checkpoint_for_backup(cold_backup_context_ptr backup
             backup_context->checkpoint_decree = last_committed_decree();
         } else { // backup_context->durable_decree_when_checkpoint != durable_decree
             // checkpoint generated, but is behind checkpoint_decree, need trigger again
-            dassert(backup_context->durable_decree_when_checkpoint < durable_decree,
-                    "durable_decree_when_checkpoint(%" PRId64 ") < durable_decree(%" PRId64 ")",
-                    backup_context->durable_decree_when_checkpoint,
-                    durable_decree);
+            CHECK_LT(backup_context->durable_decree_when_checkpoint, durable_decree);
             LOG_INFO("%s: need trigger async checkpoint again", backup_context->name);
         }
         backup_context->checkpoint_timestamp = dsn_now_ms();
@@ -651,10 +648,7 @@ void replica::local_create_backup_checkpoint(cold_backup_context_ptr backup_cont
             0,
             std::chrono::seconds(10));
     } else {
-        dassert(last_decree >= backup_context->checkpoint_decree,
-                "%" PRId64 " VS %" PRId64 "",
-                last_decree,
-                backup_context->checkpoint_decree);
+        CHECK_GE(last_decree, backup_context->checkpoint_decree);
         backup_context->checkpoint_decree = last_decree; // update to real decree
         std::string backup_checkpoint_dir_path = utils::filesystem::path_combine(
             _app->backup_dir(),

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -223,7 +223,7 @@ void replica::on_group_check_reply(error_code err,
     }
 
     auto r = _primary_states.group_check_pending_replies.erase(req->node);
-    CHECK_EQ_MSG(r, 1, "invalid node address, address = {}", req->node.to_string());
+    CHECK_EQ_MSG(r, 1, "invalid node address, address = {}", req->node);
 
     if (err != ERR_OK || resp->err != ERR_OK) {
         if (ERR_OK == err) {

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -60,7 +60,7 @@ void replica::init_group_check()
     if (partition_status::PS_PRIMARY != status() || _options->group_check_disabled)
         return;
 
-    dassert(nullptr == _primary_states.group_check_task, "");
+    CHECK(nullptr == _primary_states.group_check_task, "");
     _primary_states.group_check_task =
         tasking::enqueue_timer(LPC_GROUP_CHECK,
                                &_tracker,
@@ -223,7 +223,7 @@ void replica::on_group_check_reply(error_code err,
     }
 
     auto r = _primary_states.group_check_pending_replies.erase(req->node);
-    dassert(r == 1, "invalid node address, address = %s", req->node.to_string());
+    CHECK_EQ_MSG(r, 1, "invalid node address, address = {}", req->node.to_string());
 
     if (err != ERR_OK || resp->err != ERR_OK) {
         if (ERR_OK == err) {

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -112,16 +112,13 @@ void replica::on_config_proposal(configuration_update_request &proposal)
         remove(proposal);
         break;
     default:
-        dassert(false, "invalid config_type, type = %s", enum_to_string(proposal.type));
+        CHECK(false, "invalid config_type, type = {}", enum_to_string(proposal.type));
     }
 }
 
 void replica::assign_primary(configuration_update_request &proposal)
 {
-    dassert(proposal.node == _stub->_primary_address,
-            "%s VS %s",
-            proposal.node.to_string(),
-            _stub->_primary_address_str);
+    CHECK_EQ(proposal.node, _stub->_primary_address);
 
     if (status() == partition_status::PS_PRIMARY) {
         LOG_WARNING("%s: invalid assgin primary proposal as the node is in %s",
@@ -158,30 +155,16 @@ void replica::add_potential_secondary(configuration_update_request &proposal)
         return;
     }
 
-    dassert(proposal.config.ballot == get_ballot(),
-            "invalid ballot, %" PRId64 " VS %" PRId64 "",
-            proposal.config.ballot,
-            get_ballot());
-    dassert(proposal.config.pid == _primary_states.membership.pid,
-            "(%d.%d) VS (%d.%d)",
-            proposal.config.pid.get_app_id(),
-            proposal.config.pid.get_partition_index(),
-            _primary_states.membership.pid.get_app_id(),
-            _primary_states.membership.pid.get_partition_index());
-    dassert(proposal.config.primary == _primary_states.membership.primary,
-            "%s VS %s",
-            proposal.config.primary.to_string(),
-            _primary_states.membership.primary.to_string());
-    dassert(proposal.config.secondaries == _primary_states.membership.secondaries,
-            "count(%d) VS count(%d)",
-            (int)proposal.config.secondaries.size(),
-            (int)_primary_states.membership.secondaries.size());
-    dassert(!_primary_states.check_exist(proposal.node, partition_status::PS_PRIMARY),
-            "node = %s",
-            proposal.node.to_string());
-    dassert(!_primary_states.check_exist(proposal.node, partition_status::PS_SECONDARY),
-            "node = %s",
-            proposal.node.to_string());
+    CHECK_EQ(proposal.config.ballot, get_ballot());
+    CHECK_EQ(proposal.config.pid, _primary_states.membership.pid);
+    CHECK_EQ(proposal.config.primary, _primary_states.membership.primary);
+    CHECK(proposal.config.secondaries == _primary_states.membership.secondaries, "");
+    CHECK(!_primary_states.check_exist(proposal.node, partition_status::PS_PRIMARY),
+          "node = {}",
+          proposal.node.to_string());
+    CHECK(!_primary_states.check_exist(proposal.node, partition_status::PS_SECONDARY),
+          "node = {}",
+          proposal.node.to_string());
 
     int potential_secondaries_count =
         _primary_states.membership.secondaries.size() + _primary_states.learners.size();
@@ -205,7 +188,7 @@ void replica::add_potential_secondary(configuration_update_request &proposal)
                          proposal.node.to_string());
             }
         } else {
-            dassert(false, "invalid config_type, type = %s", enum_to_string(proposal.type));
+            CHECK(false, "invalid config_type, type = {}", enum_to_string(proposal.type));
         }
     }
 
@@ -255,21 +238,10 @@ void replica::downgrade_to_secondary_on_primary(configuration_update_request &pr
     if (proposal.config.ballot != get_ballot() || status() != partition_status::PS_PRIMARY)
         return;
 
-    dassert(proposal.config.pid == _primary_states.membership.pid,
-            "(%d.%d) VS (%d.%d)",
-            proposal.config.pid.get_app_id(),
-            proposal.config.pid.get_partition_index(),
-            _primary_states.membership.pid.get_app_id(),
-            _primary_states.membership.pid.get_partition_index());
-    dassert(proposal.config.primary == _primary_states.membership.primary,
-            "%s VS %s",
-            proposal.config.primary.to_string(),
-            _primary_states.membership.primary.to_string());
-    dassert(proposal.config.secondaries == _primary_states.membership.secondaries, "");
-    dassert(proposal.node == proposal.config.primary,
-            "%s VS %s",
-            proposal.node.to_string(),
-            proposal.config.primary.to_string());
+    CHECK_EQ(proposal.config.pid, _primary_states.membership.pid);
+    CHECK_EQ(proposal.config.primary, _primary_states.membership.primary);
+    CHECK(proposal.config.secondaries == _primary_states.membership.secondaries, "");
+    CHECK_EQ(proposal.node, proposal.config.primary);
 
     proposal.config.primary.set_invalid();
     proposal.config.secondaries.push_back(proposal.node);
@@ -283,23 +255,16 @@ void replica::downgrade_to_inactive_on_primary(configuration_update_request &pro
     if (proposal.config.ballot != get_ballot() || status() != partition_status::PS_PRIMARY)
         return;
 
-    dassert(proposal.config.pid == _primary_states.membership.pid,
-            "(%d.%d) VS (%d.%d)",
-            proposal.config.pid.get_app_id(),
-            proposal.config.pid.get_partition_index(),
-            _primary_states.membership.pid.get_app_id(),
-            _primary_states.membership.pid.get_partition_index());
-    dassert(proposal.config.primary == _primary_states.membership.primary,
-            "%s VS %s",
-            proposal.config.primary.to_string(),
-            _primary_states.membership.primary.to_string());
-    dassert(proposal.config.secondaries == _primary_states.membership.secondaries, "");
+    CHECK_EQ(proposal.config.pid, _primary_states.membership.pid);
+    CHECK_EQ(proposal.config.primary, _primary_states.membership.primary);
+    CHECK(proposal.config.secondaries == _primary_states.membership.secondaries, "");
 
     if (proposal.node == proposal.config.primary) {
         proposal.config.primary.set_invalid();
     } else {
-        auto rt = replica_helper::remove_node(proposal.node, proposal.config.secondaries);
-        dassert(rt, "remove node failed, node = %s", proposal.node.to_string());
+        CHECK(replica_helper::remove_node(proposal.node, proposal.config.secondaries),
+              "remove node failed, node = {}",
+              proposal.node);
     }
 
     update_configuration_on_meta_server(
@@ -311,31 +276,21 @@ void replica::remove(configuration_update_request &proposal)
     if (proposal.config.ballot != get_ballot() || status() != partition_status::PS_PRIMARY)
         return;
 
-    dassert(proposal.config.pid == _primary_states.membership.pid,
-            "(%d.%d) VS (%d.%d)",
-            proposal.config.pid.get_app_id(),
-            proposal.config.pid.get_partition_index(),
-            _primary_states.membership.pid.get_app_id(),
-            _primary_states.membership.pid.get_partition_index());
-    dassert(proposal.config.primary == _primary_states.membership.primary,
-            "%s VS %s",
-            proposal.config.primary.to_string(),
-            _primary_states.membership.primary.to_string());
-    dassert(proposal.config.secondaries == _primary_states.membership.secondaries, "");
+    CHECK_EQ(proposal.config.pid, _primary_states.membership.pid);
+    CHECK_EQ(proposal.config.primary, _primary_states.membership.primary);
+    CHECK(proposal.config.secondaries == _primary_states.membership.secondaries, "");
 
     auto st = _primary_states.get_node_status(proposal.node);
 
     switch (st) {
     case partition_status::PS_PRIMARY:
-        dassert(proposal.config.primary == proposal.node,
-                "%s VS %s",
-                proposal.config.primary.to_string(),
-                proposal.node.to_string());
+        CHECK_EQ(proposal.config.primary, proposal.node);
         proposal.config.primary.set_invalid();
         break;
     case partition_status::PS_SECONDARY: {
-        auto rt = replica_helper::remove_node(proposal.node, proposal.config.secondaries);
-        dassert(rt, "remove_node failed, node = %s", proposal.node.to_string());
+        CHECK(replica_helper::remove_node(proposal.node, proposal.config.secondaries),
+              "remove_node failed, node = {}",
+              proposal.node.to_string());
     } break;
     case partition_status::PS_POTENTIAL_SECONDARY:
         break;
@@ -370,9 +325,7 @@ void replica::on_remove(const replica_configuration &request)
         return;
     }
 
-    dassert(request.status == partition_status::PS_INACTIVE,
-            "invalid partition_status, status = %s",
-            enum_to_string(request.status));
+    CHECK_EQ(request.status, partition_status::PS_INACTIVE);
     update_local_configuration(request);
 }
 
@@ -390,20 +343,14 @@ void replica::update_configuration_on_meta_server(config_type::type type,
     newConfig.last_committed_decree = last_committed_decree();
 
     if (type == config_type::CT_PRIMARY_FORCE_UPDATE_BALLOT) {
-        dassert(status() == partition_status::PS_INACTIVE && _inactive_is_transient &&
-                    _is_initializing,
-                "");
-        dassert(
-            newConfig.primary == node, "%s VS %s", newConfig.primary.to_string(), node.to_string());
+        CHECK(status() == partition_status::PS_INACTIVE && _inactive_is_transient &&
+                  _is_initializing,
+              "");
+        CHECK_EQ(newConfig.primary, node);
     } else if (type != config_type::CT_ASSIGN_PRIMARY &&
                type != config_type::CT_UPGRADE_TO_PRIMARY) {
-        dassert(status() == partition_status::PS_PRIMARY,
-                "partition status must be primary, status = %s",
-                enum_to_string(status()));
-        dassert(newConfig.ballot == _primary_states.membership.ballot,
-                "invalid ballot, %" PRId64 " VS %" PRId64 "",
-                newConfig.ballot,
-                _primary_states.membership.ballot);
+        CHECK_EQ(status(), partition_status::PS_PRIMARY);
+        CHECK_EQ(newConfig.ballot, _primary_states.membership.ballot);
     }
 
     // disable 2pc during reconfiguration
@@ -514,17 +461,9 @@ void replica::on_update_configuration_on_meta_server_reply(
 
     // post-update work items?
     if (resp.err == ERR_OK) {
-        dassert(req->config.pid == resp.config.pid,
-                "(%d.%d) VS (%d.%d)",
-                req->config.pid.get_app_id(),
-                req->config.pid.get_partition_index(),
-                resp.config.pid.get_app_id(),
-                resp.config.pid.get_partition_index());
-        dassert(req->config.primary == resp.config.primary,
-                "%s VS %s",
-                req->config.primary.to_string(),
-                resp.config.primary.to_string());
-        dassert(req->config.secondaries == resp.config.secondaries, "");
+        CHECK_EQ(req->config.pid, resp.config.pid);
+        CHECK_EQ(req->config.primary, resp.config.primary);
+        CHECK(req->config.secondaries == resp.config.secondaries, "");
 
         switch (req->type) {
         case config_type::CT_UPGRADE_TO_PRIMARY:
@@ -546,11 +485,11 @@ void replica::on_update_configuration_on_meta_server_reply(
             }
             break;
         case config_type::CT_PRIMARY_FORCE_UPDATE_BALLOT:
-            dassert(_is_initializing, "");
+            CHECK(_is_initializing, "");
             _is_initializing = false;
             break;
         default:
-            dassert(false, "invalid config_type, type = %s", enum_to_string(req->type));
+            CHECK(false, "invalid config_type, type = {}", enum_to_string(req->type));
         }
     }
 
@@ -652,10 +591,7 @@ void replica::query_app_envs(/*out*/ std::map<std::string, std::string> &envs)
 
 bool replica::update_configuration(const partition_configuration &config)
 {
-    dassert(config.ballot >= get_ballot(),
-            "invalid ballot, %" PRId64 " VS %" PRId64 "",
-            config.ballot,
-            get_ballot());
+    CHECK_GE(config.ballot, get_ballot());
 
     replica_configuration rconfig;
     replica_helper::get_replica_config(config, _stub->_primary_address, rconfig);
@@ -706,16 +642,11 @@ bool replica::update_local_configuration(const replica_configuration &config,
         return true;
     });
 
-    dassert(config.ballot > get_ballot() || (same_ballot && config.ballot == get_ballot()),
-            "invalid ballot, %" PRId64 " VS %" PRId64 "",
-            config.ballot,
-            get_ballot());
-    dassert(config.pid == get_gpid(),
-            "(%d.%d) VS (%d.%d)",
-            config.pid.get_app_id(),
-            config.pid.get_partition_index(),
-            get_gpid().get_app_id(),
-            get_gpid().get_partition_index());
+    CHECK(config.ballot > get_ballot() || (same_ballot && config.ballot == get_ballot()),
+          "invalid ballot, {} VS {}",
+          config.ballot,
+          get_ballot());
+    CHECK_EQ(config.pid, get_gpid());
 
     partition_status::type old_status = status();
     ballot old_ballot = get_ballot();
@@ -827,10 +758,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
         _split_mgr->parent_cleanup_split_context();
     }
     _last_config_change_time_ms = dsn_now_ms();
-    dassert(max_prepared_decree() >= last_committed_decree(),
-            "%" PRId64 " VS %" PRId64 "",
-            max_prepared_decree(),
-            last_committed_decree());
+    CHECK_GE(max_prepared_decree(), last_committed_decree());
 
     _bulk_loader->clear_bulk_load_states_if_needed(old_status, config.status);
 
@@ -877,10 +805,10 @@ bool replica::update_local_configuration(const replica_configuration &config,
             clear_cold_backup_state();
             break;
         case partition_status::PS_POTENTIAL_SECONDARY:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
             break;
         default:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
         }
         break;
     case partition_status::PS_SECONDARY:
@@ -913,20 +841,20 @@ bool replica::update_local_configuration(const replica_configuration &config,
             // _secondary_states.cleanup(true); => do it in close as it may block
             break;
         default:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
         }
         break;
     case partition_status::PS_POTENTIAL_SECONDARY:
         switch (config.status) {
         case partition_status::PS_PRIMARY:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
             break;
         case partition_status::PS_SECONDARY:
             _prepare_list->truncate(_app->last_committed_decree());
 
             // using force cleanup now as all tasks must be done already
             r = _potential_secondary_states.cleanup(true);
-            dassert(r, "%s: potential secondary context cleanup failed", name());
+            CHECK(r, "{}: potential secondary context cleanup failed", name());
 
             check_state_completeness();
             break;
@@ -939,10 +867,10 @@ bool replica::update_local_configuration(const replica_configuration &config,
             _potential_secondary_states.cleanup(false);
             // => do this in close as it may block
             // r = _potential_secondary_states.cleanup(true);
-            // dassert(r, "%s: potential secondary context cleanup failed", name());
+            // CHECK(r, "{}: potential secondary context cleanup failed", name());
             break;
         default:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
         }
         break;
     case partition_status::PS_PARTITION_SPLIT:
@@ -956,7 +884,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
             _split_states.cleanup(true);
             break;
         case partition_status::PS_POTENTIAL_SECONDARY:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
             break;
         case partition_status::PS_INACTIVE:
             break;
@@ -964,7 +892,7 @@ bool replica::update_local_configuration(const replica_configuration &config,
             _split_states.cleanup(false);
             break;
         default:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
         }
         break;
     case partition_status::PS_INACTIVE:
@@ -975,13 +903,13 @@ bool replica::update_local_configuration(const replica_configuration &config,
         }
         switch (config.status) {
         case partition_status::PS_PRIMARY:
-            dassert(_inactive_is_transient, "must be in transient state for being primary next");
+            CHECK(_inactive_is_transient, "must be in transient state for being primary next");
             _inactive_is_transient = false;
             init_group_check();
             replay_prepare_list();
             break;
         case partition_status::PS_SECONDARY:
-            dassert(_inactive_is_transient, "must be in transient state for being secondary next");
+            CHECK(_inactive_is_transient, "must be in transient state for being secondary next");
             _inactive_is_transient = false;
             break;
         case partition_status::PS_POTENTIAL_SECONDARY:
@@ -1003,31 +931,31 @@ bool replica::update_local_configuration(const replica_configuration &config,
             _inactive_is_transient = false;
             break;
         default:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
         }
         break;
     case partition_status::PS_ERROR:
         switch (config.status) {
         case partition_status::PS_PRIMARY:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
             break;
         case partition_status::PS_SECONDARY:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
             break;
         case partition_status::PS_POTENTIAL_SECONDARY:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
             break;
         case partition_status::PS_INACTIVE:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
             break;
         case partition_status::PS_ERROR:
             break;
         default:
-            dassert(false, "invalid execution path");
+            CHECK(false, "invalid execution path");
         }
         break;
     default:
-        dassert(false, "invalid execution path");
+        CHECK(false, "invalid execution path");
     }
 
     LOG_INFO("%s: status change %s @ %" PRId64 " => %s @ %" PRId64 ", pre(%" PRId64 ", %" PRId64

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -161,10 +161,10 @@ void replica::add_potential_secondary(configuration_update_request &proposal)
     CHECK(proposal.config.secondaries == _primary_states.membership.secondaries, "");
     CHECK(!_primary_states.check_exist(proposal.node, partition_status::PS_PRIMARY),
           "node = {}",
-          proposal.node.to_string());
+          proposal.node);
     CHECK(!_primary_states.check_exist(proposal.node, partition_status::PS_SECONDARY),
           "node = {}",
-          proposal.node.to_string());
+          proposal.node);
 
     int potential_secondaries_count =
         _primary_states.membership.secondaries.size() + _primary_states.learners.size();
@@ -290,7 +290,7 @@ void replica::remove(configuration_update_request &proposal)
     case partition_status::PS_SECONDARY: {
         CHECK(replica_helper::remove_node(proposal.node, proposal.config.secondaries),
               "remove_node failed, node = {}",
-              proposal.node.to_string());
+              proposal.node);
     } break;
     case partition_status::PS_POTENTIAL_SECONDARY:
         break;

--- a/src/replica/replica_failover.cpp
+++ b/src/replica/replica_failover.cpp
@@ -67,9 +67,7 @@ void replica::handle_remote_failure(partition_status::type st,
               enum_to_string(st),
               node.to_string());
 
-    dassert(status() == partition_status::PS_PRIMARY,
-            "invalid partition_status, status = %s",
-            enum_to_string(status()));
+    CHECK_EQ(status(), partition_status::PS_PRIMARY);
     dassert(
         node != _stub->_primary_address, "%s VS %s", node.to_string(), _stub->_primary_address_str);
 

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -218,12 +218,12 @@ decree replica::get_replay_start_decree()
 
 error_code replica::init_app_and_prepare_list(bool create_new)
 {
-    dassert(nullptr == _app, "");
+    CHECK(nullptr == _app, "");
     error_code err;
     std::string log_dir = utils::filesystem::path_combine(dir(), "plog");
 
     _app.reset(replication_app_base::new_storage_instance(_app_info.app_type, this));
-    dassert(nullptr == _private_log, "private log must not be initialized yet");
+    CHECK(nullptr == _private_log, "");
 
     if (create_new) {
         err = _app->open_new_internal(this, _stub->_log->on_partition_reset(get_gpid(), 0), 0);
@@ -240,10 +240,7 @@ error_code replica::init_app_and_prepare_list(bool create_new)
     } else {
         err = _app->open_internal(this);
         if (err == ERR_OK) {
-            dassert(_app->last_committed_decree() == _app->last_durable_decree(),
-                    "invalid app state, %" PRId64 " VS %" PRId64 "",
-                    _app->last_committed_decree(),
-                    _app->last_durable_decree());
+            CHECK_EQ(_app->last_committed_decree(), _app->last_durable_decree());
             _config.ballot = _app->init_info().init_ballot;
             _prepare_list->reset(_app->last_committed_decree());
 

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -93,12 +93,13 @@ bool replica::read_cold_backup_metadata(const std::string &file,
         return false;
     }
     fin.read(buf.get(), file_sz);
-    dassert(file_sz == fin.gcount(),
-            "%s: read file(%s) failed, need %" PRId64 ", but read %" PRId64 "",
-            name(),
-            file.c_str(),
-            file_sz,
-            fin.gcount());
+    CHECK_EQ_MSG(file_sz,
+                 fin.gcount(),
+                 "{}: read file({}) failed, need {}, but read {}",
+                 name(),
+                 file,
+                 file_sz,
+                 fin.gcount());
     fin.close();
 
     buf.get()[fin.gcount()] = '\0';

--- a/src/replica/storage/simple_kv/test/case.cpp
+++ b/src/replica/storage/simple_kv/test/case.cpp
@@ -903,7 +903,7 @@ void client_case_line::get_write_params(int &id,
                                         std::string &value,
                                         int &timeout_ms) const
 {
-    dassert(_type == begin_write, "");
+    CHECK_EQ(_type, begin_write);
     id = _id;
     key = _key;
     value = _value;
@@ -912,7 +912,7 @@ void client_case_line::get_write_params(int &id,
 
 void client_case_line::get_read_params(int &id, std::string &key, int &timeout_ms) const
 {
-    dassert(_type == begin_read, "");
+    CHECK_EQ(_type, begin_read);
     id = _id;
     key = _key;
     timeout_ms = _timeout;
@@ -922,7 +922,7 @@ void client_case_line::get_replica_config_params(rpc_address &receiver,
                                                  dsn::replication::config_type::type &type,
                                                  rpc_address &node) const
 {
-    dassert(_type == replica_config, "");
+    CHECK_EQ(_type, replica_config);
     receiver = _config_receiver;
     type = _config_type;
     node = _config_node;
@@ -1039,7 +1039,7 @@ bool test_case::init(const std::string &case_input)
 void test_case::forward()
 {
     _null_loop_count = 0; // reset null loop count
-    dassert(_next < _case_lines.size(), "");
+    CHECK_LT(_next, _case_lines.size());
     while (true) {
         case_line *cl = _case_lines[_next];
         if (cl != nullptr) {
@@ -1078,7 +1078,7 @@ void test_case::forward()
 void test_case::fail(const std::string &other)
 {
     _null_loop_count = 0; // reset null loop count
-    dassert(_next < _case_lines.size(), "");
+    CHECK_LT(_next, _case_lines.size());
     case_line *cl = _case_lines[_next];
     output(other);
     print(cl, other);
@@ -1097,8 +1097,8 @@ void test_case::output(const std::string &line)
 void test_case::print(case_line *cl, const std::string &other, bool is_skip)
 {
     if (is_skip) {
-        dassert(cl == nullptr, "");
-        dassert(!other.empty(), "");
+        CHECK(cl == nullptr, "");
+        CHECK(!other.empty(), "");
         std::cout << "    s  " << other << std::endl;
         return;
     }
@@ -1395,7 +1395,7 @@ void test_case::on_state_change(const state_snapshot &last, const state_snapshot
 
 void test_case::internal_register_creator(const std::string &name, case_line_creator creator)
 {
-    dassert(_creators.find(name) == _creators.end(), "");
+    CHECK(_creators.find(name) == _creators.end(), "");
     _creators[name] = creator;
 }
 }

--- a/src/replica/storage/simple_kv/test/checker.cpp
+++ b/src/replica/storage/simple_kv/test/checker.cpp
@@ -290,7 +290,7 @@ void test_checker::get_current_states(state_snapshot &states)
 
         for (auto &kv : app->_stub->_replicas) {
             replica_ptr r = kv.second;
-            dassert(kv.first == r->get_gpid(), "");
+            CHECK_EQ(kv.first, r->get_gpid());
             replica_id id(r->get_gpid(), app->info().full_name);
             replica_state &rs = states.state_map[id];
             rs.id = id;

--- a/src/replica/storage/simple_kv/test/common.cpp
+++ b/src/replica/storage/simple_kv/test/common.cpp
@@ -246,10 +246,7 @@ std::string state_snapshot::diff_string(const state_snapshot &other) const
             oss << add_mark << cur_it->second.to_string() << std::endl;
             ++cur_it;
         } else {
-            dassert(oth_it->first == cur_it->first,
-                    "invalid replica_id, %s VS %s",
-                    oth_it->first.to_string().c_str(),
-                    cur_it->first.to_string().c_str());
+            CHECK_EQ(oth_it->first, cur_it->first);
             if (oth_it->second != cur_it->second) {
                 oss << chg_mark << cur_it->second.to_string()
                     << " <= " << oth_it->second.to_string() << std::endl;

--- a/src/replica/storage/simple_kv/test/common.h
+++ b/src/replica/storage/simple_kv/test/common.h
@@ -98,6 +98,10 @@ struct replica_id
     bool operator!=(const replica_id &o) const { return !(*this == o); }
     std::string to_string() const;
     bool from_string(const std::string &str);
+    friend std::ostream &operator<<(std::ostream &os, const replica_id &rid)
+    {
+        return os << rid.to_string();
+    }
 };
 
 struct replica_state

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
@@ -176,7 +176,7 @@ void simple_kv_service_impl::recover(const std::string &name, int64_t version)
 
     is.read((char *)&count, sizeof(count));
     is.read((char *)&magic, sizeof(magic));
-    dassert(magic == 0xdeadbeef, "invalid checkpoint");
+    CHECK_EQ_MSG(magic, 0xdeadbeef, "invalid checkpoint");
 
     for (uint64_t i = 0; i < count; i++) {
         std::string key;
@@ -291,9 +291,8 @@ void simple_kv_service_impl::recover(const std::string &name, int64_t version)
         // PRId64 "", last_committed_decree());
         return ERR_OK;
     } else {
-        dassert(replication_app_base::chkpt_apply_mode::copy == mode, "invalid mode %d", (int)mode);
-        dassert(state.to_decree_included > last_durable_decree(),
-                "checkpoint's decree is smaller than current");
+        CHECK_EQ_MSG(replication_app_base::chkpt_apply_mode::copy, mode, "invalid mode");
+        CHECK_GT(state.to_decree_included, last_durable_decree());
 
         char name[256];
         sprintf(name, "%s/checkpoint.%" PRId64, data_dir().c_str(), state.to_decree_included);

--- a/src/runtime/global_config.cpp
+++ b/src/runtime/global_config.cpp
@@ -365,7 +365,7 @@ bool service_spec::init_app_specs()
 
                 // add app
                 app_specs.push_back(app);
-                dassert((int)app_specs.size() == app.id, "incorrect app id");
+                CHECK_EQ(app_specs.size(), app.id);
 
                 // for next instance
                 app.ports.clear();

--- a/src/runtime/rpc/dsn_message_parser.cpp
+++ b/src/runtime/rpc/dsn_message_parser.cpp
@@ -112,7 +112,7 @@ void dsn_message_parser::prepare_on_send(message_ex *msg)
     for (int i = 0; i <= i_max; i++) {
         len += (size_t)buffers[i].length();
     }
-    dassert(len == (size_t)header->body_length + sizeof(message_header), "data length is wrong");
+    CHECK_EQ(len, header->body_length + sizeof(message_header));
 #endif
 
     if (task_spec::get(msg->local_rpc_code)->rpc_message_crc_required) {
@@ -140,7 +140,7 @@ void dsn_message_parser::prepare_on_send(message_ex *msg)
                 len += sz;
             }
 
-            dassert(len == (size_t)header->body_length, "data length is wrong");
+            CHECK_EQ(len, header->body_length);
             header->body_crc32 = crc32;
         }
 
@@ -200,8 +200,7 @@ int dsn_message_parser::get_buffers_on_send(message_ex *msg, /*out*/ send_buf *b
             len += sz;
         }
 
-        dassert(len == (size_t)header->body_length, "data length is wrong");
-
+        CHECK_EQ(len, header->body_length);
         bool r = (header->body_crc32 == crc32);
         if (!r) {
             LOG_ERROR("dsn message body crc check failed");

--- a/src/runtime/rpc/group_address.h
+++ b/src/runtime/rpc/group_address.h
@@ -121,7 +121,7 @@ inline rpc_group_address &rpc_group_address::operator=(const rpc_group_address &
 
 inline bool rpc_group_address::add(rpc_address addr)
 {
-    dassert(addr.type() == HOST_TYPE_IPV4, "rpc group address member must be ipv4");
+    CHECK_EQ_MSG(addr.type(), HOST_TYPE_IPV4, "rpc group address member must be ipv4");
 
     alw_t l(_lock);
     if (_members.end() == std::find(_members.begin(), _members.end(), addr)) {
@@ -146,7 +146,7 @@ inline void rpc_group_address::set_leader(rpc_address addr)
     if (addr.is_invalid()) {
         _leader_index = -1;
     } else {
-        dassert(addr.type() == HOST_TYPE_IPV4, "rpc group address member must be ipv4");
+        CHECK_EQ_MSG(addr.type(), HOST_TYPE_IPV4, "rpc group address member must be ipv4");
         for (int i = 0; i < (int)_members.size(); i++) {
             if (_members[i] == addr) {
                 _leader_index = i;

--- a/src/runtime/rpc/message_parser.cpp
+++ b/src/runtime/rpc/message_parser.cpp
@@ -161,12 +161,7 @@ char *message_reader::read_buffer_ptr(unsigned int read_next)
             _buffer_occupied = rb.length();
         }
 
-        dassert(read_next + _buffer_occupied <= _buffer.length(),
-                "%u(%u + %u) VS %u",
-                read_next + _buffer_occupied,
-                read_next,
-                _buffer_occupied,
-                _buffer.length());
+        CHECK_LE(read_next + _buffer_occupied, _buffer.length());
     }
 
     return (char *)(_buffer.data() + _buffer_occupied);

--- a/src/runtime/rpc/message_parser.cpp
+++ b/src/runtime/rpc/message_parser.cpp
@@ -161,7 +161,11 @@ char *message_reader::read_buffer_ptr(unsigned int read_next)
             _buffer_occupied = rb.length();
         }
 
-        CHECK_LE(read_next + _buffer_occupied, _buffer.length());
+        CHECK_LE_MSG(read_next + _buffer_occupied,
+                     _buffer.length(),
+                     "read_next: {}, _buffer_occupied: {}",
+                     read_next,
+                     _buffer_occupied);
     }
 
     return (char *)(_buffer.data() + _buffer_occupied);

--- a/src/runtime/rpc/network.sim.cpp
+++ b/src/runtime/rpc/network.sim.cpp
@@ -172,9 +172,9 @@ sim_network_provider::sim_network_provider(rpc_engine *rpc, network *inner_provi
 
 error_code sim_network_provider::start(rpc_channel channel, int port, bool client_only)
 {
-    dassert(channel == RPC_CHANNEL_TCP || channel == RPC_CHANNEL_UDP,
-            "invalid given channel %s",
-            channel.to_string());
+    CHECK(channel == RPC_CHANNEL_TCP || channel == RPC_CHANNEL_UDP,
+          "invalid given channel {}",
+          channel.to_string());
 
     _address = ::dsn::rpc_address("localhost", port);
     auto hostname = boost::asio::ip::host_name();

--- a/src/runtime/rpc/rpc_engine.cpp
+++ b/src/runtime/rpc/rpc_engine.cpp
@@ -67,8 +67,8 @@ private:
 rpc_client_matcher::~rpc_client_matcher()
 {
     for (int i = 0; i < MATCHER_BUCKET_NR; i++) {
-        dassert(_requests[i].size() == 0,
-                "all rpc entries must be removed before the matcher ends");
+        CHECK_EQ_MSG(
+            _requests[i].size(), 0, "all rpc entries must be removed before the matcher ends");
     }
 }
 
@@ -87,8 +87,8 @@ bool rpc_client_matcher::on_recv_reply(network *net, uint64_t key, message_ex *r
             _requests[bucket_index].erase(it);
         } else {
             if (reply) {
-                dassert(reply->get_count() == 0,
-                        "reply should not be referenced by anybody so far");
+                CHECK_EQ_MSG(
+                    reply->get_count(), 0, "reply should not be referenced by anybody so far");
                 delete reply;
             }
             return false;
@@ -154,7 +154,7 @@ bool rpc_client_matcher::on_recv_reply(network *net, uint64_t key, message_ex *r
         // TODO(qinzuoyan): reset timeout to new value
         _engine->call_ip(addr, req, call, true);
 
-        dassert(reply->get_count() == 0, "reply should not be referenced by anybody so far");
+        CHECK_EQ_MSG(reply->get_count(), 0, "reply should not be referenced by anybody so far");
         delete reply;
     } else {
         // server address side effect
@@ -327,8 +327,8 @@ rpc_server_dispatcher::~rpc_server_dispatcher()
     }
     _vhandlers.clear();
     _handlers.clear();
-    dassert(_handlers.size() == 0,
-            "please make sure all rpc handlers are unregistered at this point");
+    CHECK_EQ_MSG(
+        _handlers.size(), 0, "please make sure all rpc handlers are unregistered at this point");
 }
 
 bool rpc_server_dispatcher::register_rpc_handler(dsn::task_code code,
@@ -543,7 +543,7 @@ void rpc_engine::on_recv_request(network *net, message_ex *msg, int delay_ms)
             msg->header->from_address.to_string(),
             msg->header->trace_id);
 
-        dassert(msg->get_count() == 0, "request should not be referenced by anybody so far");
+        CHECK_EQ_MSG(msg->get_count(), 0, "request should not be referenced by anybody so far");
         delete msg;
         return;
     }
@@ -591,7 +591,7 @@ void rpc_engine::on_recv_request(network *net, message_ex *msg, int delay_ms)
                         msg->header->from_address.to_string(),
                         msg->header->trace_id);
 
-            dassert(msg->get_count() == 0, "request should not be referenced by anybody so far");
+            CHECK_EQ_MSG(msg->get_count(), 0, "request should not be referenced by anybody so far");
             msg->add_ref();
             dsn_rpc_reply(msg->create_response(), ::dsn::ERR_HANDLER_NOT_FOUND);
             msg->release_ref();
@@ -602,7 +602,7 @@ void rpc_engine::on_recv_request(network *net, message_ex *msg, int delay_ms)
                     msg->header->from_address.to_string(),
                     msg->header->trace_id);
 
-        dassert(msg->get_count() == 0, "request should not be referenced by anybody so far");
+        CHECK_EQ_MSG(msg->get_count(), 0, "request should not be referenced by anybody so far");
         msg->add_ref();
         dsn_rpc_reply(msg->create_response(), ::dsn::ERR_HANDLER_NOT_FOUND);
         msg->release_ref();

--- a/src/runtime/rpc/rpc_holder.h
+++ b/src/runtime/rpc/rpc_holder.h
@@ -240,8 +240,8 @@ public:
     using mail_box_u_ptr = std::unique_ptr<mail_box_t>;
     static void enable_mocking()
     {
-        dassert(_mail_box == nullptr && _forward_mail_box == nullptr,
-                "remember to call clear_mocking_env after testing");
+        CHECK(_mail_box == nullptr && _forward_mail_box == nullptr,
+              "remember to call clear_mocking_env after testing");
         _mail_box = make_unique<mail_box_t>();
         _forward_mail_box = make_unique<mail_box_t>();
     }

--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -264,9 +264,9 @@ message_ex *message_ex::copy_and_prepare_send(bool clone_content)
 
     if (_is_read) {
         // the message_header is hidden ahead of the buffer, expose it to buffer
-        dassert(buffers.size() == 1, "there must be only one buffer for read msg");
-        dassert((char *)header + sizeof(message_header) == (char *)buffers[0].data(),
-                "header and content must be contigous");
+        CHECK_EQ_MSG(buffers.size(), 1, "there must be only one buffer for read msg");
+        CHECK((char *)header + sizeof(message_header) == (char *)buffers[0].data(),
+              "header and content must be contigous");
 
         copy->buffers[0] = copy->buffers[0].range(-(int)sizeof(message_header));
 
@@ -406,8 +406,7 @@ void message_ex::write_next(void **ptr, size_t *size, size_t min_size)
     this->_rw_offset = 0;
     this->buffers.push_back(buffer);
 
-    dassert(this->_rw_index + 1 == (int)this->buffers.size(),
-            "message write buffer count is not right");
+    CHECK_EQ_MSG(_rw_index + 1, buffers.size(), "message write buffer count is not right");
 }
 
 void message_ex::write_commit(size_t size)

--- a/src/runtime/rpc/thrift_message_parser.cpp
+++ b/src/runtime/rpc/thrift_message_parser.cpp
@@ -354,11 +354,11 @@ void thrift_message_parser::prepare_on_send(message_ex *msg)
     int dsn_buf_count = 0;
     while (dsn_size > 0 && dsn_buf_count < buffers.size()) {
         blob &buf = buffers[dsn_buf_count];
-        dassert(dsn_size >= buf.length(), "%u VS %u", dsn_size, buf.length());
+        CHECK_GE(dsn_size, buf.length());
         dsn_size -= buf.length();
         ++dsn_buf_count;
     }
-    dassert(dsn_size == 0, "dsn_size = %u", dsn_size);
+    CHECK_EQ(dsn_size, 0);
 
     // put header_bb and end_bb at the end
     buffers.resize(dsn_buf_count);
@@ -379,7 +379,7 @@ int thrift_message_parser::get_buffers_on_send(message_ex *msg, /*out*/ send_buf
     int dsn_buf_count = 0;
     while (dsn_size > 0 && dsn_buf_count < msg_buffers.size()) {
         blob &buf = msg_buffers[dsn_buf_count];
-        dassert(dsn_size >= buf.length(), "%u VS %u", dsn_size, buf.length());
+        CHECK_GE(dsn_size, buf.length());
         dsn_size -= buf.length();
         ++dsn_buf_count;
 
@@ -392,8 +392,8 @@ int thrift_message_parser::get_buffers_on_send(message_ex *msg, /*out*/ send_buf
         offset = 0;
         ++i;
     }
-    dassert(dsn_size == 0, "dsn_size = %u", dsn_size);
-    dassert(dsn_buf_count + 2 == msg_buffers.size(), "must have 2 more blob at the end");
+    CHECK_EQ(dsn_size, 0);
+    CHECK_EQ_MSG(dsn_buf_count + 2, msg_buffers.size(), "must have 2 more blob at the end");
 
     // set header
     blob &header_bb = msg_buffers[dsn_buf_count];

--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -124,9 +124,7 @@ DSN_API bool dsn_rpc_unregiser_handler(dsn::task_code code)
 
 DSN_API void dsn_rpc_call(dsn::rpc_address server, dsn::rpc_response_task *rpc_call)
 {
-    dassert(rpc_call->spec().type == TASK_TYPE_RPC_RESPONSE,
-            "invalid task_type, type = %s",
-            enum_to_string(rpc_call->spec().type));
+    CHECK_EQ_MSG(rpc_call->spec().type, TASK_TYPE_RPC_RESPONSE, "invalid task_type");
 
     auto msg = rpc_call->get_request();
     msg->server_address = server;
@@ -200,7 +198,7 @@ NORETURN DSN_API void dsn_exit(int code)
 DSN_API bool dsn_mimic_app(const char *app_role, int index)
 {
     auto worker = ::dsn::task::get_current_worker2();
-    dassert(worker == nullptr, "cannot call dsn_mimic_app in rDSN threads");
+    CHECK(worker == nullptr, "cannot call dsn_mimic_app in rDSN threads");
 
     auto cnode = ::dsn::task::get_current_node2();
     if (cnode != nullptr) {

--- a/src/runtime/service_engine.cpp
+++ b/src/runtime/service_engine.cpp
@@ -245,7 +245,7 @@ void service_engine::start_node(service_app_spec &app_spec)
 
         auto node = std::make_shared<service_node>(app_spec);
         error_code err = node->start();
-        dassert_f(err == ERR_OK, "service node start failed, err = {}", err.to_string());
+        CHECK_EQ_MSG(err, ERR_OK, "service node start failed");
 
         _nodes_by_app_id[node->id()] = node;
     }

--- a/src/runtime/task/task.cpp
+++ b/src/runtime/task/task.cpp
@@ -57,10 +57,10 @@ __thread uint16_t tls_dsn_lower32_task_id_mask = 0;
         tls_dsn.node_id = node->id();
 
         if (worker != nullptr) {
-            dassert(worker->pool()->node() == node,
-                    "worker not belonging to the given node: %s vs %s",
-                    worker->pool()->node()->full_name(),
-                    node->full_name());
+            CHECK(worker->pool()->node() == node,
+                  "worker not belonging to the given node: {} vs {}",
+                  worker->pool()->node()->full_name(),
+                  node->full_name());
         }
 
         tls_dsn.node = node;
@@ -161,7 +161,8 @@ void task::exec_internal()
 
     if (_state.compare_exchange_strong(
             READY_STATE, TASK_STATE_RUNNING, std::memory_order_relaxed)) {
-        dassert(tls_dsn.magic == 0xdeadbeef, "thread is not inited with task::set_tls_dsn_context");
+        CHECK_EQ_MSG(
+            tls_dsn.magic, 0xdeadbeef, "thread is not inited with task::set_tls_dsn_context");
 
         task *parent_task = tls_dsn.current_task;
         tls_dsn.current_task = this;
@@ -405,7 +406,7 @@ void task::enqueue(task_worker_pool *pool)
 
     // fast execution
     if (_is_null) {
-        dassert(_node == task::get_current_node(), "");
+        CHECK(_node == task::get_current_node(), "");
         exec_internal();
         return;
     }

--- a/src/runtime/task/task.h
+++ b/src/runtime/task/task.h
@@ -498,9 +498,9 @@ public:
     void replace_callback(rpc_response_handler &&cb)
     {
         task_state cur_state = state();
-        dassert(cur_state == TASK_STATE_READY || cur_state == TASK_STATE_RUNNING,
-                "invalid task_state: %s",
-                enum_to_string(cur_state));
+        CHECK(cur_state == TASK_STATE_READY || cur_state == TASK_STATE_RUNNING,
+              "invalid task_state: {}",
+              enum_to_string(cur_state));
         _cb = std::move(cb);
     }
     void replace_callback(const rpc_response_handler &cb)

--- a/src/runtime/task/task_engine.cpp
+++ b/src/runtime/task/task_engine.cpp
@@ -120,8 +120,8 @@ void task_worker_pool::stop()
 
 void task_worker_pool::add_timer(task *t)
 {
-    dassert(t->delay_milliseconds() > 0,
-            "task delayed should be dispatched to timer service first");
+    CHECK_GT_MSG(
+        t->delay_milliseconds(), 0, "task delayed should be dispatched to timer service first");
 
     unsigned int idx = (_spec.partitioned
                             ? static_cast<unsigned int>(t->hash()) %
@@ -132,15 +132,15 @@ void task_worker_pool::add_timer(task *t)
 
 void task_worker_pool::enqueue(task *t)
 {
-    dassert(t->spec().pool_code == spec().pool_code || t->spec().type == TASK_TYPE_RPC_RESPONSE,
-            "Invalid thread pool used");
-    dassert(t->delay_milliseconds() == 0,
-            "task delayed should be dispatched to timer service first");
+    CHECK(t->spec().pool_code == spec().pool_code || t->spec().type == TASK_TYPE_RPC_RESPONSE,
+          "Invalid thread pool used");
+    CHECK_EQ_MSG(
+        t->delay_milliseconds(), 0, "task delayed should be dispatched to timer service first");
 
-    dassert(_is_running,
-            "worker pool %s must be started before enqueue task %s",
-            spec().name.c_str(),
-            t->spec().name.c_str());
+    CHECK(_is_running,
+          "worker pool {} must be started before enqueue task {}",
+          spec().name,
+          t->spec().name);
     unsigned int idx =
         (_spec.partitioned
              ? static_cast<unsigned int>(t->hash()) % static_cast<unsigned int>(_queues.size())

--- a/src/runtime/task/task_engine.sim.cpp
+++ b/src/runtime/task/task_engine.sim.cpp
@@ -49,7 +49,7 @@ sim_task_queue::sim_task_queue(task_worker_pool *pool, int index, task_queue *in
 
 void sim_task_queue::enqueue(task *t)
 {
-    dassert(0 == t->delay_milliseconds(), "delay time must be zero");
+    CHECK_EQ_MSG(0, t->delay_milliseconds(), "delay time must be zero");
     if (_tasks.size() > 0) {
         do {
             int random_pos = rand::next_u32(0, 1000000);
@@ -146,7 +146,7 @@ void sim_lock_provider::lock()
 
     _sema.wait(TIME_MS_MAX);
 
-    dassert(-1 == _current_holder && _lock_depth == 0, "must be unlocked state");
+    CHECK(-1 == _current_holder && _lock_depth == 0, "must be unlocked state");
     _current_holder = ctid;
     ++_lock_depth;
 }
@@ -165,7 +165,7 @@ bool sim_lock_provider::try_lock()
 
     bool r = _sema.wait(0);
     if (r) {
-        dassert(-1 == _current_holder && _lock_depth == 0, "must be unlocked state");
+        CHECK(-1 == _current_holder && _lock_depth == 0, "must be unlocked state");
         _current_holder = ctid;
         ++_lock_depth;
     }
@@ -178,8 +178,9 @@ void sim_lock_provider::unlock()
     if (scheduler::is_scheduling())
         return;
 
-    dassert(::dsn::utils::get_current_tid() == _current_holder,
-            "lock must be locked must current holder");
+    CHECK_EQ_MSG(::dsn::utils::get_current_tid(),
+                 _current_holder,
+                 "lock must be locked must current holder");
 
     if (0 == --_lock_depth) {
         _current_holder = -1;
@@ -208,7 +209,7 @@ void sim_lock_nr_provider::lock()
 
     _sema.wait(TIME_MS_MAX);
 
-    dassert(-1 == _current_holder && _lock_depth == 0, "must be unlocked state");
+    CHECK(-1 == _current_holder && _lock_depth == 0, "must be unlocked state");
     _current_holder = ctid;
     ++_lock_depth;
 }
@@ -224,7 +225,7 @@ bool sim_lock_nr_provider::try_lock()
 
     bool r = _sema.wait(0);
     if (r) {
-        dassert(-1 == _current_holder && _lock_depth == 0, "must be unlocked state");
+        CHECK(-1 == _current_holder && _lock_depth == 0, "must be unlocked state");
         _current_holder = ctid;
         ++_lock_depth;
     }
@@ -237,8 +238,9 @@ void sim_lock_nr_provider::unlock()
     if (scheduler::is_scheduling())
         return;
 
-    dassert(::dsn::utils::get_current_tid() == _current_holder,
-            "lock must be locked must current holder");
+    CHECK_EQ_MSG(::dsn::utils::get_current_tid(),
+                 _current_holder,
+                 "lock must be locked must current holder");
 
     if (0 == --_lock_depth) {
         _current_holder = -1;

--- a/src/runtime/task/task_spec.cpp
+++ b/src/runtime/task/task_spec.cpp
@@ -165,11 +165,12 @@ task_spec::task_spec(int code,
       on_rpc_response_enqueue((std::string(name) + std::string(".rpc.response.enqueue")).c_str()),
       on_rpc_create_response((std::string(name) + std::string(".rpc.response.create")).c_str())
 {
-    dassert(strlen(name) < DSN_MAX_TASK_CODE_NAME_LENGTH,
-            "task code name '%s' is too long: length must be smaller than "
-            "DSN_MAX_TASK_CODE_NAME_LENGTH (%u)",
-            name,
-            DSN_MAX_TASK_CODE_NAME_LENGTH);
+    CHECK_LT_MSG(strlen(name),
+                 DSN_MAX_TASK_CODE_NAME_LENGTH,
+                 "task code name '{}' is too long: length must be smaller than "
+                 "DSN_MAX_TASK_CODE_NAME_LENGTH ({})",
+                 name,
+                 DSN_MAX_TASK_CODE_NAME_LENGTH);
 
     rpc_call_channel = RPC_CHANNEL_TCP;
     rpc_timeout_milliseconds = 5 * 1000; // 5 seconds
@@ -210,9 +211,9 @@ bool task_spec::init()
             spec->allow_inline = true;
         }
 
-        dassert(spec->rpc_request_delays_milliseconds.size() == 0 ||
-                    spec->rpc_request_delays_milliseconds.size() == 6,
-                "invalid length of rpc_request_delays_milliseconds, must be of length 6");
+        CHECK(spec->rpc_request_delays_milliseconds.size() == 0 ||
+                  spec->rpc_request_delays_milliseconds.size() == 6,
+              "invalid length of rpc_request_delays_milliseconds, must be of length 6");
         if (spec->rpc_request_delays_milliseconds.size() > 0) {
             spec->rpc_request_delayer.initialize(spec->rpc_request_delays_milliseconds);
         }

--- a/src/runtime/task/task_tracker.h
+++ b/src/runtime/task/task_tracker.h
@@ -24,23 +24,15 @@
  * THE SOFTWARE.
  */
 
-/*
- * Description:
- *     tracker abstraction for tasks, to ensure the tasks are cancelled
- *     appropriately when the context is gone
- *
- * Revision history:
- *     Mar., 2015, @imzhenyu (Zhenyu Guo), first version
- *     xxxx-xx-xx, author, fix bug about xxx
- */
-
 #pragma once
 
+#include <atomic>
+
+#include "utils/api_utilities.h"
+#include "utils/error_code.h"
+#include "utils/fmt_logging.h"
 #include "utils/link.h"
 #include "utils/synchronize.h"
-#include "utils/error_code.h"
-#include "utils/api_utilities.h"
-#include <atomic>
 
 namespace dsn {
 //
@@ -184,7 +176,7 @@ private:
 // ------- inlined implementation ----------
 inline void trackable_task::set_tracker(task_tracker *owner, task *tsk)
 {
-    dassert(_owner == nullptr, "task tracker is already set");
+    CHECK(_owner == nullptr, "task tracker is already set");
     _owner = owner;
     _task = tsk;
     _deleting_owner.store(OWNER_DELETE_NOT_LOCKED, std::memory_order_release);

--- a/src/runtime/task/task_worker.cpp
+++ b/src/runtime/task/task_worker.cpp
@@ -135,13 +135,15 @@ void task_worker::set_priority(worker_priority_t pri)
 void task_worker::set_affinity(uint64_t affinity)
 {
 #if defined(__linux__)
-    dassert(affinity > 0, "affinity cannot be 0.");
+    CHECK_GT(affinity, 0);
 
     int nr_cpu = static_cast<int>(std::thread::hardware_concurrency());
     if (nr_cpu < 64) {
-        dassert(affinity <= (((uint64_t)1 << nr_cpu) - 1),
-                "There are %d cpus in total, while setting thread affinity to a nonexistent one.",
-                nr_cpu);
+        CHECK_LE_MSG(
+            affinity,
+            (((uint64_t)1 << nr_cpu) - 1),
+            "There are {} cpus in total, while setting thread affinity to a nonexistent one.",
+            nr_cpu);
     }
 
     int err = 0;
@@ -229,10 +231,7 @@ void task_worker::loop()
         }
 
 #ifndef NDEBUG
-        dassert(count == batch_size,
-                "returned task count and batch size do not match: %d vs %d",
-                count,
-                batch_size);
+        CHECK_EQ_MSG(count, batch_size, "returned task count and batch size do not match");
 #endif
 
         _processed_task_count += batch_size;

--- a/src/runtime/tool_api.cpp
+++ b/src/runtime/tool_api.cpp
@@ -58,7 +58,7 @@ public:
         if (_start) {
             error_code err;
             err = _node->start_app();
-            dassert(err == ERR_OK, "start app failed, err = %s", err.to_string());
+            CHECK_EQ_MSG(err, ERR_OK, "start app failed");
         } else {
             LOG_INFO("stop app result(%s)", _node->stop_app(_cleanup).to_string());
         }

--- a/src/server/available_detector.cpp
+++ b/src/server/available_detector.cpp
@@ -49,12 +49,12 @@ available_detector::available_detector()
     _cluster_name = dsn::get_current_cluster_name();
     _app_name = dsn_config_get_value_string(
         "pegasus.collector", "available_detect_app", "", "available detector app name");
-    dassert(_app_name.size() > 0, "");
+    CHECK(!_app_name.empty(), "");
     _alert_script_dir = dsn_config_get_value_string("pegasus.collector",
                                                     "available_detect_alert_script_dir",
                                                     ".",
                                                     "available detect alert script dir");
-    dassert(_alert_script_dir.size() > 0, "");
+    CHECK(!_alert_script_dir.empty(), "");
     _alert_email_address = dsn_config_get_value_string(
         "pegasus.collector",
         "available_detect_alert_email_address",
@@ -62,7 +62,7 @@ available_detector::available_detector()
         "available detect alert email address, empty means not send email");
     _meta_list.clear();
     dsn::replication::replica_helper::load_meta_servers(_meta_list);
-    dassert(_meta_list.size() > 0, "");
+    CHECK(!_meta_list.empty(), "");
     _detect_interval_seconds =
         (uint32_t)dsn_config_get_value_uint64("pegasus.collector",
                                               "available_detect_interval_seconds",

--- a/src/server/brief_stat.cpp
+++ b/src/server/brief_stat.cpp
@@ -17,11 +17,13 @@
  * under the License.
  */
 
-#include <iomanip>
-#include "utils/api_utilities.h"
-#include "perf_counter/perf_counters.h"
-
 #include "brief_stat.h"
+
+#include <iomanip>
+
+#include "perf_counter/perf_counters.h"
+#include "utils/api_utilities.h"
+#include "utils/fmt_logging.h"
 
 namespace pegasus {
 
@@ -73,7 +75,7 @@ std::string get_brief_stat()
     std::vector<bool> match_result;
     dsn::perf_counters::instance().query_snapshot(stat_counters, iter, &match_result);
 
-    dassert(stat_counters.size() == match_result.size(), "");
+    CHECK_EQ(stat_counters.size(), match_result.size());
     for (int i = 0; i < match_result.size(); ++i) {
         if (!match_result[i]) {
             if (!first_item)

--- a/src/server/hashkey_transform.h
+++ b/src/server/hashkey_transform.h
@@ -48,8 +48,8 @@ public:
 
         // hash_key_len is in big endian
         uint16_t hash_key_len = dsn::endian::ntoh(*(uint16_t *)(src.data()));
-        dassert(src.size() >= 2 + hash_key_len,
-                "key length must be no less than (2 + hash_key_len)");
+        CHECK_GE_MSG(
+            src.size(), 2 + hash_key_len, "key length must be no less than (2 + hash_key_len)");
         return rocksdb::Slice(src.data(), 2 + hash_key_len);
     }
 

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -146,10 +146,12 @@ void hotspot_partition_calculator::update_hot_point(uint32_t data_type,
 
 void hotspot_partition_calculator::data_analyse()
 {
-    dassert(_partitions_stat_histories.back().size() == _hot_points.size(),
-            "The number of partitions in this table has changed, and hotspot analysis cannot be "
-            "performed,in %s",
-            _app_name.c_str());
+    CHECK_EQ_MSG(
+        _partitions_stat_histories.back().size(),
+        _hot_points.size(),
+        "The number of partitions in this table has changed, and hotspot analysis cannot be "
+        "performed, in {}",
+        _app_name);
 
     std::vector<int> read_hot_points;
     stat_histories_analyse(READ_HOTSPOT_DATA, read_hot_points);

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2165,25 +2165,16 @@ pegasus_server_impl::storage_apply_checkpoint(chkpt_apply_mode mode,
     int64_t ci = state.to_decree_included;
 
     if (mode == chkpt_apply_mode::copy) {
-        dassert(ci > last_durable_decree(),
-                "state.to_decree_included(%" PRId64 ") <= last_durable_decree(%" PRId64 ")",
-                ci,
-                last_durable_decree());
+        CHECK_GT(ci, last_durable_decree());
 
         auto learn_dir = ::dsn::utils::filesystem::remove_file_name(state.files[0]);
         auto chkpt_dir = ::dsn::utils::filesystem::path_combine(data_dir(), chkpt_get_dir_name(ci));
         if (::dsn::utils::filesystem::rename_path(learn_dir, chkpt_dir)) {
             ::dsn::utils::auto_lock<::dsn::utils::ex_lock_nr> l(_checkpoints_lock);
-            dassert(ci > last_durable_decree(),
-                    "%" PRId64 " VS %" PRId64 "",
-                    ci,
-                    last_durable_decree());
+            CHECK_GT(ci, last_durable_decree());
             _checkpoints.push_back(ci);
             if (!_checkpoints.empty()) {
-                dassert(ci > _checkpoints.back(),
-                        "%" PRId64 " VS %" PRId64 "",
-                        ci,
-                        _checkpoints.back());
+                CHECK_GT(ci, _checkpoints.back());
             }
             set_last_durable_decree(ci);
             err = ::dsn::ERR_OK;
@@ -2243,7 +2234,7 @@ pegasus_server_impl::storage_apply_checkpoint(chkpt_apply_mode mode,
     }
 
     CHECK(_is_open, "");
-    dassert(ci == last_durable_decree(), "%" PRId64 " VS %" PRId64 "", ci, last_durable_decree());
+    CHECK_EQ(ci, last_durable_decree());
 
     LOG_INFO("%s: apply checkpoint succeed, last_durable_decree = %" PRId64,
              replica_name(),

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -169,7 +169,7 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
         100000000,
         "get/multi-get operation duration exceed this threshold will be logged");
     _slow_query_threshold_ns = _slow_query_threshold_ns_in_config;
-    dassert(_slow_query_threshold_ns > 0, "slow query threshold must be greater than 0");
+    CHECK_GT(_slow_query_threshold_ns, 0);
     _abnormal_get_size_threshold = dsn_config_get_value_uint64(
         "pegasus.server",
         "rocksdb_abnormal_get_size_threshold",

--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -61,7 +61,7 @@ int pegasus_server_write::on_batched_write_requests(dsn::message_ex **requests,
     try {
         auto iter = _non_batch_write_handlers.find(requests[0]->rpc_code());
         if (iter != _non_batch_write_handlers.end()) {
-            dassert_f(count == 1, "count = {}", count);
+            CHECK_EQ(count, 1);
             return iter->second(requests[0]);
         }
     } catch (TTransportException &ex) {
@@ -140,10 +140,10 @@ void pegasus_server_write::request_key_check(int64_t decree,
     // TODO(wutao1): server should not assert when client's hash is incorrect.
     if (msg->header->client.partition_hash != 0) {
         uint64_t partition_hash = pegasus_key_hash(key);
-        dassert(msg->header->client.partition_hash == partition_hash,
-                "inconsistent partition hash");
+        CHECK_EQ_MSG(
+            msg->header->client.partition_hash, partition_hash, "inconsistent partition hash");
         int thread_hash = get_gpid().thread_hash();
-        dassert(msg->header->client.thread_hash == thread_hash, "inconsistent thread hash");
+        CHECK_EQ_MSG(msg->header->client.thread_hash, thread_hash, "inconsistent thread hash");
     }
 
     if (_verbose_log) {

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -234,8 +234,8 @@ int pegasus_write_service::check_and_mutate(int64_t decree,
 
 void pegasus_write_service::batch_prepare(int64_t decree)
 {
-    dassert(_batch_start_time == 0,
-            "batch_prepare and batch_commit/batch_abort must be called in pair");
+    CHECK_EQ_MSG(
+        _batch_start_time, 0, "batch_prepare and batch_commit/batch_abort must be called in pair");
 
     _batch_start_time = dsn_now_ns();
 }

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -446,9 +446,7 @@ public:
                     resp.error = _rocksdb_wrapper->write_batch_put(
                         decree, key, m.value, static_cast<uint32_t>(m.set_expire_ts_seconds));
                 } else {
-                    dassert_f(m.operation == ::dsn::apps::mutate_operation::MO_DELETE,
-                              "m.operation = %d",
-                              m.operation);
+                    CHECK_EQ(m.operation, ::dsn::apps::mutate_operation::MO_DELETE);
                     resp.error = _rocksdb_wrapper->write_batch_delete(decree, key);
                 }
 

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -196,7 +196,7 @@ struct scan_data_context
     {
         // max_batch_count should > 1 because scan may be terminated
         // when split_request_count = 1
-        dassert(max_batch_count > 1, "");
+        CHECK_GT(max_batch_count, 1);
     }
     void set_sort_key_filter(pegasus::pegasus_client::filter_type type, const std::string &pattern)
     {
@@ -1014,11 +1014,8 @@ get_app_partitions(shell_context *sc,
             LOG_ERROR("list app %s failed, error = %s", app.app_name.c_str(), err.to_string());
             return false;
         }
-        dassert(app_id == app.app_id, "%d VS %d", app_id, app.app_id);
-        dassert(partition_count == app.partition_count,
-                "%d VS %d",
-                partition_count,
-                app.partition_count);
+        CHECK_EQ(app_id, app.app_id);
+        CHECK_EQ(partition_count, app.partition_count);
     }
     return true;
 }
@@ -1200,11 +1197,8 @@ get_app_stat(shell_context *sc, const std::string &app_name, std::vector<row_dat
             LOG_ERROR("list app %s failed, error = %s", app_name.c_str(), err.to_string());
             return false;
         }
-        dassert(app_id == app_info->app_id, "%d VS %d", app_id, app_info->app_id);
-        dassert(partition_count == app_info->partition_count,
-                "%d VS %d",
-                partition_count,
-                app_info->partition_count);
+        CHECK_EQ(app_id, app_info->app_id);
+        CHECK_EQ(partition_count, app_info->partition_count);
 
         for (int i = 0; i < nodes.size(); ++i) {
             dsn::rpc_address node_addr = nodes[i].address;
@@ -1217,8 +1211,8 @@ get_app_stat(shell_context *sc, const std::string &app_name, std::vector<row_dat
                 bool parse_ret = parse_app_pegasus_perf_counter_name(
                     m.name, app_id_x, partition_index_x, counter_name);
                 CHECK(parse_ret, "name = {}", m.name);
-                dassert(app_id_x == app_id, "name = %s", m.name.c_str());
-                dassert(partition_index_x < partition_count, "name = %s", m.name.c_str());
+                CHECK_EQ_MSG(app_id_x, app_id, "name = {}", m.name);
+                CHECK_LT_MSG(partition_index_x, partition_count, "name = {}", m.name);
                 if (partitions[partition_index_x].primary != node_addr)
                     continue;
                 update_app_pegasus_perf_counter(rows[partition_index_x], counter_name, m.value);

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -2570,7 +2570,7 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
 std::string unescape_str(const char *escaped)
 {
     std::string dst, src = escaped;
-    dassert(pegasus::utils::c_unescape_string(src, dst) >= 0, "");
+    CHECK_GE(pegasus::utils::c_unescape_string(src, dst), 0);
     return dst;
 }
 

--- a/src/test/kill_test/data_verifier.cpp
+++ b/src/test/kill_test/data_verifier.cpp
@@ -46,6 +46,7 @@
 
 #include "pegasus/client.h"
 #include "data_verifier.h"
+#include "utils/fmt_logging.h"
 
 using namespace std;
 using namespace ::pegasus;
@@ -349,7 +350,7 @@ void do_mark()
     while (true) {
         sleep(1);
         long long new_id = get_min_thread_setting_id();
-        dassert(new_id >= old_id, "%" PRId64 " VS %" PRId64 "", new_id, old_id);
+        CHECK_GE(new_id, old_id);
         if (new_id == old_id) {
             continue;
         }

--- a/src/test/kill_test/killer_handler_shell.cpp
+++ b/src/test/kill_test/killer_handler_shell.cpp
@@ -37,7 +37,7 @@ killer_handler_shell::killer_handler_shell()
     const char *section = "killer.handler.shell";
     _run_script_path = dsn_config_get_value_string(
         section, "onebox_run_path", "~/pegasus/run.sh", "onebox run path");
-    dassert(_run_script_path.size() > 0, "");
+    CHECK(!_run_script_path.empty(), "");
 }
 
 bool killer_handler_shell::has_meta_dumped_core(int index)

--- a/src/test/kill_test/process_kill_testor.cpp
+++ b/src/test/kill_test/process_kill_testor.cpp
@@ -51,7 +51,7 @@ process_kill_testor::process_kill_testor(const char *config_file) : kill_testor(
     // initialize killer_handler
     std::string killer_name =
         dsn_config_get_value_string(section, "killer_handler", "", "killer handler");
-    dassert(killer_name.size() > 0, "");
+    CHECK(!killer_name.empty(), "");
     _killer_handler.reset(killer_handler::new_handler(killer_name.c_str()));
     CHECK(_killer_handler, "invalid killer_name({})", killer_name);
 

--- a/src/test/pressure_test/main.cpp
+++ b/src/test/pressure_test/main.cpp
@@ -249,7 +249,7 @@ int main(int argc, const char **argv)
     value_len =
         (int32_t)dsn_config_get_value_uint64("pressureclient", "value_len", 64, "value length");
 
-    dassert(qps > 0, "qps must GT 0, but qps(%d)", qps);
+    CHECK_GT(qps, 0);
     CHECK(!op_name.empty(), "must assign operation name");
 
     LOG_INFO("pressureclient %s qps = %d", op_name.c_str(), qps);

--- a/src/utils/alloc.cpp
+++ b/src/utils/alloc.cpp
@@ -42,7 +42,7 @@ namespace dsn {
     // [ENOMEM]
     //     There is insufficient memory available with the requested alignment.
     // Thus making an assertion here is enough.
-    dassert_f(err == 0, "error calling posix_memalign: {}", utils::safe_strerror(err).c_str());
+    CHECK_EQ_MSG(err, 0, "error calling posix_memalign: {}", utils::safe_strerror(err));
 
     return buffer;
 }

--- a/src/utils/alloc.h
+++ b/src/utils/alloc.h
@@ -51,16 +51,17 @@ cacheline_aligned_ptr<T> cacheline_aligned_alloc_array(size_t len)
     if (sizeof(T) <= CACHELINE_SIZE && (sizeof(T) & (sizeof(T) - 1)) == 0) {
         for (size_t i = 0; i < len; ++i) {
             T *elem = &(array[i]);
-            dassert_f((reinterpret_cast<const uintptr_t>(elem) & (sizeof(T) - 1)) == 0,
-                      "unaligned array element for cache line: array={}, length={}, index={}, "
-                      "elem={}, elem_size={}, mask={}, cacheline_size={}",
-                      fmt::ptr(array),
-                      len,
-                      i,
-                      fmt::ptr(elem),
-                      sizeof(T),
-                      sizeof(T) - 1,
-                      CACHELINE_SIZE);
+            CHECK_EQ_MSG((reinterpret_cast<const uintptr_t>(elem) & (sizeof(T) - 1)),
+                         0,
+                         "unaligned array element for cache line: array={}, length={}, index={}, "
+                         "elem={}, elem_size={}, mask={}, cacheline_size={}",
+                         fmt::ptr(array),
+                         len,
+                         i,
+                         fmt::ptr(elem),
+                         sizeof(T),
+                         sizeof(T) - 1,
+                         CACHELINE_SIZE);
         }
     }
 #endif

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -25,11 +25,12 @@
  */
 
 #include <iostream>
-#include <thread>
 #include <sstream>
+#include <thread>
 
-#include "utils/utils.h"
 #include "utils/command_manager.h"
+#include "utils/fmt_logging.h"
+#include "utils/utils.h"
 
 namespace dsn {
 
@@ -45,7 +46,7 @@ dsn_handle_t command_manager::register_command(const std::vector<std::string> &c
         if (!cmd.empty()) {
             is_valid_cmd = true;
             auto it = _handlers.find(cmd);
-            dassert(it == _handlers.end(), "command '%s' already regisered", cmd.c_str());
+            CHECK(it == _handlers.end(), "command '{}' already regisered", cmd);
         }
     }
     dassert(is_valid_cmd, "should not register empty command");

--- a/src/utils/filesystem.cpp
+++ b/src/utils/filesystem.cpp
@@ -671,7 +671,7 @@ error_code get_process_image_path(int pid, std::string &path)
 
     err = snprintf_p(
         tmp, ARRAYSIZE(tmp), "/proc/%s/exe", (pid == -1) ? "self" : std::to_string(pid).c_str());
-    dassert(err >= 0, "snprintf_p failed.");
+    CHECK_GE(err, 0);
 
     err = (int)readlink(tmp, tls_path_buffer, TLS_PATH_BUFFER_SIZE);
     if (err == -1) {
@@ -806,11 +806,12 @@ error_code read_file(const std::string &fname, std::string &buf)
         return ERR_FILE_OPERATION_FAILED;
     }
     fin.read(&buf[0], file_sz);
-    dassert_f(file_sz == fin.gcount(),
-              "read file({}) failed, file_size = {} but read size = {}",
-              fname,
-              file_sz,
-              fin.gcount());
+    CHECK_EQ_MSG(file_sz,
+                 fin.gcount(),
+                 "read file({}) failed, file_size = {} but read size = {}",
+                 fname,
+                 file_sz,
+                 fin.gcount());
     fin.close();
     return ERR_OK;
 }

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -59,33 +59,90 @@
 
 // Macros to check expected condition. It will abort the application
 // and log a fatal message when the condition is not met.
-#define CHECK_NE(var1, var2) CHECK(var1 != var2, "{} vs {}", var1, var2)
-#define CHECK_EQ(var1, var2) CHECK(var1 == var2, "{} vs {}", var1, var2)
-#define CHECK_GE(var1, var2) CHECK(var1 >= var2, "{} vs {}", var1, var2)
-#define CHECK_LE(var1, var2) CHECK(var1 <= var2, "{} vs {}", var1, var2)
-#define CHECK_GT(var1, var2) CHECK(var1 > var2, "{} vs {}", var1, var2)
-#define CHECK_LT(var1, var2) CHECK(var1 < var2, "{} vs {}", var1, var2)
-
 #define CHECK_NE_MSG(var1, var2, ...)                                                              \
-    CHECK(var1 != var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        CHECK(_v1 != _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));                      \
+    } while (false)
+
 #define CHECK_EQ_MSG(var1, var2, ...)                                                              \
-    CHECK(var1 == var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        CHECK(_v1 == _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));                      \
+    } while (false)
+
 #define CHECK_GE_MSG(var1, var2, ...)                                                              \
-    CHECK(var1 >= var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        CHECK(_v1 >= _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));                      \
+    } while (false)
+
 #define CHECK_LE_MSG(var1, var2, ...)                                                              \
-    CHECK(var1 <= var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        CHECK(_v1 <= _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));                      \
+    } while (false)
+
 #define CHECK_GT_MSG(var1, var2, ...)                                                              \
-    CHECK(var1 > var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        CHECK(_v1 > _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));                       \
+    } while (false)
+
 #define CHECK_LT_MSG(var1, var2, ...)                                                              \
-    CHECK(var1 < var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        CHECK(_v1 < _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));                       \
+    } while (false)
+
+#define CHECK_NE(var1, var2) CHECK_NE_MSG(var1, var2, "")
+#define CHECK_EQ(var1, var2) CHECK_EQ_MSG(var1, var2, "")
+#define CHECK_GE(var1, var2) CHECK_GE_MSG(var1, var2, "")
+#define CHECK_LE(var1, var2) CHECK_LE_MSG(var1, var2, "")
+#define CHECK_GT(var1, var2) CHECK_GT_MSG(var1, var2, "")
+#define CHECK_LT(var1, var2) CHECK_LT_MSG(var1, var2, "")
 
 // TODO(yingchun): add CHECK_NULL(ptr), CHECK_OK(err), CHECK(cond)
+#define CHECK_EQ_PREFIX(var1, var2)                                                                \
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        dassert_replica(_v1 == _v2, "{} vs {}", _v1, _v2);                                         \
+    } while (false)
 
-#define CHECK_EQ_PREFIX(var1, var2) dassert_replica(var1 == var2, "{} vs {}", var1, var2)
-#define CHECK_GE_PREFIX(var1, var2) dassert_replica(var1 >= var2, "{} vs {}", var1, var2)
-#define CHECK_LE_PREFIX(var1, var2) dassert_replica(var1 <= var2, "{} vs {}", var1, var2)
-#define CHECK_GT_PREFIX(var1, var2) dassert_replica(var1 > var2, "{} vs {}", var1, var2)
-#define CHECK_LT_PREFIX(var1, var2) dassert_replica(var1 < var2, "{} vs {}", var1, var2)
+#define CHECK_GE_PREFIX(var1, var2)                                                                \
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        dassert_replica(_v1 >= _v2, "{} vs {}", _v1, _v2);                                         \
+    } while (false)
+
+#define CHECK_LE_PREFIX(var1, var2)                                                                \
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        dassert_replica(_v1 <= _v2, "{} vs {}", _v1, _v2);                                         \
+    } while (false)
+
+#define CHECK_GT_PREFIX(var1, var2)                                                                \
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        dassert_replica(_v1 > _v2, "{} vs {}", _v1, _v2);                                          \
+    } while (false)
+
+#define CHECK_LT_PREFIX(var1, var2)                                                                \
+    do {                                                                                           \
+        const auto &_v1 = (var1);                                                                  \
+        const auto &_v2 = (var2);                                                                  \
+        dassert_replica(_v1 < _v2, "{} vs {}", _v1, _v2);                                          \
+    } while (false)
 
 // Return the given status if condition is not true.
 #define ERR_LOG_AND_RETURN_NOT_TRUE(s, err, ...)                                                   \

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -59,11 +59,27 @@
 
 // Macros to check expected condition. It will abort the application
 // and log a fatal message when the condition is not met.
+#define CHECK_NE(var1, var2) CHECK(var1 != var2, "{} vs {}", var1, var2)
 #define CHECK_EQ(var1, var2) CHECK(var1 == var2, "{} vs {}", var1, var2)
 #define CHECK_GE(var1, var2) CHECK(var1 >= var2, "{} vs {}", var1, var2)
 #define CHECK_LE(var1, var2) CHECK(var1 <= var2, "{} vs {}", var1, var2)
 #define CHECK_GT(var1, var2) CHECK(var1 > var2, "{} vs {}", var1, var2)
 #define CHECK_LT(var1, var2) CHECK(var1 < var2, "{} vs {}", var1, var2)
+
+#define CHECK_NE_MSG(var1, var2, ...)                                                              \
+    CHECK(var1 != var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+#define CHECK_EQ_MSG(var1, var2, ...)                                                              \
+    CHECK(var1 == var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+#define CHECK_GE_MSG(var1, var2, ...)                                                              \
+    CHECK(var1 >= var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+#define CHECK_LE_MSG(var1, var2, ...)                                                              \
+    CHECK(var1 <= var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+#define CHECK_GT_MSG(var1, var2, ...)                                                              \
+    CHECK(var1 > var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+#define CHECK_LT_MSG(var1, var2, ...)                                                              \
+    CHECK(var1 < var2, "{} vs {} {}", var1, var2, fmt::format(__VA_ARGS__))
+
+// TODO(yingchun): add CHECK_NULL(ptr), CHECK_OK(err), CHECK(cond)
 
 #define CHECK_EQ_PREFIX(var1, var2) dassert_replica(var1 == var2, "{} vs {}", var1, var2)
 #define CHECK_GE_PREFIX(var1, var2) dassert_replica(var1 >= var2, "{} vs {}", var1, var2)

--- a/src/utils/long_adder.cpp
+++ b/src/utils/long_adder.cpp
@@ -73,7 +73,7 @@ cacheline_aligned_int64 *const kCellsLocked = reinterpret_cast<cacheline_aligned
     // [ENOMEM]
     //     There is insufficient memory available with the requested alignment.
     // Thus making an assertion here is enough.
-    dassert_f(err == 0, "error calling posix_memalign: {}", utils::safe_strerror(err).c_str());
+    CHECK_EQ_MSG(err, 0, "error calling posix_memalign: {}", utils::safe_strerror(err));
 
     cacheline_aligned_int64 *array = new (buffer) cacheline_aligned_int64[size];
     for (uint32_t i = 0; i < size; ++i) {

--- a/src/utils/math.cpp
+++ b/src/utils/math.cpp
@@ -15,10 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <numeric>
+#include "math.h"
+
 #include <algorithm>
-#include <math.h>
+#include <numeric>
+
 #include "utils/api_utilities.h"
+#include "utils/fmt_logging.h"
 #include "utils/math.h"
 
 namespace dsn {
@@ -26,7 +29,7 @@ namespace utils {
 
 double mean_stddev(const std::vector<uint32_t> &result_set, bool partial_sample)
 {
-    dassert(result_set.size() > 1, "invalid sample data input for stddev");
+    CHECK_GT_MSG(result_set.size(), 1, "invalid sample data input for stddev");
 
     double sum = std::accumulate(result_set.begin(), result_set.end(), 0.0);
     double mean = sum / result_set.size();

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -99,7 +99,7 @@ void metric_entity::set_attributes(attr_map &&attrs)
 metric_entity_ptr metric_entity_prototype::instantiate(const std::string &id,
                                                        metric_entity::attr_map attrs) const
 {
-    dassert_f(attrs.find("entity") == attrs.end(), "{}'s attribute \"entity\" is reserved", id);
+    CHECK(attrs.find("entity") == attrs.end(), "{}'s attribute \"entity\" is reserved", id);
 
     attrs["entity"] = _name;
     return metric_registry::instance().find_or_create_entity(id, std::move(attrs));
@@ -243,9 +243,10 @@ void percentile_timer::on_timer(const boost::system::error_code &ec)
     } while (0)
 
     if (dsn_unlikely(!!ec)) {
-        dassert_f(ec == boost::system::errc::operation_canceled,
-                  "failed to exec on_timer with an error that cannot be handled: {}",
-                  ec.message());
+        CHECK_EQ_MSG(ec,
+                     boost::system::errc::operation_canceled,
+                     "failed to exec on_timer with an error that cannot be handled: {}",
+                     ec.message());
 
         // Cancel can only be launched by close().
         auto expected_state = state::kClosing;

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -541,7 +541,7 @@ public:
     // NOTICE: x MUST be a non-negative integer.
     void increment_by(int64_t x)
     {
-        dassert_f(x >= 0, "delta({}) by increment for counter must be a non-negative integer", x);
+        CHECK_GE_MSG(x, 0, "delta({}) by increment for counter must be a non-negative integer", x);
         _adder.increment_by(x);
     }
 
@@ -782,10 +782,9 @@ protected:
           _nth_element_finder(),
           _timer()
     {
-        dassert(_sample_size > 0 && (_sample_size & (_sample_size - 1)) == 0,
-                "sample_sizes should be > 0 and power of 2");
-
-        dassert(_samples, "_samples should be valid pointer");
+        CHECK(_sample_size > 0 && (_sample_size & (_sample_size - 1)) == 0,
+              "sample_sizes should be > 0 and power of 2");
+        CHECK(_samples, "");
 
         for (const auto &kth : kth_percentiles) {
             _kth_percentile_bitset.set(static_cast<size_t>(kth));

--- a/src/utils/nth_element.h
+++ b/src/utils/nth_element.h
@@ -89,7 +89,7 @@ public:
     {
         for (size_type i = 0; i < _nths.size();) {
             auto nth_iter = begin + _nths[i];
-            dassert_f(nth_iter >= first && nth_iter < last, "Invalid iterators for nth_element()");
+            CHECK(nth_iter >= first && nth_iter < last, "Invalid iterators for nth_element()");
             std::nth_element(first, nth_iter, last, _comp);
             _elements[i] = *nth_iter;
 

--- a/src/utils/output_utils.cpp
+++ b/src/utils/output_utils.cpp
@@ -68,7 +68,7 @@ void table_printer::add_title(const std::string &title, alignment align)
 void table_printer::add_column(const std::string &col_name, alignment align)
 {
     check_mode(data_mode::kMultiColumns);
-    dassert(_matrix_data.size() == 1, "`add_column` must be called before real data appendding");
+    CHECK_EQ_MSG(_matrix_data.size(), 1, "'add_column' must be called before real data appendding");
     _max_col_width.push_back(col_name.length());
     _align_left.push_back(align == alignment::kLeft);
     append_data(col_name);
@@ -117,7 +117,7 @@ void table_printer::output_in_tabular(std::ostream &out) const
     if (_mode == data_mode::kSingleColumn) {
         separator = ": ";
     } else {
-        dassert(_mode == data_mode::kMultiColumns, "Unknown mode");
+        CHECK(_mode == data_mode::kMultiColumns, "Unknown mode");
     }
 
     if (!_name.empty()) {
@@ -138,7 +138,7 @@ void table_printer::append_string_data(const std::string &data)
 {
     _matrix_data.rbegin()->emplace_back(data);
     int last_index = _matrix_data.rbegin()->size() - 1;
-    dassert(last_index <= _max_col_width.size(), "column data exceed");
+    CHECK_LE_MSG(last_index, _max_col_width.size(), "column data exceed");
 
     // update column max length
     int &cur_len = _max_col_width[last_index];
@@ -153,7 +153,7 @@ void table_printer::check_mode(data_mode mode)
         _mode = mode;
         return;
     }
-    dassert(_mode == mode, "");
+    CHECK(_mode == mode, "");
 }
 
 void multi_table_printer::add(table_printer &&tp) { _tps.emplace_back(std::move(tp)); }

--- a/src/utils/rpc_address.h
+++ b/src/utils/rpc_address.h
@@ -183,6 +183,11 @@ public:
         }
     }
 
+    friend std::ostream &operator<<(std::ostream &os, const rpc_address &addr)
+    {
+        return os << addr.to_string();
+    }
+
     // for serialization in thrift format
     uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
     uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;

--- a/src/utils/test/metrics_test.cpp
+++ b/src/utils/test/metrics_test.cpp
@@ -676,7 +676,7 @@ void run_percentile(const metric_entity_ptr &my_entity,
                     const std::vector<T> &expected_elements,
                     Checker checker)
 {
-    dassert_f(num_threads > 0, "Invalid num_threads({})", num_threads);
+    CHECK_GT(num_threads, 0);
     CHECK(data.size() <= sample_size && data.size() % num_threads == 0,
           "Invalid arguments, data_size={}, sample_size={}, num_threads={}",
           data.size(),

--- a/src/utils/thread_access_checker.cpp
+++ b/src/utils/thread_access_checker.cpp
@@ -23,9 +23,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
+#include "utils/api_utilities.h"
+#include "utils/fmt_logging.h"
 #include "utils/process_utils.h"
 #include "utils/thread_access_checker.h"
-#include "utils/api_utilities.h"
 
 namespace dsn {
 
@@ -36,8 +38,9 @@ thread_access_checker::~thread_access_checker() { _access_thread_id_inited = fal
 void thread_access_checker::only_one_thread_access()
 {
     if (_access_thread_id_inited) {
-        dassert(::dsn::utils::get_current_tid() == _access_thread_id,
-                "the service is assumed to be accessed by one thread only!");
+        CHECK_EQ_MSG(::dsn::utils::get_current_tid(),
+                     _access_thread_id,
+                     "the service is assumed to be accessed by one thread only!");
     } else {
         _access_thread_id = ::dsn::utils::get_current_tid();
         _access_thread_id_inited = true;

--- a/src/zookeeper/test/distributed_lock_zookeeper.cpp
+++ b/src/zookeeper/test/distributed_lock_zookeeper.cpp
@@ -77,7 +77,7 @@ public:
 
         _dlock_service = new distributed_lock_service_zookeeper();
         auto err = _dlock_service->initialize({"/dsn/tests/simple_adder_server"});
-        dassert(err == ERR_OK, "err = %s", err.to_string());
+        CHECK_EQ(err, ERR_OK);
 
         distributed_lock_service::lock_options opt = {true, true};
         while (!ss_finish) {

--- a/src/zookeeper/zookeeper_session.cpp
+++ b/src/zookeeper/zookeeper_session.cpp
@@ -322,7 +322,7 @@ void zookeeper_session::global_watcher(
     if (type != ZOO_SESSION_EVENT && path != nullptr)
         LOG_INFO("watcher path: %s", path);
 
-    dassert(zoo_session->_handle == handle, "");
+    CHECK(zoo_session->_handle == handle, "");
     zoo_session->dispatch_event(type, state, type == ZOO_SESSION_EVENT ? "" : path);
 }
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1204

- `dassert` -> `CHECK`
- `dassert/dassert_f(a == b, msg)` -> `CHECK_EQ_MSG(a, b, msg)`
- `dassert/dassert_f(a > b, msg)` -> `CHECK_GT_MSG(a, b, msg)`
- `dassert/dassert_f(a >= b, msg)` -> `CHECK_GE_MSG(a, b, msg)`
- `dassert/dassert_f(a < b, msg)` -> `CHECK_LT_MSG(a, b, msg)`
- `dassert/dassert_f(a <= b, msg)` -> `CHECK_LE_MSG(a, b, msg)`
- remove some verbose and meanless messages

TODO: refactor dangling-else `CHECK(false, ...)`