### PR TITLE
refactor(log): use LOG_WARNING_F instead of LOG_WARNING (1/3)

### DIFF
--- a/src/replica/log_file.cpp
+++ b/src/replica/log_file.cpp
@@ -46,7 +46,7 @@ log_file::~log_file() { close(); }
     // log.index.start_offset
     if (name.length() < strlen("log.") || name.substr(0, strlen("log.")) != std::string("log.")) {
         err = ERR_INVALID_PARAMETERS;
-        LOG_WARNING("invalid log path %s", path);
+        LOG_WARNING_F("invalid log path {}", path);
         return nullptr;
     }
 
@@ -55,7 +55,7 @@ log_file::~log_file() { close(); }
     auto pos2 = name.find_first_of('.', pos + 1);
     if (pos2 == std::string::npos) {
         err = ERR_INVALID_PARAMETERS;
-        LOG_WARNING("invalid log path %s", path);
+        LOG_WARNING_F("invalid log path {}", path);
         return nullptr;
     }
 
@@ -64,7 +64,7 @@ log_file::~log_file() { close(); }
     std::string start_offset_str = name.substr(pos2 + 1);
     if (index_str.empty() || start_offset_str.empty()) {
         err = ERR_INVALID_PARAMETERS;
-        LOG_WARNING("invalid log path %s", path);
+        LOG_WARNING_F("invalid log path {}", path);
         return nullptr;
     }
 
@@ -72,20 +72,20 @@ log_file::~log_file() { close(); }
     int index = static_cast<int>(strtol(index_str.c_str(), &p, 10));
     if (*p != 0) {
         err = ERR_INVALID_PARAMETERS;
-        LOG_WARNING("invalid log path %s", path);
+        LOG_WARNING_F("invalid log path {}", path);
         return nullptr;
     }
     int64_t start_offset = static_cast<int64_t>(strtoll(start_offset_str.c_str(), &p, 10));
     if (*p != 0) {
         err = ERR_INVALID_PARAMETERS;
-        LOG_WARNING("invalid log path %s", path);
+        LOG_WARNING_F("invalid log path {}", path);
         return nullptr;
     }
 
     disk_file *hfile = file::open(path, O_RDONLY | O_BINARY, 0);
     if (!hfile) {
         err = ERR_FILE_OPERATION_FAILED;
-        LOG_WARNING("open log file %s failed", path);
+        LOG_WARNING_F("open log file {} failed", path);
         return nullptr;
     }
 
@@ -135,13 +135,13 @@ log_file::~log_file() { close(); }
     sprintf(path, "%s/log.%d.%" PRId64, dir, index, start_offset);
 
     if (dsn::utils::filesystem::path_exists(std::string(path))) {
-        LOG_WARNING("log file %s already exist", path);
+        LOG_WARNING_F("log file {} already exist", path);
         return nullptr;
     }
 
     disk_file *hfile = file::open(path, O_RDWR | O_CREAT | O_BINARY, 0666);
     if (!hfile) {
-        LOG_WARNING("create log %s failed", path);
+        LOG_WARNING_F("create log {} failed", path);
         return nullptr;
     }
 

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -541,8 +541,7 @@ error_code mutation_log::open(replay_callback read_callback,
         if (log == nullptr) {
             if (err == ERR_HANDLE_EOF || err == ERR_INCOMPLETE_DATA ||
                 err == ERR_INVALID_PARAMETERS) {
-                LOG_WARNING(
-                    "skip file %s during log init, err = %s", fpath.c_str(), err.to_string());
+                LOG_WARNING_F("skip file {} during log init, err = {}", fpath, err);
                 continue;
             } else {
                 return err;
@@ -997,26 +996,26 @@ int64_t mutation_log::on_partition_reset(gpid gpid, decree max_decree)
         replica_log_info old_info = _private_log_info;
         _private_log_info.max_decree = max_decree;
         _private_log_info.valid_start_offset = _global_end_offset;
-        LOG_WARNING("replica %d.%d has changed private log max_decree from %" PRId64 " to %" PRId64
-                    ", valid_start_offset from %" PRId64 " to %" PRId64,
-                    gpid.get_app_id(),
-                    gpid.get_partition_index(),
-                    old_info.max_decree,
-                    _private_log_info.max_decree,
-                    old_info.valid_start_offset,
-                    _private_log_info.valid_start_offset);
+        LOG_WARNING_F("replica {}.{} has changed private log max_decree from {} to {}, "
+                      "valid_start_offset from {} to {}",
+                      gpid,
+                      gpid.get_partition_index(),
+                      old_info.max_decree,
+                      _private_log_info.max_decree,
+                      old_info.valid_start_offset,
+                      _private_log_info.valid_start_offset);
     } else {
         replica_log_info info(max_decree, _global_end_offset);
         auto it = _shared_log_info_map.insert(replica_log_info_map::value_type(gpid, info));
         if (!it.second) {
-            LOG_WARNING("replica %d.%d has changed shared log max_decree from %" PRId64
-                        " to %" PRId64 ", valid_start_offset from %" PRId64 " to %" PRId64,
-                        gpid.get_app_id(),
-                        gpid.get_partition_index(),
-                        it.first->second.max_decree,
-                        info.max_decree,
-                        it.first->second.valid_start_offset,
-                        info.valid_start_offset);
+            LOG_WARNING_F("replica {}.{} has changed shared log max_decree from {} to {}, "
+                          "valid_start_offset from {} to {} ",
+                          gpid,
+                          gpid.get_partition_index(),
+                          it.first->second.max_decree,
+                          info.max_decree,
+                          it.first->second.valid_start_offset,
+                          info.valid_start_offset);
             _shared_log_info_map[gpid] = info;
         }
     }
@@ -1247,7 +1246,7 @@ static bool should_reserve_file(log_file_ptr log,
         time_t tm;
         if (!dsn::utils::filesystem::last_write_time(log->path(), tm)) {
             // get file last write time failed, reserve it for safety
-            LOG_WARNING("get last write time of file %s failed", log->path().c_str());
+            LOG_WARNING_F("get last write time of file {} failed", log->path());
             return true;
         }
         file_last_write_time = (uint64_t)tm;

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -996,10 +996,9 @@ int64_t mutation_log::on_partition_reset(gpid gpid, decree max_decree)
         replica_log_info old_info = _private_log_info;
         _private_log_info.max_decree = max_decree;
         _private_log_info.valid_start_offset = _global_end_offset;
-        LOG_WARNING_F("replica {}.{} has changed private log max_decree from {} to {}, "
+        LOG_WARNING_F("replica {} has changed private log max_decree from {} to {}, "
                       "valid_start_offset from {} to {}",
                       gpid,
-                      gpid.get_partition_index(),
                       old_info.max_decree,
                       _private_log_info.max_decree,
                       old_info.valid_start_offset,
@@ -1008,10 +1007,9 @@ int64_t mutation_log::on_partition_reset(gpid gpid, decree max_decree)
         replica_log_info info(max_decree, _global_end_offset);
         auto it = _shared_log_info_map.insert(replica_log_info_map::value_type(gpid, info));
         if (!it.second) {
-            LOG_WARNING_F("replica {}.{} has changed shared log max_decree from {} to {}, "
+            LOG_WARNING_F("replica {} has changed shared log max_decree from {} to {}, "
                           "valid_start_offset from {} to {} ",
                           gpid,
-                          gpid.get_partition_index(),
                           it.first->second.max_decree,
                           info.max_decree,
                           it.first->second.valid_start_offset,

--- a/src/replica/mutation_log_replay.cpp
+++ b/src/replica/mutation_log_replay.cpp
@@ -178,7 +178,7 @@ namespace replication {
         } else if (err == ERR_INCOMPLETE_DATA) {
             // If the file is not corrupted, it may also return the value of ERR_INCOMPLETE_DATA.
             // In this case, the correctness is relying on the check of start_offset.
-            LOG_WARNING("delay handling error: %s", err.to_string());
+            LOG_WARNING_F("delay handling error: {}", err);
         } else {
             // for other errors, we should break
             break;

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -462,7 +462,7 @@ void replica::close()
         std::unique_ptr<replication_app_base> tmp_app = std::move(_app);
         error_code err = tmp_app->close(false);
         if (err != dsn::ERR_OK) {
-            LOG_WARNING("%s: close app failed, err = %s", name(), err.to_string());
+            LOG_WARNING_PREFIX("close app failed, err = {}", err);
         }
     }
 

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -291,11 +291,11 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
             int delay_ms = _options->log_shared_pending_size_throttling_delay_ms;
             for (dsn::message_ex *r : mu->client_requests) {
                 if (r && r->io_session->delay_recv(delay_ms)) {
-                    LOG_WARNING("too large pending shared log (%" PRId64 "), "
-                                "delay traffic from %s for %d milliseconds",
-                                pending_size,
-                                r->header->from_address.to_string(),
-                                delay_ms);
+                    LOG_WARNING_F("too large pending shared log ({}), delay traffic from {} for {} "
+                                  "milliseconds",
+                                  pending_size,
+                                  r->header->from_address,
+                                  delay_ms);
                 }
             }
         }
@@ -645,9 +645,8 @@ void replica::on_prepare_reply(std::pair<mutation_ptr, partition_status::type> p
             }
             break;
         default:
-            LOG_WARNING("%s: mutation %s prepare ack skipped coz the node is now inactive",
-                        name(),
-                        mu->name());
+            LOG_WARNING_PREFIX("mutation {} prepare ack skipped coz the node is now inactive",
+                               mu->name());
             break;
         }
     }

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -198,8 +198,8 @@ void replica::on_cold_backup(const backup_request &request, /*out*/ backup_respo
             _backup_mgr->background_clear_backup_checkpoint(policy_name);
             response.err = ERR_OK;
         } else {
-            LOG_WARNING(
-                "%s: unhandled case, handle_status = %s, real_time_status = %s, response ERR_BUSY",
+            LOG_WARNING_F(
+                "{}: unhandled case, handle_status = {}, real_time_status = {}, response ERR_BUSY",
                 backup_context->name,
                 cold_backup_status_to_string(backup_status),
                 cold_backup_status_to_string(backup_context->status()));
@@ -297,8 +297,8 @@ static int is_related_or_valid_checkpoint(const std::string &chkpt_dirname,
         }
     } else {
         // unknown dir, ignore it
-        LOG_WARNING(
-            "%s: found a invalid checkpoint dir(%s)", backup_context->name, chkpt_dirname.c_str());
+        LOG_WARNING_F(
+            "{}: found a invalid checkpoint dir({})", backup_context->name, chkpt_dirname);
     }
     return 0;
 }
@@ -480,9 +480,9 @@ void replica::generate_backup_checkpoint(cold_backup_context_ptr backup_context)
                    backup_context->name,
                    full_path);
         if (!utils::filesystem::remove_path(full_path)) {
-            LOG_WARNING("%s: remove obsolete backup checkpoint dir(%s) failed",
-                        backup_context->name,
-                        full_path.c_str());
+            LOG_WARNING_F("{}: remove obsolete backup checkpoint dir({}) failed",
+                          backup_context->name,
+                          full_path);
         }
     }
 }

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -78,11 +78,9 @@ void replica::broadcast_group_check()
     LOG_INFO_PREFIX("start to broadcast group check");
 
     if (_primary_states.group_check_pending_replies.size() > 0) {
-        LOG_WARNING(
-            "%s: %u group check replies are still pending when doing next round check, cancel "
-            "first",
-            name(),
-            static_cast<int>(_primary_states.group_check_pending_replies.size()));
+        LOG_WARNING_PREFIX(
+            "{} group check replies are still pending when doing next round check, cancel first",
+            _primary_states.group_check_pending_replies.size());
 
         for (auto it = _primary_states.group_check_pending_replies.begin();
              it != _primary_states.group_check_pending_replies.end();
@@ -160,12 +158,12 @@ void replica::on_group_check(const group_check_request &request,
 
     if (request.config.ballot < get_ballot()) {
         response.err = ERR_VERSION_OUTDATED;
-        LOG_WARNING("%s: on_group_check reply %s", name(), response.err.to_string());
+        LOG_WARNING_PREFIX("on_group_check reply {}", response.err);
         return;
     } else if (request.config.ballot > get_ballot()) {
         if (!update_local_configuration(request.config)) {
             response.err = ERR_INVALID_STATE;
-            LOG_WARNING("%s: on_group_check reply %s", name(), response.err.to_string());
+            LOG_WARNING_PREFIX("on_group_check reply {}", response.err);
             return;
         }
     } else if (is_same_ballot_status_change_allowed(status(), request.config.status)) {
@@ -199,7 +197,7 @@ void replica::on_group_check(const group_check_request &request,
     response.err = ERR_OK;
     if (status() == partition_status::PS_ERROR) {
         response.err = ERR_INVALID_STATE;
-        LOG_WARNING("%s: on_group_check reply %s", name(), response.err.to_string());
+        LOG_WARNING_PREFIX("on_group_check reply {}", response.err);
     }
 
     response.last_committed_decree_in_app = _app->last_committed_decree();

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -200,7 +200,7 @@ error_code replica::initialize_on_load()
                   "load_replica: failed to move directory '{}' to '{}'",
                   dir,
                   rename_dir);
-            LOG_WARNING_F("load_replica: [replica_dir_op] succeed to move directory '{}' to '{}'",
+            LOG_WARNING_F("load_replica: replica_dir_op succeed to move directory '{}' to '{}'",
                           dir,
                           rename_dir);
             stub->_counter_replicas_recent_replica_move_error_count->increment();

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -200,9 +200,9 @@ error_code replica::initialize_on_load()
                   "load_replica: failed to move directory '{}' to '{}'",
                   dir,
                   rename_dir);
-            LOG_WARNING("load_replica: {replica_dir_op} succeed to move directory '%s' to '%s'",
-                        dir,
-                        rename_dir);
+            LOG_WARNING_F("load_replica: [replica_dir_op] succeed to move directory '{}' to '{}'",
+                          dir,
+                          rename_dir);
             stub->_counter_replicas_recent_replica_move_error_count->increment();
             stub->_fs_manager.remove_replica(pid);
         }

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -180,7 +180,7 @@ void replica::init_learn(uint64_t signature)
             _potential_secondary_states.learning_version,
             _config.primary,
             _potential_secondary_states.duration_ms(),
-            _stub->_learn_app_concurrent_count.load(),
+            _stub->_learn_app_concurrent_count,
             _options->learn_app_max_concurrent_count);
         return;
     }
@@ -690,7 +690,7 @@ void replica::on_learn_reply(error_code err, learn_request &&req, learn_response
                 "learn_app_max_concurrent_count({}), skip this round",
                 _potential_secondary_states.learning_version,
                 _config.primary,
-                _stub->_learn_app_concurrent_count.load(),
+                _stub->_learn_app_concurrent_count,
                 _options->learn_app_max_concurrent_count);
             _potential_secondary_states.learning_round_is_running = false;
             return;

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -636,7 +636,7 @@ void replica::on_learn_reply(error_code err, learn_request &&req, learn_response
                       name(),
                       old_dir,
                       rename_dir);
-                LOG_WARNING_PREFIX("{replica_dir_op} succeed to move directory from '{}' to '{}'",
+                LOG_WARNING_PREFIX("replica_dir_op succeed to move directory from '{}' to '{}'",
                                    old_dir,
                                    rename_dir);
             }

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -632,9 +632,9 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
                   "init_replica: failed to move directory '{}' to '{}'",
                   dir,
                   rename_dir);
-            LOG_WARNING("init_replica: {replica_dir_op} succeed to move directory '%s' to '%s'",
-                        dir,
-                        rename_dir);
+            LOG_WARNING_F("init_replica: {replica_dir_op} succeed to move directory '{}' to '{}'",
+                          dir,
+                          rename_dir);
             _counter_replicas_recent_replica_move_error_count->increment();
         }
         rps.clear();
@@ -939,11 +939,11 @@ void replica_stub::on_client_read(gpid id, dsn::message_ex *request)
 void replica_stub::on_config_proposal(const configuration_update_request &proposal)
 {
     if (!is_connected()) {
-        LOG_WARNING("%s@%s: received config proposal %s for %s: not connected, ignore",
-                    proposal.config.pid.to_string(),
-                    _primary_address_str,
-                    enum_to_string(proposal.type),
-                    proposal.node.to_string());
+        LOG_WARNING_F("{}@{}: received config proposal {} for {}: not connected, ignore",
+                      proposal.config.pid,
+                      _primary_address_str,
+                      enum_to_string(proposal.type),
+                      proposal.node);
         return;
     }
 
@@ -1196,9 +1196,9 @@ void replica_stub::on_group_check(group_check_rpc rpc)
     const group_check_request &request = rpc.request();
     group_check_response &response = rpc.response();
     if (!is_connected()) {
-        LOG_WARNING("%s@%s: received group check: not connected, ignore",
-                    request.config.pid.to_string(),
-                    _primary_address_str);
+        LOG_WARNING_F("{}@{}: received group check: not connected, ignore",
+                      request.config.pid,
+                      _primary_address_str);
         return;
     }
 
@@ -1260,10 +1260,10 @@ void replica_stub::on_learn_completion_notification(learn_completion_notificatio
 void replica_stub::on_add_learner(const group_check_request &request)
 {
     if (!is_connected()) {
-        LOG_WARNING("%s@%s: received add learner: not connected, ignore",
-                    request.config.pid.to_string(),
-                    _primary_address_str,
-                    request.config.primary.to_string());
+        LOG_WARNING_F("{}@{}: received add learner, primary = {}, not connected, ignore",
+                      request.config.pid,
+                      _primary_address_str,
+                      request.config.primary);
         return;
     }
 
@@ -1306,7 +1306,7 @@ void replica_stub::get_replica_info(replica_info &info, replica_ptr r)
 
     dsn::error_code err = _fs_manager.get_disk_tag(r->dir(), info.disk_tag);
     if (dsn::ERR_OK != err) {
-        LOG_WARNING("get disk tag of %s failed: %s", r->dir().c_str(), err.to_string());
+        LOG_WARNING_F("get disk tag of {} failed: {}", r->dir(), err);
     }
 
     info.__set_manual_compact_status(r->get_manual_compact_status());
@@ -1677,9 +1677,8 @@ void replica_stub::on_gc_replica(replica_stub_ptr this_, gpid id)
 
     replica_path = get_replica_dir(closed_info.first.app_type.c_str(), id, false);
     if (replica_path.empty()) {
-        LOG_WARNING("gc closed replica(%s.%s) failed, no exist data",
-                    id.to_string(),
-                    closed_info.first.app_type.c_str());
+        LOG_WARNING_F(
+            "gc closed replica({}.{}) failed, no exist data", id, closed_info.first.app_type);
         return;
     }
 
@@ -1687,17 +1686,17 @@ void replica_stub::on_gc_replica(replica_stub_ptr this_, gpid id)
     char rename_path[1024];
     sprintf(rename_path, "%s.%" PRIu64 ".gar", replica_path.c_str(), dsn_now_us());
     if (!dsn::utils::filesystem::rename_path(replica_path, rename_path)) {
-        LOG_WARNING(
-            "gc_replica: failed to move directory '%s' to '%s'", replica_path.c_str(), rename_path);
+        LOG_WARNING_F(
+            "gc_replica: failed to move directory '{}' to '{}'", replica_path, rename_path);
 
         // if gc the replica failed, add it back
         zauto_write_lock l(_replicas_lock);
         _fs_manager.add_replica(id, replica_path);
         _closed_replicas.emplace(id, closed_info);
     } else {
-        LOG_WARNING("gc_replica: {replica_dir_op} succeed to move directory '%s' to '%s'",
-                    replica_path.c_str(),
-                    rename_path);
+        LOG_WARNING_F("gc_replica: {replica_dir_op} succeed to move directory '{}' to '{}'",
+                      replica_path,
+                      rename_path);
         _counter_replicas_recent_replica_move_garbage_count->increment();
     }
 }

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -632,7 +632,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
                   "init_replica: failed to move directory '{}' to '{}'",
                   dir,
                   rename_dir);
-            LOG_WARNING_F("init_replica: {replica_dir_op} succeed to move directory '{}' to '{}'",
+            LOG_WARNING_F("init_replica: replica_dir_op succeed to move directory '{}' to '{}'",
                           dir,
                           rename_dir);
             _counter_replicas_recent_replica_move_error_count->increment();
@@ -1694,7 +1694,7 @@ void replica_stub::on_gc_replica(replica_stub_ptr this_, gpid id)
         _fs_manager.add_replica(id, replica_path);
         _closed_replicas.emplace(id, closed_info);
     } else {
-        LOG_WARNING_F("gc_replica: {replica_dir_op} succeed to move directory '{}' to '{}'",
+        LOG_WARNING_F("gc_replica: replica_dir_op succeed to move directory '{}' to '{}'",
                       replica_path,
                       rename_path);
         _counter_replicas_recent_replica_move_garbage_count->increment();


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#1305

This patch aim to use LOG_WARNING_F instead of LOG_WARNING for replica module. Includes:
- Use LOG_WARNING_F instead of LOG_WARNING in replica module.
- Use LOG_WARNING_PREFIX instaed of LOG_WARNING for class replica