### PR TITLE
refactor(log): adjust default log level from DEBUG to INFO

### DIFF
--- a/src/geo/bench/config.ini
+++ b/src/geo/bench/config.ini
@@ -35,7 +35,7 @@ tool = nativerun
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
 
-logging_start_level = LOG_LEVEL_DEBUG
+logging_start_level = LOG_LEVEL_INFO
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
 logging_flush_on_exit = true

--- a/src/redis_protocol/proxy/config.ini
+++ b/src/redis_protocol/proxy/config.ini
@@ -45,7 +45,7 @@ toollets = profiler
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
 
-logging_start_level = LOG_LEVEL_DEBUG
+logging_start_level = LOG_LEVEL_INFO
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
 enable_default_app_mimic = true

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -67,7 +67,7 @@
   tls_trans_memory_KB = 1024
   tcmalloc_release_rate = 1.0
 
-  logging_start_level = LOG_LEVEL_DEBUG
+  logging_start_level = LOG_LEVEL_INFO
   logging_factory_name = dsn::tools::simple_logger
   logging_flush_on_exit = true
 

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -40,7 +40,7 @@
   tool = nativerun
   toollets = profiler
   enable_default_app_mimic = true
-  logging_start_level = LOG_LEVEL_DEBUG
+  logging_start_level = LOG_LEVEL_INFO
 
 [network]
   primary_interface = lo

--- a/src/shell/config.ini
+++ b/src/shell/config.ini
@@ -35,7 +35,7 @@ tool = nativerun
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
 
-logging_start_level = LOG_LEVEL_DEBUG
+logging_start_level = LOG_LEVEL_INFO
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
 logging_flush_on_exit = false

--- a/src/test/bench_test/config.ini
+++ b/src/test/bench_test/config.ini
@@ -35,7 +35,7 @@ tool = nativerun
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
 
-logging_start_level = LOG_LEVEL_DEBUG
+logging_start_level = LOG_LEVEL_INFO
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
 logging_flush_on_exit = true

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -45,7 +45,6 @@ enable_default_app_mimic = true
 [tools.simple_logger]
 fast_flush = true
 max_number_of_log_files_on_disk = 1000
-stderr_start_level = LOG_LEVEL_INFO
 
 [tools.simulator]
 random_seed = 0

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -36,7 +36,7 @@ tool = nativerun
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
 
-logging_start_level = LOG_LEVEL_DEBUG
+logging_start_level = LOG_LEVEL_INFO
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
 
@@ -45,7 +45,7 @@ enable_default_app_mimic = true
 [tools.simple_logger]
 fast_flush = true
 max_number_of_log_files_on_disk = 1000
-stderr_start_level = LOG_LEVEL_DEBUG
+stderr_start_level = LOG_LEVEL_INFO
 
 [tools.simulator]
 random_seed = 0

--- a/src/test/kill_test/config.ini
+++ b/src/test/kill_test/config.ini
@@ -36,7 +36,7 @@ tool = nativerun
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
 
-logging_start_level = LOG_LEVEL_DEBUG
+logging_start_level = LOG_LEVEL_INFO
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
 logging_flush_on_exit = true

--- a/src/test/pressure_test/config-pressure.ini
+++ b/src/test/pressure_test/config-pressure.ini
@@ -41,7 +41,7 @@ cli_remote = false
 
 start_nfs = false
 
-logging_start_level = LOG_LEVEL_DEBUG
+logging_start_level = LOG_LEVEL_INFO
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
 ;logging_factory_name = dsn::tools::hpc_logger

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -34,10 +34,10 @@
 #include "utils/smart_pointers.h"
 #include "simple_logger.h"
 
-dsn_log_level_t dsn_log_start_level = dsn_log_level_t::LOG_LEVEL_DEBUG;
+dsn_log_level_t dsn_log_start_level = dsn_log_level_t::LOG_LEVEL_INFO;
 DSN_DEFINE_string("core",
                   logging_start_level,
-                  "LOG_LEVEL_DEBUG",
+                  "LOG_LEVEL_INFO",
                   "logs with level below this will not be logged");
 
 DSN_DEFINE_bool("core", logging_flush_on_exit, true, "flush log when exit system");


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1249

Adjust the default log level from DEBUG to INFO to reduce too verbose logs for server, shell tool, and benchmark tests. The other unit tests are left in DEBUG level for debug.