### PR TITLE
refactor(FLAG): remove the quotes of section field of FLAG

### DIFF
--- a/src/block_service/directio_writable_file.cpp
+++ b/src/block_service/directio_writable_file.cpp
@@ -34,13 +34,13 @@ namespace dsn {
 namespace dist {
 namespace block_service {
 
-DSN_DEFINE_uint32("replication",
+DSN_DEFINE_uint32(replication,
                   direct_io_buffer_pages,
                   64,
                   "Number of pages we need to set to direct io buffer");
 DSN_TAG_VARIABLE(direct_io_buffer_pages, FT_MUTABLE);
 
-DSN_DEFINE_bool("replication",
+DSN_DEFINE_bool(replication,
                 enable_direct_io,
                 false,
                 "Whether to enable direct I/O when download files");

--- a/src/block_service/fds/fds_service.cpp
+++ b/src/block_service/fds/fds_service.cpp
@@ -46,16 +46,16 @@ namespace dsn {
 namespace dist {
 namespace block_service {
 
-DSN_DEFINE_uint32("replication", fds_write_limit_rate, 100, "write rate limit of fds(MB/s)");
+DSN_DEFINE_uint32(replication, fds_write_limit_rate, 100, "write rate limit of fds(MB/s)");
 DSN_TAG_VARIABLE(fds_write_limit_rate, FT_MUTABLE);
 
-DSN_DEFINE_uint32("replication", fds_write_burst_size, 500, "write burst size of fds(MB)");
+DSN_DEFINE_uint32(replication, fds_write_burst_size, 500, "write burst size of fds(MB)");
 DSN_TAG_VARIABLE(fds_write_burst_size, FT_MUTABLE);
 
-DSN_DEFINE_uint32("replication", fds_read_limit_rate, 100, "read rate limit of fds(MB/s)");
+DSN_DEFINE_uint32(replication, fds_read_limit_rate, 100, "read rate limit of fds(MB/s)");
 DSN_TAG_VARIABLE(fds_read_limit_rate, FT_MUTABLE);
 
-DSN_DEFINE_uint32("replication", fds_read_batch_size, 100, "read batch size of fds(MB)");
+DSN_DEFINE_uint32(replication, fds_read_batch_size, 100, "read batch size of fds(MB)");
 DSN_TAG_VARIABLE(fds_read_batch_size, FT_MUTABLE);
 
 class utils

--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -38,19 +38,19 @@ namespace block_service {
 
 DEFINE_TASK_CODE(LPC_HDFS_SERVICE_CALL, TASK_PRIORITY_COMMON, THREAD_POOL_BLOCK_SERVICE)
 
-DSN_DEFINE_uint64("replication",
+DSN_DEFINE_uint64(replication,
                   hdfs_read_batch_size_bytes,
                   64 << 20,
                   "hdfs read batch size, the default value is 64MB");
 DSN_TAG_VARIABLE(hdfs_read_batch_size_bytes, FT_MUTABLE);
 
-DSN_DEFINE_uint32("replication", hdfs_read_limit_rate_mb_per_sec, 200, "hdfs read limit(MB/s)");
+DSN_DEFINE_uint32(replication, hdfs_read_limit_rate_mb_per_sec, 200, "hdfs read limit(MB/s)");
 DSN_TAG_VARIABLE(hdfs_read_limit_rate_mb_per_sec, FT_MUTABLE);
 
-DSN_DEFINE_uint32("replication", hdfs_write_limit_rate_mb_per_sec, 200, "hdfs write limit(MB/s)");
+DSN_DEFINE_uint32(replication, hdfs_write_limit_rate_mb_per_sec, 200, "hdfs write limit(MB/s)");
 DSN_TAG_VARIABLE(hdfs_write_limit_rate_mb_per_sec, FT_MUTABLE);
 
-DSN_DEFINE_uint64("replication",
+DSN_DEFINE_uint64(replication,
                   hdfs_write_batch_size_bytes,
                   64 << 20,
                   "hdfs write batch size, the default value is 64MB");

--- a/src/block_service/test/hdfs_service_test.cpp
+++ b/src/block_service/test/hdfs_service_test.cpp
@@ -34,14 +34,14 @@ static std::string example_name_node = "<hdfs_name_none>";
 static std::string example_backup_path = "<hdfs_path>";
 // Please modify following paras in 'config-test.ini' to enable hdfs_service_test,
 // or hdfs_service_test will be skipped and return true.
-DSN_DEFINE_string("hdfs_test", test_name_node, "<hdfs_name_none>", "hdfs name node");
-DSN_DEFINE_string("hdfs_test",
+DSN_DEFINE_string(hdfs_test, test_name_node, "<hdfs_name_none>", "hdfs name node");
+DSN_DEFINE_string(hdfs_test,
                   test_backup_path,
                   "<hdfs_path>",
                   "path for uploading and downloading test files");
 
-DSN_DEFINE_uint32("hdfs_test", num_test_file_lines, 4096, "number of lines in test file");
-DSN_DEFINE_uint32("hdfs_test",
+DSN_DEFINE_uint32(hdfs_test, num_test_file_lines, 4096, "number of lines in test file");
+DSN_DEFINE_uint32(hdfs_test,
                   num_total_files_for_hdfs_concurrent_test,
                   64,
                   "number of total files for hdfs concurrent test");

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -22,7 +22,7 @@
 #include "utils/strings.h"
 
 namespace dsn {
-DSN_DEFINE_string("replication", cluster_name, "", "name of this cluster");
+DSN_DEFINE_string(replication, cluster_name, "", "name of this cluster");
 
 /*extern*/ const char *get_current_cluster_name()
 {

--- a/src/common/duplication_common.cpp
+++ b/src/common/duplication_common.cpp
@@ -32,7 +32,7 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_uint32("replication",
+DSN_DEFINE_uint32(replication,
                   duplicate_log_batch_bytes,
                   4096,
                   "send mutation log batch bytes size per rpc");

--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -42,7 +42,7 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_int32("replication",
+DSN_DEFINE_int32(replication,
                  disk_min_available_space_ratio,
                  10,
                  "if disk available space ratio "

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -37,7 +37,7 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_int32("replication",
+DSN_DEFINE_int32(replication,
                  max_concurrent_bulk_load_downloading_count,
                  5,
                  "concurrent bulk load downloading replica count");
@@ -46,7 +46,7 @@ DSN_DEFINE_int32("replication",
  * Empty write is used for flushing WAL log entry which is submit asynchronously.
  * Make sure it can work well if you diable it.
  */
-DSN_DEFINE_bool("replication",
+DSN_DEFINE_bool(replication,
                 empty_write_disabled,
                 false,
                 "whether to disable empty write, default is false");

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -32,7 +32,7 @@
 
 namespace dsn {
 
-DSN_DEFINE_bool("http", enable_http_server, true, "whether to enable the embedded HTTP server");
+DSN_DEFINE_bool(http, enable_http_server, true, "whether to enable the embedded HTTP server");
 
 namespace {
 error_s update_config(const http_request &req)

--- a/src/meta/cluster_balance_policy.cpp
+++ b/src/meta/cluster_balance_policy.cpp
@@ -22,7 +22,7 @@
 
 namespace dsn {
 namespace replication {
-DSN_DEFINE_uint32("meta_server",
+DSN_DEFINE_uint32(meta_server,
                   balance_op_count_per_round,
                   10,
                   "balance operation count per round for cluster balancer");

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -39,7 +39,7 @@
 
 namespace dsn {
 namespace replication {
-DSN_DEFINE_bool("meta_server", balance_cluster, false, "whether to enable cluster balancer");
+DSN_DEFINE_bool(meta_server, balance_cluster, false, "whether to enable cluster balancer");
 DSN_TAG_VARIABLE(balance_cluster, FT_MUTABLE);
 
 DSN_DECLARE_uint64(min_live_node_count_for_unfreeze);

--- a/src/meta/meta_bulk_load_ingestion_context.cpp
+++ b/src/meta/meta_bulk_load_ingestion_context.cpp
@@ -24,13 +24,13 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_uint32("meta_server",
+DSN_DEFINE_uint32(meta_server,
                   bulk_load_node_max_ingesting_count,
                   4,
                   "max partition_count executing ingestion for one node at the same time");
 DSN_TAG_VARIABLE(bulk_load_node_max_ingesting_count, FT_MUTABLE);
 
-DSN_DEFINE_uint32("meta_server", bulk_load_node_min_disk_count, 1, "min disk count of one node");
+DSN_DEFINE_uint32(meta_server, bulk_load_node_min_disk_count, 1, "min disk count of one node");
 DSN_TAG_VARIABLE(bulk_load_node_min_disk_count, FT_MUTABLE);
 
 ingestion_context::ingestion_context() { reset_all(); }

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -25,7 +25,7 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_uint32("meta_server",
+DSN_DEFINE_uint32(meta_server,
                   bulk_load_max_rollback_times,
                   10,
                   "if bulk load rollback time "
@@ -35,13 +35,13 @@ DSN_DEFINE_uint32("meta_server",
                   "failed");
 DSN_TAG_VARIABLE(bulk_load_max_rollback_times, FT_MUTABLE);
 
-DSN_DEFINE_bool("meta_server",
+DSN_DEFINE_bool(meta_server,
                 bulk_load_verify_before_ingest,
                 false,
                 "verify files according to metadata before ingest");
 DSN_TAG_VARIABLE(bulk_load_verify_before_ingest, FT_MUTABLE);
 
-DSN_DEFINE_bool("meta_server",
+DSN_DEFINE_bool(meta_server,
                 enable_concurrent_bulk_load,
                 false,
                 "whether to enable different apps to execute bulk load at the same time");

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -84,7 +84,7 @@ namespace replication {
 // To be consistent with `max_replicas_in_group`, default value of `max_reserved_dropped_replicas`
 // is set to 1 so that the unit tests can be passed. For production environments, it should be set
 // to 0.
-DSN_DEFINE_uint32("meta_server",
+DSN_DEFINE_uint32(meta_server,
                   max_reserved_dropped_replicas,
                   1,
                   "max reserved number allowed for dropped replicas");

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -50,7 +50,7 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_uint64("meta_server",
+DSN_DEFINE_uint64(meta_server,
                   min_live_node_count_for_unfreeze,
                   3,
                   "minimum live node count without which the state is freezed");

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -59,7 +59,7 @@ using namespace dsn;
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_int32("meta_server",
+DSN_DEFINE_int32(meta_server,
                  max_allowed_replica_count,
                  5,
                  "max replica count allowed for any app of a cluster");
@@ -68,7 +68,7 @@ DSN_DEFINE_validator(max_allowed_replica_count, [](int32_t allowed_replica_count
     return allowed_replica_count > 0;
 });
 
-DSN_DEFINE_int32("meta_server",
+DSN_DEFINE_int32(meta_server,
                  min_allowed_replica_count,
                  1,
                  "min replica count allowed for any app of a cluster");

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -39,12 +39,12 @@ namespace dsn {
 namespace service {
 static uint32_t current_max_copy_rate_megabytes = 0;
 
-DSN_DEFINE_uint32("nfs",
+DSN_DEFINE_uint32(nfs,
                   nfs_copy_block_bytes,
                   4 * 1024 * 1024,
                   "max block size (bytes) for each network copy");
 DSN_DEFINE_uint32(
-    "nfs",
+    nfs,
     max_copy_rate_megabytes_per_disk,
     0,
     "max rate per disk of copying from remote node(MB/s), zero means disable rate limiter");
@@ -56,34 +56,31 @@ DSN_DEFINE_group_validator(max_copy_rate_megabytes_per_disk, [](std::string &mes
            (FLAGS_max_copy_rate_megabytes_per_disk << 20) > FLAGS_nfs_copy_block_bytes;
 });
 
-DSN_DEFINE_int32("nfs",
+DSN_DEFINE_int32(nfs,
                  max_concurrent_remote_copy_requests,
                  50,
                  "max concurrent remote copy to the same server on nfs client");
-DSN_DEFINE_int32("nfs", max_concurrent_local_writes, 50, "max local file writes on nfs client");
-DSN_DEFINE_int32("nfs", max_buffered_local_writes, 500, "max buffered file writes on nfs client");
-DSN_DEFINE_int32("nfs",
+DSN_DEFINE_int32(nfs, max_concurrent_local_writes, 50, "max local file writes on nfs client");
+DSN_DEFINE_int32(nfs, max_buffered_local_writes, 500, "max buffered file writes on nfs client");
+DSN_DEFINE_int32(nfs,
                  high_priority_speed_rate,
                  2,
                  "the copy speed rate of high priority comparing with low priority on nfs client");
-DSN_DEFINE_int32("nfs",
+DSN_DEFINE_int32(nfs,
                  file_close_expire_time_ms,
                  60 * 1000,
                  "max idle time for an opening file on nfs server");
-DSN_DEFINE_int32("nfs",
+DSN_DEFINE_int32(nfs,
                  file_close_timer_interval_ms_on_server,
                  30 * 1000,
                  "time interval for checking whether cached file handles need to be closed");
-DSN_DEFINE_int32("nfs",
+DSN_DEFINE_int32(nfs,
                  max_file_copy_request_count_per_file,
                  2,
                  "maximum concurrent remote copy requests for the same file on nfs client"
                  "to limit each file copy speed");
-DSN_DEFINE_int32("nfs",
-                 max_retry_count_per_copy_request,
-                 2,
-                 "maximum retry count when copy failed");
-DSN_DEFINE_int32("nfs",
+DSN_DEFINE_int32(nfs, max_retry_count_per_copy_request, 2, "maximum retry count when copy failed");
+DSN_DEFINE_int32(nfs,
                  rpc_timeout_ms,
                  1e5, // 100s
                  "rpc timeout in milliseconds for nfs copy, "

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -40,7 +40,7 @@ namespace dsn {
 namespace service {
 
 DSN_DEFINE_uint32(
-    "nfs",
+    nfs,
     max_send_rate_megabytes_per_disk,
     0,
     "max rate per disk of send to remote node(MB/s)，zero means disable rate limiter");

--- a/src/replica/disk_cleaner.cpp
+++ b/src/replica/disk_cleaner.cpp
@@ -28,27 +28,27 @@ namespace dsn {
 namespace replication {
 
 DSN_DEFINE_uint64(
-    "replication",
+    replication,
     gc_disk_error_replica_interval_seconds,
     7 * 24 * 3600 /*7day*/,
     "Duration of error replica being removed, which is in a directory with '.err' suffixed");
 DSN_TAG_VARIABLE(gc_disk_error_replica_interval_seconds, FT_MUTABLE);
 
 DSN_DEFINE_uint64(
-    "replication",
+    replication,
     gc_disk_garbage_replica_interval_seconds,
     24 * 3600 /*1day*/,
     "Duration of garbaged replica being removed, which is in a directory with '.gar' suffixed");
 DSN_TAG_VARIABLE(gc_disk_garbage_replica_interval_seconds, FT_MUTABLE);
 
-DSN_DEFINE_uint64("replication",
+DSN_DEFINE_uint64(replication,
                   gc_disk_migration_tmp_replica_interval_seconds,
                   24 * 3600 /*1day*/,
                   "Duration of disk-migration tmp replica being removed, which is in a directory "
                   "with '.tmp' suffixed");
 DSN_TAG_VARIABLE(gc_disk_migration_tmp_replica_interval_seconds, FT_MUTABLE);
 
-DSN_DEFINE_uint64("replication",
+DSN_DEFINE_uint64(replication,
                   gc_disk_migration_origin_replica_interval_seconds,
                   7 * 24 * 3600 /*7day*/,
                   "Duration of disk-migration origin replica being removed, which is in a "

--- a/src/replica/mutation.cpp
+++ b/src/replica/mutation.cpp
@@ -42,7 +42,7 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_uint64("replication",
+DSN_DEFINE_uint64(replication,
                   abnormal_write_trace_latency_threshold,
                   1000 * 1000 * 1000, // 1s
                   "latency trace will be logged when exceed the write latency threshold");

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -38,7 +38,7 @@
 
 namespace dsn {
 namespace replication {
-DSN_DEFINE_bool("replication",
+DSN_DEFINE_bool(replication,
                 plog_force_flush,
                 false,
                 "when write private log, whether to flush file after write done");

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -38,7 +38,7 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_bool("replication",
+DSN_DEFINE_bool(replication,
                 reject_write_when_disk_insufficient,
                 true,
                 "reject client write requests if disk status is space insufficient");

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -33,7 +33,7 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_uint64("replication",
+DSN_DEFINE_uint64(replication,
                   max_concurrent_uploading_file_count,
                   10,
                   "concurrent uploading file count to block service");

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -66,19 +66,19 @@
 namespace dsn {
 namespace replication {
 
-DSN_DEFINE_bool("replication",
+DSN_DEFINE_bool(replication,
                 ignore_broken_disk,
                 true,
                 "true means ignore broken data disk when initialize");
 
-DSN_DEFINE_uint32("replication",
+DSN_DEFINE_uint32(replication,
                   max_concurrent_manual_emergency_checkpointing_count,
                   10,
                   "max concurrent manual emergency checkpoint running count");
 DSN_TAG_VARIABLE(max_concurrent_manual_emergency_checkpointing_count, FT_MUTABLE);
 
 DSN_DEFINE_uint32(
-    "replication",
+    replication,
     config_sync_interval_ms,
     30000,
     "The interval milliseconds of replica server to syncs replica configuration with meta server");

--- a/src/reporter/pegasus_counter_reporter.cpp
+++ b/src/reporter/pegasus_counter_reporter.cpp
@@ -44,19 +44,19 @@
 
 using namespace ::dsn;
 
-DSN_DEFINE_uint64("pegasus.server",
+DSN_DEFINE_uint64(pegasus.server,
                   perf_counter_update_interval_seconds,
                   10,
                   "perf_counter_update_interval_seconds");
-DSN_DEFINE_bool("pegasus.server", perf_counter_enable_logging, true, "perf_counter_enable_logging");
+DSN_DEFINE_bool(pegasus.server, perf_counter_enable_logging, true, "perf_counter_enable_logging");
 
-DSN_DEFINE_string("pegasus.server", perf_counter_sink, "", "perf_counter_sink");
+DSN_DEFINE_string(pegasus.server, perf_counter_sink, "", "perf_counter_sink");
 
-DSN_DEFINE_uint64("pegasus.server", prometheus_port, 9091, "prometheus exposer port");
+DSN_DEFINE_uint64(pegasus.server, prometheus_port, 9091, "prometheus exposer port");
 
-DSN_DEFINE_string("pegasus.server", falcon_host, "127.0.0.1", "falcon agent host");
-DSN_DEFINE_uint64("pegasus.server", falcon_port, 1988, "falcon agent port");
-DSN_DEFINE_string("pegasus.server", falcon_path, "/v1/push", "falcon agent http path");
+DSN_DEFINE_string(pegasus.server, falcon_host, "127.0.0.1", "falcon agent host");
+DSN_DEFINE_uint64(pegasus.server, falcon_port, 1988, "falcon agent port");
+DSN_DEFINE_string(pegasus.server, falcon_path, "/v1/push", "falcon agent http path");
 
 namespace pegasus {
 namespace server {

--- a/src/runtime/providers.common.cpp
+++ b/src/runtime/providers.common.cpp
@@ -48,7 +48,7 @@
 namespace dsn {
 namespace tools {
 
-DSN_DEFINE_bool("network", enable_udp, true, "whether to enable udp rpc engine");
+DSN_DEFINE_bool(network, enable_udp, true, "whether to enable udp rpc engine");
 
 void register_std_lock_providers()
 {

--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -35,7 +35,7 @@
 namespace dsn {
 namespace tools {
 
-DSN_DEFINE_uint32("network",
+DSN_DEFINE_uint32(network,
                   io_service_worker_count,
                   1,
                   "thread number for io service (timer and boost network)");

--- a/src/runtime/security/access_controller.cpp
+++ b/src/runtime/security/access_controller.cpp
@@ -25,10 +25,10 @@
 
 namespace dsn {
 namespace security {
-DSN_DEFINE_bool("security", enable_acl, false, "whether enable access controller or not");
+DSN_DEFINE_bool(security, enable_acl, false, "whether enable access controller or not");
 DSN_TAG_VARIABLE(enable_acl, FT_MUTABLE);
 
-DSN_DEFINE_string("security", super_users, "", "super user for access controller");
+DSN_DEFINE_string(security, super_users, "", "super user for access controller");
 
 access_controller::access_controller() { utils::split_args(FLAGS_super_users, _super_users, ','); }
 

--- a/src/runtime/security/kinit_context.cpp
+++ b/src/runtime/security/kinit_context.cpp
@@ -44,11 +44,11 @@ DSN_DECLARE_bool(enable_zookeeper_kerberos);
         }                                                                                          \
     } while (0);
 
-DSN_DEFINE_string("security", krb5_keytab, "", "absolute path of keytab file");
-DSN_DEFINE_string("security", krb5_config, "", "absolute path of krb5_config file");
-DSN_DEFINE_string("security", krb5_principal, "", "kerberos principal");
-DSN_DEFINE_string("security", service_fqdn, "", "the fully qualified domain name of the server");
-DSN_DEFINE_string("security", service_name, "", "service name");
+DSN_DEFINE_string(security, krb5_keytab, "", "absolute path of keytab file");
+DSN_DEFINE_string(security, krb5_config, "", "absolute path of krb5_config file");
+DSN_DEFINE_string(security, krb5_principal, "", "kerberos principal");
+DSN_DEFINE_string(security, service_fqdn, "", "the fully qualified domain name of the server");
+DSN_DEFINE_string(security, service_name, "", "service name");
 
 // Attention: we can't do these check work by `DSN_DEFINE_validator`, because somebody may don't
 // want to use security, so these configuration may not setted. In this situation, these checks

--- a/src/runtime/security/meta_access_controller.cpp
+++ b/src/runtime/security/meta_access_controller.cpp
@@ -25,7 +25,7 @@
 
 namespace dsn {
 namespace security {
-DSN_DEFINE_string("security",
+DSN_DEFINE_string(security,
                   meta_acl_rpc_allow_list,
                   "",
                   "allowed list of rpc codes for meta_access_controller");

--- a/src/runtime/security/negotiation.cpp
+++ b/src/runtime/security/negotiation.cpp
@@ -30,12 +30,12 @@ namespace security {
 /// so we should get supported mechanisms from config in the later
 const std::set<std::string> supported_mechanisms{"GSSAPI"};
 
-DSN_DEFINE_bool("security", enable_auth, false, "whether open auth or not");
-DSN_DEFINE_bool("security",
+DSN_DEFINE_bool(security, enable_auth, false, "whether open auth or not");
+DSN_DEFINE_bool(security,
                 enable_zookeeper_kerberos,
                 false,
                 "whether to enable kerberos for zookeeper client");
-DSN_DEFINE_bool("security", mandatory_auth, false, "wheter to do authertication mandatorily");
+DSN_DEFINE_bool(security, mandatory_auth, false, "wheter to do authertication mandatorily");
 DSN_TAG_VARIABLE(mandatory_auth, FT_MUTABLE);
 
 negotiation::~negotiation() {}

--- a/src/runtime/security/sasl_init.cpp
+++ b/src/runtime/security/sasl_init.cpp
@@ -29,7 +29,7 @@
 
 namespace dsn {
 namespace security {
-DSN_DEFINE_string("security", sasl_plugin_path, "/usr/lib/sasl2", "path to search sasl plugins");
+DSN_DEFINE_string(security, sasl_plugin_path, "/usr/lib/sasl2", "path to search sasl plugins");
 
 dsn_log_level_t get_dsn_log_level(int level)
 {

--- a/src/server/hotkey_collector.cpp
+++ b/src/server/hotkey_collector.cpp
@@ -29,20 +29,20 @@ namespace pegasus {
 namespace server {
 
 DSN_DEFINE_uint32(
-    "pegasus.server",
+    pegasus.server,
     hot_bucket_variance_threshold,
     7,
     "the variance threshold to detect hot bucket during coarse analysis of hotkey detection");
 DSN_TAG_VARIABLE(hot_bucket_variance_threshold, FT_MUTABLE);
 
 DSN_DEFINE_uint32(
-    "pegasus.server",
+    pegasus.server,
     hot_key_variance_threshold,
     5,
     "the variance threshold to detect hot key during fine analysis of hotkey detection");
 DSN_TAG_VARIABLE(hot_key_variance_threshold, FT_MUTABLE);
 
-DSN_DEFINE_uint32("pegasus.server",
+DSN_DEFINE_uint32(pegasus.server,
                   hotkey_buckets_num,
                   37,
                   "the number of data capture hash buckets");
@@ -61,7 +61,7 @@ DSN_DEFINE_validator(hotkey_buckets_num, [](uint32_t bucket_num) -> bool {
 });
 
 DSN_DEFINE_uint32(
-    "pegasus.server",
+    pegasus.server,
     max_seconds_to_detect_hotkey,
     150,
     "the max time (in seconds) allowed to capture hotkey, will stop if hotkey's not found");

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -28,7 +28,7 @@
 namespace pegasus {
 namespace server {
 
-DSN_DEFINE_int64("pegasus.collector",
+DSN_DEFINE_int64(pegasus.collector,
                  max_hotspot_store_size,
                  100,
                  "the max count of historical data "
@@ -37,20 +37,20 @@ DSN_DEFINE_int64("pegasus.collector",
                  "eliminate outdated historical "
                  "data");
 
-DSN_DEFINE_bool("pegasus.collector",
+DSN_DEFINE_bool(pegasus.collector,
                 enable_detect_hotkey,
                 false,
                 "auto detect hot key in the hot paritition");
 DSN_TAG_VARIABLE(enable_detect_hotkey, FT_MUTABLE);
 
-DSN_DEFINE_uint32("pegasus.collector",
+DSN_DEFINE_uint32(pegasus.collector,
                   hot_partition_threshold,
                   3,
                   "threshold of hotspot partition value, if app.stat.hotspots >= "
                   "FLAGS_hotpartition_threshold, this partition is a hot partition");
 DSN_TAG_VARIABLE(hot_partition_threshold, FT_MUTABLE);
 
-DSN_DEFINE_uint32("pegasus.collector",
+DSN_DEFINE_uint32(pegasus.collector,
                   occurrence_threshold,
                   3,
                   "hot paritiotion occurrence times' threshold to send rpc to detect hotkey");

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -52,7 +52,7 @@ namespace server {
 DEFINE_TASK_CODE(LPC_PEGASUS_SERVER_DELAY, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
 DSN_DECLARE_int32(read_amp_bytes_per_bit);
 
-DSN_DEFINE_int32("pegasus.server",
+DSN_DEFINE_int32(pegasus.server,
                  hotkey_analyse_time_interval_s,
                  10,
                  "hotkey analyse interval in seconds");

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -35,12 +35,12 @@ namespace pegasus {
 namespace server {
 
 DSN_DEFINE_int64(
-    "pegasus.server",
+    pegasus.server,
     rocksdb_limiter_max_write_megabytes_per_sec,
     500,
     "max rate of rocksdb flush and compaction(MB/s), if less than or equal to 0 means close limit");
 
-DSN_DEFINE_bool("pegasus.server",
+DSN_DEFINE_bool(pegasus.server,
                 rocksdb_limiter_enable_auto_tune,
                 false,
                 "whether to enable write rate auto tune when open rocksdb write limit");
@@ -67,7 +67,7 @@ DSN_DEFINE_bool("pegasus.server",
 //
 // Default: 0 (disabled)
 // see https://github.com/XiaoMi/pegasus-rocksdb/blob/v6.6.4-compatible/include/rocksdb/table.h#L247
-DSN_DEFINE_int32("pegasus.server",
+DSN_DEFINE_int32(pegasus.server,
                  read_amp_bytes_per_bit,
                  0,
                  "config for using to calculate the "
@@ -81,7 +81,7 @@ DSN_DEFINE_validator(read_amp_bytes_per_bit, [](const int64_t read_amp_bytes_per
             (read_amp_bytes_per_bit & (read_amp_bytes_per_bit - 1)) == 0);
 });
 
-DSN_DEFINE_uint64("pegasus.server",
+DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_abnormal_batch_get_bytes_threshold,
                   1e7,
                   "batch-get operation total key-value bytes size exceed this "
@@ -89,7 +89,7 @@ DSN_DEFINE_uint64("pegasus.server",
 DSN_TAG_VARIABLE(rocksdb_abnormal_batch_get_bytes_threshold, FT_MUTABLE);
 
 DSN_DEFINE_uint64(
-    "pegasus.server",
+    pegasus.server,
     rocksdb_abnormal_batch_get_count_threshold,
     2000,
     "batch-get operation iterate count exceed this threshold will be logged, 0 means no check");
@@ -106,14 +106,14 @@ DSN_TAG_VARIABLE(rocksdb_abnormal_batch_get_count_threshold, FT_MUTABLE);
 // On the other hand, the max size of a log file is restricted to 8MB. In practice, the size of
 // logs over a day tends to be less than 1MB; however, once errors are reported very frequently,
 // the log file will grow larger and go far beyond several hundreds of KB.
-DSN_DEFINE_uint64("pegasus.server",
+DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_max_log_file_size,
                   8 * 1024 * 1024,
                   "specify the maximal size of the info log file: once the log file is larger "
                   "than this option, a new info log file will be created; if this option is set "
                   "to 0, all logs will be written to one log file.");
 
-DSN_DEFINE_uint64("pegasus.server",
+DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_log_file_time_to_roll,
                   24 * 60 * 60,
                   "specify time for the info log file to roll (in seconds): if this option is "
@@ -121,7 +121,7 @@ DSN_DEFINE_uint64("pegasus.server",
                   "longer than this option; otherwise, if this options is set to 0, log file will "
                   "never be rolled by life time");
 
-DSN_DEFINE_uint64("pegasus.server",
+DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_keep_log_file_num,
                   32,
                   "specify the maximal numbers of info log files to be kept: once the number of "

--- a/src/server/result_writer.cpp
+++ b/src/server/result_writer.cpp
@@ -23,7 +23,7 @@
 namespace pegasus {
 namespace server {
 
-DSN_DEFINE_int32("pegasus.collector",
+DSN_DEFINE_int32(pegasus.collector,
                  capacity_unit_saving_ttl_days,
                  90,
                  "the ttl of the CU data, 0 if no ttl");

--- a/src/utils/flags.cpp
+++ b/src/utils/flags.cpp
@@ -108,6 +108,8 @@ public:
           _name(name),
           _desc(desc)
     {
+        // For historical reason, check the 'section' parameter doesn't start with '"'.
+        CHECK_NE_MSG(*section, '"', "config section({}) should not start with '\"'", section);
     }
 
     error_s update(const std::string &val)

--- a/src/utils/flags.h
+++ b/src/utils/flags.h
@@ -45,7 +45,7 @@ struct hash<flag_tag>
 } // namespace std
 
 // Example:
-//    DSN_DEFINE_string("core", filename, "my_file.txt", "The file to read");
+//    DSN_DEFINE_string(core, filename, "my_file.txt", "The file to read");
 //    DSN_DEFINE_validator(filename, [](const char *fname){ return is_file(fname); });
 //    auto fptr = file::open(FLAGS_filename, O_RDONLY | O_BINARY, 0);
 
@@ -61,7 +61,7 @@ struct hash<flag_tag>
 
 #define DSN_DEFINE_VARIABLE(type, section, name, default_value, desc)                              \
     type FLAGS_##name = default_value;                                                             \
-    static dsn::flag_registerer FLAGS_REG_##name(section, #name, desc, &FLAGS_##name)
+    static dsn::flag_registerer FLAGS_REG_##name(#section, #name, desc, &FLAGS_##name)
 
 #define DSN_DEFINE_int32(section, name, val, desc)                                                 \
     DSN_DEFINE_VARIABLE(int32_t, section, name, val, desc)

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -32,19 +32,19 @@
 namespace dsn {
 namespace utils {
 
-DSN_DEFINE_bool("replication",
+DSN_DEFINE_bool(replication,
                 enable_latency_tracer,
                 false,
                 "whether enable the global latency tracer");
 DSN_TAG_VARIABLE(enable_latency_tracer, FT_MUTABLE);
 
-DSN_DEFINE_bool("replication",
+DSN_DEFINE_bool(replication,
                 enable_latency_tracer_report,
                 false,
                 "whether open the latency tracer report perf counter");
 DSN_TAG_VARIABLE(enable_latency_tracer_report, FT_MUTABLE);
 
-DSN_DEFINE_string("replication",
+DSN_DEFINE_string(replication,
                   latency_tracer_counter_name_prefix,
                   "trace_latency",
                   "perf counter common name prefix");

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -36,12 +36,12 @@
 #include "simple_logger.h"
 
 dsn_log_level_t dsn_log_start_level = dsn_log_level_t::LOG_LEVEL_INFO;
-DSN_DEFINE_string("core",
+DSN_DEFINE_string(core,
                   logging_start_level,
                   "LOG_LEVEL_INFO",
                   "logs with level below this will not be logged");
 
-DSN_DEFINE_bool("core", logging_flush_on_exit, true, "flush log when exit system");
+DSN_DEFINE_bool(core, logging_flush_on_exit, true, "flush log when exit system");
 
 namespace dsn {
 

--- a/src/utils/shared_io_service.cpp
+++ b/src/utils/shared_io_service.cpp
@@ -23,7 +23,7 @@ namespace dsn {
 namespace tools {
 
 const uint32_t kMinTimerServiceWorkerCount = 3;
-DSN_DEFINE_uint32("core",
+DSN_DEFINE_uint32(core,
                   timer_service_worker_count,
                   kMinTimerServiceWorkerCount,
                   "the number of threads for timer service");

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -39,19 +39,19 @@ DSN_DECLARE_string(logging_start_level);
 namespace dsn {
 namespace tools {
 
-DSN_DEFINE_bool("tools.simple_logger", fast_flush, false, "whether to flush immediately");
+DSN_DEFINE_bool(tools.simple_logger, fast_flush, false, "whether to flush immediately");
 
-DSN_DEFINE_bool("tools.simple_logger",
+DSN_DEFINE_bool(tools.simple_logger,
                 short_header,
                 true,
                 "whether to use short header (excluding file/function etc.)");
 
-DSN_DEFINE_uint64("tools.simple_logger",
+DSN_DEFINE_uint64(tools.simple_logger,
                   max_number_of_log_files_on_disk,
                   20,
                   "max number of log files reserved on disk, older logs are auto deleted");
 
-DSN_DEFINE_string("tools.simple_logger",
+DSN_DEFINE_string(tools.simple_logger,
                   stderr_start_level,
                   "LOG_LEVEL_WARNING",
                   "copy log messages at or above this level to stderr in addition to logfiles");

--- a/src/utils/test/flag_test.cpp
+++ b/src/utils/test/flag_test.cpp
@@ -22,27 +22,27 @@
 namespace dsn {
 namespace utils {
 
-DSN_DEFINE_int32("flag_test", test_int32, 5, "");
+DSN_DEFINE_int32(flag_test, test_int32, 5, "");
 DSN_TAG_VARIABLE(test_int32, FT_MUTABLE);
 
-DSN_DEFINE_uint32("flag_test", test_uint32, 5, "");
+DSN_DEFINE_uint32(flag_test, test_uint32, 5, "");
 DSN_TAG_VARIABLE(test_uint32, FT_MUTABLE);
 
-DSN_DEFINE_int64("flag_test", test_int64, 5, "");
+DSN_DEFINE_int64(flag_test, test_int64, 5, "");
 DSN_TAG_VARIABLE(test_int64, FT_MUTABLE);
 
-DSN_DEFINE_uint64("flag_test", test_uint64, 5, "");
+DSN_DEFINE_uint64(flag_test, test_uint64, 5, "");
 DSN_TAG_VARIABLE(test_uint64, FT_MUTABLE);
 
-DSN_DEFINE_double("flag_test", test_double, 5.0, "");
+DSN_DEFINE_double(flag_test, test_double, 5.0, "");
 DSN_TAG_VARIABLE(test_double, FT_MUTABLE);
 
-DSN_DEFINE_bool("flag_test", test_bool, true, "");
+DSN_DEFINE_bool(flag_test, test_bool, true, "");
 DSN_TAG_VARIABLE(test_bool, FT_MUTABLE);
 
-DSN_DEFINE_string("flag_test", test_string_immutable, "immutable_string", "");
+DSN_DEFINE_string(flag_test, test_string_immutable, "immutable_string", "");
 
-DSN_DEFINE_int32("flag_test", test_validator, 10, "");
+DSN_DEFINE_int32(flag_test, test_validator, 10, "");
 DSN_TAG_VARIABLE(test_validator, FT_MUTABLE);
 DSN_DEFINE_validator(test_validator, [](int32_t test_validator) -> bool {
     if (test_validator < 0) {
@@ -51,21 +51,21 @@ DSN_DEFINE_validator(test_validator, [](int32_t test_validator) -> bool {
     return true;
 });
 
-DSN_DEFINE_bool("flag_test", condition_a, false, "");
+DSN_DEFINE_bool(flag_test, condition_a, false, "");
 DSN_TAG_VARIABLE(condition_a, FT_MUTABLE);
 
-DSN_DEFINE_bool("flag_test", condition_b, false, "");
+DSN_DEFINE_bool(flag_test, condition_b, false, "");
 DSN_TAG_VARIABLE(condition_b, FT_MUTABLE);
 
 DSN_DEFINE_group_validator(inconsistent_conditions, [](std::string &message) -> bool {
     return !FLAGS_condition_a || !FLAGS_condition_b;
 });
 
-DSN_DEFINE_int32("flag_test", min_value, 1, "");
+DSN_DEFINE_int32(flag_test, min_value, 1, "");
 DSN_TAG_VARIABLE(min_value, FT_MUTABLE);
 DSN_DEFINE_validator(min_value, [](int32_t value) -> bool { return value > 0; });
 
-DSN_DEFINE_int32("flag_test", max_value, 5, "");
+DSN_DEFINE_int32(flag_test, max_value, 5, "");
 DSN_TAG_VARIABLE(max_value, FT_MUTABLE);
 DSN_DEFINE_validator(max_value, [](int32_t value) -> bool { return value <= 10; });
 
@@ -77,13 +77,13 @@ DSN_DEFINE_group_validator(min_max, [](std::string &message) -> bool {
     return true;
 });
 
-DSN_DEFINE_int32("flag_test", small_value, 0, "");
+DSN_DEFINE_int32(flag_test, small_value, 0, "");
 DSN_TAG_VARIABLE(small_value, FT_MUTABLE);
 
-DSN_DEFINE_int32("flag_test", medium_value, 5, "");
+DSN_DEFINE_int32(flag_test, medium_value, 5, "");
 DSN_TAG_VARIABLE(medium_value, FT_MUTABLE);
 
-DSN_DEFINE_int32("flag_test", large_value, 10, "");
+DSN_DEFINE_int32(flag_test, large_value, 10, "");
 DSN_TAG_VARIABLE(large_value, FT_MUTABLE);
 
 DSN_DEFINE_group_validator(small_medium_large, [](std::string &message) -> bool {
@@ -102,13 +102,13 @@ DSN_DEFINE_group_validator(small_medium_large, [](std::string &message) -> bool 
     return true;
 });
 
-DSN_DEFINE_int32("flag_test", lesser, 0, "");
+DSN_DEFINE_int32(flag_test, lesser, 0, "");
 DSN_TAG_VARIABLE(lesser, FT_MUTABLE);
 
-DSN_DEFINE_int32("flag_test", greater_0, 5, "");
+DSN_DEFINE_int32(flag_test, greater_0, 5, "");
 DSN_TAG_VARIABLE(greater_0, FT_MUTABLE);
 
-DSN_DEFINE_int32("flag_test", greater_1, 10, "");
+DSN_DEFINE_int32(flag_test, greater_1, 10, "");
 DSN_TAG_VARIABLE(greater_1, FT_MUTABLE);
 
 DSN_DEFINE_group_validator(lesser_greater_0, [](std::string &message) -> bool {
@@ -244,10 +244,10 @@ TEST(flag_test, update_config)
     std::cout << res.description() << std::endl;
 }
 
-DSN_DEFINE_int32("flag_test", has_tag, 5, "");
+DSN_DEFINE_int32(flag_test, has_tag, 5, "");
 DSN_TAG_VARIABLE(has_tag, FT_MUTABLE);
 
-DSN_DEFINE_int32("flag_test", no_tag, 5, "");
+DSN_DEFINE_int32(flag_test, no_tag, 5, "");
 
 TEST(flag_test, tag_flag)
 {
@@ -264,19 +264,19 @@ TEST(flag_test, tag_flag)
     ASSERT_FALSE(res);
 }
 
-DSN_DEFINE_int32("flag_test", get_flag_int32, 5, "test get_flag_int32");
+DSN_DEFINE_int32(flag_test, get_flag_int32, 5, "test get_flag_int32");
 DSN_TAG_VARIABLE(get_flag_int32, FT_MUTABLE);
-DSN_DEFINE_uint32("flag_test", get_flag_uint32, 5, "test get_flag_uint32");
+DSN_DEFINE_uint32(flag_test, get_flag_uint32, 5, "test get_flag_uint32");
 DSN_TAG_VARIABLE(get_flag_uint32, FT_MUTABLE);
-DSN_DEFINE_int64("flag_test", get_flag_int64, 5, "test get_flag_int64");
+DSN_DEFINE_int64(flag_test, get_flag_int64, 5, "test get_flag_int64");
 DSN_TAG_VARIABLE(get_flag_int64, FT_MUTABLE);
-DSN_DEFINE_uint64("flag_test", get_flag_uint64, 5, "test get_flag_uint64");
+DSN_DEFINE_uint64(flag_test, get_flag_uint64, 5, "test get_flag_uint64");
 DSN_TAG_VARIABLE(get_flag_uint64, FT_MUTABLE);
-DSN_DEFINE_double("flag_test", get_flag_double, 5.12, "test get_flag_double");
+DSN_DEFINE_double(flag_test, get_flag_double, 5.12, "test get_flag_double");
 DSN_TAG_VARIABLE(get_flag_double, FT_MUTABLE);
-DSN_DEFINE_bool("flag_test", get_flag_bool, true, "test get_flag_bool");
+DSN_DEFINE_bool(flag_test, get_flag_bool, true, "test get_flag_bool");
 DSN_TAG_VARIABLE(get_flag_bool, FT_MUTABLE);
-DSN_DEFINE_string("flag_test", get_flag_string, "flag_string", "test get_flag_string");
+DSN_DEFINE_string(flag_test, get_flag_string, "flag_string", "test get_flag_string");
 DSN_TAG_VARIABLE(get_flag_string, FT_MUTABLE);
 
 TEST(flag_test, get_config)

--- a/src/zookeeper/zookeeper_session.cpp
+++ b/src/zookeeper/zookeeper_session.cpp
@@ -43,7 +43,7 @@
 namespace dsn {
 namespace security {
 DSN_DECLARE_bool(enable_zookeeper_kerberos);
-DSN_DEFINE_string("security",
+DSN_DEFINE_string(security,
                   zookeeper_kerberos_service_name,
                   "zookeeper",
                   "zookeeper kerberos service name");


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1309

The quotes of DSN_DEFINE_*'s fisrt parameter are useless, we can remove them as how does `gflag` do. Also adds a check when init flags to ensure no one left.