### PR TITLE
build(pom): Use --release when building java client with java11+

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -49,7 +49,9 @@
 
   <properties>
     <pegasus.shade.name>org.apache.pegasus.thirdparty</pegasus.shade.name>
-
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <compileSource>1.8</compileSource>
+    <releaseTarget>8</releaseTarget>
     <junit.engine.version>5.3.2</junit.engine.version>
     <junit.platform.runner.version>1.3.0</junit.platform.runner.version>
     <guava.version>28.1-jre</guava.version>
@@ -166,6 +168,37 @@
       </plugin>
     </plugins>
   </reporting>
+  <profiles>
+    <profile>
+      <id>build-with-jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.source>${compileSource}</maven.compiler.source>
+        <maven.compiler.target>${compileSource}</maven.compiler.target>
+      </properties>
+    </profile>
+    <profile>
+      <id>build-with-jdk11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>${releaseTarget}</maven.compiler.release>
+        <argLine>@{argLine} -Dio.netty.tryReflectionSetAccessible=true
+          --add-modules jdk.unsupported
+          --add-opens java.base/java.nio=ALL-UNNAMED
+          --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+          --add-opens java.base/java.lang=ALL-UNNAMED
+          --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
+          --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+          --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+          --add-exports java.security.jgss/sun.security.krb5=ALL-UNNAMED
+          </argLine>
+      </properties>
+    </profile>
+  </profiles>
   <build>
     <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
     <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
@@ -214,13 +247,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.10.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
           <fork>true</fork>
           <verbose>true</verbose>
-          <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
       <plugin>

--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -186,7 +186,7 @@
       </activation>
       <properties>
         <maven.compiler.release>${releaseTarget}</maven.compiler.release>
-        <argLine>@{argLine} -Dio.netty.tryReflectionSetAccessible=true
+        <argLine>-Dio.netty.tryReflectionSetAccessible=true
           --add-modules jdk.unsupported
           --add-opens java.base/java.nio=ALL-UNNAMED
           --add-opens java.base/sun.nio.ch=ALL-UNNAMED
@@ -256,9 +256,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>3.0.0-M7</version>
         <configuration>
-          <skipTests>${skipTests}</skipTests>
           <additionalClasspathElements>
             <additionalClasspathElement>${project.basedir}/configuration</additionalClasspathElement>
           </additionalClasspathElements>


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1255

Add different profiles when building with jdk8 and jdk11+.
Also bump the maven compiler plugin to 3.10.1.
