### PR TITLE
chore(action): support checking issue number prefixed with '#' in github actions for PRs

### DIFF
--- a/.github/workflows/standardization_lint.yaml
+++ b/.github/workflows/standardization_lint.yaml
@@ -54,11 +54,12 @@ jobs:
     name: Check issue
     runs-on: ubuntu-latest
     steps:
-      - uses: neofinancial/ticket-check-action@v1.3.0
+      - uses: neofinancial/ticket-check-action@v1.3.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           titleFormat: '%title%'
           quiet: true
+          bodyRegex: '#(\d+)'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/apache)(\/incubator-pegasus)(\/issues)\/\d+'
 
   dockerfile_linter:

--- a/.github/workflows/standardization_lint.yaml
+++ b/.github/workflows/standardization_lint.yaml
@@ -54,7 +54,7 @@ jobs:
     name: Check issue
     runs-on: ubuntu-latest
     steps:
-      - uses: neofinancial/ticket-check-action@v1.3.3
+      - uses: neofinancial/ticket-check-action@v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           titleFormat: '%title%'


### PR DESCRIPTION
This PR is to solve #1269.

BTW, while trying to upgrade [neofinancial/ticket-check-action](https://github.com/marketplace/actions/pull-request-ticket-check-action) to the latest version 1.3.3, error message is showed as below:

```
neofinancial/ticket-check-action@v1.3.3 is not allowed to be used in apache/incubator-pegasus. Actions in this workflow must be: within a repository owned by apache, created by GitHub, verified in the GitHub Marketplace, or matching the following: */*@[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]+, AdoptOpenJDK/install-jdk@*, JamesIves/github-pages-deploy-action@5dc1d5a192aeb5ab5b7d5a77b7d36aea4a7f5c92, TobKed/label-when-approved-action@*, actions-cool/issues-helper@*, actions-rs/*, al-cheb/configure-pagefile-action@*, amannn/action-semantic-pull-request@*, apache/*, burrunan/gradle-cache-action@*, bytedeco/javacpp-presets/.github/actions/*, chromaui/action@*, codecov/codecov-action@*, conda-incubator/setup-miniconda@*, container-tools/kind-action@*, container-tools/microshift-action@*, dawidd6/action-download-artifact@*, delaguardo/setup-graalvm@*, docker://jekyll/jekyll:*, docker://pandoc/core:2.9, eps1lon/actions-label-merge-conflict@*, gaurav-nelson/github-action-mark...
```