### PR TITLE
refactor(macro): use the more general CHECK_PREFIX* to replace dassert_replica

### DIFF
--- a/src/meta/duplication/duplication_info.cpp
+++ b/src/meta/duplication/duplication_info.cpp
@@ -152,7 +152,7 @@ void duplication_info::persist_progress(int partition_index)
     zauto_write_lock l(_lock);
 
     auto &p = _progress[partition_index];
-    dassert_dup(p.is_altering, this, "partition_index: {}", partition_index);
+    CHECK_PREFIX_MSG(p.is_altering, "partition_index: {}", partition_index);
     p.is_altering = false;
     p.stored_decree = p.volatile_decree;
 }

--- a/src/meta/duplication/duplication_info.h
+++ b/src/meta/duplication/duplication_info.h
@@ -251,9 +251,5 @@ extern void json_encode(dsn::json::JsonWriter &out, const duplication_fail_mode:
 
 extern bool json_decode(const dsn::json::JsonObject &in, duplication_fail_mode::type &s);
 
-// TODO(yingchun): remember to cleanup dassert_dup
-#define dassert_dup(_pred_, _dup_, ...)                                                            \
-    CHECK(_pred_, "[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
-
 } // namespace replication
 } // namespace dsn

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -67,7 +67,7 @@ bool load_from_private_log::switch_to_next_log_file()
 
 void load_from_private_log::run()
 {
-    dassert_replica(_start_decree != invalid_decree, "{}", _start_decree);
+    CHECK_NE_PREFIX(_start_decree, invalid_decree);
     _duplicator->verify_start_decree(_start_decree);
 
     // last_decree() == invalid_decree is the init status of mutation_buffer when create
@@ -163,7 +163,7 @@ void load_from_private_log::replay_log_block()
         mutation_log::replay_block(_current,
                                    [this](int log_bytes_length, mutation_ptr &mu) -> bool {
                                        auto es = _mutation_batch.add(std::move(mu));
-                                       dassert_replica(es.is_ok(), es.description());
+                                       CHECK_PREFIX_MSG(es.is_ok(), es.description());
                                        _counter_dup_log_read_bytes_rate->add(log_bytes_length);
                                        _counter_dup_log_read_mutations_rate->increment();
                                        return true;
@@ -203,9 +203,9 @@ void load_from_private_log::replay_log_block()
                     repeat(_repeat_delay);
                     return;
                 }
-            } else if (dsn_unlikely(will_fail_fast())) {
-                dassert_replica(
-                    false,
+            } else {
+                CHECK_PREFIX_MSG(
+                    !will_fail_fast(),
                     "unable to load file {}, fail fast. please check if the file is corrupted",
                     _current->path());
             }

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -42,9 +42,7 @@ void mutation_buffer::commit(decree d, commit_type ct)
     if (d <= last_committed_decree())
         return;
 
-    if (ct != COMMIT_TO_DECREE_HARD) {
-        dassert_replica(false, "invalid commit type {}", (int)ct);
-    }
+    CHECK_EQ_PREFIX(ct, COMMIT_TO_DECREE_HARD);
 
     ballot last_bt = 0;
     for (decree d0 = last_committed_decree() + 1; d0 <= d; d0++) {

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -423,14 +423,14 @@ bool replica::verbose_commit_log() const { return _stub->_verbose_commit_log; }
 
 void replica::close()
 {
-    dassert_replica(status() == partition_status::PS_ERROR ||
-                        status() == partition_status::PS_INACTIVE ||
-                        _disk_migrator->status() == disk_migration_status::IDLE ||
-                        _disk_migrator->status() >= disk_migration_status::MOVED,
-                    "invalid state(partition_status={}, migration_status={}) when calling "
-                    "replica close",
-                    enum_to_string(status()),
-                    enum_to_string(_disk_migrator->status()));
+    CHECK_PREFIX_MSG(status() == partition_status::PS_ERROR ||
+                         status() == partition_status::PS_INACTIVE ||
+                         _disk_migrator->status() == disk_migration_status::IDLE ||
+                         _disk_migrator->status() >= disk_migration_status::MOVED,
+                     "invalid state(partition_status={}, migration_status={}) when calling "
+                     "replica close",
+                     enum_to_string(status()),
+                     enum_to_string(_disk_migrator->status()));
 
     uint64_t start_time = dsn_now_ms();
 
@@ -453,10 +453,10 @@ void replica::close()
 
     // for partition_status::PS_ERROR, context cleanup is done here as they may block
     else {
-        dassert_replica(_secondary_states.cleanup(true), "secondary context is not cleared");
-        dassert_replica(_potential_secondary_states.cleanup(true),
-                        "potential secondary context is not cleared");
-        dassert_replica(_split_states.cleanup(true), "partition split context is not cleared");
+        CHECK_PREFIX_MSG(_secondary_states.cleanup(true), "secondary context is not cleared");
+        CHECK_PREFIX_MSG(_potential_secondary_states.cleanup(true),
+                         "potential secondary context is not cleared");
+        CHECK_PREFIX_MSG(_split_states.cleanup(true), "partition split context is not cleared");
     }
 
     if (_private_log != nullptr) {
@@ -496,13 +496,13 @@ void replica::close()
 
 std::string replica::query_manual_compact_state() const
 {
-    dassert_replica(_app != nullptr, "");
+    CHECK_PREFIX(_app);
     return _app->query_compact_state();
 }
 
 manual_compaction_status::type replica::get_manual_compact_status() const
 {
-    dassert_replica(_app != nullptr, "");
+    CHECK_PREFIX(_app);
     return _app->query_compact_status();
 }
 
@@ -539,7 +539,7 @@ void replica::on_detect_hotkey(const detect_hotkey_request &req, detect_hotkey_r
 
 uint32_t replica::query_data_version() const
 {
-    dassert_replica(_app != nullptr, "");
+    CHECK_PREFIX(_app);
     return _app->query_data_version();
 }
 

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -336,9 +336,7 @@ void replica::update_configuration_on_meta_server(config_type::type type,
     // type should never be `CT_REGISTER_CHILD`
     // if this happens, it means serious mistake happened during partition split
     // assert here to stop split and avoid splitting wrong
-    if (type == config_type::CT_REGISTER_CHILD) {
-        dassert_replica(false, "invalid config_type, type = {}", enum_to_string(type));
-    }
+    CHECK_NE_PREFIX(type, config_type::CT_REGISTER_CHILD);
 
     newConfig.last_committed_decree = last_committed_decree();
 
@@ -1081,15 +1079,14 @@ void replica::update_app_max_replica_count(int32_t max_replica_count)
     auto old_max_replica_count = _app_info.max_replica_count;
     _app_info.max_replica_count = max_replica_count;
 
-    auto ec = store_app_info(_app_info);
-    dassert_replica(ec == ERR_OK,
-                    "store_app_info for max_replica_count failed: error_code={}, app_name={}, "
-                    "app_id={}, old_max_replica_count={}, new_max_replica_count={}",
-                    ec.to_string(),
-                    _app_info.app_name,
-                    _app_info.app_id,
-                    old_max_replica_count,
-                    _app_info.max_replica_count);
+    CHECK_EQ_PREFIX_MSG(store_app_info(_app_info),
+                        ERR_OK,
+                        "store_app_info for max_replica_count failed: app_name={}, "
+                        "app_id={}, old_max_replica_count={}, new_max_replica_count={}",
+                        _app_info.app_name,
+                        _app_info.app_id,
+                        old_max_replica_count,
+                        _app_info.max_replica_count);
 }
 
 void replica::replay_prepare_list()

--- a/src/replica/replica_disk_migrator.cpp
+++ b/src/replica/replica_disk_migrator.cpp
@@ -171,11 +171,12 @@ bool replica_disk_migrator::check_migration_args(replica_disk_migrate_rpc rpc)
 // THREAD_POOL_REPLICATION_LONG
 void replica_disk_migrator::migrate_replica(const replica_disk_migrate_request &req)
 {
-    dassert_replica(status() == disk_migration_status::MOVING,
-                    "disk migration(origin={}, target={}), err = Invalid migration status({})",
-                    req.origin_disk,
-                    req.target_disk,
-                    enum_to_string(status()));
+    CHECK_EQ_MSG(status(),
+                 disk_migration_status::MOVING,
+                 "disk migration(origin={}, target={}), err = Invalid migration status({})",
+                 req.origin_disk,
+                 req.target_disk,
+                 enum_to_string(status()));
 
     if (init_target_dir(req) && migrate_replica_checkpoint(req) && migrate_replica_app_info(req)) {
         _status = disk_migration_status::MOVED;

--- a/src/replica/replica_disk_migrator.cpp
+++ b/src/replica/replica_disk_migrator.cpp
@@ -171,12 +171,12 @@ bool replica_disk_migrator::check_migration_args(replica_disk_migrate_rpc rpc)
 // THREAD_POOL_REPLICATION_LONG
 void replica_disk_migrator::migrate_replica(const replica_disk_migrate_request &req)
 {
-    CHECK_EQ_MSG(status(),
-                 disk_migration_status::MOVING,
-                 "disk migration(origin={}, target={}), err = Invalid migration status({})",
-                 req.origin_disk,
-                 req.target_disk,
-                 enum_to_string(status()));
+    CHECK_EQ_PREFIX_MSG(status(),
+                        disk_migration_status::MOVING,
+                        "disk migration(origin={}, target={}), err = Invalid migration status({})",
+                        req.origin_disk,
+                        req.target_disk,
+                        enum_to_string(status()));
 
     if (init_target_dir(req) && migrate_replica_checkpoint(req) && migrate_replica_app_info(req)) {
         _status = disk_migration_status::MOVED;

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -1460,9 +1460,7 @@ void replica::on_add_learner(const group_check_request &request)
         if (!update_local_configuration(request.config, true))
             return;
 
-        dassert_replica(partition_status::PS_POTENTIAL_SECONDARY == status(),
-                        "invalid partition_status, status = {}",
-                        enum_to_string(status()));
+        CHECK_EQ_PREFIX(partition_status::PS_POTENTIAL_SECONDARY, status());
 
         _is_duplication_master = request.app.duplicating;
         init_learn(request.config.learner_signature);

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -308,35 +308,35 @@ dsn::error_code replica::restore_checkpoint()
     // first check the parameter
     configuration_restore_request restore_req;
     auto iter = _app_info.envs.find(backup_restore_constant::BLOCK_SERVICE_PROVIDER);
-    dassert_replica(iter != _app_info.envs.end(),
-                    "can't find {} in app_info.envs",
-                    backup_restore_constant::BLOCK_SERVICE_PROVIDER);
+    CHECK_PREFIX_MSG(iter != _app_info.envs.end(),
+                     "can't find {} in app_info.envs",
+                     backup_restore_constant::BLOCK_SERVICE_PROVIDER);
     restore_req.backup_provider_name = iter->second;
     iter = _app_info.envs.find(backup_restore_constant::CLUSTER_NAME);
-    dassert_replica(iter != _app_info.envs.end(),
-                    "can't find {} in app_info.envs",
-                    backup_restore_constant::CLUSTER_NAME);
+    CHECK_PREFIX_MSG(iter != _app_info.envs.end(),
+                     "can't find {} in app_info.envs",
+                     backup_restore_constant::CLUSTER_NAME);
     restore_req.cluster_name = iter->second;
     iter = _app_info.envs.find(backup_restore_constant::POLICY_NAME);
-    dassert_replica(iter != _app_info.envs.end(),
-                    "can't find {} in app_info.envs",
-                    backup_restore_constant::POLICY_NAME);
+    CHECK_PREFIX_MSG(iter != _app_info.envs.end(),
+                     "can't find {} in app_info.envs",
+                     backup_restore_constant::POLICY_NAME);
     restore_req.policy_name = iter->second;
     iter = _app_info.envs.find(backup_restore_constant::APP_NAME);
-    dassert_replica(iter != _app_info.envs.end(),
-                    "can't find {} in app_info.envs",
-                    backup_restore_constant::APP_NAME);
+    CHECK_PREFIX_MSG(iter != _app_info.envs.end(),
+                     "can't find {} in app_info.envs",
+                     backup_restore_constant::APP_NAME);
     restore_req.app_name = iter->second;
     iter = _app_info.envs.find(backup_restore_constant::APP_ID);
-    dassert_replica(iter != _app_info.envs.end(),
-                    "can't find {} in app_info.envs",
-                    backup_restore_constant::APP_ID);
+    CHECK_PREFIX_MSG(iter != _app_info.envs.end(),
+                     "can't find {} in app_info.envs",
+                     backup_restore_constant::APP_ID);
     restore_req.app_id = boost::lexical_cast<int32_t>(iter->second);
 
     iter = _app_info.envs.find(backup_restore_constant::BACKUP_ID);
-    dassert_replica(iter != _app_info.envs.end(),
-                    "can't find {} in app_info.envs",
-                    backup_restore_constant::BACKUP_ID);
+    CHECK_PREFIX_MSG(iter != _app_info.envs.end(),
+                     "can't find {} in app_info.envs",
+                     backup_restore_constant::BACKUP_ID);
     restore_req.time_stamp = boost::lexical_cast<int64_t>(iter->second);
 
     bool skip_bad_partition = false;

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -447,7 +447,7 @@ error_code replication_app_base::apply_mutation(const mutation *mu)
             str = "PS";
             break;
         default:
-            dassert_replica(false, "status = {}", enum_to_string(status));
+            CHECK_PREFIX_MSG(false, "status = {}", enum_to_string(status));
             __builtin_unreachable();
         }
         LOG_INFO_PREFIX(

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -638,7 +638,7 @@ void replica_split_manager::parent_handle_child_catch_up(
         mutation_ptr mu = _replica->new_mutation(invalid_decree);
         mu->add_client_request(RPC_REPLICATION_WRITE_EMPTY, nullptr);
         _replica->init_prepare(mu, false);
-        CHECK_EQ_MSG(
+        CHECK_EQ_PREFIX_MSG(
             sync_point, mu->data.header.decree, "sync_point should be equal to mutation's decree");
     };
 

--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -78,11 +78,11 @@ std::string meta_store::get_usage_scenario() const
     // If couldn't find rocksdb usage scenario in meta column family, return normal in default.
     std::string usage_scenario = ROCKSDB_ENV_USAGE_SCENARIO_NORMAL;
     auto ec = get_string_value_from_meta_cf(false, ROCKSDB_ENV_USAGE_SCENARIO_KEY, &usage_scenario);
-    dassert_replica(ec == ::dsn::ERR_OK || ec == ::dsn::ERR_OBJECT_NOT_FOUND,
-                    "rocksdb {} get {} from meta column family failed: {}",
-                    _db->GetName(),
-                    ROCKSDB_ENV_USAGE_SCENARIO_KEY,
-                    ec.to_string());
+    CHECK_PREFIX_MSG(ec == ::dsn::ERR_OK || ec == ::dsn::ERR_OBJECT_NOT_FOUND,
+                     "rocksdb {} get {} from meta column family failed: {}",
+                     _db->GetName(),
+                     ROCKSDB_ENV_USAGE_SCENARIO_KEY,
+                     ec);
     return usage_scenario;
 }
 

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -3284,8 +3284,8 @@ void pegasus_server_impl::set_partition_version(int32_t partition_version)
 void pegasus_server_impl::release_db()
 {
     if (_db) {
-        CHECK_NOTNULL_PREFIX_MSG(_data_cf, "");
-        CHECK_NOTNULL_PREFIX_MSG(_meta_cf, "");
+        CHECK_NOTNULL_PREFIX(_data_cf);
+        CHECK_NOTNULL_PREFIX(_meta_cf);
         _db->DestroyColumnFamilyHandle(_data_cf);
         _data_cf = nullptr;
         _db->DestroyColumnFamilyHandle(_meta_cf);

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1471,7 +1471,7 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
 
 dsn::error_code pegasus_server_impl::start(int argc, char **argv)
 {
-    dassert_replica(!_is_open, "replica is already opened.");
+    CHECK_PREFIX_MSG(!_is_open, "replica is already opened");
     LOG_INFO_PREFIX("start to open app {}", data_dir());
 
     // parse envs for parameters
@@ -1587,8 +1587,8 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
             LOG_ERROR_PREFIX("check column families failed");
             return dsn::ERR_LOCAL_APP_FAILURE;
         }
-        dassert_replica(!missing_meta_cf, "You must upgrade Pegasus server from 2.0");
-        dassert_replica(!missing_data_cf, "Missing data column family");
+        CHECK_PREFIX_MSG(!missing_meta_cf, "You must upgrade Pegasus server from 2.0");
+        CHECK_PREFIX_MSG(!missing_data_cf, "Missing data column family");
 
         // Load latest options from option file stored in the db directory.
         rocksdb::DBOptions loaded_db_opt;
@@ -3284,7 +3284,8 @@ void pegasus_server_impl::set_partition_version(int32_t partition_version)
 void pegasus_server_impl::release_db()
 {
     if (_db) {
-        dassert_replica(_data_cf != nullptr && _meta_cf != nullptr, "");
+        CHECK_NOTNULL_PREFIX_MSG(_data_cf, "");
+        CHECK_NOTNULL_PREFIX_MSG(_meta_cf, "");
         _db->DestroyColumnFamilyHandle(_data_cf);
         _data_cf = nullptr;
         _db->DestroyColumnFamilyHandle(_meta_cf);

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -55,7 +55,6 @@
 #define LOG_WARNING_PREFIX(...) LOG_WARNING_F("[{}] {}", log_prefix(), fmt::format(__VA_ARGS__))
 #define LOG_ERROR_PREFIX(...) LOG_ERROR_F("[{}] {}", log_prefix(), fmt::format(__VA_ARGS__))
 #define LOG_FATAL_PREFIX(...) LOG_FATAL_F("[{}] {}", log_prefix(), fmt::format(__VA_ARGS__))
-#define dassert_replica(x, ...) CHECK(x, "[{}] {}", log_prefix(), fmt::format(__VA_ARGS__))
 
 // Macros to check expected condition. It will abort the application
 // and log a fatal message when the condition is not met.
@@ -109,47 +108,59 @@
 #define CHECK_LT(var1, var2) CHECK_LT_MSG(var1, var2, "")
 
 // TODO(yingchun): add CHECK_NULL(ptr), CHECK_OK(err), CHECK(cond)
-#define CHECK_NE_PREFIX(var1, var2)                                                                \
+
+#define CHECK_PREFIX_MSG(x, ...) CHECK(x, "[{}] {}", log_prefix(), fmt::format(__VA_ARGS__))
+#define CHECK_NOTNULL_PREFIX_MSG(p, ...) CHECK_PREFIX_MSG(p != nullptr, fmt::format(__VA_ARGS__))
+
+#define CHECK_NE_PREFIX_MSG(var1, var2, ...)                                                       \
     do {                                                                                           \
         const auto &_v1 = (var1);                                                                  \
         const auto &_v2 = (var2);                                                                  \
-        dassert_replica(_v1 != _v2, "{} vs {}", _v1, _v2);                                         \
+        CHECK_PREFIX_MSG(_v1 != _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));           \
     } while (false)
 
-#define CHECK_EQ_PREFIX(var1, var2)                                                                \
+#define CHECK_EQ_PREFIX_MSG(var1, var2, ...)                                                       \
     do {                                                                                           \
         const auto &_v1 = (var1);                                                                  \
         const auto &_v2 = (var2);                                                                  \
-        dassert_replica(_v1 == _v2, "{} vs {}", _v1, _v2);                                         \
+        CHECK_PREFIX_MSG(_v1 == _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));           \
     } while (false)
 
-#define CHECK_GE_PREFIX(var1, var2)                                                                \
+#define CHECK_GE_PREFIX_MSG(var1, var2, ...)                                                       \
     do {                                                                                           \
         const auto &_v1 = (var1);                                                                  \
         const auto &_v2 = (var2);                                                                  \
-        dassert_replica(_v1 >= _v2, "{} vs {}", _v1, _v2);                                         \
+        CHECK_PREFIX_MSG(_v1 >= _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));           \
     } while (false)
 
-#define CHECK_LE_PREFIX(var1, var2)                                                                \
+#define CHECK_LE_PREFIX_MSG(var1, var2, ...)                                                       \
     do {                                                                                           \
         const auto &_v1 = (var1);                                                                  \
         const auto &_v2 = (var2);                                                                  \
-        dassert_replica(_v1 <= _v2, "{} vs {}", _v1, _v2);                                         \
+        CHECK_PREFIX_MSG(_v1 <= _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));           \
     } while (false)
 
-#define CHECK_GT_PREFIX(var1, var2)                                                                \
+#define CHECK_GT_PREFIX_MSG(var1, var2, ...)                                                       \
     do {                                                                                           \
         const auto &_v1 = (var1);                                                                  \
         const auto &_v2 = (var2);                                                                  \
-        dassert_replica(_v1 > _v2, "{} vs {}", _v1, _v2);                                          \
+        CHECK_PREFIX_MSG(_v1 > _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));            \
     } while (false)
 
-#define CHECK_LT_PREFIX(var1, var2)                                                                \
+#define CHECK_LT_PREFIX_MSG(var1, var2, ...)                                                       \
     do {                                                                                           \
         const auto &_v1 = (var1);                                                                  \
         const auto &_v2 = (var2);                                                                  \
-        dassert_replica(_v1 < _v2, "{} vs {}", _v1, _v2);                                          \
+        CHECK_PREFIX_MSG(_v1 < _v2, "{} vs {} {}", _v1, _v2, fmt::format(__VA_ARGS__));            \
     } while (false)
+
+#define CHECK_PREFIX(x) CHECK_PREFIX_MSG(x, "")
+#define CHECK_NE_PREFIX(var1, var2) CHECK_NE_PREFIX_MSG(var1, var2, "")
+#define CHECK_EQ_PREFIX(var1, var2) CHECK_EQ_PREFIX_MSG(var1, var2, "")
+#define CHECK_GE_PREFIX(var1, var2) CHECK_GE_PREFIX_MSG(var1, var2, "")
+#define CHECK_LE_PREFIX(var1, var2) CHECK_LE_PREFIX_MSG(var1, var2, "")
+#define CHECK_GT_PREFIX(var1, var2) CHECK_GT_PREFIX_MSG(var1, var2, "")
+#define CHECK_LT_PREFIX(var1, var2) CHECK_LT_PREFIX_MSG(var1, var2, "")
 
 // Return the given status if condition is not true.
 #define ERR_LOG_AND_RETURN_NOT_TRUE(s, err, ...)                                                   \

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -111,6 +111,7 @@
 
 #define CHECK_PREFIX_MSG(x, ...) CHECK(x, "[{}] {}", log_prefix(), fmt::format(__VA_ARGS__))
 #define CHECK_NOTNULL_PREFIX_MSG(p, ...) CHECK_PREFIX_MSG(p != nullptr, fmt::format(__VA_ARGS__))
+#define CHECK_NOTNULL_PREFIX(p) CHECK_NOTNULL_PREFIX_MSG(p, "")
 
 #define CHECK_NE_PREFIX_MSG(var1, var2, ...)                                                       \
     do {                                                                                           \


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1204

Adds some more general macros `CHECK_PREFIX_MSG`, `CHECK_NOTNULL_PREFIX_MSG`, `CHECK_NE/EQ/GE/GT/LE/LT_PREFIX[_MSG]` to replace `dassert_replica`