### PR TITLE
refactor(log): use LOG_FATAL_F instead of LOG_FATAL

### DIFF
--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -62,7 +62,7 @@ error_s update_config(const http_request &req)
     case http_status_code::internal_server_error:
         return "500 Internal Server Error";
     default:
-        LOG_FATAL_F("invalid code: {}", http_status_code_to_string(code));
+        LOG_FATAL_F("invalid code: {}", static_cast<int>(code));
         __builtin_unreachable();
     }
 }

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -62,7 +62,7 @@ error_s update_config(const http_request &req)
     case http_status_code::internal_server_error:
         return "500 Internal Server Error";
     default:
-        LOG_FATAL("invalid code: %d", code);
+        LOG_FATAL_F("invalid code: {}", http_status_code_to_string(code));
         __builtin_unreachable();
     }
 }

--- a/src/runtime/task/simple_task_queue.cpp
+++ b/src/runtime/task/simple_task_queue.cpp
@@ -78,7 +78,7 @@ void simple_timer_service::add_timer(task *task)
         if (!ec) {
             task->enqueue();
         } else if (ec != ::boost::asio::error::operation_aborted) {
-            LOG_FATAL("timer failed for task %s, err = %u", task->spec().name.c_str(), ec.value());
+            LOG_FATAL_F("timer failed for task {}, err = {}", task->spec().name, ec.value());
         }
 
         // to consume the added ref count by task::enqueue for add_timer

--- a/src/runtime/task/simple_task_queue.cpp
+++ b/src/runtime/task/simple_task_queue.cpp
@@ -78,7 +78,7 @@ void simple_timer_service::add_timer(task *task)
         if (!ec) {
             task->enqueue();
         } else if (ec != ::boost::asio::error::operation_aborted) {
-            LOG_FATAL_F("timer failed for task {}, err = {}", task->spec().name, ec.value());
+            LOG_FATAL_F("timer failed for task {}, err = {}", task->spec().name, ec.message());
         }
 
         // to consume the added ref count by task::enqueue for add_timer

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -65,7 +65,7 @@ using namespace dsn::literals::chrono_literals;
         dsn::from_blob_to_thrift(data, thrift_request);
         return pegasus_hash_key_hash(thrift_request.hash_key);
     }
-    LOG_FATAL("unexpected task code: %s", tc.to_string());
+    LOG_FATAL_F("unexpected task code: {}", tc);
     __builtin_unreachable();
 }
 

--- a/src/shell/commands/duplication.cpp
+++ b/src/shell/commands/duplication.cpp
@@ -216,7 +216,7 @@ bool change_dup_status(command_executor *e,
         operation = "removing duplication";
         break;
     default:
-        LOG_FATAL("can't change duplication under status %d", status);
+        LOG_FATAL_F("can't change duplication under status {}", status);
     }
 
     auto err_resp = sc->ddl_client->change_dup_status(app_name, dup_id, status);

--- a/src/test/kill_test/data_verifier.cpp
+++ b/src/test/kill_test/data_verifier.cpp
@@ -202,30 +202,30 @@ void do_get_range(int thread_id, int round_id, long long start_id, long long end
         if (ret == PERR_OK || ret == PERR_NOT_FOUND) {
             long cur_time = get_time();
             if (ret == PERR_NOT_FOUND) {
-                LOG_FATAL("GetThread[%d]: round(%d): get not found: id=%lld, try=%d, time=%ld "
-                          "(gpid=%d.%d, server=%s), and exit",
-                          thread_id,
-                          round_id,
-                          id,
-                          try_count,
-                          (cur_time - last_time),
-                          info.app_id,
-                          info.partition_index,
-                          info.server.c_str());
+                LOG_FATAL_F("GetThread[{}]: round({}): get not found: id={}, try={}, time={} "
+                            "(gpid={}.{}, server={}), and exit",
+                            thread_id,
+                            round_id,
+                            id,
+                            try_count,
+                            (cur_time - last_time),
+                            info.app_id,
+                            info.partition_index,
+                            info.server);
                 exit(-1);
             } else if (value != get_value) {
-                LOG_FATAL("GetThread[%d]: round(%d): get mismatched: id=%lld, try=%d, time=%ld, "
-                          "expect_value=%s, real_value=%s (gpid=%d.%d, server=%s), and exit",
-                          thread_id,
-                          round_id,
-                          id,
-                          try_count,
-                          (cur_time - last_time),
-                          value.c_str(),
-                          get_value.c_str(),
-                          info.app_id,
-                          info.partition_index,
-                          info.server.c_str());
+                LOG_FATAL_F("GetThread[{}]: round({}): get mismatched: id={}, try={}, time={}, "
+                            "expect_value={}, real_value={} (gpid={}.{}, server={}), and exit",
+                            thread_id,
+                            round_id,
+                            id,
+                            try_count,
+                            (cur_time - last_time),
+                            value,
+                            get_value,
+                            info.app_id,
+                            info.partition_index,
+                            info.server);
                 exit(-1);
             } else {
                 LOG_DEBUG_F("GetThread[{}]: round({}): get succeed: id={}, try={}, time={} "

--- a/src/test/kill_test/data_verifier.cpp
+++ b/src/test/kill_test/data_verifier.cpp
@@ -220,7 +220,7 @@ void do_get_range(int thread_id, int round_id, long long start_id, long long end
                             round_id,
                             id,
                             try_count,
-                            (cur_time - last_time),
+                            cur_time - last_time,
                             value,
                             get_value,
                             info.app_id,

--- a/src/test/kill_test/data_verifier.cpp
+++ b/src/test/kill_test/data_verifier.cpp
@@ -208,7 +208,7 @@ void do_get_range(int thread_id, int round_id, long long start_id, long long end
                             round_id,
                             id,
                             try_count,
-                            (cur_time - last_time),
+                            cur_time - last_time,
                             info.app_id,
                             info.partition_index,
                             info.server);

--- a/src/test/kill_test/process_kill_testor.cpp
+++ b/src/test/kill_test/process_kill_testor.cpp
@@ -223,7 +223,7 @@ void process_kill_testor::stop_verifier_and_exit(const char *msg)
     int ret = dsn::utils::pipe_execute(
         "ps aux | grep pegasus | grep verifier | awk '{print $2}' | xargs kill -9", ss);
     CHECK(ret == 0 || ret == 256, "");
-    LOG_FATAL(msg);
+    LOG_FATAL_F(msg);
 }
 
 bool process_kill_testor::check_coredump()

--- a/src/utils/api_utilities.h
+++ b/src/utils/api_utilities.h
@@ -89,7 +89,6 @@ extern void dsn_coredump();
 
 #define LOG_WARNING(...) dlog(LOG_LEVEL_WARNING, __VA_ARGS__)
 #define LOG_ERROR(...) dlog(LOG_LEVEL_ERROR, __VA_ARGS__)
-#define LOG_FATAL(...) dlog(LOG_LEVEL_FATAL, __VA_ARGS__)
 
 #define dreturn_not_ok_logged(err, ...)                                                            \
     do {                                                                                           \

--- a/src/utils/fail_point.cpp
+++ b/src/utils/fail_point.cpp
@@ -62,7 +62,7 @@ inline const char *task_type_to_string(fail_point::task_type t)
     case fail_point::Void:
         return "Void";
     default:
-        LOG_FATAL("unexpected type: %d", t);
+        LOG_FATAL_F("unexpected type: {}", t);
         __builtin_unreachable();
     }
 }
@@ -92,7 +92,7 @@ inline const char *task_type_to_string(fail_point::task_type t)
 void fail_point::set_action(string_view action)
 {
     if (!parse_from_string(action)) {
-        LOG_FATAL("unrecognized command: %s", action.data());
+        LOG_FATAL_F("unrecognized command: {}", action);
     }
 }
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1305

This patch aim to use LOG_FATAL_F instead of LOG_FATAL for all parts:
- Remove the defination of `LOG_FATAL`
- Use `LOG_FATAL_F` instead of `LOG_FATAL`