### PR TITLE
refactor: let cmds deregister automatically

### DIFF
--- a/src/failure_detector/failure_detector.cpp
+++ b/src/failure_detector/failure_detector.cpp
@@ -50,11 +50,7 @@ failure_detector::failure_detector()
     _is_started = false;
 }
 
-failure_detector::~failure_detector()
-{
-    stop();
-    unregister_ctrl_commands();
-}
+failure_detector::~failure_detector() { stop(); }
 
 void failure_detector::register_ctrl_commands()
 {
@@ -67,8 +63,6 @@ void failure_detector::register_ctrl_commands()
             [this](const std::vector<std::string> &args) { return get_allow_list(args); });
     });
 }
-
-void failure_detector::unregister_ctrl_commands() { _get_allow_list.reset(); }
 
 error_code failure_detector::start(uint32_t check_interval_seconds,
                                    uint32_t beacon_interval_seconds,

--- a/src/failure_detector/failure_detector.h
+++ b/src/failure_detector/failure_detector.h
@@ -100,7 +100,6 @@ public:
     virtual void end_ping(::dsn::error_code err, const beacon_ack &ack, void *context);
 
     virtual void register_ctrl_commands();
-    virtual void unregister_ctrl_commands();
 
 public:
     error_code start(uint32_t check_interval_seconds,
@@ -109,6 +108,7 @@ public:
                      uint32_t grace_seconds,
                      bool use_allow_list = false);
 
+    // TODO(yingchun): can it be removed ?
     void stop();
 
     uint32_t get_lease_ms() const { return _lease_milliseconds; }

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -73,7 +73,7 @@ greedy_load_balancer::greedy_load_balancer(meta_service *_svc) : server_load_bal
         "copy secondary count by balancer in the recent period");
 }
 
-greedy_load_balancer::~greedy_load_balancer() { unregister_ctrl_commands(); }
+greedy_load_balancer::~greedy_load_balancer() {}
 
 void greedy_load_balancer::register_ctrl_commands()
 {
@@ -83,8 +83,6 @@ void greedy_load_balancer::register_ctrl_commands()
         "get balance operation count",
         [this](const std::vector<std::string> &args) { return get_balance_operation_count(args); });
 }
-
-void greedy_load_balancer::unregister_ctrl_commands() { _get_balance_operation_count.reset(); }
 
 std::string greedy_load_balancer::get_balance_operation_count(const std::vector<std::string> &args)
 {

--- a/src/meta/greedy_load_balancer.h
+++ b/src/meta/greedy_load_balancer.h
@@ -44,14 +44,13 @@ class greedy_load_balancer : public server_load_balancer
 {
 public:
     explicit greedy_load_balancer(meta_service *svc);
-    ~greedy_load_balancer() override;
+    virtual ~greedy_load_balancer();
     bool balance(meta_view view, migration_list &list) override;
     bool check(meta_view view, migration_list &list) override;
     void report(const migration_list &list, bool balance_checker) override;
     void score(meta_view view, double &primary_stddev, double &total_stddev) override;
 
     void register_ctrl_commands() override;
-    void unregister_ctrl_commands() override;
 
     std::string get_balance_operation_count(const std::vector<std::string> &args) override;
 

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -100,7 +100,10 @@ void meta_service::stop()
         return;
     }
     _tracker.cancel_outstanding_tasks();
-    unregister_ctrl_commands();
+    _ctrl_node_live_percentage_threshold_for_update.reset();
+    _failure_detector.reset();
+    _balancer.reset();
+    _partition_guardian.reset();
     _started = false;
 }
 
@@ -233,22 +236,6 @@ void meta_service::register_ctrl_commands()
                 }
                 return result;
             });
-}
-
-void meta_service::unregister_ctrl_commands()
-{
-    // TODO(yingchun): the commands can be unregister automatiically, maybe we can remove the manual
-    // unregister code later
-    _ctrl_node_live_percentage_threshold_for_update.reset();
-    if (_partition_guardian != nullptr) {
-        _partition_guardian->unregister_ctrl_commands();
-    }
-    if (_balancer != nullptr) {
-        _balancer->unregister_ctrl_commands();
-    }
-    if (_failure_detector != nullptr) {
-        _failure_detector->unregister_ctrl_commands();
-    }
 }
 
 void meta_service::start_service()

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -179,7 +179,6 @@ public:
 private:
     void register_rpc_handlers();
     void register_ctrl_commands();
-    void unregister_ctrl_commands();
 
     // client => meta server
     void on_query_configuration_by_index(configuration_query_by_index_rpc rpc);

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -684,8 +684,6 @@ void partition_guardian::register_ctrl_commands()
         }));
 }
 
-void partition_guardian::unregister_ctrl_commands() { _cmds.clear(); }
-
 std::string partition_guardian::ctrl_assign_delay_ms(const std::vector<std::string> &args)
 {
     std::string result("OK");

--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -40,7 +40,6 @@ public:
     cure(meta_view view, const dsn::gpid &gpid, configuration_proposal_action &action);
     void reconfig(meta_view view, const configuration_update_request &request);
     void register_ctrl_commands();
-    void unregister_ctrl_commands();
     void get_ddd_partitions(const gpid &pid, std::vector<ddd_partition_info> &partitions);
     void clear_ddd_partitions()
     {

--- a/src/meta/server_load_balancer.h
+++ b/src/meta/server_load_balancer.h
@@ -173,11 +173,6 @@ public:
     virtual void register_ctrl_commands() {}
 
     //
-    // Try to unregister cli-commands
-    //
-    virtual void unregister_ctrl_commands() {}
-
-    //
     // Get balancer proposal counts
     // params:
     //   args: proposal type


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1234

Remove the manual deregistering of remote commands.