### PR TITLE
fix: valid zookeeper directory for clear

### DIFF
--- a/scripts/clear_zk.sh
+++ b/scripts/clear_zk.sh
@@ -34,7 +34,7 @@ then
 fi
 
 cd $INSTALL_DIR
-ZOOKEEPER_HOME=`pwd`/apache-zookeeper-3.4.10
+ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.10
 
 if [ -d "$ZOOKEEPER_HOME" ]
 then


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1243

`clear_zk.sh` is invalid.