### PR TITLE
feat(new_metrics): migrate replica-level metrics for pegasus_server_impl (part 1)

### DIFF
--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -262,7 +262,8 @@ int pegasus_server_impl::on_batched_write_requests(int64_t decree,
 void pegasus_server_impl::on_get(get_rpc rpc)
 {
     CHECK(_is_open, "");
-    _pfc_get_qps->increment();
+
+    METRIC_VAR_INCREMENT(get_requests);
     uint64_t start_time = dsn_now_ns();
 
     const auto &key = rpc.request();
@@ -342,7 +343,9 @@ void pegasus_server_impl::on_get(get_rpc rpc)
 void pegasus_server_impl::on_multi_get(multi_get_rpc rpc)
 {
     CHECK(_is_open, "");
-    _pfc_multi_get_qps->increment();
+
+    METRIC_VAR_INCREMENT(multi_get_requests);
+
     uint64_t start_time = dsn_now_ns();
 
     const auto &request = rpc.request();
@@ -765,7 +768,9 @@ void pegasus_server_impl::on_multi_get(multi_get_rpc rpc)
 void pegasus_server_impl::on_batch_get(batch_get_rpc rpc)
 {
     CHECK(_is_open, "");
-    _pfc_batch_get_qps->increment();
+
+    METRIC_VAR_INCREMENT(batch_get_requests);
+
     int64_t start_time = dsn_now_ns();
 
     auto &response = rpc.response();
@@ -883,7 +888,8 @@ void pegasus_server_impl::on_sortkey_count(sortkey_count_rpc rpc)
 {
     CHECK(_is_open, "");
 
-    _pfc_scan_qps->increment();
+    METRIC_VAR_INCREMENT(scan_requests);
+
     uint64_t start_time = dsn_now_ns();
 
     const auto &hash_key = rpc.request();
@@ -1026,7 +1032,9 @@ void pegasus_server_impl::on_ttl(ttl_rpc rpc)
 void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
 {
     CHECK(_is_open, "");
-    _pfc_scan_qps->increment();
+
+    METRIC_VAR_INCREMENT(scan_requests);
+
     uint64_t start_time = dsn_now_ns();
 
     const auto &request = rpc.request();
@@ -1285,7 +1293,9 @@ void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
 void pegasus_server_impl::on_scan(scan_rpc rpc)
 {
     CHECK(_is_open, "");
-    _pfc_scan_qps->increment();
+
+    METRIC_VAR_INCREMENT(scan_requests);
+
     uint64_t start_time = dsn_now_ns();
     const auto &request = rpc.request();
     dsn::message_ex *req = rpc.dsn_request();

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -285,7 +285,7 @@ void pegasus_server_impl::on_get(get_rpc rpc)
 
     if (status.ok()) {
         if (check_if_record_expired(utils::epoch_now(), value)) {
-            _pfc_recent_expire_count->increment();
+            METRIC_VAR_INCREMENT(read_expired_values);
             if (_verbose_log) {
                 LOG_ERROR_PREFIX("rocksdb data expired for get from {}", rpc.remote_address());
             }
@@ -745,7 +745,7 @@ void pegasus_server_impl::on_multi_get(multi_get_rpc rpc)
     }
 
     if (expire_count > 0) {
-        _pfc_recent_expire_count->add(expire_count);
+        METRIC_VAR_INCREMENT_BY(read_expired_values, expire_count);
     }
     if (filter_count > 0) {
         _pfc_recent_filter_count->add(filter_count);
@@ -872,7 +872,7 @@ void pegasus_server_impl::on_batch_get(batch_get_rpc rpc)
     }
 
     if (expire_count > 0) {
-        _pfc_recent_expire_count->add(expire_count);
+        METRIC_VAR_INCREMENT_BY(read_expired_values, expire_count);
     }
 
     _cu_calculator->add_batch_get_cu(rpc.dsn_request(), response.error, response.data);
@@ -931,7 +931,7 @@ void pegasus_server_impl::on_sortkey_count(sortkey_count_rpc rpc)
         it->Next();
     }
     if (expire_count > 0) {
-        _pfc_recent_expire_count->add(expire_count);
+        METRIC_VAR_INCREMENT_BY(read_expired_values, expire_count);
     }
 
     resp.error = it->status().code();
@@ -985,7 +985,7 @@ void pegasus_server_impl::on_ttl(ttl_rpc rpc)
     if (status.ok()) {
         expire_ts = pegasus_extract_expire_ts(_pegasus_data_version, value);
         if (check_if_ts_expired(now_ts, expire_ts)) {
-            _pfc_recent_expire_count->increment();
+            METRIC_VAR_INCREMENT(read_expired_values);
             if (_verbose_log) {
                 LOG_ERROR_PREFIX("rocksdb data expired for ttl from {}", rpc.remote_address());
             }
@@ -1269,7 +1269,7 @@ void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
     }
 
     if (expire_count > 0) {
-        _pfc_recent_expire_count->add(expire_count);
+        METRIC_VAR_INCREMENT_BY(read_expired_values, expire_count);
     }
     if (filter_count > 0) {
         _pfc_recent_filter_count->add(filter_count);
@@ -1422,7 +1422,7 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
         }
 
         if (expire_count > 0) {
-            _pfc_recent_expire_count->add(expire_count);
+            METRIC_VAR_INCREMENT_BY(read_expired_values, expire_count);
         }
         if (filter_count > 0) {
             _pfc_recent_filter_count->add(filter_count);

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -748,7 +748,7 @@ void pegasus_server_impl::on_multi_get(multi_get_rpc rpc)
         METRIC_VAR_INCREMENT_BY(read_expired_values, expire_count);
     }
     if (filter_count > 0) {
-        _pfc_recent_filter_count->add(filter_count);
+        METRIC_VAR_INCREMENT_BY(read_filtered_values, filter_count);
     }
 
     _cu_calculator->add_multi_get_cu(req, resp.error, request.hash_key, resp.kvs);
@@ -1272,7 +1272,7 @@ void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
         METRIC_VAR_INCREMENT_BY(read_expired_values, expire_count);
     }
     if (filter_count > 0) {
-        _pfc_recent_filter_count->add(filter_count);
+        METRIC_VAR_INCREMENT_BY(read_filtered_values, filter_count);
     }
 
     _cu_calculator->add_scan_cu(req, resp.error, resp.kvs);
@@ -1425,7 +1425,7 @@ void pegasus_server_impl::on_scan(scan_rpc rpc)
             METRIC_VAR_INCREMENT_BY(read_expired_values, expire_count);
         }
         if (filter_count > 0) {
-            _pfc_recent_filter_count->add(filter_count);
+            METRIC_VAR_INCREMENT_BY(read_filtered_values, filter_count);
         }
     } else {
         resp.error = rocksdb::Status::Code::kNotFound;

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -327,7 +327,7 @@ void pegasus_server_impl::on_get(get_rpc rpc)
                            status.ToString(),
                            value.size(),
                            time_used);
-        _pfc_recent_abnormal_count->increment();
+        METRIC_VAR_INCREMENT(abnormal_read_requests);
     }
 
     resp.error = status.code();
@@ -741,7 +741,7 @@ void pegasus_server_impl::on_multi_get(multi_get_rpc rpc)
             expire_count,
             filter_count,
             time_used);
-        _pfc_recent_abnormal_count->increment();
+        METRIC_VAR_INCREMENT(abnormal_read_requests);
     }
 
     if (expire_count > 0) {
@@ -868,7 +868,7 @@ void pegasus_server_impl::on_batch_get(batch_get_rpc rpc)
             total_data_size,
             request.keys.size(),
             time_used / 1000);
-        _pfc_recent_abnormal_count->increment();
+        METRIC_VAR_INCREMENT(abnormal_read_requests);
     }
 
     if (expire_count > 0) {

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -485,16 +485,15 @@ private:
 
     std::shared_ptr<throttling_controller> _read_size_throttling_controller;
 
-    // perf counters
     METRIC_VAR_DECLARE_counter(get_requests);
     METRIC_VAR_DECLARE_counter(multi_get_requests);
     METRIC_VAR_DECLARE_counter(batch_get_requests);
     METRIC_VAR_DECLARE_counter(scan_requests);
 
-    ::dsn::perf_counter_wrapper _pfc_get_latency;
-    ::dsn::perf_counter_wrapper _pfc_multi_get_latency;
-    ::dsn::perf_counter_wrapper _pfc_batch_get_latency;
-    ::dsn::perf_counter_wrapper _pfc_scan_latency;
+    METRIC_VAR_DECLARE_percentile_int64(get_latency_ns);
+    METRIC_VAR_DECLARE_percentile_int64(multi_get_latency_ns);
+    METRIC_VAR_DECLARE_percentile_int64(batch_get_latency_ns);
+    METRIC_VAR_DECLARE_percentile_int64(scan_latency_ns);
 
     ::dsn::perf_counter_wrapper _pfc_recent_expire_count;
     ::dsn::perf_counter_wrapper _pfc_recent_filter_count;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -495,7 +495,7 @@ private:
     METRIC_VAR_DECLARE_percentile_int64(batch_get_latency_ns);
     METRIC_VAR_DECLARE_percentile_int64(scan_latency_ns);
 
-    METRIC_VAR_DECLARE_counter(_pfc_recent_expire_count);
+    METRIC_VAR_DECLARE_counter(read_expired_values);
     ::dsn::perf_counter_wrapper _pfc_recent_filter_count;
     ::dsn::perf_counter_wrapper _pfc_recent_abnormal_count;
 

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -486,10 +486,10 @@ private:
     std::shared_ptr<throttling_controller> _read_size_throttling_controller;
 
     // perf counters
-    ::dsn::perf_counter_wrapper _pfc_get_qps;
-    ::dsn::perf_counter_wrapper _pfc_multi_get_qps;
-    ::dsn::perf_counter_wrapper _pfc_batch_get_qps;
-    ::dsn::perf_counter_wrapper _pfc_scan_qps;
+    METRIC_VAR_DECLARE_counter(get_requests);
+    METRIC_VAR_DECLARE_counter(multi_get_requests);
+    METRIC_VAR_DECLARE_counter(batch_get_requests);
+    METRIC_VAR_DECLARE_counter(scan_requests);
 
     ::dsn::perf_counter_wrapper _pfc_get_latency;
     ::dsn::perf_counter_wrapper _pfc_multi_get_latency;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -496,7 +496,7 @@ private:
     METRIC_VAR_DECLARE_percentile_int64(scan_latency_ns);
 
     METRIC_VAR_DECLARE_counter(read_expired_values);
-    ::dsn::perf_counter_wrapper _pfc_recent_filter_count;
+    METRIC_VAR_DECLARE_counter(read_filtered_values);
     ::dsn::perf_counter_wrapper _pfc_recent_abnormal_count;
 
     // rocksdb internal statistics

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -495,7 +495,7 @@ private:
     METRIC_VAR_DECLARE_percentile_int64(batch_get_latency_ns);
     METRIC_VAR_DECLARE_percentile_int64(scan_latency_ns);
 
-    ::dsn::perf_counter_wrapper _pfc_recent_expire_count;
+    METRIC_VAR_DECLARE_counter(_pfc_recent_expire_count);
     ::dsn::perf_counter_wrapper _pfc_recent_filter_count;
     ::dsn::perf_counter_wrapper _pfc_recent_abnormal_count;
 

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -406,6 +406,22 @@ private:
 
     dsn::replication::manual_compaction_status::type query_compact_status() const override;
 
+    void log_expired_data(const char *op,
+                          const dsn::rpc_address &addr,
+                          const dsn::blob &hash_key,
+                          const dsn::blob &sort_key) const;
+    void log_expired_data(const char *op, const dsn::rpc_address &addr, const dsn::blob &key) const;
+    void log_expired_data_if_verbose(const char *op,
+                                     const dsn::rpc_address &addr,
+                                     const dsn::blob &hash_key,
+                                     const dsn::blob &sort_key) const;
+    void log_expired_data_if_verbose(const char *op,
+                                     const dsn::rpc_address &addr,
+                                     const dsn::blob &key) const;
+    void log_expired_data_if_verbose(const char *op,
+                                     const dsn::rpc_address &addr,
+                                     const rocksdb::Slice &key) const;
+
 private:
     static const std::chrono::seconds kServerStatUpdateTimeSec;
     static const std::string COMPRESSION_HEADER;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -406,21 +406,14 @@ private:
 
     dsn::replication::manual_compaction_status::type query_compact_status() const override;
 
+    // Log expired keys for verbose mode.
     void log_expired_data(const char *op,
                           const dsn::rpc_address &addr,
                           const dsn::blob &hash_key,
                           const dsn::blob &sort_key) const;
     void log_expired_data(const char *op, const dsn::rpc_address &addr, const dsn::blob &key) const;
-    void log_expired_data_if_verbose(const char *op,
-                                     const dsn::rpc_address &addr,
-                                     const dsn::blob &hash_key,
-                                     const dsn::blob &sort_key) const;
-    void log_expired_data_if_verbose(const char *op,
-                                     const dsn::rpc_address &addr,
-                                     const dsn::blob &key) const;
-    void log_expired_data_if_verbose(const char *op,
-                                     const dsn::rpc_address &addr,
-                                     const rocksdb::Slice &key) const;
+    void
+    log_expired_data(const char *op, const dsn::rpc_address &addr, const rocksdb::Slice &key) const;
 
 private:
     static const std::chrono::seconds kServerStatUpdateTimeSec;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -497,7 +497,7 @@ private:
 
     METRIC_VAR_DECLARE_counter(read_expired_values);
     METRIC_VAR_DECLARE_counter(read_filtered_values);
-    ::dsn::perf_counter_wrapper _pfc_recent_abnormal_count;
+    METRIC_VAR_DECLARE_counter(abnormal_read_requests);
 
     // rocksdb internal statistics
     // server level

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -51,6 +51,26 @@ METRIC_DEFINE_counter(replica,
                       dsn::metric_unit::kRequests,
                       "The number of SCAN requests for each replica");
 
+METRIC_DEFINE_percentile_int64(replica,
+                               get_latency_ns,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The latency of GET requests for each replica");
+
+METRIC_DEFINE_percentile_int64(replica,
+                               multi_get_latency_ns,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The latency of MULTI_GET requests for each replica");
+
+METRIC_DEFINE_percentile_int64(replica,
+                               batch_get_latency_ns,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The latency of BATCH_GET requests for each replica");
+
+METRIC_DEFINE_percentile_int64(replica,
+                               scan_latency_ns,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The latency of SCAN requests for each replica");
+
 namespace pegasus {
 namespace server {
 
@@ -220,6 +240,10 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
       METRIC_VAR_INIT_replica(multi_get_requests),
       METRIC_VAR_INIT_replica(batch_get_requests),
       METRIC_VAR_INIT_replica(scan_requests),
+      METRIC_VAR_INIT_replica(get_latency_ns),
+      METRIC_VAR_INIT_replica(multi_get_latency_ns),
+      METRIC_VAR_INIT_replica(batch_get_latency_ns),
+      METRIC_VAR_INIT_replica(scan_latency_ns)
 {
     _primary_address = dsn::rpc_address(dsn_primary_address()).to_string();
     _gpid = get_gpid();
@@ -625,30 +649,6 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     char name[256];
 
     // register the perf counters
-    snprintf(name, 255, "get_latency@%s", str_gpid.c_str());
-    _pfc_get_latency.init_app_counter("app.pegasus",
-                                      name,
-                                      COUNTER_TYPE_NUMBER_PERCENTILES,
-                                      "statistic the latency of GET request");
-
-    snprintf(name, 255, "multi_get_latency@%s", str_gpid.c_str());
-    _pfc_multi_get_latency.init_app_counter("app.pegasus",
-                                            name,
-                                            COUNTER_TYPE_NUMBER_PERCENTILES,
-                                            "statistic the latency of MULTI_GET request");
-
-    snprintf(name, 255, "batch_get_latency@%s", str_gpid.c_str());
-    _pfc_batch_get_latency.init_app_counter("app.pegasus",
-                                            name,
-                                            COUNTER_TYPE_NUMBER_PERCENTILES,
-                                            "statistic the latency of BATCH_GET request");
-
-    snprintf(name, 255, "scan_latency@%s", str_gpid.c_str());
-    _pfc_scan_latency.init_app_counter("app.pegasus",
-                                       name,
-                                       COUNTER_TYPE_NUMBER_PERCENTILES,
-                                       "statistic the latency of SCAN request");
-
     snprintf(name, 255, "recent.expire.count@%s", str_gpid.c_str());
     _pfc_recent_expire_count.init_app_counter("app.pegasus",
                                               name,

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -72,14 +72,9 @@ METRIC_DEFINE_percentile_int64(replica,
                                "The latency of SCAN requests for each replica");
 
 METRIC_DEFINE_counter(replica,
-                       expired_read_requests,
-                               dsn::metric_unit::kNanoSeconds,
-                               "The number of SCAN requests for each replica");
-
-    _pfc_recent_expire_count.init_app_counter("app.pegasus",
-                                              name,
-                                              COUNTER_TYPE_VOLATILE_NUMBER,
-                                              "statistic the recent expired value read count");
+                      read_expired_values,
+                      dsn::metric_unit::kValues,
+                      "The number of expired values read for each replica");
 
 namespace pegasus {
 namespace server {
@@ -253,7 +248,8 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
       METRIC_VAR_INIT_replica(get_latency_ns),
       METRIC_VAR_INIT_replica(multi_get_latency_ns),
       METRIC_VAR_INIT_replica(batch_get_latency_ns),
-      METRIC_VAR_INIT_replica(scan_latency_ns)
+      METRIC_VAR_INIT_replica(scan_latency_ns),
+      METRIC_VAR_INIT_replica(read_expired_values)
 {
     _primary_address = dsn::rpc_address(dsn_primary_address()).to_string();
     _gpid = get_gpid();
@@ -659,12 +655,6 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     char name[256];
 
     // register the perf counters
-    snprintf(name, 255, "recent.expire.count@%s", str_gpid.c_str());
-    _pfc_recent_expire_count.init_app_counter("app.pegasus",
-                                              name,
-                                              COUNTER_TYPE_VOLATILE_NUMBER,
-                                              "statistic the recent expired value read count");
-
     snprintf(name, 255, "recent.filter.count@%s", str_gpid.c_str());
     _pfc_recent_filter_count.init_app_counter("app.pegasus",
                                               name,

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -71,6 +71,16 @@ METRIC_DEFINE_percentile_int64(replica,
                                dsn::metric_unit::kNanoSeconds,
                                "The latency of SCAN requests for each replica");
 
+METRIC_DEFINE_counter(replica,
+                       expired_read_requests,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The number of SCAN requests for each replica");
+
+    _pfc_recent_expire_count.init_app_counter("app.pegasus",
+                                              name,
+                                              COUNTER_TYPE_VOLATILE_NUMBER,
+                                              "statistic the recent expired value read count");
+
 namespace pegasus {
 namespace server {
 

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -81,6 +81,11 @@ METRIC_DEFINE_counter(replica,
                       dsn::metric_unit::kValues,
                       "The number of filtered values read for each replica");
 
+METRIC_DEFINE_counter(replica,
+                      abnormal_read_requests,
+                      dsn::metric_unit::kValues,
+                      "The number of abnormal read requests for each replica");
+
 namespace pegasus {
 namespace server {
 
@@ -255,7 +260,8 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
       METRIC_VAR_INIT_replica(batch_get_latency_ns),
       METRIC_VAR_INIT_replica(scan_latency_ns),
       METRIC_VAR_INIT_replica(read_expired_values),
-      METRIC_VAR_INIT_replica(read_filtered_values)
+      METRIC_VAR_INIT_replica(read_filtered_values),
+      METRIC_VAR_INIT_replica(abnormal_read_requests)
 {
     _primary_address = dsn::rpc_address(dsn_primary_address()).to_string();
     _gpid = get_gpid();
@@ -661,12 +667,6 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     char name[256];
 
     // register the perf counters
-    snprintf(name, 255, "recent.abnormal.count@%s", str_gpid.c_str());
-    _pfc_recent_abnormal_count.init_app_counter("app.pegasus",
-                                                name,
-                                                COUNTER_TYPE_VOLATILE_NUMBER,
-                                                "statistic the recent abnormal read count");
-
     snprintf(name, 255, "disk.storage.sst.count@%s", str_gpid.c_str());
     _pfc_rdb_sst_count.init_app_counter(
         "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistic the count of sstable files");

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -76,6 +76,11 @@ METRIC_DEFINE_counter(replica,
                       dsn::metric_unit::kValues,
                       "The number of expired values read for each replica");
 
+METRIC_DEFINE_counter(replica,
+                      read_filtered_values,
+                      dsn::metric_unit::kValues,
+                      "The number of filtered values read for each replica");
+
 namespace pegasus {
 namespace server {
 
@@ -249,7 +254,8 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
       METRIC_VAR_INIT_replica(multi_get_latency_ns),
       METRIC_VAR_INIT_replica(batch_get_latency_ns),
       METRIC_VAR_INIT_replica(scan_latency_ns),
-      METRIC_VAR_INIT_replica(read_expired_values)
+      METRIC_VAR_INIT_replica(read_expired_values),
+      METRIC_VAR_INIT_replica(read_filtered_values)
 {
     _primary_address = dsn::rpc_address(dsn_primary_address()).to_string();
     _gpid = get_gpid();
@@ -655,12 +661,6 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     char name[256];
 
     // register the perf counters
-    snprintf(name, 255, "recent.filter.count@%s", str_gpid.c_str());
-    _pfc_recent_filter_count.init_app_counter("app.pegasus",
-                                              name,
-                                              COUNTER_TYPE_VOLATILE_NUMBER,
-                                              "statistic the recent filtered value read count");
-
     snprintf(name, 255, "recent.abnormal.count@%s", str_gpid.c_str());
     _pfc_recent_abnormal_count.init_app_counter("app.pegasus",
                                                 name,

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -83,7 +83,7 @@ METRIC_DEFINE_counter(replica,
 
 METRIC_DEFINE_counter(replica,
                       abnormal_read_requests,
-                      dsn::metric_unit::kValues,
+                      dsn::metric_unit::kRequests,
                       "The number of abnormal read requests for each replica");
 
 namespace pegasus {

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -89,7 +89,7 @@ public:
         : replica_base(server),
           _primary_address(server->_primary_address),
           _pegasus_data_version(server->_pegasus_data_version),
-          _pfc_recent_expire_count(server->_pfc_recent_expire_count)
+          METRIC_VAR_INIT_REF(read_expired_values, server)
     {
         _rocksdb_wrapper = dsn::make_unique<rocksdb_wrapper>(server);
     }
@@ -689,7 +689,7 @@ private:
     const std::string _primary_address;
     const uint32_t _pegasus_data_version;
 
-    ::dsn::perf_counter_wrapper &_pfc_recent_expire_count;
+    METRIC_VAR_DECLARE_counter(read_expired_values);
 
     std::unique_ptr<rocksdb_wrapper> _rocksdb_wrapper;
 

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -32,6 +32,8 @@
 #include "utils/string_conv.h"
 #include "utils/strings.h"
 
+METRIC_DECLARE_counter(read_expired_values);
+
 namespace pegasus {
 namespace server {
 
@@ -89,7 +91,7 @@ public:
         : replica_base(server),
           _primary_address(server->_primary_address),
           _pegasus_data_version(server->_pegasus_data_version),
-          METRIC_VAR_INIT_REF(read_expired_values, server)
+          METRIC_VAR_INIT_replica(read_expired_values)
     {
         _rocksdb_wrapper = dsn::make_unique<rocksdb_wrapper>(server);
     }

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -32,8 +32,6 @@
 #include "utils/string_conv.h"
 #include "utils/strings.h"
 
-METRIC_DECLARE_counter(read_expired_values);
-
 namespace pegasus {
 namespace server {
 
@@ -90,8 +88,7 @@ public:
     explicit impl(pegasus_server_impl *server)
         : replica_base(server),
           _primary_address(server->_primary_address),
-          _pegasus_data_version(server->_pegasus_data_version),
-          METRIC_VAR_INIT_replica(read_expired_values)
+          _pegasus_data_version(server->_pegasus_data_version)
     {
         _rocksdb_wrapper = dsn::make_unique<rocksdb_wrapper>(server);
     }
@@ -690,8 +687,6 @@ private:
 
     const std::string _primary_address;
     const uint32_t _pegasus_data_version;
-
-    METRIC_VAR_DECLARE_counter(read_expired_values);
 
     std::unique_ptr<rocksdb_wrapper> _rocksdb_wrapper;
 

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -24,6 +24,8 @@
 #include "pegasus_write_service_impl.h"
 #include "base/pegasus_value_schema.h"
 
+METRIC_DECLARE_counter(read_expired_values);
+
 namespace pegasus {
 namespace server {
 
@@ -33,7 +35,7 @@ rocksdb_wrapper::rocksdb_wrapper(pegasus_server_impl *server)
       _rd_opts(server->_data_cf_rd_opts),
       _meta_cf(server->_meta_cf),
       _pegasus_data_version(server->_pegasus_data_version),
-      METRIC_VAR_INIT_REF(read_expired_values, server),
+      METRIC_VAR_INIT_replica(read_expired_values),
       _default_ttl(0)
 {
     _write_batch = dsn::make_unique<rocksdb::WriteBatch>();

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -33,7 +33,7 @@ rocksdb_wrapper::rocksdb_wrapper(pegasus_server_impl *server)
       _rd_opts(server->_data_cf_rd_opts),
       _meta_cf(server->_meta_cf),
       _pegasus_data_version(server->_pegasus_data_version),
-      _pfc_recent_expire_count(server->_pfc_recent_expire_count),
+      METRIC_VAR_INIT_REF(read_expired_values, server),
       _default_ttl(0)
 {
     _write_batch = dsn::make_unique<rocksdb::WriteBatch>();
@@ -55,7 +55,7 @@ int rocksdb_wrapper::get(dsn::string_view raw_key, /*out*/ db_get_context *ctx)
         ctx->expire_ts = pegasus_extract_expire_ts(_pegasus_data_version, ctx->raw_value);
         if (check_if_ts_expired(utils::epoch_now(), ctx->expire_ts)) {
             ctx->expired = true;
-            _pfc_recent_expire_count->increment();
+            METRIC_VAR_INCREMENT(read_expired_values);
         }
         return rocksdb::Status::kOk;
     } else if (s.IsNotFound()) {

--- a/src/server/rocksdb_wrapper.h
+++ b/src/server/rocksdb_wrapper.h
@@ -81,7 +81,7 @@ private:
     rocksdb::ColumnFamilyHandle *_meta_cf;
 
     const uint32_t _pegasus_data_version;
-    dsn::perf_counter_wrapper &_pfc_recent_expire_count;
+    METRIC_VAR_DECLARE_counter(read_expired_values);
     volatile uint32_t _default_ttl;
 
     friend class rocksdb_wrapper_test;

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -54,7 +54,7 @@ public:
             _server->update_app_envs(envs);
 
             // do on_get/on_multi_get operation,
-            long before_count = _server->_pfc_recent_abnormal_count->get_integer_value();
+            auto before_count = _server->METRIC_VAR_VALUE(abnormal_read_requests);
             if (!test.is_multi_get) {
                 get_rpc rpc(dsn::make_unique<dsn::blob>(test_key), dsn::apps::RPC_RRDB_RRDB_GET);
                 _server->on_get(rpc);
@@ -67,7 +67,7 @@ public:
                                   dsn::apps::RPC_RRDB_RRDB_MULTI_GET);
                 _server->on_multi_get(rpc);
             }
-            long after_count = _server->_pfc_recent_abnormal_count->get_integer_value();
+            auto after_count = _server->METRIC_VAR_VALUE(abnormal_read_requests);
 
             ASSERT_EQ(before_count + test.expect_perf_counter_incr, after_count);
         }

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -154,7 +154,6 @@
 
 // Initialize a metric variable in user class.
 #define METRIC_VAR_INIT(name, entity) _##name(METRIC_##name.instantiate(entity##_metric_entity()))
-#define METRIC_VAR_INIT_REF(name, obj) _##name(obj->_##name)
 #define METRIC_VAR_INIT_replica(name) METRIC_VAR_INIT(name, replica)
 
 // Perform increment-related operations on metrics including gauge and counter.

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -172,6 +172,9 @@
 #define METRIC_VAR_AUTO_LATENCY(name, ...)                                                         \
     dsn::auto_latency __##name##_auto_latency(_##name, ##__VA_ARGS__)
 
+#define METRIC_VAR_AUTO_LATENCY_DURATION_NS(name) \
+    __##name##_auto_latency.duration_ns()
+
 namespace dsn {
 
 class metric_prototype;
@@ -1398,6 +1401,11 @@ public:
         if (_callback) {
             _callback(latency);
         }
+    }
+
+    inline uint64_t duration_ns() const
+    {
+        return _chrono.duration_ns();
     }
 
 private:

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -172,8 +172,7 @@
 #define METRIC_VAR_AUTO_LATENCY(name, ...)                                                         \
     dsn::auto_latency __##name##_auto_latency(_##name, ##__VA_ARGS__)
 
-#define METRIC_VAR_AUTO_LATENCY_DURATION_NS(name) \
-    __##name##_auto_latency.duration_ns()
+#define METRIC_VAR_AUTO_LATENCY_DURATION_NS(name) __##name##_auto_latency.duration_ns()
 
 namespace dsn {
 
@@ -1403,10 +1402,7 @@ public:
         }
     }
 
-    inline uint64_t duration_ns() const
-    {
-        return _chrono.duration_ns();
-    }
+    inline uint64_t duration_ns() const { return _chrono.duration_ns(); }
 
 private:
     percentile_ptr<int64_t> _percentile;

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -157,7 +157,13 @@
 #define METRIC_VAR_INIT_replica(name) METRIC_VAR_INIT(name, replica)
 
 // Perform increment-related operations on metrics including gauge and counter.
-#define METRIC_VAR_INCREMENT_BY(name, x) _##name->increment_by(x)
+#define METRIC_VAR_INCREMENT_BY(name, x)                                                           \
+    do {                                                                                           \
+        if (x != 0) {                                                                              \
+            _##name->increment_by(x);                                                              \
+        }                                                                                          \
+    } while (0)
+
 #define METRIC_VAR_INCREMENT(name) _##name->increment()
 
 // Perform set() operations on metrics including gauge and percentile.

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -169,6 +169,9 @@
 // such as percentile.
 #define METRIC_VAR_SET(name, ...) _##name->set(__VA_ARGS__)
 
+// Read the current measurement of the metric.
+#define METRIC_VAR_VALUE(name) _##name->value()
+
 // Convenient macro that is used to compute latency automatically, which is dedicated to percentile.
 #define METRIC_VAR_AUTO_LATENCY(name, ...)                                                         \
     dsn::auto_latency __##name##_auto_latency(_##name, ##__VA_ARGS__)

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -154,6 +154,7 @@
 
 // Initialize a metric variable in user class.
 #define METRIC_VAR_INIT(name, entity) _##name(METRIC_##name.instantiate(entity##_metric_entity()))
+#define METRIC_VAR_INIT_REF(name, obj) _##name(obj->_##name)
 #define METRIC_VAR_INIT_replica(name) METRIC_VAR_INIT(name, replica)
 
 // Perform increment-related operations on metrics including gauge and counter.
@@ -591,6 +592,7 @@ enum class metric_unit : size_t
     kMilliSeconds,
     kSeconds,
     kRequests,
+    kValues,
     kInvalidUnit,
 };
 

--- a/src/utils/test/metrics_test.cpp
+++ b/src/utils/test/metrics_test.cpp
@@ -3121,8 +3121,6 @@ void MetricVarTest::test_set_percentile(size_t n, int64_t val)
     EXPECT_EQ(std::vector<int64_t>(n, val), METRIC_VAR_SAMPLES(test_replica_percentile_int64_ns));
 }
 
-#define METRIC_VAR_VALUE(name) _##name->value()
-
 #define TEST_METRIC_VAR_INCREMENT(name)                                                            \
     do {                                                                                           \
         ASSERT_EQ(0, METRIC_VAR_VALUE(name));                                                      \

--- a/src/utils/time_utils.h
+++ b/src/utils/time_utils.h
@@ -139,7 +139,7 @@ public:
 
     inline void reset_start_time() { _start_time_ns = dsn_now_ns(); }
 
-    inline uint64_t duration_ns()
+    inline uint64_t duration_ns() const
     {
         auto now = dsn_now_ns();
         CHECK_GE(now, _start_time_ns);


### PR DESCRIPTION
This PR is to migrate replica-level metrics of `pegasus_server_impl` to new framework
(https://github.com/apache/incubator-pegasus/issues/1333). Since there are many replica-level
metrics in `pegasus_server_impl`, this PR is part 1 for this migration and other metrics (all
of which are gauges) will be migrated in the later PRs.