### PR TITLE
refactor: use linux_fd_t instead of dsn_handle_t for file descriptor

### DIFF
--- a/src/aio/aio_provider.h
+++ b/src/aio/aio_provider.h
@@ -37,8 +37,6 @@ class service_node;
 class task_worker_pool;
 class task_queue;
 
-#define DSN_INVALID_FILE_HANDLE ((dsn_handle_t)(uintptr_t)-1)
-
 class aio_provider
 {
 public:
@@ -54,11 +52,10 @@ public:
     virtual ~aio_provider() = default;
 
     // return DSN_INVALID_FILE_HANDLE if failed
-    // TODO(wutao1): return uint64_t instead (because we only support linux now)
-    virtual dsn_handle_t open(const char *file_name, int flag, int pmode) = 0;
+    virtual int open(const char *file_name, int flag, int pmode) = 0;
 
-    virtual error_code close(dsn_handle_t fh) = 0;
-    virtual error_code flush(dsn_handle_t fh) = 0;
+    virtual error_code close(int fd) = 0;
+    virtual error_code flush(int fd) = 0;
     virtual error_code write(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) = 0;
     virtual error_code read(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) = 0;
 

--- a/src/aio/aio_provider.h
+++ b/src/aio/aio_provider.h
@@ -37,6 +37,15 @@ class service_node;
 class task_worker_pool;
 class task_queue;
 
+#define DSN_INVALID_FILE_HANDLE -1
+struct linux_fd_t
+{
+    int fd;
+
+    explicit linux_fd_t(int f) : fd(f) {}
+    inline bool is_invalid() const { return fd == DSN_INVALID_FILE_HANDLE; }
+};
+
 class aio_provider
 {
 public:
@@ -52,10 +61,10 @@ public:
     virtual ~aio_provider() = default;
 
     // return DSN_INVALID_FILE_HANDLE if failed
-    virtual int open(const char *file_name, int flag, int pmode) = 0;
+    virtual linux_fd_t open(const char *file_name, int flag, int pmode) = 0;
 
-    virtual error_code close(int fd) = 0;
-    virtual error_code flush(int fd) = 0;
+    virtual error_code close(linux_fd_t fd) = 0;
+    virtual error_code flush(linux_fd_t fd) = 0;
     virtual error_code write(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) = 0;
     virtual error_code read(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) = 0;
 

--- a/src/aio/aio_provider.h
+++ b/src/aio/aio_provider.h
@@ -60,7 +60,6 @@ public:
     explicit aio_provider(disk_engine *disk);
     virtual ~aio_provider() = default;
 
-    // return DSN_INVALID_FILE_HANDLE if failed
     virtual linux_fd_t open(const char *file_name, int flag, int pmode) = 0;
 
     virtual error_code close(linux_fd_t fd) = 0;

--- a/src/aio/aio_task.h
+++ b/src/aio/aio_task.h
@@ -57,7 +57,6 @@ class aio_context : public ref_counter
 {
 public:
     // filled by apps
-    int fd;
     void *buffer;
     uint64_t buffer_size;
     uint64_t file_offset;
@@ -68,8 +67,7 @@ public:
     disk_file *dfile;
 
     aio_context()
-        : fd(DSN_INVALID_FILE_HANDLE),
-          buffer(nullptr),
+        : buffer(nullptr),
           buffer_size(0),
           file_offset(0),
           type(AIO_Invalid),

--- a/src/aio/aio_task.h
+++ b/src/aio/aio_task.h
@@ -26,11 +26,13 @@
 
 #pragma once
 
-#include "runtime/task/task.h"
-
 #include <vector>
 
+#include "runtime/task/task.h"
+
 namespace dsn {
+
+#define DSN_INVALID_FILE_HANDLE -1
 
 namespace utils {
 class latency_tracer;
@@ -50,11 +52,12 @@ typedef struct
 } dsn_file_buffer_t;
 
 class disk_engine;
+class disk_file;
 class aio_context : public ref_counter
 {
 public:
     // filled by apps
-    dsn_handle_t file;
+    int fd;
     void *buffer;
     uint64_t buffer_size;
     uint64_t file_offset;
@@ -62,16 +65,16 @@ public:
     // filled by frameworks
     aio_type type;
     disk_engine *engine;
-    void *file_object; // TODO(wutao1): make it disk_file*, and distinguish it from `file`
+    disk_file *dfile;
 
     aio_context()
-        : file(nullptr),
+        : fd(DSN_INVALID_FILE_HANDLE),
           buffer(nullptr),
           buffer_size(0),
           file_offset(0),
           type(AIO_Invalid),
           engine(nullptr),
-          file_object(nullptr)
+          dfile(nullptr)
     {
     }
 };

--- a/src/aio/aio_task.h
+++ b/src/aio/aio_task.h
@@ -32,8 +32,6 @@
 
 namespace dsn {
 
-#define DSN_INVALID_FILE_HANDLE -1
-
 namespace utils {
 class latency_tracer;
 }

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -253,7 +253,7 @@ void disk_engine::complete_io(aio_task *aio, error_code err, uint64_t bytes)
         auto dfile = aio->get_aio_context()->dfile;
         if (aio->get_aio_context()->type == AIO_Read) {
             auto wk = dfile->on_read_completed(aio, err, (size_t)bytes);
-            if (wk != nullptr) {
+            if (wk) {
                 _provider->submit_aio_task(wk);
             }
         }
@@ -262,7 +262,7 @@ void disk_engine::complete_io(aio_task *aio, error_code err, uint64_t bytes)
         else {
             uint64_t sz;
             auto wk = dfile->on_write_completed(aio, (void *)&sz, err, (size_t)bytes);
-            if (wk != nullptr) {
+            if (wk) {
                 process_write(wk, sz);
             }
         }

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -182,9 +182,10 @@ void disk_engine::write(aio_task *aio)
     }
 
     auto dio = aio->get_aio_context();
+    CHECK_NE(dio->fd, DSN_INVALID_FILE_HANDLE);
     auto dfile = (disk_file *)(void *)(uintptr_t)(dio->fd);
-    dio->fd = dfile->native_handle();
-    dio->dfile = dfile;
+    CHECK_EQ(dio->fd, dfile->native_handle());
+    dio->dfile = dfile; // dio->dfile is initialized here
     dio->engine = this;
     dio->type = AIO_Write;
 

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -91,7 +91,7 @@ aio_task *disk_write_queue::unlink_next_workload(void *plength)
     return first;
 }
 
-disk_file::disk_file(linux_fd_t fd) : _fd(fd.fd) {}
+disk_file::disk_file(linux_fd_t fd) : _fd(fd) {}
 
 aio_task *disk_file::read(aio_task *tsk)
 {

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -91,7 +91,7 @@ aio_task *disk_write_queue::unlink_next_workload(void *plength)
     return first;
 }
 
-disk_file::disk_file(int fd) : _fd(fd) {}
+disk_file::disk_file(linux_fd_t fd) : _fd(fd.fd) {}
 
 aio_task *disk_file::read(aio_task *tsk)
 {

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -253,7 +253,7 @@ void disk_engine::complete_io(aio_task *aio, error_code err, uint64_t bytes)
         auto dfile = aio->get_aio_context()->dfile;
         if (aio->get_aio_context()->type == AIO_Read) {
             auto wk = dfile->on_read_completed(aio, err, (size_t)bytes);
-            if (wk) {
+            if (wk != nullptr) {
                 _provider->submit_aio_task(wk);
             }
         }
@@ -262,7 +262,7 @@ void disk_engine::complete_io(aio_task *aio, error_code err, uint64_t bytes)
         else {
             uint64_t sz;
             auto wk = dfile->on_write_completed(aio, (void *)&sz, err, (size_t)bytes);
-            if (wk) {
+            if (wk != nullptr) {
                 process_write(wk, sz);
             }
         }

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -182,15 +182,10 @@ void disk_engine::write(aio_task *aio)
     }
 
     auto dio = aio->get_aio_context();
-    CHECK_NE(dio->fd, DSN_INVALID_FILE_HANDLE);
-    auto dfile = (disk_file *)(void *)(uintptr_t)(dio->fd);
-    CHECK_EQ(dio->fd, dfile->native_handle());
-    dio->dfile = dfile; // dio->dfile is initialized here
     dio->engine = this;
-    dio->type = AIO_Write;
 
     uint64_t sz;
-    auto wk = dfile->write(aio, &sz);
+    auto wk = dio->dfile->write(aio, &sz);
     if (wk) {
         process_write(wk, sz);
     }
@@ -213,7 +208,6 @@ void disk_engine::process_write(aio_task *aio, uint64_t sz)
         auto new_dio = new_task->get_aio_context();
         new_dio->buffer_size = sz;
         new_dio->file_offset = dio->file_offset;
-        new_dio->fd = dio->fd;
         new_dio->dfile = dio->dfile;
         new_dio->engine = dio->engine;
         new_dio->type = AIO_Write;

--- a/src/aio/disk_engine.h
+++ b/src/aio/disk_engine.h
@@ -52,17 +52,17 @@ private:
 class disk_file
 {
 public:
-    explicit disk_file(int fd);
+    explicit disk_file(linux_fd_t fd);
     aio_task *read(aio_task *tsk);
     aio_task *write(aio_task *tsk, void *ctx);
 
     aio_task *on_read_completed(aio_task *wk, error_code err, size_t size);
     aio_task *on_write_completed(aio_task *wk, void *ctx, error_code err, size_t size);
 
-    int native_handle() const { return _fd; }
+    linux_fd_t native_handle() const { return _fd; }
 
 private:
-    int _fd;
+    linux_fd_t _fd;
     disk_write_queue _write_queue;
     work_queue<aio_task> _read_queue;
 };

--- a/src/aio/disk_engine.h
+++ b/src/aio/disk_engine.h
@@ -52,18 +52,17 @@ private:
 class disk_file
 {
 public:
-    disk_file(dsn_handle_t handle);
+    disk_file(int fd);
     aio_task *read(aio_task *tsk);
     aio_task *write(aio_task *tsk, void *ctx);
 
     aio_task *on_read_completed(aio_task *wk, error_code err, size_t size);
     aio_task *on_write_completed(aio_task *wk, void *ctx, error_code err, size_t size);
 
-    // TODO(wutao1): make it uint64_t
-    dsn_handle_t native_handle() const { return _handle; }
+    int native_handle() const { return _fd; }
 
 private:
-    dsn_handle_t _handle;
+    int _fd;
     disk_write_queue _write_queue;
     work_queue<aio_task> _read_queue;
 };

--- a/src/aio/disk_engine.h
+++ b/src/aio/disk_engine.h
@@ -52,7 +52,7 @@ private:
 class disk_file
 {
 public:
-    disk_file(int fd);
+    explicit disk_file(int fd);
     aio_task *read(aio_task *tsk);
     aio_task *write(aio_task *tsk, void *ctx);
 

--- a/src/aio/file_io.cpp
+++ b/src/aio/file_io.cpp
@@ -32,12 +32,12 @@ namespace file {
 
 /*extern*/ disk_file *open(const char *file_name, int flag, int pmode)
 {
-    int fd = disk_engine::provider().open(file_name, flag, pmode);
-    if (fd != DSN_INVALID_FILE_HANDLE) {
-        return new disk_file(fd);
-    } else {
+    linux_fd_t fd = disk_engine::provider().open(file_name, flag, pmode);
+    if (fd.is_invalid()) {
         return nullptr;
     }
+
+    return new disk_file(fd);
 }
 
 /*extern*/ error_code close(disk_file *file)

--- a/src/aio/file_io.cpp
+++ b/src/aio/file_io.cpp
@@ -72,11 +72,10 @@ namespace file {
     auto cb = create_aio_task(callback_code, tracker, std::move(callback), hash);
     cb->get_aio_context()->buffer = buffer;
     cb->get_aio_context()->buffer_size = count;
-    cb->get_aio_context()->dfile = file;
-    cb->get_aio_context()->fd = file->native_handle();
     cb->get_aio_context()->file_offset = offset;
     cb->get_aio_context()->type = AIO_Read;
     cb->get_aio_context()->engine = &disk_engine::instance();
+    cb->get_aio_context()->dfile = file;
 
     if (!cb->spec().on_aio_call.execute(task::get_current_task(), cb, true)) {
         cb->enqueue(ERR_FILE_OPERATION_FAILED, 0);
@@ -101,9 +100,9 @@ namespace file {
     auto cb = create_aio_task(callback_code, tracker, std::move(callback), hash);
     cb->get_aio_context()->buffer = (char *)buffer;
     cb->get_aio_context()->buffer_size = count;
-    cb->get_aio_context()->fd = file->native_handle();
     cb->get_aio_context()->file_offset = offset;
     cb->get_aio_context()->type = AIO_Write;
+    cb->get_aio_context()->dfile = file;
 
     disk_engine::instance().write(cb);
     return cb;
@@ -119,9 +118,9 @@ namespace file {
                                      int hash /*= 0*/)
 {
     auto cb = create_aio_task(callback_code, tracker, std::move(callback), hash);
-    cb->get_aio_context()->fd = file->native_handle();
     cb->get_aio_context()->file_offset = offset;
     cb->get_aio_context()->type = AIO_Write;
+    cb->get_aio_context()->dfile = file;
     for (int i = 0; i < buffer_count; i++) {
         if (buffers[i].size > 0) {
             cb->_unmerged_write_buffers.push_back(buffers[i]);

--- a/src/aio/file_io.cpp
+++ b/src/aio/file_io.cpp
@@ -32,9 +32,9 @@ namespace file {
 
 /*extern*/ disk_file *open(const char *file_name, int flag, int pmode)
 {
-    dsn_handle_t nh = disk_engine::provider().open(file_name, flag, pmode);
-    if (nh != DSN_INVALID_FILE_HANDLE) {
-        return new disk_file(nh);
+    int fd = disk_engine::provider().open(file_name, flag, pmode);
+    if (fd != DSN_INVALID_FILE_HANDLE) {
+        return new disk_file(fd);
     } else {
         return nullptr;
     }
@@ -72,8 +72,8 @@ namespace file {
     auto cb = create_aio_task(callback_code, tracker, std::move(callback), hash);
     cb->get_aio_context()->buffer = buffer;
     cb->get_aio_context()->buffer_size = count;
-    cb->get_aio_context()->file_object = file;
-    cb->get_aio_context()->file = file->native_handle();
+    cb->get_aio_context()->dfile = file;
+    cb->get_aio_context()->fd = file->native_handle();
     cb->get_aio_context()->file_offset = offset;
     cb->get_aio_context()->type = AIO_Read;
     cb->get_aio_context()->engine = &disk_engine::instance();
@@ -101,7 +101,7 @@ namespace file {
     auto cb = create_aio_task(callback_code, tracker, std::move(callback), hash);
     cb->get_aio_context()->buffer = (char *)buffer;
     cb->get_aio_context()->buffer_size = count;
-    cb->get_aio_context()->file = file;
+    cb->get_aio_context()->fd = file->native_handle();
     cb->get_aio_context()->file_offset = offset;
     cb->get_aio_context()->type = AIO_Write;
 
@@ -119,7 +119,7 @@ namespace file {
                                      int hash /*= 0*/)
 {
     auto cb = create_aio_task(callback_code, tracker, std::move(callback), hash);
-    cb->get_aio_context()->file = file;
+    cb->get_aio_context()->fd = file->native_handle();
     cb->get_aio_context()->file_offset = offset;
     cb->get_aio_context()->type = AIO_Write;
     for (int i = 0; i < buffer_count; i++) {

--- a/src/aio/file_io.cpp
+++ b/src/aio/file_io.cpp
@@ -32,7 +32,7 @@ namespace file {
 
 /*extern*/ disk_file *open(const char *file_name, int flag, int pmode)
 {
-    linux_fd_t fd = disk_engine::provider().open(file_name, flag, pmode);
+    auto fd = disk_engine::provider().open(file_name, flag, pmode);
     if (fd.is_invalid()) {
         return nullptr;
     }

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -35,6 +35,7 @@
 #include "utils/fail_point.h"
 #include "utils/fmt_logging.h"
 #include "utils/latency_tracer.h"
+#include "utils/safe_strerror_posix.h"
 
 namespace dsn {
 

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -28,12 +28,12 @@
 
 #include <fcntl.h>
 
+#include "aio/disk_engine.h"
 #include "runtime/service_engine.h"
-
 #include "runtime/task/async_calls.h"
 #include "utils/api_utilities.h"
-#include "utils/fmt_logging.h"
 #include "utils/fail_point.h"
+#include "utils/fmt_logging.h"
 #include "utils/latency_tracer.h"
 
 namespace dsn {
@@ -78,7 +78,7 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
     uint64_t buffer_offset = 0;
     do {
         // ret is the written data size
-        auto ret = pwrite(aio_ctx.fd,
+        auto ret = pwrite(aio_ctx.dfile->native_handle(),
                           (char *)aio_ctx.buffer + buffer_offset,
                           aio_ctx.buffer_size - buffer_offset,
                           aio_ctx.file_offset + buffer_offset);
@@ -117,7 +117,8 @@ error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
 error_code native_linux_aio_provider::read(const aio_context &aio_ctx,
                                            /*out*/ uint64_t *processed_bytes)
 {
-    ssize_t ret = pread(aio_ctx.fd, aio_ctx.buffer, aio_ctx.buffer_size, aio_ctx.file_offset);
+    ssize_t ret = pread(
+        aio_ctx.dfile->native_handle(), aio_ctx.buffer, aio_ctx.buffer_size, aio_ctx.file_offset);
     if (ret < 0) {
         return ERR_FILE_OPERATION_FAILED;
     }

--- a/src/aio/native_linux_aio_provider.h
+++ b/src/aio/native_linux_aio_provider.h
@@ -36,9 +36,9 @@ public:
     explicit native_linux_aio_provider(disk_engine *disk);
     ~native_linux_aio_provider() override;
 
-    int open(const char *file_name, int flag, int pmode) override;
-    error_code close(int fd) override;
-    error_code flush(int fd) override;
+    linux_fd_t open(const char *file_name, int flag, int pmode) override;
+    error_code close(linux_fd_t fd) override;
+    error_code flush(linux_fd_t fd) override;
     error_code write(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) override;
     error_code read(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) override;
 

--- a/src/aio/native_linux_aio_provider.h
+++ b/src/aio/native_linux_aio_provider.h
@@ -36,9 +36,9 @@ public:
     explicit native_linux_aio_provider(disk_engine *disk);
     ~native_linux_aio_provider() override;
 
-    dsn_handle_t open(const char *file_name, int flag, int pmode) override;
-    error_code close(dsn_handle_t fh) override;
-    error_code flush(dsn_handle_t fh) override;
+    int open(const char *file_name, int flag, int pmode) override;
+    error_code close(int fd) override;
+    error_code flush(int fd) override;
     error_code write(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) override;
     error_code read(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) override;
 

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -117,7 +117,6 @@ void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
     cp->dst_dir = request.dst_dir;
     cp->source_disk_tag = request.source_disk_tag;
     cp->file_path = std::move(file_path);
-    cp->fd = dfile->native_handle();
     cp->offset = request.offset;
     cp->size = request.size;
 

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -85,7 +85,7 @@ void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
 
         if (it == _handles_map.end()) {
             dfile = file::open(file_path.c_str(), O_RDONLY | O_BINARY, 0);
-            if (dfile) {
+            if (dfile != nullptr) {
                 auto fh = std::make_shared<file_handle_info_on_server>();
                 fh->file_handle = dfile;
                 fh->file_access_count = 1;

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -26,11 +26,12 @@
 
 #include "nfs_server_impl.h"
 
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 
 #include <cstdlib>
 
+#include "aio/disk_engine.h"
 #include "utils/filesystem.h"
 #include "runtime/task/async_calls.h"
 
@@ -76,26 +77,23 @@ void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
 
     std::string file_path =
         dsn::utils::filesystem::path_combine(request.source_dir, request.file_name);
-    disk_file *hfile;
+    disk_file *dfile = nullptr;
 
     {
         zauto_lock l(_handles_map_lock);
         auto it = _handles_map.find(file_path); // find file handle cache first
 
-        if (it == _handles_map.end()) // not found
-        {
-            hfile = file::open(file_path.c_str(), O_RDONLY | O_BINARY, 0);
-            if (hfile) {
-
+        if (it == _handles_map.end()) {
+            dfile = file::open(file_path.c_str(), O_RDONLY | O_BINARY, 0);
+            if (dfile) {
                 auto fh = std::make_shared<file_handle_info_on_server>();
-                fh->file_handle = hfile;
+                fh->file_handle = dfile;
                 fh->file_access_count = 1;
                 fh->last_access_time = dsn_now_ms();
                 _handles_map.insert(std::make_pair(file_path, std::move(fh)));
             }
-        } else // found
-        {
-            hfile = it->second->file_handle;
+        } else {
+            dfile = it->second->file_handle;
             it->second->file_access_count++;
             it->second->last_access_time = dsn_now_ms();
         }
@@ -106,7 +104,7 @@ void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
               request.offset,
               request.offset + request.size);
 
-    if (hfile == 0) {
+    if (dfile == nullptr) {
         LOG_ERROR("{nfs_service} open file %s failed", file_path.c_str());
         ::dsn::service::copy_response resp;
         resp.error = ERR_OBJECT_NOT_FOUND;
@@ -119,14 +117,14 @@ void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
     cp->dst_dir = request.dst_dir;
     cp->source_disk_tag = request.source_disk_tag;
     cp->file_path = std::move(file_path);
-    cp->hfile = hfile;
+    cp->fd = dfile->native_handle();
     cp->offset = request.offset;
     cp->size = request.size;
 
     auto buffer_save = cp->bb.buffer().get();
 
     file::read(
-        hfile,
+        dfile,
         buffer_save,
         request.size,
         request.offset,

--- a/src/nfs/nfs_server_impl.h
+++ b/src/nfs/nfs_server_impl.h
@@ -71,7 +71,6 @@ protected:
 private:
     struct callback_para
     {
-        int fd;
         std::string source_disk_tag;
         std::string file_path;
         std::string dst_dir;
@@ -80,20 +79,15 @@ private:
         uint32_t size;
         rpc_replier<copy_response> replier;
 
-        callback_para(rpc_replier<copy_response> &&r)
-            : fd(DSN_INVALID_FILE_HANDLE), offset(0), size(0), replier(std::move(r))
-        {
-        }
+        callback_para(rpc_replier<copy_response> &&r) : offset(0), size(0), replier(std::move(r)) {}
         callback_para(callback_para &&r)
-            : fd(r.fd),
-              file_path(std::move(r.file_path)),
+            : file_path(std::move(r.file_path)),
               dst_dir(std::move(r.dst_dir)),
               bb(std::move(r.bb)),
               offset(r.offset),
               size(r.size),
               replier(std::move(r.replier))
         {
-            r.fd = DSN_INVALID_FILE_HANDLE;
             r.offset = 0;
             r.size = 0;
         }

--- a/src/nfs/nfs_server_impl.h
+++ b/src/nfs/nfs_server_impl.h
@@ -71,7 +71,7 @@ protected:
 private:
     struct callback_para
     {
-        dsn_handle_t hfile;
+        int fd;
         std::string source_disk_tag;
         std::string file_path;
         std::string dst_dir;
@@ -81,11 +81,11 @@ private:
         rpc_replier<copy_response> replier;
 
         callback_para(rpc_replier<copy_response> &&r)
-            : hfile(nullptr), offset(0), size(0), replier(std::move(r))
+            : fd(DSN_INVALID_FILE_HANDLE), offset(0), size(0), replier(std::move(r))
         {
         }
         callback_para(callback_para &&r)
-            : hfile(r.hfile),
+            : fd(r.fd),
               file_path(std::move(r.file_path)),
               dst_dir(std::move(r.dst_dir)),
               bb(std::move(r.bb)),
@@ -93,7 +93,7 @@ private:
               size(r.size),
               replier(std::move(r.replier))
         {
-            r.hfile = nullptr;
+            r.fd = DSN_INVALID_FILE_HANDLE;
             r.offset = 0;
             r.size = 0;
         }


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1234

including changes:
1. change `dsn_handle_t` which is used for files descriptor to `linux_fd_t` which wrap an `int`
2. remove useless `dsn_handle_t` type member from `class aio_context`, `struct callback_para`
3. change `file_object` from `void *` to `disk_file *`