### PR TITLE
feat(security): Use Apache Ranger for access control(1/n)

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -26,9 +26,11 @@ add_subdirectory(test)
 add_subdirectory(rpc)
 add_subdirectory(task)
 add_subdirectory(security)
+add_subdirectory(ranger)
 
 # TODO(zlw) remove perf_counter from dsn_runtime after the refactor by WuTao
 add_library(dsn_runtime STATIC
+        $<TARGET_OBJECTS:dsn_ranger>
         $<TARGET_OBJECTS:dsn.security>
         $<TARGET_OBJECTS:dsn.rpc>
         $<TARGET_OBJECTS:dsn.task>

--- a/src/runtime/ranger/CMakeLists.txt
+++ b/src/runtime/ranger/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(MY_PROJ_NAME dsn_ranger)
+
+# Search mode for source files under CURRENT project directory?
+# "GLOB_RECURSE" for recursive search
+# "GLOB" for non-recursive search
+set(MY_SRC_SEARCH_MODE "GLOB")
+
+set(MY_PROJ_LIBS "")
+
+# Extra files that will be installed
+set(MY_BINPLACES "")
+
+dsn_add_object()

--- a/src/runtime/ranger/ranger_resource_policy.cpp
+++ b/src/runtime/ranger/ranger_resource_policy.cpp
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ranger_resource_policy.h"
+
+namespace dsn {
+namespace ranger {
+
+bool policy_item::match(const access_type &ac_type, const std::string &user_name) const
+{
+    return (access_types & ac_type) != 0 && users.count(user_name) != 0;
+}
+
+bool acl_policies::allowed(const access_type &ac_type, const std::string &user_name) const
+{
+    // 1. Check if it is not allowed.
+    for (const auto &deny_policy : deny_policies) {
+        // 1.1. In 'deny_policies'.
+        if (!deny_policy.match(ac_type, user_name)) {
+            continue;
+        }
+        bool in_deny_policies_exclude = false;
+        for (const auto &deny_policy_exclude : deny_policies_exclude) {
+            if (deny_policy_exclude.match(ac_type, user_name)) {
+                in_deny_policies_exclude = true;
+                break;
+            }
+        }
+        // 1.2. Not in any 'deny_policies_exclude', it's not allowed.
+        if (!in_deny_policies_exclude) {
+            return false;
+        }
+    }
+
+    // 2. Check if it is allowed.
+    for (const auto &allow_policy : allow_policies) {
+        // 2.1. In 'allow_policies'.
+        if (!allow_policy.match(ac_type, user_name)) {
+            continue;
+        }
+        for (const auto &allow_policy_exclude : allow_policies_exclude) {
+            // 2.2. In some 'allow_policies_exclude', it's not allowed.
+            if (allow_policy_exclude.match(ac_type, user_name)) {
+                return false;
+            }
+        }
+        // 2.3. Not in any 'allow_policies_exclude', it's allowed.
+        return true;
+    }
+
+    // 3. Otherwise, it's not allowed.
+    return false;
+}
+
+void ranger_resource_policy::create_default_database_policy(ranger_resource_policy &acl)
+{
+    acl.name = "default database policy";
+    acl.database_names = {"*"};
+    policy_item item;
+    item.access_types = CREATE | DROP | LIST | METADATA | CONTROL;
+    acl.policies.allow_policies.emplace_back(item);
+}
+
+} // namespace ranger
+} // namespace dsn

--- a/src/runtime/ranger/ranger_resource_policy.cpp
+++ b/src/runtime/ranger/ranger_resource_policy.cpp
@@ -66,14 +66,5 @@ bool acl_policies::allowed(const access_type &ac_type, const std::string &user_n
     return false;
 }
 
-void ranger_resource_policy::create_default_database_policy(ranger_resource_policy &acl)
-{
-    acl.name = "default database policy";
-    acl.database_names = {"*"};
-    policy_item item;
-    item.access_types = CREATE | DROP | LIST | METADATA | CONTROL;
-    acl.policies.allow_policies.emplace_back(item);
-}
-
 } // namespace ranger
 } // namespace dsn

--- a/src/runtime/ranger/ranger_resource_policy.cpp
+++ b/src/runtime/ranger/ranger_resource_policy.cpp
@@ -20,9 +20,21 @@
 namespace dsn {
 namespace ranger {
 
+/*extern*/ access_type operator|(access_type lhs, access_type rhs)
+{
+    using act = std::underlying_type<access_type>::type;
+    return access_type(static_cast<act>(lhs) | static_cast<act>(rhs));
+}
+
+/*extern*/ access_type operator&(access_type lhs, access_type rhs)
+{
+    using act = std::underlying_type<access_type>::type;
+    return access_type(static_cast<act>(lhs) & static_cast<act>(rhs));
+}
+
 bool policy_item::match(const access_type &ac_type, const std::string &user_name) const
 {
-    return (access_types & ac_type) != 0 && users.count(user_name) != 0;
+    return static_cast<bool>(access_types & ac_type) && users.count(user_name) != 0;
 }
 
 bool acl_policies::allowed(const access_type &ac_type, const std::string &user_name) const

--- a/src/runtime/ranger/ranger_resource_policy.h
+++ b/src/runtime/ranger/ranger_resource_policy.h
@@ -31,7 +31,7 @@ namespace dsn {
 namespace ranger {
 
 // ACL type defined in Range service for RPC matching policy
-enum class access_type : int8_t
+enum class access_type : uint8_t
 {
     KRead = 1,
     KWrite = 1 << 1,

--- a/src/runtime/ranger/ranger_resource_policy.h
+++ b/src/runtime/ranger/ranger_resource_policy.h
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <rapidjson/document.h>
+
+#include "common/json_helper.h"
+#include "utils/fmt_logging.h"
+
+namespace dsn {
+namespace ranger {
+
+// ACL type defined in Range service for RPC matching policy
+enum access_type
+{
+    READ = 1,
+    WRITE = 1 << 1,
+    CREATE = 1 << 2,
+    DROP = 1 << 3,
+    LIST = 1 << 4,
+    METADATA = 1 << 5,
+    CONTROL = 1 << 6,
+};
+
+// Ranger policy data structure
+struct policy_item
+{
+    int8_t access_types;
+    std::unordered_set<std::string> users;
+
+    // Check if the 'acl_type' - 'user_name' pair is matched to the policy.
+    // Return true if it is matched, otherwise return false.
+    // TODO(wanghao): add benchmark test
+    bool match(const access_type &ac_type, const std::string &user_name) const;
+};
+
+// Data structure of policies with different priorities
+struct acl_policies
+{
+    // policy priority: deny_policies_exclude > deny_policies > allow_policies_exclude >
+    // allow_policies
+    std::vector<policy_item> allow_policies;
+    std::vector<policy_item> allow_policies_exclude;
+    std::vector<policy_item> deny_policies;
+    std::vector<policy_item> deny_policies_exclude;
+
+    // Check whether the 'user_name' is allowed to access the resource by type of 'ac_type'.
+    bool allowed(const access_type &ac_type, const std::string &user_name) const;
+};
+
+// A policy data structure definition of ranger resources
+struct ranger_resource_policy
+{
+public:
+    ranger_resource_policy() = default;
+    ~ranger_resource_policy() = default;
+
+    // Create the default policy to adapt legacy tables.
+    // In Ranger policy, database prefix is required to identify the database it belongs to, but for
+    // the tables which are created before Ranger policy is introduced to Pegasus, they don't have
+    // such a prefix. So we create a default database policy for them.
+    static void create_default_database_policy(ranger_resource_policy &acl);
+
+public:
+    std::string name;
+    std::unordered_set<std::string> database_names;
+    std::unordered_set<std::string> table_names;
+    acl_policies policies;
+};
+
+} // namespace ranger
+} // namespace dsn

--- a/src/runtime/ranger/ranger_resource_policy.h
+++ b/src/runtime/ranger/ranger_resource_policy.h
@@ -75,12 +75,6 @@ public:
     ranger_resource_policy() = default;
     ~ranger_resource_policy() = default;
 
-    // Create the default policy to adapt legacy tables.
-    // In Ranger policy, database prefix is required to identify the database it belongs to, but for
-    // the tables which are created before Ranger policy is introduced to Pegasus, they don't have
-    // such a prefix. So we create a default database policy for them.
-    static void create_default_database_policy(ranger_resource_policy &acl);
-
 public:
     std::string name;
     std::unordered_set<std::string> database_names;

--- a/src/runtime/ranger/ranger_resource_policy.h
+++ b/src/runtime/ranger/ranger_resource_policy.h
@@ -31,15 +31,15 @@ namespace dsn {
 namespace ranger {
 
 // ACL type defined in Range service for RPC matching policy
-enum access_type
+enum access_type : int8_t
 {
-    READ = 1,
-    WRITE = 1 << 1,
-    CREATE = 1 << 2,
-    DROP = 1 << 3,
-    LIST = 1 << 4,
-    METADATA = 1 << 5,
-    CONTROL = 1 << 6,
+    KRead = 1,
+    KWrite = 1 << 1,
+    KCreate = 1 << 2,
+    KDrop = 1 << 3,
+    KList = 1 << 4,
+    KMetadata = 1 << 5,
+    KControl = 1 << 6,
 };
 
 // Ranger policy data structure
@@ -71,11 +71,6 @@ struct acl_policies
 // A policy data structure definition of ranger resources
 struct ranger_resource_policy
 {
-public:
-    ranger_resource_policy() = default;
-    ~ranger_resource_policy() = default;
-
-public:
     std::string name;
     std::unordered_set<std::string> database_names;
     std::unordered_set<std::string> table_names;

--- a/src/runtime/ranger/ranger_resource_policy.h
+++ b/src/runtime/ranger/ranger_resource_policy.h
@@ -31,7 +31,7 @@ namespace dsn {
 namespace ranger {
 
 // ACL type defined in Range service for RPC matching policy
-enum access_type : int8_t
+enum class access_type : int8_t
 {
     KRead = 1,
     KWrite = 1 << 1,
@@ -39,13 +39,17 @@ enum access_type : int8_t
     KDrop = 1 << 3,
     KList = 1 << 4,
     KMetadata = 1 << 5,
-    KControl = 1 << 6,
+    KControl = 1 << 6
 };
+
+extern access_type operator|(access_type lhs, access_type rhs);
+
+extern access_type operator&(access_type lhs, access_type rhs);
 
 // Ranger policy data structure
 struct policy_item
 {
-    int8_t access_types;
+    access_type access_types;
     std::unordered_set<std::string> users;
 
     // Check if the 'acl_type' - 'user_name' pair is matched to the policy.

--- a/src/runtime/test/ranger_resource_policy_test.cpp
+++ b/src/runtime/test/ranger_resource_policy_test.cpp
@@ -24,22 +24,22 @@ namespace ranger {
 
 TEST(ranger_resource_policy_test, policy_item_match)
 {
-    policy_item item = {READ | WRITE | CREATE, {"user1", "user2"}};
+    policy_item item = {KRead | KWrite | KCreate, {"user1", "user2"}};
     struct test_case
     {
         access_type ac_type;
         std::string user_name;
         bool expected_result;
-    } tests[] = {{READ, "", false},
-                 {READ, "user", false},
-                 {READ, "user1", true},
-                 {WRITE, "user1", true},
-                 {CREATE, "user1", true},
-                 {DROP, "user1", false},
-                 {LIST, "user1", false},
-                 {METADATA, "user1", false},
-                 {CONTROL, "user1", false},
-                 {WRITE, "user2", true}};
+    } tests[] = {{KRead, "", false},
+                 {KRead, "user", false},
+                 {KRead, "user1", true},
+                 {KWrite, "user1", true},
+                 {KCreate, "user1", true},
+                 {KDrop, "user1", false},
+                 {KList, "user1", false},
+                 {KMetadata, "user1", false},
+                 {KControl, "user1", false},
+                 {KWrite, "user2", true}};
     for (const auto &test : tests) {
         auto actual_result = item.match(test.ac_type, test.user_name);
         EXPECT_EQ(test.expected_result, actual_result);
@@ -49,23 +49,24 @@ TEST(ranger_resource_policy_test, policy_item_match)
 TEST(ranger_resource_policy_test, acl_policies_allowed)
 {
     acl_policies policy;
-    policy.allow_policies = {{READ | WRITE | CREATE, {"user1", "user2", "user3", "user4"}}};
-    policy.allow_policies_exclude = {{WRITE | CREATE, {"user2"}}};
-    policy.deny_policies = {{READ | WRITE, {"user3", "user4"}}};
-    policy.deny_policies_exclude = {{READ, {"user4"}}};
+    policy.allow_policies = {{KRead | KWrite | KCreate, {"user1", "user2", "user3", "user4"}}};
+    policy.allow_policies_exclude = {{KWrite | KCreate, {"user2"}}};
+    policy.deny_policies = {{KRead | KWrite, {"user3", "user4"}}};
+    policy.deny_policies_exclude = {{KRead, {"user4"}}};
     struct test_case
     {
         access_type ac_type;
         std::string user_name;
         bool expected_result;
-    } tests[] = {{READ, "user", false},      {READ, "user1", true},      {WRITE, "user1", true},
-                 {CREATE, "user1", true},    {DROP, "user1", false},     {LIST, "user1", false},
-                 {METADATA, "user1", false}, {CONTROL, "user1", false},  {READ, "user2", true},
-                 {WRITE, "user2", false},    {CREATE, "user2", false},   {DROP, "user2", false},
-                 {LIST, "user2", false},     {METADATA, "user2", false}, {CONTROL, "user2", false},
-                 {READ, "user3", false},     {CREATE, "user3", true},    {LIST, "user3", false},
-                 {READ, "user4", true},      {WRITE, "user4", false},    {CREATE, "user4", true},
-                 {LIST, "user4", false}};
+    } tests[] = {
+        {KRead, "user", false},      {KRead, "user1", true},      {KWrite, "user1", true},
+        {KCreate, "user1", true},    {KDrop, "user1", false},     {KList, "user1", false},
+        {KMetadata, "user1", false}, {KControl, "user1", false},  {KRead, "user2", true},
+        {KWrite, "user2", false},    {KCreate, "user2", false},   {KDrop, "user2", false},
+        {KList, "user2", false},     {KMetadata, "user2", false}, {KControl, "user2", false},
+        {KRead, "user3", false},     {KCreate, "user3", true},    {KList, "user3", false},
+        {KRead, "user4", true},      {KWrite, "user4", false},    {KCreate, "user4", true},
+        {KList, "user4", false}};
     for (const auto &test : tests) {
         auto actual_result = policy.allowed(test.ac_type, test.user_name);
         EXPECT_EQ(test.expected_result, actual_result);

--- a/src/runtime/test/ranger_resource_policy_test.cpp
+++ b/src/runtime/test/ranger_resource_policy_test.cpp
@@ -24,22 +24,23 @@ namespace ranger {
 
 TEST(ranger_resource_policy_test, policy_item_match)
 {
-    policy_item item = {KRead | KWrite | KCreate, {"user1", "user2"}};
+    policy_item item = {access_type::KRead | access_type::KWrite | access_type::KCreate,
+                        {"user1", "user2"}};
     struct test_case
     {
         access_type ac_type;
         std::string user_name;
         bool expected_result;
-    } tests[] = {{KRead, "", false},
-                 {KRead, "user", false},
-                 {KRead, "user1", true},
-                 {KWrite, "user1", true},
-                 {KCreate, "user1", true},
-                 {KDrop, "user1", false},
-                 {KList, "user1", false},
-                 {KMetadata, "user1", false},
-                 {KControl, "user1", false},
-                 {KWrite, "user2", true}};
+    } tests[] = {{access_type::KRead, "", false},
+                 {access_type::KRead, "user", false},
+                 {access_type::KRead, "user1", true},
+                 {access_type::KWrite, "user1", true},
+                 {access_type::KCreate, "user1", true},
+                 {access_type::KDrop, "user1", false},
+                 {access_type::KList, "user1", false},
+                 {access_type::KMetadata, "user1", false},
+                 {access_type::KControl, "user1", false},
+                 {access_type::KWrite, "user2", true}};
     for (const auto &test : tests) {
         auto actual_result = item.match(test.ac_type, test.user_name);
         EXPECT_EQ(test.expected_result, actual_result);
@@ -49,24 +50,27 @@ TEST(ranger_resource_policy_test, policy_item_match)
 TEST(ranger_resource_policy_test, acl_policies_allowed)
 {
     acl_policies policy;
-    policy.allow_policies = {{KRead | KWrite | KCreate, {"user1", "user2", "user3", "user4"}}};
-    policy.allow_policies_exclude = {{KWrite | KCreate, {"user2"}}};
-    policy.deny_policies = {{KRead | KWrite, {"user3", "user4"}}};
-    policy.deny_policies_exclude = {{KRead, {"user4"}}};
+    policy.allow_policies = {{access_type::KRead | access_type::KWrite | access_type::KCreate,
+                              {"user1", "user2", "user3", "user4"}}};
+    policy.allow_policies_exclude = {{access_type::KWrite | access_type::KCreate, {"user2"}}};
+    policy.deny_policies = {{access_type::KRead | access_type::KWrite, {"user3", "user4"}}};
+    policy.deny_policies_exclude = {{access_type::KRead, {"user4"}}};
     struct test_case
     {
         access_type ac_type;
         std::string user_name;
         bool expected_result;
-    } tests[] = {
-        {KRead, "user", false},      {KRead, "user1", true},      {KWrite, "user1", true},
-        {KCreate, "user1", true},    {KDrop, "user1", false},     {KList, "user1", false},
-        {KMetadata, "user1", false}, {KControl, "user1", false},  {KRead, "user2", true},
-        {KWrite, "user2", false},    {KCreate, "user2", false},   {KDrop, "user2", false},
-        {KList, "user2", false},     {KMetadata, "user2", false}, {KControl, "user2", false},
-        {KRead, "user3", false},     {KCreate, "user3", true},    {KList, "user3", false},
-        {KRead, "user4", true},      {KWrite, "user4", false},    {KCreate, "user4", true},
-        {KList, "user4", false}};
+    } tests[] = {{access_type::KRead, "user", false},      {access_type::KRead, "user1", true},
+                 {access_type::KWrite, "user1", true},     {access_type::KCreate, "user1", true},
+                 {access_type::KDrop, "user1", false},     {access_type::KList, "user1", false},
+                 {access_type::KMetadata, "user1", false}, {access_type::KControl, "user1", false},
+                 {access_type::KRead, "user2", true},      {access_type::KWrite, "user2", false},
+                 {access_type::KCreate, "user2", false},   {access_type::KDrop, "user2", false},
+                 {access_type::KList, "user2", false},     {access_type::KMetadata, "user2", false},
+                 {access_type::KControl, "user2", false},  {access_type::KRead, "user3", false},
+                 {access_type::KCreate, "user3", true},    {access_type::KList, "user3", false},
+                 {access_type::KRead, "user4", true},      {access_type::KWrite, "user4", false},
+                 {access_type::KCreate, "user4", true},    {access_type::KList, "user4", false}};
     for (const auto &test : tests) {
         auto actual_result = policy.allowed(test.ac_type, test.user_name);
         EXPECT_EQ(test.expected_result, actual_result);

--- a/src/runtime/test/ranger_resource_policy_test.cpp
+++ b/src/runtime/test/ranger_resource_policy_test.cpp
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "runtime/ranger/ranger_resource_policy.h"
+
+namespace dsn {
+namespace ranger {
+
+TEST(ranger_resource_policy_test, policy_item_match)
+{
+    policy_item item = {READ | WRITE | CREATE, {"user1", "user2"}};
+    struct test_case
+    {
+        access_type ac_type;
+        std::string user_name;
+        bool expected_result;
+    } tests[] = {{READ, "", false},
+                 {READ, "user", false},
+                 {READ, "user1", true},
+                 {WRITE, "user1", true},
+                 {CREATE, "user1", true},
+                 {DROP, "user1", false},
+                 {LIST, "user1", false},
+                 {METADATA, "user1", false},
+                 {CONTROL, "user1", false},
+                 {WRITE, "user2", true}};
+    for (const auto &test : tests) {
+        auto actual_result = item.match(test.ac_type, test.user_name);
+        EXPECT_EQ(test.expected_result, actual_result);
+    }
+}
+
+TEST(ranger_resource_policy_test, acl_policies_allowed)
+{
+    acl_policies policy;
+    policy.allow_policies = {{READ | WRITE | CREATE, {"user1", "user2", "user3", "user4"}}};
+    policy.allow_policies_exclude = {{WRITE | CREATE, {"user2"}}};
+    policy.deny_policies = {{READ | WRITE, {"user3", "user4"}}};
+    policy.deny_policies_exclude = {{READ, {"user4"}}};
+    struct test_case
+    {
+        access_type ac_type;
+        std::string user_name;
+        bool expected_result;
+    } tests[] = {{READ, "user", false},      {READ, "user1", true},      {WRITE, "user1", true},
+                 {CREATE, "user1", true},    {DROP, "user1", false},     {LIST, "user1", false},
+                 {METADATA, "user1", false}, {CONTROL, "user1", false},  {READ, "user2", true},
+                 {WRITE, "user2", false},    {CREATE, "user2", false},   {DROP, "user2", false},
+                 {LIST, "user2", false},     {METADATA, "user2", false}, {CONTROL, "user2", false},
+                 {READ, "user3", false},     {CREATE, "user3", true},    {LIST, "user3", false},
+                 {READ, "user4", true},      {WRITE, "user4", false},    {CREATE, "user4", true},
+                 {LIST, "user4", false}};
+    for (const auto &test : tests) {
+        auto actual_result = policy.allowed(test.ac_type, test.user_name);
+        EXPECT_EQ(test.expected_result, actual_result);
+    }
+}
+} // namespace ranger
+} // namespace dsn


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1054

This patch aim to define ranger policy:
- Define the ranger policy data structure.
- Realized the judgment logic function when performing ACL with different priorities.
- Add some unit test for test
