### PR TITLE
refactor(log): use LOG_INFO_F instead of LOG_INFO (1/3)

### DIFF
--- a/src/replica/backup/replica_backup_server.cpp
+++ b/src/replica/backup/replica_backup_server.cpp
@@ -40,10 +40,10 @@ void replica_backup_server::on_cold_backup(backup_rpc rpc)
     const backup_request &request = rpc.request();
     backup_response &response = rpc.response();
 
-    LOG_INFO("received cold backup request: backup{%s.%s.%" PRId64 "}",
-             request.pid.to_string(),
-             request.policy.policy_name.c_str(),
-             request.backup_id);
+    LOG_INFO_F("received cold backup request: backup[{}.{}.{}]",
+               request.pid,
+               request.policy.policy_name,
+               request.backup_id);
     response.pid = request.pid;
     response.policy_name = request.policy.policy_name;
     response.backup_id = request.backup_id;

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -1568,7 +1568,7 @@ int mutation_log::garbage_collection(const replica_log_info_map &gc_condition,
                        "reserved_log_count = {}, reserved_log_size = {}, "
                        "reserved_smallest_log = {}, reserved_largest_log = {}, "
                        "stop_gc_log_index = {}, stop_gc_replica_count = {}, "
-                       "stop_gc_replica = {}.{}, stop_gc_decree_gap = {}, "
+                       "stop_gc_replica = {}, stop_gc_decree_gap = {}, "
                        "stop_gc_garbage_max_decree = {}, stop_gc_log_max_decree = {}",
                        file_count_limit,
                        reserved_log_count,
@@ -1577,8 +1577,7 @@ int mutation_log::garbage_collection(const replica_log_info_map &gc_condition,
                        reserved_largest_log,
                        stop_gc_log_index,
                        prevent_gc_replicas.size(),
-                       stop_gc_replica.get_app_id(),
-                       stop_gc_replica.get_partition_index(),
+                       stop_gc_replica,
                        stop_gc_decree_gap,
                        stop_gc_garbage_max_decree,
                        stop_gc_log_max_decree);
@@ -1656,7 +1655,7 @@ int mutation_log::garbage_collection(const replica_log_info_map &gc_condition,
                    "deleted_log_count = {}, deleted_log_size = {}, "
                    "deleted_smallest_log = {}, deleted_largest_log = {}, "
                    "stop_gc_log_index = {}, stop_gc_replica_count = {}, "
-                   "stop_gc_replica = {}.{}, stop_gc_decree_gap = {}, "
+                   "stop_gc_replica = {}, stop_gc_decree_gap = {}, "
                    "stop_gc_garbage_max_decree = {}, stop_gc_log_max_decree = {}",
                    file_count_limit,
                    reserved_log_count,
@@ -1671,8 +1670,7 @@ int mutation_log::garbage_collection(const replica_log_info_map &gc_condition,
                    deleted_largest_log,
                    stop_gc_log_index,
                    prevent_gc_replicas.size(),
-                   stop_gc_replica.get_app_id(),
-                   stop_gc_replica.get_partition_index(),
+                   stop_gc_replica,
                    stop_gc_decree_gap,
                    stop_gc_garbage_max_decree,
                    stop_gc_log_max_decree);

--- a/src/replica/mutation_log_replay.cpp
+++ b/src/replica/mutation_log_replay.cpp
@@ -49,7 +49,7 @@ namespace replication {
         start_offset = static_cast<size_t>(end_offset - log->start_offset());
     }
 
-    LOG_INFO_F("finish to replay mutation log ({}) [err: {}]", log->path(), err.description());
+    LOG_INFO_F("finish to replay mutation log ({}) [err: {}]", log->path(), err);
     return err.code();
 }
 

--- a/src/replica/mutation_log_replay.cpp
+++ b/src/replica/mutation_log_replay.cpp
@@ -29,12 +29,11 @@ namespace replication {
                                            /*out*/ int64_t &end_offset)
 {
     end_offset = log->start_offset();
-    LOG_INFO("start to replay mutation log %s, offset = [%" PRId64 ", %" PRId64
-             "), size = %" PRId64,
-             log->path().c_str(),
-             log->start_offset(),
-             log->end_offset(),
-             log->end_offset() - log->start_offset());
+    LOG_INFO_F("start to replay mutation log {}, offset = [{}, {}), size = {}",
+               log->path(),
+               log->start_offset(),
+               log->end_offset(),
+               log->end_offset() - log->start_offset());
 
     ::dsn::blob bb;
     log->reset_stream();
@@ -50,9 +49,7 @@ namespace replication {
         start_offset = static_cast<size_t>(end_offset - log->start_offset());
     }
 
-    LOG_INFO("finish to replay mutation log (%s) [err: %s]",
-             log->path().c_str(),
-             err.description().c_str());
+    LOG_INFO_F("finish to replay mutation log ({}) [err: {}]", log->path(), err.description());
     return err.code();
 }
 

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -485,7 +485,7 @@ void replica::close()
 
     _split_mgr.reset();
 
-    LOG_INFO("%s: replica closed, time_used = %" PRIu64 "ms", name(), dsn_now_ms() - start_time);
+    LOG_INFO_PREFIX("replica closed, time_used = {} ms", dsn_now_ms() - start_time);
 }
 
 std::string replica::query_manual_compact_state() const

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -670,11 +670,8 @@ void replica::on_prepare_reply(std::pair<mutation_ptr, partition_status::type> p
                           prepare_timeout_ms,
                           dsn_now_ms());
             } else {
-                LOG_INFO("%s: mutation %s retry prepare to %s after %d ms",
-                         name(),
-                         mu->name(),
-                         node.to_string(),
-                         delay_time_ms);
+                LOG_INFO_PREFIX(
+                    "mutation {} retry prepare to {} after {} ms", mu->name(), node, delay_time_ms);
                 int64_t learn_signature = invalid_signature;
                 if (target_status == partition_status::PS_POTENTIAL_SECONDARY) {
                     auto it = _primary_states.learners.find(node);

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -55,7 +55,7 @@ void replica::init_group_check()
 
     _checker.only_one_thread_access();
 
-    LOG_INFO("%s: init group check", name());
+    LOG_INFO_PREFIX("init group check");
 
     if (partition_status::PS_PRIMARY != status() || _options->group_check_disabled)
         return;
@@ -75,7 +75,7 @@ void replica::broadcast_group_check()
 
     CHECK_NOTNULL(_primary_states.group_check_task, "");
 
-    LOG_INFO("%s: start to broadcast group check", name());
+    LOG_INFO_PREFIX("start to broadcast group check");
 
     if (_primary_states.group_check_pending_replies.size() > 0) {
         LOG_WARNING(
@@ -119,10 +119,7 @@ void replica::broadcast_group_check()
             request->config.learner_signature = it->second.signature;
         }
 
-        LOG_INFO("%s: send group check to %s with state %s",
-                 name(),
-                 addr.to_string(),
-                 enum_to_string(it->second));
+        LOG_INFO_PREFIX("send group check to %s with state {}", addr, enum_to_string(it->second));
 
         dsn::task_ptr callback_task =
             rpc::call(addr,

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -119,7 +119,7 @@ void replica::broadcast_group_check()
             request->config.learner_signature = it->second.signature;
         }
 
-        LOG_INFO_PREFIX("send group check to %s with state {}", addr, enum_to_string(it->second));
+        LOG_INFO_PREFIX("send group check to {} with state {}", addr, enum_to_string(it->second));
 
         dsn::task_ptr callback_task =
             rpc::call(addr,

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -70,8 +70,7 @@ void replica::on_checkpoint_timer()
                             _last_checkpoint_generate_time_ms);
         init_checkpoint(true);
     } else {
-        LOG_INFO_PREFIX("trigger non-emergency checkpoint by checkpoint_max_interval_hours {}h",
-                        _options->checkpoint_max_interval_hours);
+        LOG_INFO_PREFIX("trigger non-emergency checkpoint");
         init_checkpoint(false);
     }
 

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -62,17 +62,16 @@ void replica::on_checkpoint_timer()
 
     if (dsn_now_ms() > _next_checkpoint_interval_trigger_time_ms) {
         // we trigger emergency checkpoint if no checkpoint generated for a long time
-        LOG_INFO("%s: trigger emergency checkpoint by checkpoint_max_interval_hours, "
-                 "config_interval = %dh (%" PRIu64 "ms), random_interval = %" PRIu64 "ms",
-                 name(),
-                 _options->checkpoint_max_interval_hours,
-                 _options->checkpoint_max_interval_hours * 3600000UL,
-                 _next_checkpoint_interval_trigger_time_ms - _last_checkpoint_generate_time_ms);
+        LOG_INFO_PREFIX("trigger emergency checkpoint by checkpoint_max_interval_hours, "
+                        "config_interval = {}h ({}ms), random_interval = {}ms",
+                        _options->checkpoint_max_interval_hours,
+                        _options->checkpoint_max_interval_hours * 3600000UL,
+                        _next_checkpoint_interval_trigger_time_ms -
+                            _last_checkpoint_generate_time_ms);
         init_checkpoint(true);
     } else {
-        LOG_INFO("%s: trigger non-emergency checkpoint",
-                 name(),
-                 _options->checkpoint_max_interval_hours);
+        LOG_INFO_PREFIX("trigger non-emergency checkpoint by checkpoint_max_interval_hours {}h",
+                        _options->checkpoint_max_interval_hours);
         init_checkpoint(false);
     }
 
@@ -177,10 +176,9 @@ void replica::init_checkpoint(bool is_emergency)
 {
     // only applicable to primary and secondary replicas
     if (status() != partition_status::PS_PRIMARY && status() != partition_status::PS_SECONDARY) {
-        LOG_INFO("%s: ignore doing checkpoint for status = %s, is_emergency = %s",
-                 name(),
-                 enum_to_string(status()),
-                 (is_emergency ? "true" : "false"));
+        LOG_INFO_PREFIX("ignore doing checkpoint for status = {}, is_emergency = {}",
+                        enum_to_string(status()),
+                        is_emergency ? "true" : "false");
         return;
     }
 
@@ -240,14 +238,12 @@ error_code replica::background_async_checkpoint(bool is_emergency)
         if (old_durable != _app->last_durable_decree()) {
             // if no need to generate new checkpoint, async_checkpoint() also returns ERR_OK,
             // so we should check if a new checkpoint has been generated.
-            LOG_INFO("%s: call app.async_checkpoint() succeed, time_used_ns = %" PRIu64 ", "
-                     "app_last_committed_decree = %" PRId64 ", app_last_durable_decree = (%" PRId64
-                     " => %" PRId64 ")",
-                     name(),
-                     used_time,
-                     _app->last_committed_decree(),
-                     old_durable,
-                     _app->last_durable_decree());
+            LOG_INFO_PREFIX("call app.async_checkpoint() succeed, time_used_ns = {}, "
+                            "app_last_committed_decree = {}, app_last_durable_decree = ({} => {})",
+                            used_time,
+                            _app->last_committed_decree(),
+                            old_durable,
+                            _app->last_durable_decree());
             update_last_checkpoint_generate_time();
         }
 
@@ -263,10 +259,9 @@ error_code replica::background_async_checkpoint(bool is_emergency)
 
     if (err == ERR_TRY_AGAIN) {
         // already triggered memory flushing on async_checkpoint(), then try again later.
-        LOG_INFO("%s: call app.async_checkpoint() returns ERR_TRY_AGAIN, time_used_ns = %" PRIu64
-                 ", schedule later checkpoint after 10 seconds",
-                 name(),
-                 used_time);
+        LOG_INFO_PREFIX("call app.async_checkpoint() returns ERR_TRY_AGAIN, time_used_ns = {}"
+                        ", schedule later checkpoint after 10 seconds",
+                        used_time);
         tasking::enqueue(LPC_PER_REPLICA_CHECKPOINT_TIMER,
                          &_tracker,
                          [this] { init_checkpoint(false); },
@@ -283,10 +278,9 @@ error_code replica::background_async_checkpoint(bool is_emergency)
     }
     if (err == ERR_WRONG_TIMING) {
         // do nothing
-        LOG_INFO("%s: call app.async_checkpoint() returns ERR_WRONG_TIMING, time_used_ns = %" PRIu64
-                 ", just ignore",
-                 name(),
-                 used_time);
+        LOG_INFO_PREFIX(
+            "call app.async_checkpoint() returns ERR_WRONG_TIMING, time_used_ns = {}, just ignore",
+            used_time);
     } else {
         LOG_ERROR("%s: call app.async_checkpoint() failed, time_used_ns = %" PRIu64 ", err = %s",
                   name(),
@@ -308,22 +302,20 @@ error_code replica::background_sync_checkpoint()
         if (old_durable != _app->last_durable_decree()) {
             // if no need to generate new checkpoint, sync_checkpoint() also returns ERR_OK,
             // so we should check if a new checkpoint has been generated.
-            LOG_INFO("%s: call app.sync_checkpoint() succeed, time_used_ns = %" PRIu64 ", "
-                     "app_last_committed_decree = %" PRId64 ", app_last_durable_decree = (%" PRId64
-                     " => %" PRId64 ")",
-                     name(),
-                     used_time,
-                     _app->last_committed_decree(),
-                     old_durable,
-                     _app->last_durable_decree());
+            LOG_INFO_PREFIX("call app.sync_checkpoint() succeed, time_used_ns = {}, "
+                            "app_last_committed_decree = {}, "
+                            "app_last_durable_decree = ({} => {})",
+                            used_time,
+                            _app->last_committed_decree(),
+                            old_durable,
+                            _app->last_durable_decree());
             update_last_checkpoint_generate_time();
         }
     } else if (err == ERR_WRONG_TIMING) {
         // do nothing
-        LOG_INFO("%s: call app.sync_checkpoint() returns ERR_WRONG_TIMING, time_used_ns = %" PRIu64
-                 ", just ignore",
-                 name(),
-                 used_time);
+        LOG_INFO_PREFIX(
+            "call app.sync_checkpoint() returns ERR_WRONG_TIMING, time_used_ns = {}, just ignore",
+            used_time);
     } else {
         LOG_ERROR("%s: call app.sync_checkpoint() failed, time_used_ns = %" PRIu64 ", err = %s",
                   name(),

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -180,7 +180,7 @@ void replica::add_potential_secondary(configuration_update_request &proposal)
                                 "secondary proposal");
                 return;
             } else {
-                LOG_INFO_PREFIX("add a new secondary(%s) for future load balancer", proposal.node);
+                LOG_INFO_PREFIX("add a new secondary({}) for future load balancer", proposal.node);
             }
         } else {
             CHECK(false, "invalid config_type, type = {}", enum_to_string(proposal.type));

--- a/src/replica/replica_failover.cpp
+++ b/src/replica/replica_failover.cpp
@@ -43,10 +43,7 @@ namespace replication {
 
 void replica::handle_local_failure(error_code error)
 {
-    LOG_INFO("%s: handle local failure error %s, status = %s",
-             name(),
-             error.to_string(),
-             enum_to_string(status()));
+    LOG_INFO_PREFIX("handle local failure error {}, status = {}", error, enum_to_string(status()));
 
     if (status() == partition_status::PS_PRIMARY) {
         _stub->remove_replica_on_meta_server(_app_info, _primary_states.membership);
@@ -85,7 +82,7 @@ void replica::handle_remote_failure(partition_status::type st,
         }
         break;
     case partition_status::PS_POTENTIAL_SECONDARY: {
-        LOG_INFO("%s: remove learner %s for remote failure", name(), node.to_string());
+        LOG_INFO_PREFIX("remove learner {} for remote failure", node);
         // potential secondary failure does not lead to ballot change
         // therefore, it is possible to have multiple exec here
         _primary_states.learners.erase(node);
@@ -102,7 +99,7 @@ void replica::handle_remote_failure(partition_status::type st,
 
 void replica::on_meta_server_disconnected()
 {
-    LOG_INFO("%s: meta server disconnected", name());
+    LOG_INFO_PREFIX("meta server disconnected");
 
     auto old_status = status();
     update_local_configuration_with_no_ballot_change(partition_status::PS_INACTIVE);

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -202,7 +202,7 @@ void replica::init_learn(uint64_t signature)
     request.signature = _potential_secondary_states.learning_version;
     _app->prepare_get_checkpoint(request.app_specific_learn_request);
 
-    LOG_INFO_PREFIX("init_learn[{:#018x}]: learnee = {}, learn_duration = {}ms, max_gced_decree = "
+    LOG_INFO_PREFIX("init_learn[{:#018x}]: learnee = {}, learn_duration = {} ms, max_gced_decree = "
                     "{}, local_committed_decree = {}, app_committed_decree = {}, "
                     "app_durable_decree = {}, current_learning_status = {}, total_copy_file_count "
                     "= {}, total_copy_file_size = {}, total_copy_buffer_size = {}",

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -66,7 +66,7 @@ bool replica::remove_useless_file_under_chkpt(const std::string &chkpt_dir,
             LOG_ERROR("%s: remove useless file(%s) failed", name(), pair.second.c_str());
             return false;
         }
-        LOG_INFO_PREFIX("remove useless file(%s) succeed", pair.second);
+        LOG_INFO_PREFIX("remove useless file({}) succeed", pair.second);
     }
     return true;
 }

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -66,7 +66,7 @@ bool replica::remove_useless_file_under_chkpt(const std::string &chkpt_dir,
             LOG_ERROR("%s: remove useless file(%s) failed", name(), pair.second.c_str());
             return false;
         }
-        LOG_INFO("%s: remove useless file(%s) succeed", name(), pair.second.c_str());
+        LOG_INFO_PREFIX("remove useless file(%s) succeed", pair.second);
     }
     return true;
 }
@@ -400,7 +400,7 @@ dsn::error_code replica::skip_restore_partition(const std::string &restore_dir)
     // it because we use restore_dir to tell storage engine that start an app from restore
     if (utils::filesystem::remove_path(restore_dir) &&
         utils::filesystem::create_directory(restore_dir)) {
-        LOG_INFO("%s: clear restore_dir(%s) succeed", name(), restore_dir.c_str());
+        LOG_INFO_PREFIX("clear restore_dir({}) succeed", restore_dir);
         _restore_progress.store(cold_backup_constant::PROGRESS_FINISHED);
         return ERR_OK;
     } else {
@@ -430,7 +430,7 @@ void replica::tell_meta_to_restore_rollback()
                       configuration_drop_app_response response;
                       ::dsn::unmarshall(resp, response);
                       if (response.err == ERR_OK) {
-                          LOG_INFO("restore rolling backup succeed");
+                          LOG_INFO_PREFIX("restore rolling backup succeed");
                           return;
                       } else {
                           tell_meta_to_restore_rollback();

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -204,9 +204,9 @@ public:
     void generate_backup_checkpoint(cold_backup_context_ptr backup_context) override
     {
         if (backup_context->status() != ColdBackupCheckpointing) {
-            LOG_INFO("%s: ignore generating backup checkpoint because backup_status = %s",
-                     backup_context->name,
-                     cold_backup_status_to_string(backup_context->status()));
+            LOG_INFO_F("ignore generating backup checkpoint because backup_status = {}",
+                       backup_context->name,
+                       cold_backup_status_to_string(backup_context->status()));
             backup_context->ignore_checkpoint();
             return;
         }

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -204,7 +204,7 @@ public:
     void generate_backup_checkpoint(cold_backup_context_ptr backup_context) override
     {
         if (backup_context->status() != ColdBackupCheckpointing) {
-            LOG_INFO_F("ignore generating backup checkpoint because backup_status = {}",
+            LOG_INFO_F("{}: ignore generating backup checkpoint because backup_status = {}",
                        backup_context->name,
                        cold_backup_status_to_string(backup_context->status()));
             backup_context->ignore_checkpoint();


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1305

This patch aim to use LOG_INFO_F instead of LOG_INFO. Includes:
- Use `LOG_INFO_F` instead of `LOG_INFO` in replica module.
- Use `LOG_INFO_PREFIX` instaed of `LOG_INFO` for class `replica`
