### PR TITLE
fix: update commons-configuration2 version to 2.8.0

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -55,7 +55,7 @@
     <guava.version>28.1-jre</guava.version>
     <mockito.version>2.24.5</mockito.version>
     <dropwizard.version>3.1.2</dropwizard.version>
-    <apache.commons.configuration2.version>2.7</apache.commons.configuration2.version>
+    <apache.commons.configuration2.version>2.8.0</apache.commons.configuration2.version>
     <slf4j.version>1.7.2</slf4j.version>
     <apache.commons.lang3.version>3.1</apache.commons.lang3.version>
     <zkclient.version>0.2</zkclient.version>


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1224

### What problem does this PR solve? <!--add issue link with summary if exists-->
漏洞详情
Apache Commons Configuration是一个Java应用程序的配置管理工具，可以从properties或者xml文件中加载软件的配置信息，用来构建支撑软件运行的基础环境。在一些配置文件较多较复杂的情况下，使用该配置工具比较可以简化配置文件的解析和管理，提高开发效率和软件的可维护性。

从2.4版到2.7版，默认的Lookup实例集包括可能导致任意代码执行或与远程服务器联系的插值器。如公告中提到“script” 可使用JVM脚本执行引擎(javax.script)执行表达式，若使用了不受信任的配置值，在受影响的版本中使用插值默认值的应用程序就很可能受到远程代码执行的影响。

### What is changed and how does it work?
update Apache Commons Configuration version to 2.8.0
