### PR TITLE
refactor(conf): use DSN_DEFINE_uint32 to load uint32 type of configs

### DIFF
--- a/src/geo/lib/geo_client.cpp
+++ b/src/geo/lib/geo_client.cpp
@@ -68,6 +68,8 @@ DSN_DEFINE_group_validator(min_max_level, [](std::string &message) -> bool {
     }
     return true;
 });
+DSN_DEFINE_uint32(geo_client.lib, latitude_index, 5, "latitude index in value");
+DSN_DEFINE_uint32(geo_client.lib, longitude_index, 4, "longitude index in value");
 
 struct SearchResultNearer
 {
@@ -99,14 +101,11 @@ geo_client::geo_client(const char *config_file,
     _geo_data_client = pegasus_client_factory::get_client(cluster_name, geo_app_name);
     CHECK_NOTNULL(_geo_data_client, "init pegasus _geo_data_client failed");
 
-    uint32_t latitude_index = (uint32_t)dsn_config_get_value_uint64(
-        "geo_client.lib", "latitude_index", 5, "latitude index in value");
-
-    uint32_t longitude_index = (uint32_t)dsn_config_get_value_uint64(
-        "geo_client.lib", "longitude_index", 4, "longitude index in value");
-
-    dsn::error_s s = _codec.set_latlng_indices(latitude_index, longitude_index);
-    CHECK(s.is_ok(), "set_latlng_indices({}, {}) failed", latitude_index, longitude_index);
+    dsn::error_s s = _codec.set_latlng_indices(FLAGS_latitude_index, FLAGS_longitude_index);
+    CHECK(s.is_ok(),
+          "set_latlng_indices({}, {}) failed",
+          FLAGS_latitude_index,
+          FLAGS_longitude_index);
 }
 
 dsn::error_s geo_client::set_max_level(int level)

--- a/src/meta/test/main.cpp
+++ b/src/meta/test/main.cpp
@@ -47,6 +47,8 @@ DEFINE_TASK_CODE(TASK_META_TEST, TASK_PRIORITY_COMMON, THREAD_POOL_META_TEST)
 
 meta_service_test_app *g_app;
 
+DSN_DEFINE_uint32(tools.simulator, random_seed, 0, "random seed");
+
 // as it is not easy to clean test environment in some cases, we simply run these tests in several
 // commands,
 // please check the script "run.sh" to modify the GTEST_FILTER
@@ -80,13 +82,11 @@ TEST(meta, app_envs_basic_test) { g_app->app_envs_basic_test(); }
 
 dsn::error_code meta_service_test_app::start(const std::vector<std::string> &args)
 {
-    uint32_t seed =
-        (uint32_t)dsn_config_get_value_uint64("tools.simulator", "random_seed", 0, "random seed");
-    if (seed == 0) {
-        seed = time(0);
-        LOG_ERROR("initial seed: {}", seed);
+    if (FLAGS_random_seed == 0) {
+        FLAGS_random_seed = time(0);
+        LOG_ERROR("initial seed: {}", FLAGS_random_seed);
     }
-    srand(seed);
+    srand(FLAGS_random_seed);
 
     int argc = args.size();
     char *argv[20];

--- a/src/meta/test/main.cpp
+++ b/src/meta/test/main.cpp
@@ -83,8 +83,8 @@ TEST(meta, app_envs_basic_test) { g_app->app_envs_basic_test(); }
 dsn::error_code meta_service_test_app::start(const std::vector<std::string> &args)
 {
     if (FLAGS_random_seed == 0) {
-        FLAGS_random_seed = time(0);
-        LOG_ERROR("initial seed: {}", FLAGS_random_seed);
+        FLAGS_random_seed = static_cast<uint32_t>(time(nullptr));
+        LOG_INFO("initial seed: {}", FLAGS_random_seed);
     }
     srand(FLAGS_random_seed);
 

--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -72,10 +72,6 @@ error_code asio_network_provider::start(rpc_channel channel, int port, bool clie
     if (_acceptor != nullptr)
         return ERR_SERVICE_ALREADY_RUNNING;
 
-    // get connection threshold from config, default value 0 means no threshold
-    _cfg_conn_threshold_per_ip = (uint32_t)dsn_config_get_value_uint64(
-        "network", "conn_threshold_per_ip", 0, "max connection count to each server per ip");
-
     for (int i = 0; i < FLAGS_io_service_worker_count; i++) {
         _workers.push_back(std::make_shared<std::thread>([this, i]() {
             task::set_tls_dsn_context(node(), nullptr);

--- a/src/runtime/rpc/network.h
+++ b/src/runtime/rpc/network.h
@@ -185,7 +185,6 @@ protected:
     ip_connection_count _ip_conn_count; // from_ip => connection count
     utils::rw_lock_nr _servers_lock;
 
-    uint32_t _cfg_conn_threshold_per_ip;
     perf_counter_wrapper _client_session_count;
 };
 

--- a/src/runtime/rpc/network.sim.cpp
+++ b/src/runtime/rpc/network.sim.cpp
@@ -187,8 +187,8 @@ error_code sim_network_provider::start(rpc_channel channel, int port, bool clien
 
 uint32_t sim_network_provider::net_delay_milliseconds() const
 {
-    return static_cast<uint32_t>(rand::next_u32(FLAGS_min_message_delay_microseconds,
-                                                FLAGS_max_message_delay_microseconds)) /
+    return rand::next_u32(FLAGS_min_message_delay_microseconds,
+                          FLAGS_max_message_delay_microseconds) /
            1000;
 }
 }

--- a/src/runtime/rpc/network.sim.cpp
+++ b/src/runtime/rpc/network.sim.cpp
@@ -42,9 +42,16 @@
 #include "utils/rand.h"
 #include "runtime/node_scoper.h"
 #include "network.sim.h"
+#include "utils/flags.h"
 
 namespace dsn {
 namespace tools {
+
+DSN_DEFINE_uint32(tools.simulator, min_message_delay_microseconds, 1, "min message delay (us)");
+DSN_DEFINE_uint32(tools.simulator,
+                  max_message_delay_microseconds,
+                  100000,
+                  "max message delay (us)");
 
 // switch[channel][header_format]
 // multiple machines connect to the same switch
@@ -153,20 +160,6 @@ sim_network_provider::sim_network_provider(rpc_engine *rpc, network *inner_provi
     : connection_oriented_network(rpc, inner_provider)
 {
     _address.assign_ipv4("localhost", 1);
-
-    _min_message_delay_microseconds = 1;
-    _max_message_delay_microseconds = 100000;
-
-    _min_message_delay_microseconds =
-        (uint32_t)dsn_config_get_value_uint64("tools.simulator",
-                                              "min_message_delay_microseconds",
-                                              _min_message_delay_microseconds,
-                                              "min message delay (us)");
-    _max_message_delay_microseconds =
-        (uint32_t)dsn_config_get_value_uint64("tools.simulator",
-                                              "max_message_delay_microseconds",
-                                              _max_message_delay_microseconds,
-                                              "max message delay (us)");
 }
 
 error_code sim_network_provider::start(rpc_channel channel, int port, bool client_only)
@@ -194,8 +187,8 @@ error_code sim_network_provider::start(rpc_channel channel, int port, bool clien
 
 uint32_t sim_network_provider::net_delay_milliseconds() const
 {
-    return static_cast<uint32_t>(
-               rand::next_u32(_min_message_delay_microseconds, _max_message_delay_microseconds)) /
+    return static_cast<uint32_t>(rand::next_u32(FLAGS_min_message_delay_microseconds,
+                                                FLAGS_max_message_delay_microseconds)) /
            1000;
 }
 }

--- a/src/runtime/rpc/network.sim.h
+++ b/src/runtime/rpc/network.sim.h
@@ -99,8 +99,6 @@ public:
 
 private:
     ::dsn::rpc_address _address;
-    uint32_t _min_message_delay_microseconds;
-    uint32_t _max_message_delay_microseconds;
 };
 
 //------------- inline implementations -------------

--- a/src/runtime/rpc/rpc_engine.cpp
+++ b/src/runtime/rpc/rpc_engine.cpp
@@ -39,8 +39,10 @@
 #include "runtime/rpc/serialization.h"
 #include "utils/rand.h"
 #include <set>
+#include "utils/flags.h"
 
 namespace dsn {
+DSN_DECLARE_uint32(local_hash);
 
 DEFINE_TASK_CODE(LPC_RPC_TIMEOUT, TASK_PRIORITY_COMMON, THREAD_POOL_DEFAULT)
 
@@ -735,7 +737,7 @@ void rpc_engine::reply(message_ex *response, error_code err)
             sizeof(response->header->server.error_name) - 1);
     response->header->server.error_name[sizeof(response->header->server.error_name) - 1] = '\0';
     response->header->server.error_code.local_code = err;
-    response->header->server.error_code.local_hash = message_ex::s_local_hash;
+    response->header->server.error_code.local_hash = FLAGS_local_hash;
 
     // response rpc code may be TASK_CODE_INVALID when request rpc code is not exist
     auto sp = response->local_rpc_code == TASK_CODE_INVALID

--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -32,13 +32,20 @@
 #include <cctype>
 
 #include "runtime/task/task_engine.h"
+#include "utils/flags.h"
 
 using namespace dsn::utils;
 
 namespace dsn {
+// init common for all per-node providers
+DSN_DEFINE_uint32(core,
+                  local_hash,
+                  0,
+                  "a same hash value from two processes indicate the rpc code are registered in "
+                  "the same order, and therefore the mapping between rpc code string and integer "
+                  "is the same, which we leverage for fast rpc handler lookup optimization");
 
 std::atomic<uint64_t> message_ex::_id(0);
-uint32_t message_ex::s_local_hash = 0;
 
 message_ex::message_ex()
     : header(nullptr),
@@ -82,11 +89,11 @@ error_code message_ex::error()
 {
     dsn::error_code code;
     auto binary_hash = header->server.error_code.local_hash;
-    if (binary_hash != 0 && binary_hash == ::dsn::message_ex::s_local_hash) {
+    if (binary_hash != 0 && binary_hash == FLAGS_local_hash) {
         code = dsn::error_code(header->server.error_code.local_code);
     } else {
         code = error_code::try_get(header->server.error_name, dsn::ERR_UNKNOWN);
-        header->server.error_code.local_hash = ::dsn::message_ex::s_local_hash;
+        header->server.error_code.local_hash = FLAGS_local_hash;
         header->server.error_code.local_code = code;
     }
     return code;
@@ -99,11 +106,11 @@ task_code message_ex::rpc_code()
     }
 
     auto binary_hash = header->rpc_code.local_hash;
-    if (binary_hash != 0 && binary_hash == ::dsn::message_ex::s_local_hash) {
+    if (binary_hash != 0 && binary_hash == FLAGS_local_hash) {
         local_rpc_code = dsn::task_code(header->rpc_code.local_code);
     } else {
         local_rpc_code = dsn::task_code::try_get(header->rpc_name, ::dsn::TASK_CODE_INVALID);
-        header->rpc_code.local_hash = ::dsn::message_ex::s_local_hash;
+        header->rpc_code.local_hash = FLAGS_local_hash;
         header->rpc_code.local_code = local_rpc_code.code();
     }
 
@@ -307,7 +314,7 @@ message_ex *message_ex::create_request(dsn::task_code rpc_code,
     strncpy(hdr.rpc_name, sp->name.c_str(), sizeof(hdr.rpc_name) - 1);
     hdr.rpc_name[sizeof(hdr.rpc_name) - 1] = '\0';
     hdr.rpc_code.local_code = (uint32_t)rpc_code;
-    hdr.rpc_code.local_hash = s_local_hash;
+    hdr.rpc_code.local_hash = FLAGS_local_hash;
 
     hdr.id = new_id();
 
@@ -348,7 +355,7 @@ message_ex *message_ex::create_response()
         strncpy(hdr.rpc_name, response_sp->name.c_str(), sizeof(hdr.rpc_name) - 1);
         hdr.rpc_name[sizeof(hdr.rpc_name) - 1] = '\0';
         hdr.rpc_code.local_code = msg->local_rpc_code;
-        hdr.rpc_code.local_hash = s_local_hash;
+        hdr.rpc_code.local_hash = FLAGS_local_hash;
 
         // join point
         request_sp->on_rpc_create_response.execute(this, msg);
@@ -359,7 +366,7 @@ message_ex *message_ex::create_response()
         strncpy(hdr.rpc_name, ack_rpc_name.c_str(), sizeof(hdr.rpc_name) - 1);
         hdr.rpc_name[sizeof(hdr.rpc_name) - 1] = '\0';
         hdr.rpc_code.local_code = TASK_CODE_INVALID;
-        hdr.rpc_code.local_hash = s_local_hash;
+        hdr.rpc_code.local_hash = FLAGS_local_hash;
     }
 
     return msg;

--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -41,7 +41,7 @@ namespace dsn {
 DSN_DEFINE_uint32(core,
                   local_hash,
                   0,
-                  "a same hash value from two processes indicate the rpc code are registered in "
+                  "a same hash value from two processes indicate the rpc codes are registered in "
                   "the same order, and therefore the mapping between rpc code string and integer "
                   "is the same, which we leverage for fast rpc handler lookup optimization");
 

--- a/src/runtime/rpc/rpc_message.h
+++ b/src/runtime/rpc/rpc_message.h
@@ -233,9 +233,6 @@ private:
     int _rw_offset;     // current buffer offset
     bool _rw_committed; // mark if it is in middle state of reading/writing
     bool _is_read;      // is for read(recv) or write(send)
-
-public:
-    static uint32_t s_local_hash; // used by fast_rpc_name
 };
 typedef dsn::ref_ptr<message_ex> message_ptr;
 

--- a/src/runtime/service_engine.cpp
+++ b/src/runtime/service_engine.cpp
@@ -194,21 +194,7 @@ service_engine::service_engine()
 
 service_engine::~service_engine() { _nodes_by_app_id.clear(); }
 
-void service_engine::init_before_toollets(const service_spec &spec)
-{
-    _spec = spec;
-
-    // init common for all per-node providers
-    message_ex::s_local_hash =
-        (uint32_t)dsn_config_get_value_uint64("core",
-                                              "local_hash",
-                                              0,
-                                              "a same hash value from two processes indicate the "
-                                              "rpc code are registered in the same order, "
-                                              "and therefore the mapping between rpc code string "
-                                              "and integer is the same, which we leverage "
-                                              "for fast rpc handler lookup optimization");
-}
+void service_engine::init_before_toollets(const service_spec &spec) { _spec = spec; }
 
 void service_engine::init_after_toollets()
 {

--- a/src/server/available_detector.h
+++ b/src/server/available_detector.h
@@ -61,7 +61,6 @@ private:
     pegasus_client *_client;
     std::shared_ptr<replication_ddl_client> _ddl_client;
     std::vector<dsn::rpc_address> _meta_list;
-    uint32_t _detect_interval_seconds;
     ::dsn::utils::ex_lock_nr _alert_lock;
     // for record partition fail times.
     std::vector<std::shared_ptr<std::atomic<int32_t>>> _fail_count;
@@ -72,7 +71,6 @@ private:
     int32_t _app_id;
     int32_t _partition_count;
     std::vector<::dsn::partition_configuration> partitions;
-    uint32_t _detect_timeout;
 
     std::string _send_alert_email_cmd;
     std::string _send_availability_info_email_cmd;

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -225,7 +225,6 @@ private:
     ::dsn::rpc_address _meta_servers;
     std::string _cluster_name;
     std::shared_ptr<shell_context> _shell_context;
-    uint32_t _app_stat_interval_seconds;
     ::dsn::task_ptr _app_stat_timer_task;
     ::dsn::utils::ex_lock_nr _app_stat_counter_lock;
     std::map<std::string, app_stat_counters *> _app_stat_counters;
@@ -236,11 +235,9 @@ private:
     pegasus_client *_client;
     // for writing cu stat result
     std::unique_ptr<result_writer> _result_writer;
-    uint32_t _capacity_unit_fetch_interval_seconds;
     uint32_t _capacity_unit_retry_wait_seconds;
     uint32_t _capacity_unit_retry_max_count;
     ::dsn::task_ptr _capacity_unit_stat_timer_task;
-    uint32_t _storage_size_fetch_interval_seconds;
     uint32_t _storage_size_retry_wait_seconds;
     uint32_t _storage_size_retry_max_count;
     ::dsn::task_ptr _storage_size_stat_timer_task;

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -51,6 +51,8 @@ namespace server {
 
 DEFINE_TASK_CODE(LPC_PEGASUS_SERVER_DELAY, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
 DSN_DECLARE_int32(read_amp_bytes_per_bit);
+DSN_DECLARE_uint32(checkpoint_reserve_min_count);
+DSN_DECLARE_uint32(checkpoint_reserve_time_seconds);
 
 DSN_DEFINE_int32(pegasus.server,
                  hotkey_analyse_time_interval_s,
@@ -2622,10 +2624,11 @@ void pegasus_server_impl::update_default_ttl(const std::map<std::string, std::st
     }
 }
 
+// TODO(yingchun): change by http
 void pegasus_server_impl::update_checkpoint_reserve(const std::map<std::string, std::string> &envs)
 {
-    int32_t count = _checkpoint_reserve_min_count_in_config;
-    int32_t time = _checkpoint_reserve_time_seconds_in_config;
+    int32_t count = FLAGS_checkpoint_reserve_min_count;
+    int32_t time = FLAGS_checkpoint_reserve_time_seconds;
 
     auto find = envs.find(ROCKDB_CHECKPOINT_RESERVE_MIN_COUNT);
     if (find != envs.end()) {

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -456,8 +456,6 @@ private:
     std::unique_ptr<capacity_unit_calculator> _cu_calculator;
     std::unique_ptr<pegasus_server_write> _server_write;
 
-    uint32_t _checkpoint_reserve_min_count_in_config;
-    uint32_t _checkpoint_reserve_time_seconds_in_config;
     uint32_t _checkpoint_reserve_min_count;
     uint32_t _checkpoint_reserve_time_seconds;
     std::atomic_bool _is_checkpointing;         // whether the db is doing checkpoint

--- a/src/test/kill_test/kill_testor.h
+++ b/src/test/kill_test/kill_testor.h
@@ -63,10 +63,6 @@ protected:
     vector<dsn::rpc_address> meta_list;
 
     std::vector<partition_configuration> partitions;
-
-    int kill_interval_seconds;
-    uint32_t _sleep_time_before_recover_seconds;
-    uint32_t max_seconds_for_partitions_recover;
 };
 } // namespace test
 } // namespace pegasus

--- a/src/test/kill_test/partition_kill_testor.cpp
+++ b/src/test/kill_test/partition_kill_testor.cpp
@@ -31,9 +31,13 @@
 #include "remote_cmd/remote_command.h"
 
 #include "partition_kill_testor.h"
+#include "utils/flags.h"
 
 namespace pegasus {
 namespace test {
+
+DSN_DECLARE_uint32(kill_interval_seconds);
+
 partition_kill_testor::partition_kill_testor(const char *config_file) : kill_testor(config_file) {}
 
 void partition_kill_testor::Run()
@@ -45,8 +49,8 @@ void partition_kill_testor::Run()
         } else {
             run();
         }
-        LOG_INFO("sleep {} seconds before checking", kill_interval_seconds);
-        sleep(kill_interval_seconds);
+        LOG_INFO("sleep {} seconds before checking", FLAGS_kill_interval_seconds);
+        sleep(FLAGS_kill_interval_seconds);
     }
 }
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1323

This patch refactor the code to use `DSN_DEFINE_uint32` instead of `dsn_config_get_value_uint64` to load uint32 type of configurations, and doesn't introduce any functional changes.
- all default value and most of description are kept as before
- move the defination of flags closer to the places where they're used