### PR TITLE
chore(ci): use ubuntu-20.04 and install thrift-0.13 specially

### DIFF
--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -117,8 +117,12 @@ jobs:
 
   build_go:
     name: Build Golang
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
+      - name: Install thrift
+        # go-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0
+        # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
+        run: sudo apt-get install -y thrift-compiler
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -99,6 +99,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
       - name: go-client
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -92,35 +92,8 @@ jobs:
       - name: Packaging Server
         run: ./run.sh pack_server
 
-  lint_go:
-    name: Lint Golang
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.14
-      - name: go-client
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.29
-          working-directory: ./go-client
-      - name: admin-cli
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.29
-          working-directory: ./admin-cli
-      - name: pegic
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.29
-          working-directory: ./pegic
-
-  build_go:
-    name: Build Golang
+  build_and_lint_go:
+    name: Build and Lint Golang
     runs-on: ubuntu-20.04
     steps:
       - name: Install thrift
@@ -138,12 +111,27 @@ jobs:
       - name: Build go-client
         run: make
         working-directory: ./go-client
+      - name: Lint go-client
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.29
+          working-directory: ./go-client
       - name: Build admin-cli
         run: make
         working-directory: ./admin-cli
+      - name: Lint admin-cli
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.29
+          working-directory: ./admin-cli
       - name: Build pegic
         run: make
         working-directory: ./pegic
+      - name: Lint pegic
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.29
+          working-directory: ./pegic
 
   build_java:
     name: Build Java


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1291

- Use `ubuntu-20.04` instaed of `ubuntu-latest` in order to install thrift-0.13
- Reorder lint and build steps, because some files are generated after building successfully

It can be previewed in https://github.com/apache/incubator-pegasus/actions/runs/3681562714.

NOTE:
- Please ignore the CPP build failures, it will only work on master branch
- The failure of `Build Cpp (ubuntu1604, gcc)` on master branch will be fixed by another patch