### PR TITLE
refactor(conf): use DSN_DEFINE_string to load string type of configs

### DIFF
--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -65,8 +65,6 @@ public:
     std::vector<std::string> data_dirs;
     std::vector<std::string> data_dir_tags;
 
-    std::string cold_backup_root;
-
     int32_t max_concurrent_bulk_load_downloading_count;
 
 public:

--- a/src/meta/meta_http_service.cpp
+++ b/src/meta/meta_http_service.cpp
@@ -40,6 +40,9 @@
 #include "meta/meta_bulk_load_service.h"
 
 namespace dsn {
+namespace dist {
+DSN_DECLARE_string(hosts_list);
+} // namespace dist
 namespace replication {
 
 struct list_nodes_helper
@@ -456,10 +459,7 @@ void meta_http_service::get_cluster_info_handler(const http_request &req, http_r
     }
     tp.add_row_name_and_data("meta_servers", meta_servers_str);
     tp.add_row_name_and_data("primary_meta_server", dsn_primary_address().to_std_string());
-    std::string zk_hosts =
-        dsn_config_get_value_string("zookeeper", "hosts_list", "", "zookeeper_hosts");
-    zk_hosts.erase(std::remove_if(zk_hosts.begin(), zk_hosts.end(), ::isspace), zk_hosts.end());
-    tp.add_row_name_and_data("zookeeper_hosts", zk_hosts);
+    tp.add_row_name_and_data("zookeeper_hosts", dsn::dist::FLAGS_hosts_list);
     tp.add_row_name_and_data("zookeeper_root", _service->_cluster_root);
     tp.add_row_name_and_data(
         "meta_function_level",

--- a/src/meta/meta_options.cpp
+++ b/src/meta/meta_options.cpp
@@ -38,6 +38,24 @@
 
 namespace dsn {
 namespace replication {
+// TODO(yingchun): add more description for string configs, and add validators
+DSN_DEFINE_string(meta_server,
+                  meta_state_service_parameters,
+                  "",
+                  "meta_state_service provider parameters");
+DSN_DEFINE_string(meta_server,
+                  meta_function_level_on_start,
+                  "steady",
+                  "meta function level on start");
+DSN_DEFINE_string(meta_server,
+                  distributed_lock_service_parameters,
+                  "",
+                  "distributed_lock_service provider parameters");
+DSN_DEFINE_string(meta_server,
+                  replica_white_list,
+                  "",
+                  "white list of replica-servers in meta-server");
+
 std::string meta_options::concat_path_unix_style(const std::string &prefix,
                                                  const std::string &postfix)
 {
@@ -52,24 +70,10 @@ std::string meta_options::concat_path_unix_style(const std::string &prefix,
 
 void meta_options::initialize()
 {
-    cluster_root = dsn_config_get_value_string(
-        "meta_server", "cluster_root", "/", "cluster root of meta state service on remote");
-
-    meta_state_service_type = dsn_config_get_value_string("meta_server",
-                                                          "meta_state_service_type",
-                                                          "meta_state_service_simple",
-                                                          "meta_state_service provider type");
-    const char *meta_state_service_parameters =
-        dsn_config_get_value_string("meta_server",
-                                    "meta_state_service_parameters",
-                                    "",
-                                    "meta_state_service provider parameters");
-    utils::split_args(meta_state_service_parameters, meta_state_service_args);
+    utils::split_args(FLAGS_meta_state_service_parameters, meta_state_service_args);
 
     meta_function_level_on_start = meta_function_level::fl_invalid;
-    const char *level_str = dsn_config_get_value_string(
-        "meta_server", "meta_function_level_on_start", "steady", "meta function level on start");
-    std::string level = std::string("fl_") + level_str;
+    std::string level = std::string("fl_") + FLAGS_meta_function_level_on_start;
     for (auto &kv : _meta_function_level_VALUES_TO_NAMES) {
         if (level == kv.second) {
             meta_function_level_on_start = (meta_function_level::type)kv.first;
@@ -79,36 +83,11 @@ void meta_options::initialize()
     CHECK_NE_MSG(meta_function_level_on_start,
                  meta_function_level::fl_invalid,
                  "invalid function level: {}",
-                 level_str);
+                 FLAGS_meta_function_level_on_start);
 
-    /// failure detector options
-    _fd_opts.distributed_lock_service_type =
-        dsn_config_get_value_string("meta_server",
-                                    "distributed_lock_service_type",
-                                    "distributed_lock_service_simple",
-                                    "dist lock provider");
-    const char *distributed_lock_service_parameters =
-        dsn_config_get_value_string("meta_server",
-                                    "distributed_lock_service_parameters",
-                                    "",
-                                    "distributed_lock_service provider parameters");
-    utils::split_args(distributed_lock_service_parameters, _fd_opts.distributed_lock_service_args);
-
-    /// load balancer options
-    _lb_opts.server_load_balancer_type =
-        dsn_config_get_value_string("meta_server",
-                                    "server_load_balancer_type",
-                                    "greedy_load_balancer",
-                                    "server load balancer provider");
-
-    partition_guardian_type = dsn_config_get_value_string("meta_server",
-                                                          "partition_guardian_type",
-                                                          "partition_guardian",
-                                                          "partition guardian provider");
-
-    const char *replica_white_list_raw = dsn_config_get_value_string(
-        "meta_server", "replica_white_list", "", "white list of replica-servers in meta-server");
-    utils::split_args(replica_white_list_raw, replica_white_list, ',');
+    utils::split_args(FLAGS_distributed_lock_service_parameters,
+                      _fd_opts.distributed_lock_service_args);
+    utils::split_args(FLAGS_replica_white_list, replica_white_list, ',');
 }
 } // namespace replication
 } // namespace dsn

--- a/src/meta/meta_options.h
+++ b/src/meta/meta_options.h
@@ -54,31 +54,21 @@
 namespace dsn {
 namespace replication {
 
+// TODO(yingchun): remove it
 class fd_suboptions
 {
 public:
-    std::string distributed_lock_service_type;
     std::vector<std::string> distributed_lock_service_args;
-};
-
-class lb_suboptions
-{
-public:
-    std::string server_load_balancer_type;
 };
 
 class meta_options
 {
 public:
-    std::string cluster_root;
-    std::string meta_state_service_type;
     std::vector<std::string> meta_state_service_args;
 
     meta_function_level::type meta_function_level_on_start;
 
     fd_suboptions _fd_opts;
-    lb_suboptions _lb_opts;
-    std::string partition_guardian_type;
     std::vector<std::string> replica_white_list;
 
 public:

--- a/src/meta/meta_server_failure_detector.cpp
+++ b/src/meta/meta_server_failure_detector.cpp
@@ -46,6 +46,10 @@ DSN_DEFINE_uint64(meta_server,
                   stable_rs_min_running_seconds,
                   600,
                   "The minimal running seconds for a stable replica server");
+DSN_DEFINE_string(meta_server,
+                  distributed_lock_service_type,
+                  "distributed_lock_service_simple",
+                  "dist lock provider");
 
 namespace dsn {
 namespace replication {
@@ -59,7 +63,7 @@ meta_server_failure_detector::meta_server_failure_detector(meta_service *svc)
 {
     _fd_opts = &(svc->get_meta_options()._fd_opts);
     _lock_svc = dsn::utils::factory_store<dist::distributed_lock_service>::create(
-        _fd_opts->distributed_lock_service_type.c_str(), PROVIDER_TYPE_MAIN);
+        FLAGS_distributed_lock_service_type, PROVIDER_TYPE_MAIN);
     error_code err = _lock_svc->initialize(_fd_opts->distributed_lock_service_args);
     CHECK_EQ_MSG(err, ERR_OK, "init distributed_lock_service failed");
 }

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -42,6 +42,8 @@ namespace dsn {
 namespace replication {
 
 DSN_DECLARE_int32(cold_backup_checkpoint_reserve_minutes);
+DSN_DECLARE_string(cluster_root);
+DSN_DECLARE_string(meta_state_service_type);
 
 struct method_record
 {
@@ -728,11 +730,11 @@ protected:
         meta_test_base::SetUp();
 
         meta_options &opt = _meta_svc->_meta_opts;
-        opt.cluster_root = "/meta_test";
-        opt.meta_state_service_type = "meta_state_service_simple";
+        FLAGS_cluster_root = "/meta_test";
+        FLAGS_meta_state_service_type = "meta_state_service_simple";
         _meta_svc->remote_storage_initialize();
         std::string backup_root = "/backup_test";
-        std::string policy_meta_root = opt.cluster_root + "/backup_policies";
+        std::string policy_meta_root = std::string(FLAGS_cluster_root) + "/backup_policies";
         _meta_svc->_backup_handler = std::make_shared<backup_service>(
             _meta_svc.get(), policy_meta_root, backup_root, [](backup_service *bs) {
                 return std::make_shared<mock_policy>(bs);

--- a/src/meta/test/meta_test_base.cpp
+++ b/src/meta/test/meta_test_base.cpp
@@ -31,6 +31,8 @@ namespace dsn {
 namespace replication {
 
 DSN_DECLARE_uint64(min_live_node_count_for_unfreeze);
+DSN_DECLARE_string(partition_guardian_type);
+DSN_DECLARE_string(server_load_balancer_type);
 
 meta_test_base::~meta_test_base() {}
 
@@ -39,9 +41,9 @@ void meta_test_base::SetUp()
     _ms = make_unique<fake_receiver_meta_service>();
     _ms->_failure_detector.reset(new meta_server_failure_detector(_ms.get()));
     _ms->_balancer.reset(utils::factory_store<server_load_balancer>::create(
-        _ms->_meta_opts._lb_opts.server_load_balancer_type.c_str(), PROVIDER_TYPE_MAIN, _ms.get()));
+        FLAGS_server_load_balancer_type, PROVIDER_TYPE_MAIN, _ms.get()));
     _ms->_partition_guardian.reset(utils::factory_store<partition_guardian>::create(
-        _ms->_meta_opts.partition_guardian_type.c_str(), PROVIDER_TYPE_MAIN, _ms.get()));
+        FLAGS_partition_guardian_type, PROVIDER_TYPE_MAIN, _ms.get()));
     ASSERT_EQ(_ms->remote_storage_initialize(), ERR_OK);
     _ms->initialize_duplication_service();
     ASSERT_TRUE(_ms->_dup_svc);

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -37,6 +37,8 @@
 
 namespace dsn {
 namespace replication {
+DSN_DECLARE_string(cluster_root);
+DSN_DECLARE_string(meta_state_service_type);
 
 static const std::vector<std::string> keys = {"manual_compact.once.trigger_time",
                                               "manual_compact.once.target_level",
@@ -89,8 +91,8 @@ void meta_service_test_app::app_envs_basic_test()
     std::shared_ptr<meta_service> meta_svc = std::make_shared<meta_service>();
     meta_service *svc = meta_svc.get();
 
-    svc->_meta_opts.cluster_root = "/meta_test";
-    svc->_meta_opts.meta_state_service_type = "meta_state_service_simple";
+    FLAGS_cluster_root = "/meta_test";
+    FLAGS_meta_state_service_type = "meta_state_service_simple";
     svc->remote_storage_initialize();
 
     std::string apps_root = "/meta_test/apps";

--- a/src/meta/test/state_sync_test.cpp
+++ b/src/meta/test/state_sync_test.cpp
@@ -52,6 +52,8 @@
 
 namespace dsn {
 namespace replication {
+DSN_DECLARE_string(cluster_root);
+DSN_DECLARE_string(meta_state_service_type);
 
 static void random_assign_partition_config(std::shared_ptr<app_state> &app,
                                            const std::vector<dsn::rpc_address> &server_list,
@@ -119,8 +121,8 @@ void meta_service_test_app::state_sync_test()
     std::shared_ptr<meta_service> meta_svc = std::make_shared<meta_service>();
     meta_service *svc = meta_svc.get();
     meta_options &opt = svc->_meta_opts;
-    opt.cluster_root = "/meta_test";
-    opt.meta_state_service_type = "meta_state_service_simple";
+    FLAGS_cluster_root = "/meta_test";
+    FLAGS_meta_state_service_type = "meta_state_service_simple";
     svc->remote_storage_initialize();
 
     std::string apps_root = "/meta_test/apps";
@@ -197,7 +199,7 @@ void meta_service_test_app::state_sync_test()
         file_data_compare("meta_state.dump1", "meta_state.dump2");
     }
 
-    opt.meta_state_service_type = "meta_state_service_zookeeper";
+    FLAGS_meta_state_service_type = "meta_state_service_zookeeper";
     svc->remote_storage_initialize();
     // first clean up
     std::cerr << "start to clean up zookeeper storage" << std::endl;

--- a/src/replica/backup/replica_backup_server.cpp
+++ b/src/replica/backup/replica_backup_server.cpp
@@ -49,7 +49,7 @@ void replica_backup_server::on_cold_backup(backup_rpc rpc)
     response.policy_name = request.policy.policy_name;
     response.backup_id = request.backup_id;
 
-    if (strlen(FLAGS_cold_backup_root) == 0) {
+    if (utils::is_empty(FLAGS_cold_backup_root)) {
         LOG_ERROR(
             "backup[{}.{}.{}]: FLAGS_cold_backup_root is empty, response ERR_OPERATION_DISABLED",
             request.pid,

--- a/src/replica/backup/replica_backup_server.cpp
+++ b/src/replica/backup/replica_backup_server.cpp
@@ -22,6 +22,7 @@
 
 namespace dsn {
 namespace replication {
+DSN_DECLARE_string(cold_backup_root);
 
 replica_backup_server::replica_backup_server(const replica_stub *rs) : _stub(rs)
 {
@@ -48,11 +49,12 @@ void replica_backup_server::on_cold_backup(backup_rpc rpc)
     response.policy_name = request.policy.policy_name;
     response.backup_id = request.backup_id;
 
-    if (_stub->options().cold_backup_root.empty()) {
-        LOG_ERROR("backup[{}.{}.{}]: cold_backup_root is empty, response ERR_OPERATION_DISABLED",
-                  request.pid,
-                  request.policy.policy_name,
-                  request.backup_id);
+    if (strlen(FLAGS_cold_backup_root) == 0) {
+        LOG_ERROR(
+            "backup[{}.{}.{}]: FLAGS_cold_backup_root is empty, response ERR_OPERATION_DISABLED",
+            request.pid,
+            request.policy.policy_name,
+            request.backup_id);
         response.err = ERR_OPERATION_DISABLED;
         return;
     }

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -38,6 +38,8 @@ DSN_DEFINE_uint64(replication,
                   10,
                   "concurrent uploading file count to block service");
 
+DSN_DECLARE_string(cold_backup_root);
+
 void replica::on_cold_backup(const backup_request &request, /*out*/ backup_response &response)
 {
     _checker.only_one_thread_access();
@@ -77,8 +79,8 @@ void replica::on_cold_backup(const backup_request &request, /*out*/ backup_respo
             backup_context->block_service = block_service;
             backup_context->backup_root = request.__isset.backup_path
                                               ? dsn::utils::filesystem::path_combine(
-                                                    request.backup_path, _options->cold_backup_root)
-                                              : _options->cold_backup_root;
+                                                    request.backup_path, FLAGS_cold_backup_root)
+                                              : FLAGS_cold_backup_root;
         }
 
         CHECK_EQ_PREFIX(backup_context->request.policy.policy_name, policy_name);

--- a/src/replica/storage/simple_kv/test/checker.cpp
+++ b/src/replica/storage/simple_kv/test/checker.cpp
@@ -54,6 +54,8 @@
 
 namespace dsn {
 namespace replication {
+DSN_DECLARE_string(partition_guardian_type);
+
 namespace test {
 
 class checker_partition_guardian : public partition_guardian
@@ -174,7 +176,7 @@ bool test_checker::init(const std::string &name, const std::vector<service_app *
             meta_service_app *meta_app = (meta_service_app *)app;
             meta_app->_service->_state->set_config_change_subscriber_for_test(
                 std::bind(&test_checker::on_config_change, this, std::placeholders::_1));
-            meta_app->_service->_meta_opts.partition_guardian_type = "checker_partition_guardian";
+            FLAGS_partition_guardian_type = "checker_partition_guardian";
             _meta_servers.push_back(meta_app);
         } else if (app->info().type == "replica") {
             replication_service_app *replica_app = (replication_service_app *)app;

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -28,6 +28,7 @@
 
 namespace dsn {
 namespace replication {
+DSN_DECLARE_string(cold_backup_root);
 
 class replica_test : public replica_test_base
 {
@@ -47,10 +48,10 @@ public:
         mock_app_info();
         _mock_replica = stub->generate_replica_ptr(_app_info, pid, partition_status::PS_PRIMARY, 1);
 
-        // set cold_backup_root manually.
-        // `cold_backup_root` is set by configuration "replication.cold_backup_root",
+        // set FLAGS_cold_backup_root manually.
+        // FLAGS_cold_backup_root is set by configuration "replication.cold_backup_root",
         // which is usually the cluster_name of production clusters.
-        _mock_replica->_options->cold_backup_root = "test_cluster";
+        FLAGS_cold_backup_root = "test_cluster";
     }
 
     int get_write_size_exceed_threshold_count()
@@ -134,8 +135,8 @@ public:
         ASSERT_EQ(ERR_OK, resp.err);
 
         // test checkpoint files have been uploaded successfully.
-        std::string backup_root = dsn::utils::filesystem::path_combine(
-            user_specified_path, _mock_replica->_options->cold_backup_root);
+        std::string backup_root =
+            dsn::utils::filesystem::path_combine(user_specified_path, FLAGS_cold_backup_root);
         std::string current_chkpt_file =
             cold_backup::get_current_chkpt_file(backup_root, req.app_name, req.pid, req.backup_id);
         ASSERT_TRUE(dsn::utils::filesystem::file_exists(current_chkpt_file));
@@ -150,7 +151,7 @@ public:
         req.app_id = _app_info.app_id;
         req.app_name = _app_info.app_name;
         req.backup_provider_name = _provider_name;
-        req.cluster_name = _mock_replica->_options->cold_backup_root;
+        req.cluster_name = FLAGS_cold_backup_root;
         req.time_stamp = _backup_id;
         if (!user_specified_path.empty()) {
             req.__set_restore_path(user_specified_path);

--- a/src/runtime/global_config.cpp
+++ b/src/runtime/global_config.cpp
@@ -47,6 +47,8 @@
 
 namespace dsn {
 
+DSN_DEFINE_string(apps.mimic, type, "", "");
+
 static bool build_client_network_confs(const char *section,
                                        /*out*/ network_client_configs &nss,
                                        network_client_configs *default_spec)
@@ -325,9 +327,8 @@ bool service_spec::init_app_specs()
             dsn_config_set("apps.mimic", "pools", "THREAD_POOL_DEFAULT", "");
             all_section_names.push_back("apps.mimic");
         } else {
-            auto type = dsn_config_get_value_string("apps.mimic", "type", "", "");
-            if (!utils::equals(type, mimic_app_role_name)) {
-                printf("invalid config value '%s' for [apps.mimic] type", type);
+            if (!utils::equals(FLAGS_type, mimic_app_role_name)) {
+                printf("invalid config value '%s' for [apps.mimic] type", FLAGS_type);
                 return false;
             }
         }

--- a/src/runtime/global_config.cpp
+++ b/src/runtime/global_config.cpp
@@ -47,8 +47,6 @@
 
 namespace dsn {
 
-DSN_DEFINE_string(apps.mimic, type, "", "");
-
 static bool build_client_network_confs(const char *section,
                                        /*out*/ network_client_configs &nss,
                                        network_client_configs *default_spec)
@@ -327,8 +325,9 @@ bool service_spec::init_app_specs()
             dsn_config_set("apps.mimic", "pools", "THREAD_POOL_DEFAULT", "");
             all_section_names.push_back("apps.mimic");
         } else {
-            if (!utils::equals(FLAGS_type, mimic_app_role_name)) {
-                printf("invalid config value '%s' for [apps.mimic] type", FLAGS_type);
+            auto type = dsn_config_get_value_string("apps.mimic", "type", "", "");
+            if (!utils::equals(type, mimic_app_role_name)) {
+                printf("invalid config value '%s' for [apps.mimic] type", type);
                 return false;
             }
         }

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -41,7 +41,7 @@ DSN_DEFINE_uint32(network,
                   "max connection count to each server per ip, 0 means no limit");
 DSN_DEFINE_string(network,
                   unknown_message_header_format,
-                  NET_HDR_INVALID.to_string(),
+                  "",
                   "format for unknown message headers");
 DSN_DEFINE_string(network,
                   explicit_host_address,

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -39,10 +39,7 @@ DSN_DEFINE_uint32(network,
                   conn_threshold_per_ip,
                   0,
                   "max connection count to each server per ip, 0 means no limit");
-DSN_DEFINE_string(network,
-                  unknown_message_header_format,
-                  "",
-                  "format for unknown message headers");
+DSN_DEFINE_string(network, unknown_message_header_format, "", "format for unknown message headers");
 DSN_DEFINE_string(network,
                   explicit_host_address,
                   "",

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -39,6 +39,20 @@ DSN_DEFINE_uint32(network,
                   conn_threshold_per_ip,
                   0,
                   "max connection count to each server per ip, 0 means no limit");
+DSN_DEFINE_string(network,
+                  unknown_message_header_format,
+                  NET_HDR_INVALID.to_string(), // TODO(yingchun): fixme
+                  "format for unknown message headers, default is NET_HDR_INVALID");
+DSN_DEFINE_string(network,
+                  explicit_host_address,
+                  "",
+                  "explicit host name or ip (v4) assigned to this node (e.g., "
+                  "service ip for pods in kubernets)");
+DSN_DEFINE_string(network,
+                  primary_interface,
+                  "",
+                  "network interface name used to init primary ipv4 address, "
+                  "if empty, means using a site local address");
 
 /*static*/ join_point<void, rpc_session *>
     rpc_session::on_rpc_session_connected("rpc.session.connected");
@@ -511,13 +525,8 @@ network::network(rpc_engine *srv, network *inner_provider)
 {
     _message_buffer_block_size = 1024 * 64;
     _max_buffer_block_count_per_send = 64; // TODO: windows, how about the other platforms?
-    _unknown_msg_header_format = network_header_format::from_string(
-        dsn_config_get_value_string(
-            "network",
-            "unknown_message_header_format",
-            NET_HDR_INVALID.to_string(),
-            "format for unknown message headers, default is NET_HDR_INVALID"),
-        NET_HDR_INVALID);
+    _unknown_msg_header_format =
+        network_header_format::from_string(FLAGS_unknown_message_header_format, NET_HDR_INVALID);
 }
 
 void network::reset_parser_attr(network_header_format client_hdr_format,
@@ -548,28 +557,13 @@ message_parser *network::new_message_parser(network_header_format hdr_format)
 
 uint32_t network::get_local_ipv4()
 {
-    static const char *explicit_host =
-        dsn_config_get_value_string("network",
-                                    "explicit_host_address",
-                                    "",
-                                    "explicit host name or ip (v4) assigned to this "
-                                    "node (e.g., service ip for pods in kubernets)");
-
-    static const char *inteface =
-        dsn_config_get_value_string("network",
-                                    "primary_interface",
-                                    "",
-                                    "network interface name used to init primary ipv4 "
-                                    "address, if empty, means using a site local address");
-
     uint32_t ip = 0;
-
-    if (!utils::is_empty(explicit_host)) {
-        ip = rpc_address::ipv4_from_host(explicit_host);
+    if (!utils::is_empty(FLAGS_explicit_host_address)) {
+        ip = rpc_address::ipv4_from_host(FLAGS_explicit_host_address);
     }
 
     if (0 == ip) {
-        ip = rpc_address::ipv4_from_network_interface(inteface);
+        ip = rpc_address::ipv4_from_network_interface(FLAGS_primary_interface);
     }
 
     if (0 == ip) {

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -41,8 +41,8 @@ DSN_DEFINE_uint32(network,
                   "max connection count to each server per ip, 0 means no limit");
 DSN_DEFINE_string(network,
                   unknown_message_header_format,
-                  NET_HDR_INVALID.to_string(), // TODO(yingchun): fixme
-                  "format for unknown message headers, default is NET_HDR_INVALID");
+                  NET_HDR_INVALID.to_string(),
+                  "format for unknown message headers");
 DSN_DEFINE_string(network,
                   explicit_host_address,
                   "",

--- a/src/runtime/test/main.cpp
+++ b/src/runtime/test/main.cpp
@@ -38,6 +38,9 @@
 
 #include "test_utils.h"
 #include "utils/strings.h"
+#include "utils/flags.h"
+
+DSN_DEFINE_string(core, tool, "simulator", "");
 
 int g_test_count = 0;
 int g_test_ret = 0;
@@ -64,8 +67,7 @@ GTEST_API_ int main(int argc, char **argv)
         return g_test_ret;
     }
 
-    if (!dsn::utils::equals("simulator",
-                            dsn_config_get_value_string("core", "tool", "simulator", ""))) {
+    if (!dsn::utils::equals("simulator", FLAGS_tool)) {
         // run out-rDSN tests in other threads
         std::cout << "=========================================================== " << std::endl;
         std::cout << "================== run in non-rDSN threads ================ " << std::endl;

--- a/src/runtime/test/service_api_c.cpp
+++ b/src/runtime/test/service_api_c.cpp
@@ -50,6 +50,9 @@
 #include <thread>
 #include "utils/rand.h"
 #include "runtime/service_engine.h"
+#include "utils/flags.h"
+
+DSN_DECLARE_string(tool);
 
 using namespace dsn;
 
@@ -219,7 +222,7 @@ TEST(core, dsn_system)
 {
     ASSERT_TRUE(tools::is_engine_ready());
     tools::tool_app *tool = tools::get_current_tool();
-    ASSERT_EQ(tool->name(), dsn_config_get_value_string("core", "tool", "", ""));
+    ASSERT_EQ(tool->name(), FLAGS_tool);
 
     int app_count = 5;
     int type_count = 1;

--- a/src/server/available_detector.cpp
+++ b/src/server/available_detector.cpp
@@ -59,8 +59,6 @@ DSN_DEFINE_string(pegasus.collector,
                   available_detect_alert_email_address,
                   "",
                   "available detect alert email address, empty means not send email");
-DSN_DEFINE_validator(available_detect_alert_email_address,
-                     [](const char *value) -> bool { return !dsn::utils::is_empty(value); });
 
 available_detector::available_detector()
     : _client(nullptr),
@@ -88,7 +86,7 @@ available_detector::available_detector()
     _result_writer = dsn::make_unique<result_writer>(_client);
     _ddl_client.reset(new replication_ddl_client(_meta_list));
     CHECK_NOTNULL(_ddl_client, "Initialize the _ddl_client failed");
-    if (strlen(FLAGS_available_detect_alert_email_address) > 0) {
+    if (!dsn::utils::is_empty(FLAGS_available_detect_alert_email_address)) {
         _send_alert_email_cmd = std::string("cd ") + FLAGS_available_detect_alert_script_dir +
                                 "; bash sendmail.sh alert " +
                                 FLAGS_available_detect_alert_email_address + " " + _cluster_name +

--- a/src/server/available_detector.h
+++ b/src/server/available_detector.h
@@ -54,7 +54,6 @@ private:
 private:
     dsn::task_tracker _tracker;
     std::string _cluster_name;
-    std::string _app_name;
     // for writing detect result
     std::unique_ptr<result_writer> _result_writer;
     // client to access server.
@@ -74,8 +73,6 @@ private:
 
     std::string _send_alert_email_cmd;
     std::string _send_availability_info_email_cmd;
-    std::string _alert_script_dir;
-    std::string _alert_email_address;
 
     // total detect times and total fail times
     std::atomic<int64_t> _recent_day_detect_times;

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -54,8 +54,11 @@ DSN_DEFINE_uint32(pegasus.collector,
                   storage_size_fetch_interval_seconds,
                   3600,
                   "storage size fetch interval seconds");
-// app for recording usage statistics, including read/write capacity unit and storage size.
-DSN_DEFINE_string(pegasus.collector, usage_stat_app, "", "app for recording usage statistics");
+DSN_DEFINE_string(pegasus.collector,
+                  usage_stat_app,
+                  "",
+                  "app for recording usage statistics, including read/write capacity unit and "
+                  "storage size");
 DSN_DEFINE_validator(usage_stat_app,
                      [](const char *value) -> bool { return !dsn::utils::is_empty(value); });
 

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -54,6 +54,10 @@ DSN_DEFINE_uint32(pegasus.collector,
                   storage_size_fetch_interval_seconds,
                   3600,
                   "storage size fetch interval seconds");
+// app for recording usage statistics, including read/write capacity unit and storage size.
+DSN_DEFINE_string(pegasus.collector, usage_stat_app, "", "app for recording usage statistics");
+DSN_DEFINE_validator(usage_stat_app,
+                     [](const char *value) -> bool { return !dsn::utils::is_empty(value); });
 
 info_collector::info_collector()
 {
@@ -72,12 +76,9 @@ info_collector::info_collector()
     _shell_context->meta_list = meta_servers;
     _shell_context->ddl_client.reset(new replication_ddl_client(meta_servers));
 
-    _usage_stat_app = dsn_config_get_value_string(
-        "pegasus.collector", "usage_stat_app", "", "app for recording usage statistics");
-    CHECK(!_usage_stat_app.empty(), "");
     // initialize the _client.
     CHECK(pegasus_client_factory::initialize(nullptr), "Initialize the pegasus client failed");
-    _client = pegasus_client_factory::get_client(_cluster_name.c_str(), _usage_stat_app.c_str());
+    _client = pegasus_client_factory::get_client(_cluster_name.c_str(), FLAGS_usage_stat_app);
     CHECK_NOTNULL(_client, "Initialize the client failed");
     _result_writer = dsn::make_unique<result_writer>(_client);
 

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -229,8 +229,6 @@ private:
     ::dsn::utils::ex_lock_nr _app_stat_counter_lock;
     std::map<std::string, app_stat_counters *> _app_stat_counters;
 
-    // app for recording usage statistics, including read/write capacity unit and storage size.
-    std::string _usage_stat_app;
     // client to access server.
     pegasus_client *_client;
     // for writing cu stat result

--- a/src/test/bench_test/benchmark.cpp
+++ b/src/test/bench_test/benchmark.cpp
@@ -45,7 +45,8 @@ DSN_DEFINE_string(pegasus.benchmark, pegasus_cluster_name, "onebox", "The Pegasu
 DSN_DEFINE_validator(pegasus_cluster_name,
                      [](const char *value) -> bool { return !dsn::utils::is_empty(value); });
 DSN_DEFINE_string(pegasus.benchmark, pegasus_app_name, "temp", "pegasus app name");
-
+DSN_DEFINE_validator(pegasus_app_name,
+                     [](const char *value) -> bool { return !dsn::utils::is_empty(value); });
 DSN_DEFINE_string(
     pegasus.benchmark,
     benchmarks,
@@ -54,6 +55,8 @@ DSN_DEFINE_string(
     "\tfillrandom_pegasus       -- pegasus write N values in random key order\n"
     "\treadrandom_pegasus       -- pegasus read N times in random order\n"
     "\tdeleterandom_pegasus     -- pegasus delete N keys in random order\n");
+DSN_DEFINE_validator(benchmarks,
+                     [](const char *value) -> bool { return !dsn::utils::is_empty(value); });
 
 DSN_DECLARE_int32(hashkey_size);
 DSN_DECLARE_int32(pegasus_timeout_ms);

--- a/src/test/bench_test/benchmark.cpp
+++ b/src/test/bench_test/benchmark.cpp
@@ -19,6 +19,7 @@
 
 #include "benchmark.h"
 
+#include <cstring>
 #include <sstream>
 
 #include "rand.h"
@@ -27,6 +28,7 @@
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/ports.h"
+#include "utils/strings.h"
 
 namespace pegasus {
 namespace test {
@@ -39,6 +41,19 @@ DSN_DEFINE_uint64(pegasus.benchmark,
                   benchmark_seed,
                   1000,
                   "Seed base for random number generators. When 0 it is deterministic");
+DSN_DEFINE_string(pegasus.benchmark, pegasus_cluster_name, "onebox", "The Pegasus cluster name");
+DSN_DEFINE_validator(pegasus_cluster_name,
+                     [](const char *value) -> bool { return !dsn::utils::is_empty(value); });
+DSN_DEFINE_string(pegasus.benchmark, pegasus_app_name, "temp", "pegasus app name");
+
+DSN_DEFINE_string(
+    pegasus.benchmark,
+    benchmarks,
+    "fillrandom_pegasus,readrandom_pegasus,deleterandom_pegasus",
+    "Comma-separated list of operations to run in the specified order. Available benchmarks:\n"
+    "\tfillrandom_pegasus       -- pegasus write N values in random key order\n"
+    "\treadrandom_pegasus       -- pegasus read N times in random order\n"
+    "\tdeleterandom_pegasus     -- pegasus delete N keys in random order\n");
 
 DSN_DECLARE_int32(hashkey_size);
 DSN_DECLARE_int32(pegasus_timeout_ms);
@@ -48,8 +63,8 @@ DSN_DECLARE_int32(value_size);
 
 benchmark::benchmark()
 {
-    _client = pegasus_client_factory::get_client(config::instance().pegasus_cluster_name.c_str(),
-                                                 config::instance().pegasus_app_name.c_str());
+    _client =
+        pegasus_client_factory::get_client(FLAGS_pegasus_cluster_name, FLAGS_pegasus_app_name);
     CHECK_NOTNULL(_client, "");
 
     // init operation method map
@@ -64,7 +79,7 @@ void benchmark::run()
     // print summarize information
     print_header();
 
-    std::stringstream benchmark_stream(config::instance().benchmarks);
+    std::stringstream benchmark_stream(FLAGS_benchmarks);
     std::string name;
     while (std::getline(benchmark_stream, name, ',')) {
         // run the specified benchmark

--- a/src/test/bench_test/config.cpp
+++ b/src/test/bench_test/config.cpp
@@ -34,21 +34,6 @@ DSN_DEFINE_int32(pegasus.benchmark, hashkey_size, 16, "size of each hashkey");
 DSN_DEFINE_int32(pegasus.benchmark, sortkey_size, 16, "size of each sortkey");
 DSN_DEFINE_int32(pegasus.benchmark, value_size, 100, "Size of each value");
 
-config::config()
-{
-    pegasus_cluster_name = dsn_config_get_value_string(
-        "pegasus.benchmark", "pegasus_cluster_name", "onebox", "pegasus cluster name");
-    pegasus_app_name = dsn_config_get_value_string(
-        "pegasus.benchmark", "pegasus_app_name", "temp", "pegasus app name");
-    benchmarks = dsn_config_get_value_string(
-        "pegasus.benchmark",
-        "benchmarks",
-        "fillrandom_pegasus,readrandom_pegasus,deleterandom_pegasus",
-        "Comma-separated list of operations to run in the specified order. Available benchmarks:\n"
-        "\tfillrandom_pegasus       -- pegasus write N values in random key order\n"
-        "\treadrandom_pegasus       -- pegasus read N times in random order\n"
-        "\tdeleterandom_pegasus     -- pegasus delete N keys in random order\n");
-    env = rocksdb::Env::Default();
-}
+config::config() { env = rocksdb::Env::Default(); }
 } // namespace test
 } // namespace pegasus

--- a/src/test/bench_test/config.h
+++ b/src/test/bench_test/config.h
@@ -28,8 +28,6 @@ namespace test {
 /** Thread safety singleton */
 struct config : public dsn::utils::singleton<config>
 {
-    std::string pegasus_cluster_name;
-    std::string pegasus_app_name;
     // Comma-separated list of operations to run
     std::string benchmarks;
     // Default environment suitable for the current operating system

--- a/src/test/function_test/recovery_test/test_recovery.cpp
+++ b/src/test/function_test/recovery_test/test_recovery.cpp
@@ -45,7 +45,7 @@ using namespace pegasus;
 
 // TODO(yingchun): add a check for it, get config by curl
 // NOTE: THREAD_POOL_META_SERVER worker count should be greater than 1
-// This function test update 'distributed_lock_service_type' to
+// This function test update FLAGS_distributed_lock_service_type to
 // 'distributed_lock_service_simple', which executes in threadpool THREAD_POOL_META_SERVER
 // As a result, failure detection lock executes in this pool
 // if worker count = 1, it will lead to ERR_TIMEOUT when execute 'ddl_client_->do_recovery'

--- a/src/test/kill_test/data_verifier.h
+++ b/src/test/kill_test/data_verifier.h
@@ -19,5 +19,9 @@
 
 #pragma once
 
+namespace pegasus {
+namespace test {
 void verifier_initialize(const char *config_file);
 void verifier_start();
+} // namespace test
+} // namespace pegasus

--- a/src/test/kill_test/kill_testor.h
+++ b/src/test/kill_test/kill_testor.h
@@ -58,8 +58,6 @@ protected:
 
 protected:
     shared_ptr<replication_ddl_client> ddl_client;
-    string app_name;
-    string pegasus_cluster_name;
     vector<dsn::rpc_address> meta_list;
 
     std::vector<partition_configuration> partitions;

--- a/src/test/kill_test/killer_handler_shell.cpp
+++ b/src/test/kill_test/killer_handler_shell.cpp
@@ -29,26 +29,21 @@
 #include "utils/config_api.h"
 #include "utils/fmt_logging.h"
 #include "utils/safe_strerror_posix.h"
+#include "utils/flags.h"
+#include "utils/strings.h"
 
 namespace pegasus {
 namespace test {
 
-killer_handler_shell::killer_handler_shell()
-{
-    const char *section = "killer.handler.shell";
-    _run_script_path = dsn_config_get_value_string(
-        section, "onebox_run_path", "~/pegasus/run.sh", "onebox run path");
-    CHECK(!_run_script_path.empty(), "");
-}
+DSN_DEFINE_string(killer.handler.shell, onebox_run_path, "~/pegasus/run.sh", "onebox run path");
+DSN_DEFINE_validator(onebox_run_path,
+                     [](const char *value) -> bool { return !dsn::utils::is_empty(value); });
 
 bool killer_handler_shell::has_meta_dumped_core(int index)
 {
     char find_core[1024];
-    snprintf(find_core,
-             1024,
-             "ls %s/onebox/meta%d | grep core | wc -l",
-             _run_script_path.c_str(),
-             index);
+    snprintf(
+        find_core, 1024, "ls %s/onebox/meta%d | grep core | wc -l", FLAGS_onebox_run_path, index);
 
     std::stringstream output;
     int core_count;
@@ -64,7 +59,7 @@ bool killer_handler_shell::has_replica_dumped_core(int index)
     snprintf(find_core,
              1024,
              "ls %s/onebox/replica%d | grep core | wc -l",
-             _run_script_path.c_str(),
+             FLAGS_onebox_run_path,
              index);
 
     std::stringstream output;
@@ -176,7 +171,7 @@ std::string
 killer_handler_shell::generate_cmd(int index, const std::string &job, const std::string &action)
 {
     std::stringstream res;
-    res << "cd " << _run_script_path << "; "
+    res << "cd " << FLAGS_onebox_run_path << "; "
         << "bash run.sh";
     if (action == "stop")
         res << " stop_onebox_instance ";

--- a/src/test/kill_test/killer_handler_shell.h
+++ b/src/test/kill_test/killer_handler_shell.h
@@ -29,7 +29,7 @@ namespace test {
 class killer_handler_shell : public killer_handler
 {
 public:
-    killer_handler_shell();
+    killer_handler_shell() = default;
     virtual ~killer_handler_shell() {}
     // index begin from 1, not zero
     // kill one
@@ -57,10 +57,6 @@ private:
     std::string generate_cmd(int index, const std::string &job, const std::string &action);
     // check whether the command execute success.
     bool check(const std::string &job, int index, const std::string &type);
-
-private:
-    // using ${_run_script_path}/run.sh to kill/start
-    std::string _run_script_path;
 };
 }
 } // end namespace

--- a/src/test/kill_test/main.cpp
+++ b/src/test/kill_test/main.cpp
@@ -32,8 +32,8 @@ int main(int argc, const char **argv)
                "worker_type(verifier|process_killer|partition_killer)\n");
         return -1;
     } else if (dsn::utils::equals(argv[2], "verifier")) {
-        verifier_initialize(argv[1]);
-        verifier_start();
+        pegasus::test::verifier_initialize(argv[1]);
+        pegasus::test::verifier_start();
     } else if (dsn::utils::equals(argv[2], "process_killer")) {
         pegasus::test::kill_testor *killtestor = new pegasus::test::process_kill_testor(argv[1]);
         killtestor->Run();

--- a/src/zookeeper/zookeeper_session.cpp
+++ b/src/zookeeper/zookeeper_session.cpp
@@ -58,6 +58,7 @@ DSN_DEFINE_int32(zookeeper,
                  timeout_ms,
                  30000,
                  "The timeout of accessing ZooKeeper, in milliseconds");
+DSN_DEFINE_string(zookeeper, hosts_list, "", "Zookeeper hosts list");
 
 zookeeper_session::zoo_atomic_packet::zoo_atomic_packet(unsigned int size)
 {
@@ -164,7 +165,7 @@ int zookeeper_session::attach(void *callback_owner, const state_callback &cb)
             zoo_sasl_params_t sasl_params = {0};
             sasl_params.service = dsn::security::FLAGS_zookeeper_kerberos_service_name;
             sasl_params.mechlist = "GSSAPI";
-            _handle = zookeeper_init_sasl(zookeeper_session_mgr::instance().zoo_hosts(),
+            _handle = zookeeper_init_sasl(FLAGS_hosts_list,
                                           global_watcher,
                                           FLAGS_timeout_ms,
                                           nullptr,
@@ -173,12 +174,8 @@ int zookeeper_session::attach(void *callback_owner, const state_callback &cb)
                                           NULL,
                                           &sasl_params);
         } else {
-            _handle = zookeeper_init(zookeeper_session_mgr::instance().zoo_hosts(),
-                                     global_watcher,
-                                     FLAGS_timeout_ms,
-                                     nullptr,
-                                     this,
-                                     0);
+            _handle = zookeeper_init(
+                FLAGS_hosts_list, global_watcher, FLAGS_timeout_ms, nullptr, this, 0);
         }
         CHECK_NOTNULL(_handle, "zookeeper session init failed");
     }

--- a/src/zookeeper/zookeeper_session_mgr.cpp
+++ b/src/zookeeper/zookeeper_session_mgr.cpp
@@ -38,16 +38,16 @@
 #include <stdio.h>
 #include <zookeeper/zookeeper.h>
 #include <stdexcept>
+#include "utils/flags.h"
 
 namespace dsn {
 namespace dist {
 
+DSN_DEFINE_string(zookeeper, logfile, "", "The Zookeeper logfile");
+
 zookeeper_session_mgr::zookeeper_session_mgr()
 {
-    _zoo_hosts = dsn_config_get_value_string("zookeeper", "hosts_list", "", "zookeeper_hosts");
-    _zoo_logfile = dsn_config_get_value_string("zookeeper", "logfile", "", "zookeeper logfile");
-
-    FILE *fp = fopen(_zoo_logfile.c_str(), "a");
+    FILE *fp = fopen(FLAGS_logfile, "a");
     if (fp != nullptr)
         zoo_set_log_stream(fp);
 }
@@ -56,7 +56,6 @@ zookeeper_session *zookeeper_session_mgr::get_session(const service_app_info &in
 {
     auto &store = utils::singleton_store<int, zookeeper_session *>::instance();
     zookeeper_session *ans = nullptr;
-    utils::auto_lock<utils::ex_lock_nr> l(_store_lock);
     if (!store.get(info.entity_id, ans)) {
         ans = new zookeeper_session(info);
         store.put(info.entity_id, ans);

--- a/src/zookeeper/zookeeper_session_mgr.h
+++ b/src/zookeeper/zookeeper_session_mgr.h
@@ -59,16 +59,10 @@ class zookeeper_session_mgr : public utils::singleton<zookeeper_session_mgr>
 {
 public:
     zookeeper_session *get_session(const service_app_info &info);
-    const char *zoo_hosts() const { return _zoo_hosts.c_str(); }
-    const char *zoo_logfile() const { return _zoo_logfile.c_str(); }
 
 private:
     zookeeper_session_mgr();
     ~zookeeper_session_mgr() = default;
-
-    utils::ex_lock_nr _store_lock;
-    std::string _zoo_hosts;
-    std::string _zoo_logfile;
 
     friend class utils::singleton<zookeeper_session_mgr>;
 };


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1323

This patch refactors the code to use `DSN_DEFINE_string` instead of `dsn_config_get_value_string` to load string type of configurations, and doesn't introduce any functional changes.
- all default value and most of description are kept as before
- move the defination of flags closer to the places where they're used