### PR TITLE
refactor(conf): use DSN_DEFINE_bool to load bool type of configs

### DIFF
--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -37,6 +37,7 @@
 namespace dsn {
 namespace replication {
 
+DSN_DEFINE_bool(replication, duplication_enabled, true, "is duplication enabled");
 DSN_DEFINE_int32(replication,
                  max_concurrent_bulk_load_downloading_count,
                  5,
@@ -87,33 +88,6 @@ DSN_DEFINE_bool(replication,
                 "whether to disable empty write, default is false");
 DSN_TAG_VARIABLE(empty_write_disabled, FT_MUTABLE);
 
-replication_options::replication_options()
-{
-    deny_client_on_start = false;
-    verbose_client_log_on_start = false;
-    verbose_commit_log_on_start = false;
-    delay_for_fd_timeout_on_start = false;
-    duplication_enabled = true;
-
-    batch_write_disabled = false;
-
-    group_check_disabled = false;
-
-    checkpoint_disabled = false;
-
-    gc_disabled = false;
-
-    disk_stat_disabled = false;
-
-    fd_disabled = false;
-
-    log_shared_force_flush = false;
-
-    config_sync_disabled = false;
-
-    mem_release_enabled = true;
-}
-
 replication_options::~replication_options() {}
 
 void replication_options::initialize()
@@ -160,80 +134,6 @@ void replication_options::initialize()
     }
 
     CHECK(!data_dirs.empty(), "no replica data dir found, maybe not set or excluded by black list");
-
-    deny_client_on_start = dsn_config_get_value_bool("replication",
-                                                     "deny_client_on_start",
-                                                     deny_client_on_start,
-                                                     "whether to deny client read "
-                                                     "and write requests when "
-                                                     "starting the server, default "
-                                                     "is false");
-    verbose_client_log_on_start = dsn_config_get_value_bool("replication",
-                                                            "verbose_client_log_on_start",
-                                                            verbose_client_log_on_start,
-                                                            "whether to print verbose error "
-                                                            "log when reply to client read "
-                                                            "and write requests when "
-                                                            "starting the server, default "
-                                                            "is false");
-    verbose_commit_log_on_start = dsn_config_get_value_bool("replication",
-                                                            "verbose_commit_log_on_start",
-                                                            verbose_commit_log_on_start,
-                                                            "whether to print verbose log "
-                                                            "when commit mutation when "
-                                                            "starting the server, default "
-                                                            "is false");
-    delay_for_fd_timeout_on_start =
-        dsn_config_get_value_bool("replication",
-                                  "delay_for_fd_timeout_on_start",
-                                  delay_for_fd_timeout_on_start,
-                                  "whether to delay for beacon grace period to make failure "
-                                  "detector timeout when starting the server, default is false");
-
-    duplication_enabled = dsn_config_get_value_bool(
-        "replication", "duplication_enabled", duplication_enabled, "is duplication enabled");
-
-    batch_write_disabled =
-        dsn_config_get_value_bool("replication",
-                                  "batch_write_disabled",
-                                  batch_write_disabled,
-                                  "whether to disable auto-batch of replicated write requests");
-
-    group_check_disabled = dsn_config_get_value_bool("replication",
-                                                     "group_check_disabled",
-                                                     group_check_disabled,
-                                                     "whether group check is disabled");
-
-    checkpoint_disabled = dsn_config_get_value_bool("replication",
-                                                    "checkpoint_disabled",
-                                                    checkpoint_disabled,
-                                                    "whether checkpoint is disabled");
-
-    gc_disabled = dsn_config_get_value_bool(
-        "replication", "gc_disabled", gc_disabled, "whether to disable garbage collection");
-
-    disk_stat_disabled = dsn_config_get_value_bool(
-        "replication", "disk_stat_disabled", disk_stat_disabled, "whether to disable disk stat");
-
-    fd_disabled = dsn_config_get_value_bool(
-        "replication", "fd_disabled", fd_disabled, "whether to disable failure detection");
-
-    log_shared_force_flush =
-        dsn_config_get_value_bool("replication",
-                                  "log_shared_force_flush",
-                                  log_shared_force_flush,
-                                  "when write shared log, whether to flush file after write done");
-
-    config_sync_disabled = dsn_config_get_value_bool(
-        "replication",
-        "config_sync_disabled",
-        config_sync_disabled,
-        "whether to disable replica configuration periodical sync with the meta server");
-
-    mem_release_enabled = dsn_config_get_value_bool("replication",
-                                                    "mem_release_enabled",
-                                                    mem_release_enabled,
-                                                    "whether to enable periodic memory release");
 
     cold_backup_root = dsn_config_get_value_string(
         "replication", "cold_backup_root", "", "cold backup remote storage path prefix");

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -65,36 +65,12 @@ public:
     std::vector<std::string> data_dirs;
     std::vector<std::string> data_dir_tags;
 
-    bool deny_client_on_start;
-    bool verbose_client_log_on_start;
-    bool verbose_commit_log_on_start;
-    bool delay_for_fd_timeout_on_start;
-    bool duplication_enabled;
-
-    bool batch_write_disabled;
-
-    bool group_check_disabled;
-
-    bool checkpoint_disabled;
-
-    bool gc_disabled;
-
-    bool disk_stat_disabled;
-
-    bool fd_disabled;
-
-    bool log_shared_force_flush;
-
-    bool config_sync_disabled;
-
-    bool mem_release_enabled;
-
     std::string cold_backup_root;
 
     int32_t max_concurrent_bulk_load_downloading_count;
 
 public:
-    replication_options();
+    replication_options() = default;
     ~replication_options();
 
     void initialize();

--- a/src/common/test/config-test.ini
+++ b/src/common/test/config-test.ini
@@ -58,9 +58,6 @@ stderr_start_level = LOG_LEVEL_WARNING
 [tools.simulator]
 random_seed = 1465902258
 
-[tools.screen_logger]
-short_header = false
-
 [network]
 ; how many network threads for network library (used by asio)
 io_service_worker_count = 2

--- a/src/failure_detector/test/config-test.ini
+++ b/src/failure_detector/test/config-test.ini
@@ -82,9 +82,6 @@ stderr_start_level = LOG_LEVEL_WARNING
 [tools.simulator]
 random_seed = 0
 
-[tools.screen_logger]
-short_header = false
-
 [network]
 ; how many network threads for network library (used by asio)
 io_service_worker_count = 2

--- a/src/failure_detector/test/config-whitelist-test-failed.ini
+++ b/src/failure_detector/test/config-whitelist-test-failed.ini
@@ -83,9 +83,6 @@ stderr_start_level = LOG_LEVEL_WARNING
 [tools.simulator]
 random_seed = 0
 
-[tools.screen_logger]
-short_header = false
-
 [network]
 ; how many network threads for network library (used by asio)
 io_service_worker_count = 2

--- a/src/failure_detector/test/config-whitelist-test.ini
+++ b/src/failure_detector/test/config-whitelist-test.ini
@@ -83,9 +83,6 @@ stderr_start_level = LOG_LEVEL_WARNING
 [tools.simulator]
 random_seed = 0
 
-[tools.screen_logger]
-short_header = false
-
 [network]
 ; how many network threads for network library (used by asio)
 io_service_worker_count = 2

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -23,11 +23,8 @@
 
 namespace dsn {
 namespace replication {
-// TODO(yingchun): update?
 DSN_DEFINE_bool(meta_server, balancer_in_turn, false, "balance the apps one-by-one/concurrently");
-// TODO(yingchun): update?
 DSN_DEFINE_bool(meta_server, only_primary_balancer, false, "only try to make the primary balanced");
-// TODO(yingchun): update?
 DSN_DEFINE_bool(meta_server,
                 only_move_primary,
                 false,

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -19,16 +19,25 @@
 #include "utils/fmt_logging.h"
 #include "app_balance_policy.h"
 #include "meta_service.h"
+#include "utils/flags.h"
 
 namespace dsn {
 namespace replication {
-
+// TODO(yingchun): update?
+DSN_DEFINE_bool(meta_server, balancer_in_turn, false, "balance the apps one-by-one/concurrently");
+// TODO(yingchun): update?
+DSN_DEFINE_bool(meta_server, only_primary_balancer, false, "only try to make the primary balanced");
+// TODO(yingchun): update?
+DSN_DEFINE_bool(meta_server,
+                only_move_primary,
+                false,
+                "only try to make the primary balanced by move");
 app_balance_policy::app_balance_policy(meta_service *svc) : load_balance_policy(svc)
 {
     if (_svc != nullptr) {
-        _balancer_in_turn = _svc->get_meta_options()._lb_opts.balancer_in_turn;
-        _only_primary_balancer = _svc->get_meta_options()._lb_opts.only_primary_balancer;
-        _only_move_primary = _svc->get_meta_options()._lb_opts.only_move_primary;
+        _balancer_in_turn = FLAGS_balancer_in_turn;
+        _only_primary_balancer = FLAGS_only_primary_balancer;
+        _only_move_primary = FLAGS_only_move_primary;
     } else {
         _balancer_in_turn = false;
         _only_primary_balancer = false;

--- a/src/meta/meta_http_service.cpp
+++ b/src/meta/meta_http_service.cpp
@@ -591,7 +591,7 @@ void meta_http_service::query_duplication_handler(const http_request &req, http_
         return;
     }
     if (_service->_dup_svc == nullptr) {
-        resp.body = "duplication is not enabled [duplication_enabled=false]";
+        resp.body = "duplication is not enabled [FLAGS_duplication_enabled=false]";
         resp.status_code = http_status_code::not_found;
         return;
     }

--- a/src/meta/meta_options.cpp
+++ b/src/meta/meta_options.cpp
@@ -38,7 +38,6 @@
 
 namespace dsn {
 namespace replication {
-
 std::string meta_options::concat_path_unix_style(const std::string &prefix,
                                                  const std::string &postfix)
 {
@@ -82,18 +81,6 @@ void meta_options::initialize()
                  "invalid function level: {}",
                  level_str);
 
-    recover_from_replica_server = dsn_config_get_value_bool(
-        "meta_server",
-        "recover_from_replica_server",
-        false,
-        "whether to recover from replica server when no apps in remote storage");
-
-    add_secondary_enable_flow_control =
-        dsn_config_get_value_bool("meta_server",
-                                  "add_secondary_enable_flow_control",
-                                  false,
-                                  "enable flow control for add secondary proposal");
-
     /// failure detector options
     _fd_opts.distributed_lock_service_type =
         dsn_config_get_value_string("meta_server",
@@ -113,26 +100,11 @@ void meta_options::initialize()
                                     "server_load_balancer_type",
                                     "greedy_load_balancer",
                                     "server load balancer provider");
-    _lb_opts.balancer_in_turn = dsn_config_get_value_bool(
-        "meta_server", "balancer_in_turn", false, "balance the apps one-by-one/concurrently");
-    _lb_opts.only_primary_balancer = dsn_config_get_value_bool(
-        "meta_server", "only_primary_balancer", false, "only try to make the primary balanced");
-    _lb_opts.only_move_primary = dsn_config_get_value_bool(
-        "meta_server", "only_move_primary", false, "only try to make the primary balanced by move");
 
     partition_guardian_type = dsn_config_get_value_string("meta_server",
                                                           "partition_guardian_type",
                                                           "partition_guardian",
                                                           "partition guardian provider");
-
-    cold_backup_disabled = dsn_config_get_value_bool(
-        "meta_server", "cold_backup_disabled", true, "whether to disable cold backup");
-
-    enable_white_list =
-        dsn_config_get_value_bool("meta_server",
-                                  "enable_white_list",
-                                  false,
-                                  "whether to enable white list of replica servers");
 
     const char *replica_white_list_raw = dsn_config_get_value_string(
         "meta_server", "replica_white_list", "", "white list of replica-servers in meta-server");

--- a/src/meta/meta_options.h
+++ b/src/meta/meta_options.h
@@ -65,10 +65,6 @@ class lb_suboptions
 {
 public:
     std::string server_load_balancer_type;
-
-    bool balancer_in_turn;
-    bool only_primary_balancer;
-    bool only_move_primary;
 };
 
 class meta_options
@@ -79,17 +75,10 @@ public:
     std::vector<std::string> meta_state_service_args;
 
     meta_function_level::type meta_function_level_on_start;
-    bool recover_from_replica_server;
-
-    bool add_secondary_enable_flow_control;
 
     fd_suboptions _fd_opts;
     lb_suboptions _lb_opts;
     std::string partition_guardian_type;
-
-    bool cold_backup_disabled;
-
-    bool enable_white_list;
     std::vector<std::string> replica_white_list;
 
 public:

--- a/src/meta/test/config-test.ini
+++ b/src/meta/test/config-test.ini
@@ -56,9 +56,6 @@ stderr_start_level = LOG_LEVEL_ERROR
 [tools.simulator]
 random_seed = 1465902258
 
-[tools.screen_logger]
-short_header = false
-
 [network]
 ; how many network threads for network library (used by asio)
 io_service_worker_count = 2

--- a/src/meta/test/meta_state/config-test.ini
+++ b/src/meta/test/meta_state/config-test.ini
@@ -66,9 +66,6 @@ stderr_start_level = LOG_LEVEL_WARNING
 [tools.simulator]
 random_seed = 0
 
-[tools.screen_logger]
-short_header = false
-
 [network]
 ; how many network threads for network library (used by asio)
 io_service_worker_count = 2

--- a/src/replica/bulk_load/test/config-test.ini
+++ b/src/replica/bulk_load/test/config-test.ini
@@ -56,9 +56,6 @@ stderr_start_level = LOG_LEVEL_WARNING
 [tools.simulator]
 random_seed = 1465902258
 
-[tools.screen_logger]
-short_header = false
-
 [network]
 ; how many network threads for network library (used by asio)
 io_service_worker_count = 2

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -51,6 +51,10 @@
 namespace dsn {
 namespace replication {
 
+DSN_DEFINE_bool(replication,
+                batch_write_disabled,
+                false,
+                "whether to disable auto-batch of replicated write requests");
 DSN_DEFINE_int32(replication,
                  staleness_for_commit,
                  10,
@@ -83,7 +87,7 @@ replica::replica(replica_stub *stub,
     : serverlet<replica>("replica"),
       replica_base(gpid, fmt::format("{}@{}", gpid, stub->_primary_address_str), app.app_name),
       _app_info(app),
-      _primary_states(gpid, FLAGS_staleness_for_commit, stub->options().batch_write_disabled),
+      _primary_states(gpid, FLAGS_staleness_for_commit, FLAGS_batch_write_disabled),
       _potential_secondary_states(this),
       _cold_backup_running_count(0),
       _cold_backup_max_duration_time_ms(0),

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -47,6 +47,7 @@
 
 namespace dsn {
 namespace replication {
+DSN_DEFINE_bool(replication, group_check_disabled, false, "whether group check is disabled");
 DSN_DEFINE_int32(replication,
                  group_check_interval_ms,
                  10000,
@@ -62,7 +63,7 @@ void replica::init_group_check()
 
     LOG_INFO_PREFIX("init group check");
 
-    if (partition_status::PS_PRIMARY != status() || _options->group_check_disabled)
+    if (partition_status::PS_PRIMARY != status() || FLAGS_group_check_disabled)
         return;
 
     CHECK(nullptr == _primary_states.group_check_task, "");

--- a/src/replica/replica_http_service.cpp
+++ b/src/replica/replica_http_service.cpp
@@ -31,7 +31,7 @@ namespace replication {
 void replica_http_service::query_duplication_handler(const http_request &req, http_response &resp)
 {
     if (!_stub->_duplication_sync_timer) {
-        resp.body = "duplication is not enabled [duplication_enabled=false]";
+        resp.body = "duplication is not enabled [FLAGS_duplication_enabled=false]";
         resp.status_code = http_status_code::not_found;
         return;
     }

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -38,7 +38,7 @@
 
 namespace dsn {
 namespace replication {
-
+DSN_DEFINE_bool(replication, checkpoint_disabled, false, "whether checkpoint is disabled");
 DSN_DEFINE_int32(replication,
                  checkpoint_interval_seconds,
                  100,
@@ -354,7 +354,7 @@ error_code replica::init_app_and_prepare_list(bool create_new)
         }
 
         if (err == ERR_OK) {
-            if (_checkpoint_timer == nullptr && !_options->checkpoint_disabled) {
+            if (_checkpoint_timer == nullptr && !FLAGS_checkpoint_disabled) {
                 _checkpoint_timer =
                     tasking::enqueue_timer(LPC_PER_REPLICA_CHECKPOINT_TIMER,
                                            &_tracker,

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -70,7 +70,41 @@ DSN_DEFINE_bool(replication,
                 ignore_broken_disk,
                 true,
                 "true means ignore broken data disk when initialize");
-
+DSN_DEFINE_bool(replication,
+                deny_client_on_start,
+                false,
+                "whether to deny client read and write requests when starting the server, default "
+                "is false");
+DSN_DEFINE_bool(replication,
+                verbose_client_log_on_start,
+                false,
+                "whether to print verbose error log when reply to client read and write requests "
+                "when starting the server, default is false");
+DSN_DEFINE_bool(replication,
+                mem_release_enabled,
+                true,
+                "whether to enable periodic memory release");
+DSN_DEFINE_bool(replication,
+                log_shared_force_flush,
+                false,
+                "when write shared log, whether to flush file after write done");
+DSN_DEFINE_bool(replication, gc_disabled, false, "whether to disable garbage collection");
+DSN_DEFINE_bool(replication, disk_stat_disabled, false, "whether to disable disk stat");
+DSN_DEFINE_bool(replication,
+                delay_for_fd_timeout_on_start,
+                false,
+                "whether to delay for beacon grace period to make failure detector timeout when "
+                "starting the server, default is false");
+DSN_DEFINE_bool(replication,
+                config_sync_disabled,
+                false,
+                "whether to disable replica configuration periodical sync with the meta server");
+DSN_DEFINE_bool(replication, fd_disabled, false, "whether to disable failure detection");
+DSN_DEFINE_bool(replication,
+                verbose_commit_log_on_start,
+                false,
+                "whether to print verbose log when commit mutation when starting the server, "
+                "default is false");
 DSN_DEFINE_uint32(replication,
                   max_concurrent_manual_emergency_checkpointing_count,
                   10,
@@ -112,6 +146,7 @@ DSN_DEFINE_int32(
     "if tcmalloc reserved but not-used memory exceed this percentage of application allocated "
     "memory, replica server will release the exceeding memory back to operating system");
 
+DSN_DECLARE_bool(duplication_enabled);
 DSN_DECLARE_int32(fd_beacon_interval_seconds);
 DSN_DECLARE_int32(fd_check_interval_seconds);
 DSN_DECLARE_int32(fd_grace_seconds);
@@ -517,10 +552,10 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     }
     LOG_INFO("meta_servers = {}", oss.str());
 
-    _deny_client = _options.deny_client_on_start;
-    _verbose_client_log = _options.verbose_client_log_on_start;
-    _verbose_commit_log = _options.verbose_commit_log_on_start;
-    _release_tcmalloc_memory = _options.mem_release_enabled;
+    _deny_client = FLAGS_deny_client_on_start;
+    _verbose_client_log = FLAGS_verbose_client_log_on_start;
+    _verbose_commit_log = FLAGS_verbose_commit_log_on_start;
+    _release_tcmalloc_memory = FLAGS_mem_release_enabled;
     _mem_release_max_reserved_mem_percentage = FLAGS_mem_release_max_reserved_mem_percentage;
     _max_concurrent_bulk_load_downloading_count =
         _options.max_concurrent_bulk_load_downloading_count;
@@ -545,7 +580,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
 
     _log = new mutation_log_shared(_options.slog_dir,
                                    FLAGS_log_shared_file_size_mb,
-                                   _options.log_shared_force_flush,
+                                   FLAGS_log_shared_force_flush,
                                    &_counter_shared_log_recent_write_size);
     LOG_INFO("slog_dir = {}", _options.slog_dir);
 
@@ -672,7 +707,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
               _options.slog_dir);
         _log = new mutation_log_shared(_options.slog_dir,
                                        FLAGS_log_shared_file_size_mb,
-                                       _options.log_shared_force_flush,
+                                       FLAGS_log_shared_force_flush,
                                        &_counter_shared_log_recent_write_size);
         CHECK_EQ_MSG(_log->open(nullptr, [this](error_code err) { this->handle_log_failure(err); }),
                      ERR_OK,
@@ -719,7 +754,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     }
 
     // gc
-    if (false == _options.gc_disabled) {
+    if (false == FLAGS_gc_disabled) {
         _gc_timer_task = tasking::enqueue_timer(
             LPC_GARBAGE_COLLECT_LOGS_AND_REPLICAS,
             &_tracker,
@@ -730,7 +765,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     }
 
     // disk stat
-    if (false == _options.disk_stat_disabled) {
+    if (!FLAGS_disk_stat_disabled) {
         _disk_stat_timer_task =
             ::dsn::tasking::enqueue_timer(LPC_DISK_STAT,
                                           &_tracker,
@@ -752,7 +787,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
 
     dist::cmd::register_remote_command_rpc();
 
-    if (_options.delay_for_fd_timeout_on_start) {
+    if (FLAGS_delay_for_fd_timeout_on_start) {
         uint64_t now_time_ms = dsn_now_ms();
         uint64_t delay_time_ms =
             (FLAGS_fd_grace_seconds + 3) * 1000; // for more 3 seconds than grace seconds
@@ -811,7 +846,7 @@ void replica_stub::initialize_start()
     }
 
     // start timer for configuration sync
-    if (!_options.config_sync_disabled) {
+    if (!FLAGS_config_sync_disabled) {
         _config_sync_timer_task =
             tasking::enqueue_timer(LPC_QUERY_CONFIGURATION_ALL,
                                    &_tracker,
@@ -834,7 +869,7 @@ void replica_stub::initialize_start()
                                std::chrono::milliseconds(FLAGS_mem_release_check_interval_ms));
 #endif
 
-    if (_options.duplication_enabled) {
+    if (FLAGS_duplication_enabled) {
         _duplication_sync_timer = dsn::make_unique<duplication_sync_timer>(this);
         _duplication_sync_timer->start();
     }
@@ -843,7 +878,7 @@ void replica_stub::initialize_start()
 
     // init liveness monitor
     CHECK_EQ(NS_Disconnected, _state);
-    if (!_options.fd_disabled) {
+    if (!FLAGS_fd_disabled) {
         _failure_detector = std::make_shared<dsn::dist::slave_failure_detector_with_multimaster>(
             _options.meta_servers,
             [this]() { this->on_meta_server_disconnected(); },
@@ -1675,7 +1710,7 @@ void replica_stub::response_client(gpid id,
 
 void replica_stub::init_gc_for_test()
 {
-    CHECK(_options.gc_disabled, "");
+    CHECK(FLAGS_gc_disabled, "");
 
     _gc_timer_task = tasking::enqueue(LPC_GARBAGE_COLLECT_LOGS_AND_REPLICAS,
                                       &_tracker,

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -752,7 +752,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     }
 
     // gc
-    if (false == FLAGS_gc_disabled) {
+    if (!FLAGS_gc_disabled) {
         _gc_timer_task = tasking::enqueue_timer(
             LPC_GARBAGE_COLLECT_LOGS_AND_REPLICAS,
             &_tracker,

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -73,13 +73,12 @@ DSN_DEFINE_bool(replication,
 DSN_DEFINE_bool(replication,
                 deny_client_on_start,
                 false,
-                "whether to deny client read and write requests when starting the server, default "
-                "is false");
+                "whether to deny client read and write requests when starting the server");
 DSN_DEFINE_bool(replication,
                 verbose_client_log_on_start,
                 false,
                 "whether to print verbose error log when reply to client read and write requests "
-                "when starting the server, default is false");
+                "when starting the server");
 DSN_DEFINE_bool(replication,
                 mem_release_enabled,
                 true,
@@ -94,7 +93,7 @@ DSN_DEFINE_bool(replication,
                 delay_for_fd_timeout_on_start,
                 false,
                 "whether to delay for beacon grace period to make failure detector timeout when "
-                "starting the server, default is false");
+                "starting the server");
 DSN_DEFINE_bool(replication,
                 config_sync_disabled,
                 false,
@@ -103,8 +102,7 @@ DSN_DEFINE_bool(replication, fd_disabled, false, "whether to disable failure det
 DSN_DEFINE_bool(replication,
                 verbose_commit_log_on_start,
                 false,
-                "whether to print verbose log when commit mutation when starting the server, "
-                "default is false");
+                "whether to print verbose log when commit mutation when starting the server");
 DSN_DEFINE_uint32(replication,
                   max_concurrent_manual_emergency_checkpointing_count,
                   10,

--- a/src/replica/split/test/config-test.ini
+++ b/src/replica/split/test/config-test.ini
@@ -56,9 +56,6 @@ stderr_start_level = LOG_LEVEL_WARNING
 [tools.simulator]
 random_seed = 1465902258
 
-[tools.screen_logger]
-short_header = false
-
 [network]
 ; how many network threads for network library (used by asio)
 io_service_worker_count = 2

--- a/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
@@ -37,13 +37,10 @@
 #include <fstream>
 #include <sstream>
 #include "utils/filesystem.h"
-#include "utils/flags.h"
 
 namespace dsn {
 namespace replication {
 namespace application {
-
-DSN_DEFINE_bool(test, test_file_learning, true, "");
 
 simple_kv_service_impl::simple_kv_service_impl(replica *r) : simple_kv_service(r), _lock(true)
 {

--- a/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
@@ -37,10 +37,13 @@
 #include <fstream>
 #include <sstream>
 #include "utils/filesystem.h"
+#include "utils/flags.h"
 
 namespace dsn {
 namespace replication {
 namespace application {
+
+DSN_DEFINE_bool(test, test_file_learning, true, "");
 
 simple_kv_service_impl::simple_kv_service_impl(replica *r) : simple_kv_service(r), _lock(true)
 {
@@ -48,11 +51,7 @@ simple_kv_service_impl::simple_kv_service_impl(replica *r) : simple_kv_service(r
     LOG_INFO("simple_kv_service_impl inited");
 }
 
-void simple_kv_service_impl::reset_state()
-{
-    _test_file_learning = dsn_config_get_value_bool("test", "test_file_learning", true, "");
-    _last_durable_decree = 0;
-}
+void simple_kv_service_impl::reset_state() { _last_durable_decree = 0; }
 
 // RPC_SIMPLE_KV_READ
 void simple_kv_service_impl::on_read(const std::string &key, ::dsn::rpc_replier<std::string> &reply)

--- a/src/replica/storage/simple_kv/simple_kv.server.impl.h
+++ b/src/replica/storage/simple_kv/simple_kv.server.impl.h
@@ -109,7 +109,6 @@ private:
     typedef std::map<std::string, std::string> simple_kv;
     zlock _lock;
     simple_kv _store;
-    bool _test_file_learning;
     int64_t _last_durable_decree;
 };
 }

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
@@ -27,12 +27,15 @@
 #include <fstream>
 #include <sstream>
 #include "utils/filesystem.h"
+#include "utils/flags.h"
 
 #define VALUE_NOT_EXIST "<<not-exist>>"
 
 namespace dsn {
 namespace replication {
 namespace test {
+
+DSN_DECLARE_bool(test_file_learning);
 
 bool simple_kv_service_impl::s_simple_kv_open_fail = false;
 bool simple_kv_service_impl::s_simple_kv_close_fail = false;
@@ -45,11 +48,7 @@ simple_kv_service_impl::simple_kv_service_impl(replica *r) : simple_kv_service(r
     LOG_INFO("simple_kv_service_impl inited");
 }
 
-void simple_kv_service_impl::reset_state()
-{
-    _test_file_learning = dsn_config_get_value_bool("test", "test_file_learning", true, "");
-    _last_durable_decree = 0;
-}
+void simple_kv_service_impl::reset_state() { _last_durable_decree = 0; }
 
 // RPC_SIMPLE_KV_READ
 void simple_kv_service_impl::on_read(const std::string &key, ::dsn::rpc_replier<std::string> &reply)

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
@@ -27,15 +27,12 @@
 #include <fstream>
 #include <sstream>
 #include "utils/filesystem.h"
-#include "utils/flags.h"
 
 #define VALUE_NOT_EXIST "<<not-exist>>"
 
 namespace dsn {
 namespace replication {
 namespace test {
-
-DSN_DECLARE_bool(test_file_learning);
 
 bool simple_kv_service_impl::s_simple_kv_open_fail = false;
 bool simple_kv_service_impl::s_simple_kv_close_fail = false;

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.h
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.h
@@ -109,7 +109,6 @@ private:
     typedef std::map<std::string, std::string> simple_kv;
     simple_kv _store;
     ::dsn::zlock _lock;
-    bool _test_file_learning;
 
     int64_t _last_durable_decree;
 };

--- a/src/replica/test/config-test.ini
+++ b/src/replica/test/config-test.ini
@@ -56,9 +56,6 @@ stderr_start_level = LOG_LEVEL_WARNING
 [tools.simulator]
 random_seed = 1465902258
 
-[tools.screen_logger]
-short_header = false
-
 [network]
 ; how many network threads for network library (used by asio)
 io_service_worker_count = 2

--- a/src/replica/test/replica_http_service_test.cpp
+++ b/src/replica/test/replica_http_service_test.cpp
@@ -27,7 +27,8 @@ using std::string;
 
 namespace dsn {
 namespace replication {
-
+DSN_DECLARE_bool(duplication_enabled);
+DSN_DECLARE_bool(fd_disabled);
 DSN_DECLARE_uint32(config_sync_interval_ms);
 
 class replica_http_service_test : public replica_test_base
@@ -36,8 +37,8 @@ public:
     replica_http_service_test()
     {
         // Disable unnecessary works before starting stub.
-        stub->_options.fd_disabled = true;
-        stub->_options.duplication_enabled = false;
+        FLAGS_fd_disabled = true;
+        FLAGS_duplication_enabled = false;
         stub->initialize_start();
 
         http_call_registry::instance().clear_paths();

--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -50,6 +50,11 @@
 #include "utils/time_utils.h"
 #include "utils/process_utils.h"
 
+DSN_DEFINE_bool(core,
+                pause_on_start,
+                false,
+                "whether to pause at startup time for easier debugging");
+
 #ifdef DSN_ENABLE_GPERF
 DSN_DEFINE_double(core,
                   tcmalloc_release_rate,
@@ -372,10 +377,7 @@ bool run(const char *config_file,
     dsn_all.magic = 0xdeadbeef;
 
     // pause when necessary
-    if (dsn_config_get_value_bool("core",
-                                  "pause_on_start",
-                                  false,
-                                  "whether to pause at startup time for easier debugging")) {
+    if (FLAGS_pause_on_start) {
         printf("\nPause for debugging (pid = %d)...\n", static_cast<int>(getpid()));
         getchar();
     }

--- a/src/runtime/tracer.cpp
+++ b/src/runtime/tracer.cpp
@@ -29,9 +29,12 @@
 #include "aio/aio_task.h"
 #include "utils/filesystem.h"
 #include "utils/command_manager.h"
+#include "utils/flags.h"
 
 namespace dsn {
 namespace tools {
+
+DSN_DEFINE_bool(task..default, is_trace, false, "whether to trace tasks by default");
 
 static void tracer_on_task_create(task *caller, task *callee)
 {
@@ -278,9 +281,6 @@ static std::string tracer_log_flow(const std::vector<std::string> &args)
 
 void tracer::install(service_spec &spec)
 {
-    auto trace = dsn_config_get_value_bool(
-        "task..default", "is_trace", false, "whether to trace tasks by default");
-
     for (int i = 0; i <= dsn::task_code::max(); i++) {
         if (i == TASK_CODE_INVALID)
             continue;
@@ -290,8 +290,10 @@ void tracer::install(service_spec &spec)
         task_spec *spec = task_spec::get(i);
         CHECK_NOTNULL(spec, "");
 
-        if (!dsn_config_get_value_bool(
-                section_name.c_str(), "is_trace", trace, "whether to trace this kind of task"))
+        if (!dsn_config_get_value_bool(section_name.c_str(),
+                                       "is_trace",
+                                       FLAGS_is_trace,
+                                       "whether to trace this kind of task"))
             continue;
 
         if (dsn_config_get_value_bool(section_name.c_str(),

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -420,7 +420,6 @@ private:
 
     dsn::gpid _gpid;
     std::string _primary_address;
-    bool _verbose_log;
     // slow query time threshold. exceed this threshold will be logged.
     uint64_t _slow_query_threshold_ns;
 

--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -29,9 +29,10 @@
 
 namespace pegasus {
 namespace server {
+DSN_DECLARE_bool(rocksdb_verbose_log);
 
-pegasus_server_write::pegasus_server_write(pegasus_server_impl *server, bool verbose_log)
-    : replica_base(server), _write_svc(new pegasus_write_service(server)), _verbose_log(verbose_log)
+pegasus_server_write::pegasus_server_write(pegasus_server_impl *server)
+    : replica_base(server), _write_svc(new pegasus_write_service(server))
 {
     char name[256];
     snprintf(name, 255, "recent_corrupt_write_count@%s", get_gpid().to_string());
@@ -146,7 +147,7 @@ void pegasus_server_write::request_key_check(int64_t decree,
         CHECK_EQ_MSG(msg->header->client.thread_hash, thread_hash, "inconsistent thread hash");
     }
 
-    if (_verbose_log) {
+    if (FLAGS_rocksdb_verbose_log) {
         ::dsn::blob hash_key, sort_key;
         pegasus_restore_key(key, hash_key, sort_key);
 

--- a/src/server/pegasus_server_write.h
+++ b/src/server/pegasus_server_write.h
@@ -31,7 +31,7 @@ namespace server {
 class pegasus_server_write : public dsn::replication::replica_base
 {
 public:
-    pegasus_server_write(pegasus_server_impl *server, bool verbose_log);
+    pegasus_server_write(pegasus_server_impl *server);
 
     /// \return error code returned by rocksdb, i.e rocksdb::Status::code.
     /// **NOTE**
@@ -84,8 +84,6 @@ private:
 
     db_write_context _write_ctx;
     int64_t _decree;
-
-    const bool _verbose_log;
 
     typedef std::map<dsn::task_code, std::function<int(dsn::message_ex *)>> non_batch_writes_map;
     non_batch_writes_map _non_batch_write_handlers;

--- a/src/server/test/pegasus_server_write_test.cpp
+++ b/src/server/test/pegasus_server_write_test.cpp
@@ -37,7 +37,7 @@ public:
     pegasus_server_write_test() : pegasus_server_test_base()
     {
         start();
-        _server_write = dsn::make_unique<pegasus_server_write>(_server.get(), true);
+        _server_write = dsn::make_unique<pegasus_server_write>(_server.get());
     }
 
     void test_batch_writes()

--- a/src/server/test/pegasus_write_service_impl_test.cpp
+++ b/src/server/test/pegasus_write_service_impl_test.cpp
@@ -37,7 +37,7 @@ public:
     void SetUp() override
     {
         start();
-        _server_write = dsn::make_unique<pegasus_server_write>(_server.get(), true);
+        _server_write = dsn::make_unique<pegasus_server_write>(_server.get());
         _write_impl = _server_write->_write_svc->_impl.get();
         _rocksdb_wrapper = _write_impl->_rocksdb_wrapper.get();
     }

--- a/src/server/test/pegasus_write_service_test.cpp
+++ b/src/server/test/pegasus_write_service_test.cpp
@@ -39,7 +39,7 @@ public:
     void SetUp() override
     {
         start();
-        _server_write = dsn::make_unique<pegasus_server_write>(_server.get(), true);
+        _server_write = dsn::make_unique<pegasus_server_write>(_server.get());
         _write_svc = _server_write->_write_svc.get();
     }
 

--- a/src/server/test/rocksdb_wrapper_test.cpp
+++ b/src/server/test/rocksdb_wrapper_test.cpp
@@ -34,7 +34,7 @@ public:
     void SetUp() override
     {
         start();
-        _server_write = dsn::make_unique<pegasus_server_write>(_server.get(), true);
+        _server_write = dsn::make_unique<pegasus_server_write>(_server.get());
         _rocksdb_wrapper = _server_write->_write_svc->_impl->_rocksdb_wrapper.get();
 
         pegasus::pegasus_generate_key(

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -40,7 +40,6 @@ namespace dsn {
 namespace tools {
 
 DSN_DEFINE_bool(tools.simple_logger, fast_flush, false, "whether to flush immediately");
-
 DSN_DEFINE_bool(tools.simple_logger,
                 short_header,
                 true,
@@ -85,14 +84,7 @@ static void print_header(FILE *fp, dsn_log_level_t log_level)
 
 screen_logger::screen_logger(bool short_header) { _short_header = short_header; }
 
-screen_logger::screen_logger(const char *log_dir)
-{
-    _short_header =
-        dsn_config_get_value_bool("tools.screen_logger",
-                                  "short_header",
-                                  true,
-                                  "whether to use short header (excluding file/function etc.)");
-}
+screen_logger::screen_logger(const char *log_dir) { _short_header = FLAGS_short_header; }
 
 screen_logger::~screen_logger(void) {}
 

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -84,8 +84,6 @@ static void print_header(FILE *fp, dsn_log_level_t log_level)
 
 screen_logger::screen_logger(bool short_header) { _short_header = short_header; }
 
-screen_logger::screen_logger(const char *log_dir) { _short_header = FLAGS_short_header; }
-
 screen_logger::~screen_logger(void) {}
 
 void screen_logger::dsn_logv(const char *file,

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -40,8 +40,7 @@ namespace tools {
 class screen_logger : public logging_provider
 {
 public:
-    screen_logger(bool short_header);
-    screen_logger(const char *log_dir);
+    explicit screen_logger(bool short_header);
     ~screen_logger() override;
 
     virtual void dsn_logv(const char *file,

--- a/src/utils/test/logger.cpp
+++ b/src/utils/test/logger.cpp
@@ -94,7 +94,7 @@ TEST(tools_common, simple_logger)
     dsn::logging_provider::instance()->deregister_commands();
 
     {
-        auto logger = dsn::make_unique<screen_logger>("./");
+        auto logger = dsn::make_unique<screen_logger>(true);
         log_print(logger.get(), "%s", "test_print");
         std::thread t([](screen_logger *lg) { log_print(lg, "%s", "test_print"); }, logger.get());
         t.join();

--- a/src/zookeeper/test/config-test.ini
+++ b/src/zookeeper/test/config-test.ini
@@ -74,9 +74,6 @@ stderr_start_level = LOG_LEVEL_WARNING
 [tools.simulator]
 random_seed = 0
 
-[tools.screen_logger]
-short_header = false
-
 [network]
 ; how many network threads for network library (used by asio)
 io_service_worker_count = 2


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1323

This patch refactors the code to use `DSN_DEFINE_bool` instead of `dsn_config_get_value_bool` to load bool type of configurations, and doesn't introduce any functional changes.
- all default value and most of description are kept as before
- move the defination of flags closer to the places where they're used