### PR TITLE
refactor(log): use LOG_WARNING_F instead of LOG_WARNING (2/3)

### DIFF
--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -61,10 +61,10 @@ bool calc_disk_load(node_mapper &nodes,
         const config_context &cc = *get_config_context(apps, pid);
         auto iter = cc.find_from_serving(node);
         if (iter == cc.serving.end()) {
-            LOG_WARNING("can't collect gpid(%d.%d)'s info from %s, which should be primary",
-                        pid.get_app_id(),
-                        pid.get_partition_index(),
-                        node.to_string());
+            LOG_WARNING_F("can't collect gpid({}.{})'s info from {}, which should be primary",
+                          pid.get_app_id(),
+                          pid.get_partition_index(),
+                          node);
             return false;
         } else {
             load[iter->disk_tag]++;

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -61,10 +61,8 @@ bool calc_disk_load(node_mapper &nodes,
         const config_context &cc = *get_config_context(apps, pid);
         auto iter = cc.find_from_serving(node);
         if (iter == cc.serving.end()) {
-            LOG_WARNING_F("can't collect gpid({}.{})'s info from {}, which should be primary",
-                          pid.get_app_id(),
-                          pid.get_partition_index(),
-                          node);
+            LOG_WARNING_F(
+                "can't collect gpid({})'s info from {}, which should be primary", pid, node);
             return false;
         } else {
             load[iter->disk_tag]++;

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1546,7 +1546,7 @@ void backup_service::modify_backup_policy(configuration_modify_backup_policy_rpc
                 LOG_INFO_F("{}: remove app({}) to policy", cur_policy.policy_name, appid);
                 have_modify_policy = true;
             } else {
-                LOG_WARNING_F("{}: invalid app_id({})", cur_policy.policy_name, (int32_t)appid);
+                LOG_WARNING_F("{}: invalid app_id({})", cur_policy.policy_name, appid);
             }
         }
     }
@@ -1561,7 +1561,7 @@ void backup_service::modify_backup_policy(configuration_modify_backup_policy_rpc
             have_modify_policy = true;
         } else {
             LOG_WARNING_F("{}: invalid backup_interval_sec({})",
-                          cur_policy.policy_name.c_str(),
+                          cur_policy.policy_name,
                           request.new_backup_interval_sec);
         }
     }

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -138,9 +138,7 @@ bool construct_replica(meta_view view, const gpid &pid, int max_replica_count)
 
     std::vector<dropped_replica> &drop_list = cc.dropped;
     if (drop_list.empty()) {
-        LOG_WARNING_F("construct for ({}.{}) failed, coz no replicas collected",
-                      pid.get_app_id(),
-                      pid.get_partition_index());
+        LOG_WARNING_F("construct for ({}) failed, coz no replicas collected", pid);
         return false;
     }
 
@@ -256,11 +254,9 @@ void proposal_actions::track_current_learner(const dsn::rpc_address &node, const
                 current_learner.last_prepared_decree > info.last_prepared_decree) {
 
                 // TODO: need to add a perf counter here
-                LOG_WARNING_F(
-                    "{}.{}: learner({})'s progress step back, please trace this carefully",
-                    info.pid.get_app_id(),
-                    info.pid.get_partition_index(),
-                    node);
+                LOG_WARNING_F("{}: learner({})'s progress step back, please trace this carefully",
+                              info.pid,
+                              node);
             }
 
             // NOTICE: the flag may be abormal currently. it's balancer's duty to make use of the

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -138,9 +138,9 @@ bool construct_replica(meta_view view, const gpid &pid, int max_replica_count)
 
     std::vector<dropped_replica> &drop_list = cc.dropped;
     if (drop_list.empty()) {
-        LOG_WARNING("construct for (%d.%d) failed, coz no replicas collected",
-                    pid.get_app_id(),
-                    pid.get_partition_index());
+        LOG_WARNING_F("construct for ({}.{}) failed, coz no replicas collected",
+                      pid.get_app_id(),
+                      pid.get_partition_index());
         return false;
     }
 
@@ -256,10 +256,11 @@ void proposal_actions::track_current_learner(const dsn::rpc_address &node, const
                 current_learner.last_prepared_decree > info.last_prepared_decree) {
 
                 // TODO: need to add a perf counter here
-                LOG_WARNING("%d.%d: learner(%s)'s progress step back, please trace this carefully",
-                            info.pid.get_app_id(),
-                            info.pid.get_partition_index(),
-                            node.to_string());
+                LOG_WARNING_F(
+                    "{}.{}: learner({})'s progress step back, please trace this carefully",
+                    info.pid.get_app_id(),
+                    info.pid.get_partition_index(),
+                    node);
             }
 
             // NOTICE: the flag may be abormal currently. it's balancer's duty to make use of the

--- a/src/meta/meta_server_failure_detector.cpp
+++ b/src/meta/meta_server_failure_detector.cpp
@@ -114,7 +114,7 @@ bool meta_server_failure_detector::get_leader(rpc_address *leader)
         if (err == dsn::ERR_OK && leader->from_string_ipv4(lock_owner.c_str())) {
             return (*leader) == dsn_primary_address();
         } else {
-            LOG_WARNING("query leader from cache got error(%s)", err.to_string());
+            LOG_WARNING_F("query leader from cache got error({})", err);
             leader->set_invalid();
             return false;
         }
@@ -226,9 +226,9 @@ bool meta_server_failure_detector::update_stability_stat(const fd::beacon_msg &b
             if (beacon.start_time - w.last_start_time_ms <
                 _fd_opts->stable_rs_min_running_seconds * 1000) {
                 w.unstable_restart_count++;
-                LOG_WARNING("%s encounter an unstable restart, total_count(%d)",
-                            beacon.from_addr.to_string(),
-                            w.unstable_restart_count);
+                LOG_WARNING_F("{} encounter an unstable restart, total_count({})",
+                              beacon.from_addr,
+                              w.unstable_restart_count);
             } else if (w.unstable_restart_count > 0) {
                 LOG_INFO_F("{} restart in {} ms after last restart, may recover ok, reset "
                            "it's unstable count({}) to 0",
@@ -240,8 +240,7 @@ bool meta_server_failure_detector::update_stability_stat(const fd::beacon_msg &b
 
             w.last_start_time_ms = beacon.start_time;
         } else {
-            LOG_WARNING("%s: possible encounter a staled message, ignore it",
-                        beacon.from_addr.to_string());
+            LOG_WARNING_F("{}: possible encounter a staled message, ignore it", beacon.from_addr);
         }
         return w.unstable_restart_count < _fd_opts->max_succssive_unstable_restart;
     }
@@ -256,7 +255,7 @@ void meta_server_failure_detector::on_ping(const fd::beacon_msg &beacon,
     ack.allowed = true;
 
     if (beacon.__isset.start_time && !update_stability_stat(beacon)) {
-        LOG_WARNING("%s is unstable, don't response to it's beacon", beacon.from_addr.to_string());
+        LOG_WARNING_F("{} is unstable, don't response to it's beacon", beacon.from_addr);
         return;
     }
 

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -980,7 +980,7 @@ void meta_service::update_app_env(app_env_rpc env_rpc)
                          std::bind(&server_state::clear_app_envs, _state.get(), env_rpc));
         break;
     default: // app_env_operation::type::APP_ENV_OP_INVALID
-        LOG_WARNING("recv a invalid update app_env request, just ignore");
+        LOG_WARNING_F("recv a invalid update app_env request, just ignore");
         response.err = ERR_INVALID_PARAMETERS;
         response.hint_message =
             "recv a invalid update_app_env request with op = APP_ENV_OP_INVALID";

--- a/src/meta/meta_state_service_zookeeper.cpp
+++ b/src/meta/meta_state_service_zookeeper.cpp
@@ -372,7 +372,7 @@ void meta_state_service_zookeeper::on_zoo_session_evt(ref_this _this, int zoo_st
 
     if (ZOO_CONNECTING_STATE == zoo_state) {
         // TODO: support the switch of zookeeper session
-        LOG_WARNING("the zk session is reconnecting");
+        LOG_WARNING_F("the zk session is reconnecting");
     } else if (_this->_first_call && ZOO_CONNECTED_STATE == zoo_state) {
         _this->_first_call = false;
         _this->_notifier.notify();

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -279,9 +279,9 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
     }
     // well, all replicas in this partition is dead
     else {
-        LOG_WARNING("%s enters DDD state, we are waiting for all replicas to come back, "
-                    "and select primary according to informations collected",
-                    gpid_name);
+        LOG_WARNING_F("{} enters DDD state, we are waiting for all replicas to come back, "
+                      "and select primary according to informations collected",
+                      gpid_name);
         // when considering how to handle the DDD state, we must keep in mind that our
         // shared/private-log data only write to OS-cache.
         // so the last removed replica can't act as primary directly.
@@ -321,9 +321,9 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
         }
 
         if (pc.last_drops.size() == 1) {
-            LOG_WARNING("%s: the only node(%s) is dead, waiting it to come back",
-                        gpid_name,
-                        pc.last_drops.back().to_string());
+            LOG_WARNING_F("{}: the only node({}) is dead, waiting it to come back",
+                          gpid_name,
+                          pc.last_drops.back());
             action.node = pc.last_drops.back();
         } else {
             std::vector<dsn::rpc_address> nodes(pc.last_drops.end() - 2, pc.last_drops.end());
@@ -341,7 +341,7 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                     ready = false;
                     reason = "the last dropped node(" + nodes[i].to_std_string() +
                              ") haven't come back yet";
-                    LOG_WARNING("%s: don't select primary: %s", gpid_name, reason.c_str());
+                    LOG_WARNING_F("{}: don't select primary: {}", gpid_name, reason);
                 } else {
                     std::vector<dropped_replica>::iterator it = cc.find_from_dropped(nodes[i]);
                     if (it == cc.dropped.end() || it->ballot == invalid_ballot) {
@@ -360,7 +360,7 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                             } else {
                                 reason += "replica info has not been collected from the node";
                             }
-                            LOG_WARNING("%s: don't select primary: %s", gpid_name, reason.c_str());
+                            LOG_WARNING_F("{}: don't select primary: {}", gpid_name, reason);
                         }
                     } else {
                         collected_info[i] = *it;
@@ -371,7 +371,7 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
             if (ready && collected_info[0].ballot == -1 && collected_info[1].ballot == -1) {
                 ready = false;
                 reason = "no replica info collected from the last two drops";
-                LOG_WARNING("%s: don't select primary: %s", gpid_name, reason.c_str());
+                LOG_WARNING_F("{}: don't select primary: {}", gpid_name, reason);
             }
 
             if (ready) {
@@ -412,12 +412,12 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                                 larger_pd,
                                 pc.last_committed_decree,
                                 larger_cd);
-                        LOG_WARNING("%s: don't select primary: %s", gpid_name, reason.c_str());
+                        LOG_WARNING_F("{}: don't select primary: {}", gpid_name, reason);
                     }
                 } else {
                     reason = "for the last two drops, the node with larger ballot has smaller last "
                              "committed decree";
-                    LOG_WARNING("%s: don't select primary: %s", gpid_name, reason.c_str());
+                    LOG_WARNING_F("{}: don't select primary: {}", gpid_name, reason);
                 }
             }
         }
@@ -429,9 +429,9 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
             get_newly_partitions(*view.nodes, action.node)
                 ->newly_add_primary(gpid.get_app_id(), false);
         } else {
-            LOG_WARNING("%s: don't select any node for security reason, administrator can select "
-                        "a proper one by shell",
-                        gpid_name);
+            LOG_WARNING_F("{}: don't select any node for security reason, administrator can select "
+                          "a proper one by shell",
+                          gpid_name);
             _recent_choose_primary_fail_count->increment();
             ddd_partition_info pinfo;
             pinfo.config = pc;

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -897,11 +897,10 @@ void server_state::on_config_sync(configuration_query_by_node_rpc rpc)
                                        _meta_function_level_VALUES_TO_NAMES.find(level)->second);
                         } else {
                             response.gc_replicas.push_back(rep);
-                            LOG_WARNING_F("notify node({}) to gc replica({}.{}) coz the app is "
+                            LOG_WARNING_F("notify node({}) to gc replica({}) coz the app is "
                                           "dropped and expired",
                                           request.node,
-                                          rep.pid.get_app_id(),
-                                          rep.pid.get_partition_index());
+                                          rep.pid);
                         }
                     }
                 } else if (app->status == app_status::AS_AVAILABLE) {
@@ -916,10 +915,9 @@ void server_state::on_config_sync(configuration_query_by_node_rpc rpc)
                                        _meta_function_level_VALUES_TO_NAMES.find(level)->second);
                         } else {
                             response.gc_replicas.push_back(rep);
-                            LOG_WARNING_F("notify node({}) to gc replica({}.{}) coz it is useless",
+                            LOG_WARNING_F("notify node({}) to gc replica({}) coz it is useless",
                                           request.node,
-                                          rep.pid.get_app_id(),
-                                          rep.pid.get_partition_index());
+                                          rep.pid);
                         }
                     }
                 }
@@ -1798,12 +1796,10 @@ void server_state::downgrade_primary_to_inactive(std::shared_ptr<app_state> &app
                 "stop downgrade primary as the partitions({}.{}) is dropping", app->app_id, pidx);
             return;
         } else {
-            LOG_WARNING_F(
-                "gpid({}.{}) is syncing another request with remote, cancel it due to the "
-                "primary({}) is down",
-                pc.pid.get_app_id(),
-                pc.pid.get_partition_index(),
-                pc.primary);
+            LOG_WARNING_F("gpid({}) is syncing another request with remote, cancel it due to the "
+                          "primary({}) is down",
+                          pc.pid.get_app_id(),
+                          pc.primary);
             cc.cancel_sync();
         }
     }
@@ -1881,13 +1877,11 @@ void server_state::downgrade_stateless_nodes(std::shared_ptr<app_state> &app,
     pc.last_drops.pop_back();
 
     if (config_status::pending_remote_sync == cc.stage) {
-        LOG_WARNING_F(
-            "gpid({}.{}) is syncing another request with remote, cancel it due to meta is "
-            "removing host({}) worker({})",
-            pc.pid.get_app_id(),
-            pc.pid.get_partition_index(),
-            req->host_node,
-            req->node);
+        LOG_WARNING_F("gpid({}) is syncing another request with remote, cancel it due to meta is "
+                      "removing host({}) worker({})",
+                      pc.pid,
+                      req->host_node,
+                      req->node);
         cc.cancel_sync();
     }
     cc.stage = config_status::pending_remote_sync;

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -1798,7 +1798,7 @@ void server_state::downgrade_primary_to_inactive(std::shared_ptr<app_state> &app
         } else {
             LOG_WARNING_F("gpid({}) is syncing another request with remote, cancel it due to the "
                           "primary({}) is down",
-                          pc.pid.get_app_id(),
+                          pc.pid,
                           pc.primary);
             cc.cancel_sync();
         }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1305

This patch aim to use LOG_WARNING_F instead of LOG_WARNING. Includes:

Use LOG_WARNING_F instead of LOG_WARNING in meta module.
