### PR TITLE
refactor(conf): use DSN_DEFINE_int64 to load int64 type of configs

### DIFF
--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -100,7 +100,6 @@ replication_options::replication_options()
     group_check_disabled = false;
 
     checkpoint_disabled = false;
-    checkpoint_min_decree_gap = 10000;
 
     gc_disabled = false;
 
@@ -209,11 +208,6 @@ void replication_options::initialize()
                                                     "checkpoint_disabled",
                                                     checkpoint_disabled,
                                                     "whether checkpoint is disabled");
-    checkpoint_min_decree_gap =
-        (int64_t)dsn_config_get_value_uint64("replication",
-                                             "checkpoint_min_decree_gap",
-                                             checkpoint_min_decree_gap,
-                                             "minimum decree gap that triggers checkpoint");
 
     gc_disabled = dsn_config_get_value_bool(
         "replication", "gc_disabled", gc_disabled, "whether to disable garbage collection");

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -76,7 +76,6 @@ public:
     bool group_check_disabled;
 
     bool checkpoint_disabled;
-    int64_t checkpoint_min_decree_gap;
 
     bool gc_disabled;
 

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -255,7 +255,6 @@ stateful = true
 
   checkpoint_disabled = false
   checkpoint_interval_seconds = 300
-  checkpoint_min_decree_gap = 10000
   checkpoint_max_interval_hours = 2
 
   gc_disabled = false

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -58,6 +58,10 @@ DSN_DEFINE_int32(pegasus.server,
                  hotkey_analyse_time_interval_s,
                  10,
                  "hotkey analyse interval in seconds");
+DSN_DEFINE_int32(pegasus.server,
+                 update_rdb_stat_interval,
+                 60,
+                 "The interval seconds to update RocksDB statistics, in seconds.");
 
 static std::string chkpt_get_dir_name(int64_t decree)
 {
@@ -1695,7 +1699,7 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
         dsn::tasking::enqueue_timer(LPC_REPLICATION_LONG_COMMON,
                                     &_tracker,
                                     [this]() { this->update_replica_rocksdb_statistics(); },
-                                    _update_rdb_stat_interval);
+                                    std::chrono::seconds(FLAGS_update_rdb_stat_interval));
 
     // These counters are singletons on this server shared by all replicas, their metrics update
     // task should be scheduled once an interval on the server view.

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -464,7 +464,6 @@ private:
 
     pegasus_context_cache _context_cache;
 
-    std::chrono::seconds _update_rdb_stat_interval;
     ::dsn::task_ptr _update_replica_rdb_stat;
     static ::dsn::task_ptr _update_server_rdb_stat;
 

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -197,7 +197,6 @@ private:
     uint64_t _batch_start_time;
 
     capacity_unit_calculator *_cu_calculator;
-    int64_t _dup_lagging_write_threshold_ms;
 
     ::dsn::perf_counter_wrapper _pfc_put_qps;
     ::dsn::perf_counter_wrapper _pfc_multi_put_qps;

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -165,7 +165,6 @@ group_check_interval_ms = 100000
 
 checkpoint_disabled = false
 checkpoint_interval_seconds = 100
-checkpoint_min_decree_gap = 10000
 checkpoint_max_interval_hours = 1
 
 gc_disabled = false

--- a/src/test/pressure_test/main.cpp
+++ b/src/test/pressure_test/main.cpp
@@ -40,10 +40,14 @@ DSN_DEFINE_int32(pressureclient, hashkey_len, 64, "hashkey length");
 DSN_DEFINE_int32(pressureclient, sortkey_len, 64, "sortkey length");
 DSN_DEFINE_int32(pressureclient, value_len, 64, "value length");
 DSN_DEFINE_validator(qps, [](int32_t value) -> bool { return value > 0; });
-
-// generate hashkey/sortkey between [0, ****key_limit]
-static int64_t hashkey_limit;
-static int64_t sortkey_limit;
+DSN_DEFINE_int64(pressureclient,
+                 hashkey_limit,
+                 0,
+                 "The hashkey range to generate, in format [0, ****key_limit].");
+DSN_DEFINE_int64(pressureclient,
+                 sortkey_limit,
+                 0,
+                 "The sortkey range to generate, in format [0, ****key_limit].");
 
 // for app
 static pegasus_client *pg_client = nullptr;
@@ -59,7 +63,7 @@ std::string fill_string(const std::string &str, int len)
 
 std::string get_hashkey()
 {
-    std::string key = to_string(dsn::rand::next_u64(0, hashkey_limit));
+    std::string key = to_string(dsn::rand::next_u64(0, FLAGS_hashkey_limit));
     if (key.size() >= FLAGS_hashkey_len) {
         return key;
     } else {
@@ -69,7 +73,7 @@ std::string get_hashkey()
 
 std::string get_sortkey()
 {
-    std::string key = to_string(dsn::rand::next_u64(0, sortkey_limit));
+    std::string key = to_string(dsn::rand::next_u64(0, FLAGS_sortkey_limit));
     if (key.size() >= FLAGS_sortkey_len) {
         return key;
     } else {
@@ -229,12 +233,6 @@ int main(int argc, const char **argv)
     app_name = dsn_config_get_value_string("pressureclient", "app_name", "temp", "app name");
 
     op_name = dsn_config_get_value_string("pressureclient", "operation_name", "", "operation name");
-
-    hashkey_limit =
-        (int64_t)dsn_config_get_value_uint64("pressureclient", "hashkey_limit", 0, "hashkey limit");
-
-    sortkey_limit =
-        (int64_t)dsn_config_get_value_uint64("pressureclient", "sortkey_limit", 0, "sortkey limit");
 
     CHECK(!op_name.empty(), "must assign operation name");
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1323

This patch refactors the code to use `DSN_DEFINE_int64` instead of `dsn_config_get_value_int64/uint64` to load int64 type of configurations, and doesn't introduce any functional changes.
- all default value and most of description are kept as before
- move the defination of flags closer to the places where they're used
- remove `checkpoint_min_decree_gap` which is never used

NOTE: `rocksdb_max_open_files` is type of `int32` because `_db_opts.max_open_files` is type of `int32`.