### PR TITLE
chore(CI): Add unit test workflow for node.js client

### DIFF
--- a/.github/workflows/test_nodejs-client.yml
+++ b/.github/workflows/test_nodejs-client.yml
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Test - node.js client
+on:
+  pull_request:
+    branches:
+        - master
+        - 'v[0-9]+.*' # release branch
+        - ci-test # testing branch for github action
+        - '*dev'      # developing branch
+    paths:
+      - nodejs-client/**
+
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: test
+        working-directory: ./nodejs-client
+        run: |
+          npm install
+          ./test.sh

--- a/nodejs-client/test.sh
+++ b/nodejs-client/test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+NODEJS_CLIENT_DIR=`pwd`
+PEGASUS_PKG="pegasus-tools-2.0.0-5d969e8-glibc2.12-release"
+PEGASUS_PKG_URL="https://github.com/apache/incubator-pegasus/releases/download/v2.0.0/pegasus-tools-2.0.0-5d969e8-glibc2.12-release.tar.gz"
+
+# start pegasus onebox environment
+if [ ! -f ${PEGASUS_PKG}.tar.gz ]; then
+    wget --quiet ${PEGASUS_PKG_URL}
+    tar xf ${PEGASUS_PKG}.tar.gz
+fi
+cd ${PEGASUS_PKG}
+./run.sh clear_onebox
+./run.sh start_onebox -m 3 -r 3 -w
+
+cd "${NODEJS_CLIENT_DIR}"
+npm test


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1330

There is no functional changes in this patch, but only adding unit test workflow for node.js client.
See the workflow by link "Test - node.js client / test (pull_request)" below.