### PR TITLE
fix: fix log header not corresponding to level

### DIFF
--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -56,6 +56,12 @@ DSN_DEFINE_validator(stderr_start_level, [](const char *level) -> bool {
 
 static void print_header(FILE *fp, dsn_log_level_t log_level)
 {
+    // The leading character of each log lines, corresponding to the log level
+    // D: Debug
+    // I: Info
+    // W: Warning
+    // E: Error
+    // F: Fatal
     static char s_level_char[] = "DIWEF";
 
     uint64_t ts = dsn_now_ns();

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -56,7 +56,7 @@ DSN_DEFINE_validator(stderr_start_level, [](const char *level) -> bool {
 
 static void print_header(FILE *fp, dsn_log_level_t log_level)
 {
-    static char s_level_char[] = "IDWEF";
+    static char s_level_char[] = "DIWEF";
 
     uint64_t ts = dsn_now_ns();
     std::string time_str;


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1199

In commit https://github.com/apache/incubator-pegasus/pull/1200, we exchange DEBUG level and INFO level, but the log header prefixes have been forgot to update. This patch fix it.