### PR TITLE
fix: fix some bad links of docs

### DIFF
--- a/.github/workflows/lint_and_test_admin-cli.yml
+++ b/.github/workflows/lint_and_test_admin-cli.yml
@@ -43,6 +43,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -43,6 +43,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ under the License.
 <!-- markdown-link-check-disable -->
 [PacificA]: https://www.microsoft.com/en-us/research/publication/pacifica-replication-in-log-based-distributed-storage-systems/
 <!-- markdown-link-check-enable-->
-[pegasus-rocksdb]: https://github.com/xiaomi/pegasus-rocksdb
-[hbase]: https://hbase.apache.org/
+[rocksdb]: https://github.com/facebook/rocksdb
+[hbase]: https://hbase.apache.org
 [website]: https://pegasus.apache.org
 
 ![pegasus-logo](https://github.com/apache/incubator-pegasus-website/blob/master/assets/images/pegasus-logo-inv.png)
@@ -38,7 +38,7 @@ Apache Pegasus is a distributed key-value storage system which is designed to be
 
 - **horizontally scalable**: distributed using hash-based partitioning
 - **strongly consistent**: ensured by [PacificA][PacificA] consensus protocol
-- **high-performance**: using [RocksDB][pegasus-rocksdb] as underlying storage engine
+- **high-performance**: using [RocksDB][rocksdb] as underlying storage engine
 - **simple**: well-defined, easy-to-use APIs
 
 ## Background

--- a/admin-cli/README.md
+++ b/admin-cli/README.md
@@ -18,8 +18,6 @@ under the License.
 -->
 # admin-cli
 
-[![Golang Lint and Unit Test](https://github.com/apache/incubator-pegasus/actions/workflows/lint_and_test_admin-cli.yml/badge.svg)](https://github.com/apache/incubator-pegasus/actions/workflows/lint_and_test_admin-cli.yml)
-
 The command-line tool for the administration of Pegasus.
 
 Thanks to the portability of Go, we have provided binaries of admin-cli for multiple platforms. This is a tremendous advantage

--- a/java-client/README.md
+++ b/java-client/README.md
@@ -19,8 +19,6 @@ under the License.
 
 # Pegasus Java Client
 
-[![Test - java client](https://github.com/apache/incubator-pegasus/actions/workflows/test_java-client.yml/badge.svg)](https://github.com/apache/incubator-pegasus/actions/workflows/test_java-client.yml)
-
 ## Build
 
 ```


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1281

Fix some bad links.

Since Java-client and Admin-cli are lint and built by `.github/workflows/regular-build.yml`, the status is shown on the main page, it's not needed to show again in sub-pages.