### PR TITLE
feat(security): Use Apache Ranger for access control(2/n)

### DIFF
--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -176,6 +176,8 @@ public:
         return metas.substr(0, metas.length() - 1);
     }
 
+    std::string cluster_root() const { return _cluster_root; }
+
 private:
     void register_rpc_handlers();
     void register_ctrl_commands();

--- a/src/runtime/ranger/ranger_resource_policy_manager.cpp
+++ b/src/runtime/ranger/ranger_resource_policy_manager.cpp
@@ -23,15 +23,17 @@ namespace dsn {
 namespace ranger {
 
 namespace {
-// Register the matching between rpc_code and access contol type in resources.
-void register_rpc_access_type(access_type type,
+// Register access types of 'rpc_codes' as 'ac_type' to 'ac_type_of_rpc'.
+// TODO(wanghao): A better way is to define the ac_type when defining rpc, and traverse all RPCs to
+// register to avoid omission or duplication.
+void register_rpc_access_type(access_type ac_type,
                               const std::vector<std::string> &rpc_codes,
                               access_type_of_rpc_code &ac_type_of_rpc)
 {
     for (const auto &rpc_code : rpc_codes) {
         auto code = task_code::try_get(rpc_code, TASK_CODE_INVALID);
         CHECK_NE(code, TASK_CODE_INVALID);
-        ac_type_of_rpc.emplace(code, type);
+        ac_type_of_rpc.emplace(code, ac_type);
     }
 }
 } // anonymous namespace

--- a/src/runtime/ranger/ranger_resource_policy_manager.cpp
+++ b/src/runtime/ranger/ranger_resource_policy_manager.cpp
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "common/replication.codes.h"
+#include "meta/meta_options.h"
+#include "ranger_resource_policy_manager.h"
+
+namespace dsn {
+namespace ranger {
+
+namespace {
+// Register the matching between rpc_code and access contol type in resources.
+void register_rpc_access_type(access_type type,
+                              const std::vector<std::string> &rpc_codes,
+                              access_type_of_rpc_code &ac_type_of_rpc)
+{
+    for (const auto &rpc_code : rpc_codes) {
+        auto code = task_code::try_get(rpc_code, TASK_CODE_INVALID);
+        CHECK_NE(code, TASK_CODE_INVALID);
+        ac_type_of_rpc.emplace(code, type);
+    }
+}
+} // anonymous namespace
+
+ranger_resource_policy_manager::ranger_resource_policy_manager(
+    dsn::replication::meta_service *meta_svc)
+    : _meta_svc(meta_svc), _local_policy_version(0)
+{
+    _ranger_policy_meta_root = dsn::replication::meta_options::concat_path_unix_style(
+        _meta_svc->cluster_root(), "ranger_policy_meta_root");
+
+    // GLOBAL - KMetadata
+    register_rpc_access_type(
+        access_type::KMetadata,
+        {"RPC_CM_LIST_NODES", "RPC_CM_CLUSTER_INFO", "RPC_CM_LIST_APPS", "RPC_QUERY_DISK_INFO"},
+        _ac_type_of_global_rpcs);
+    // GLOBAL - KControl
+    register_rpc_access_type(access_type::KControl,
+                             {"RPC_HTTP_SERVICE",
+                              "RPC_CM_CONTROL_META",
+                              "RPC_CM_START_RECOVERY",
+                              "RPC_REPLICA_DISK_MIGRATE",
+                              "RPC_ADD_NEW_DISK",
+                              "RPC_DETECT_HOTKEY",
+                              "RPC_CLI_CLI_CALL_ACK"},
+                             _ac_type_of_global_rpcs);
+    // DATABASE - KList
+    register_rpc_access_type(access_type::KList, {"RPC_CM_LIST_APPS"}, _ac_type_of_database_rpcs);
+    // DATABASE - KCreate
+    register_rpc_access_type(
+        access_type::KCreate, {"RPC_CM_CREATE_APP"}, _ac_type_of_database_rpcs);
+    // DATABASE - KDrop
+    register_rpc_access_type(
+        access_type::KDrop, {"RPC_CM_DROP_APP", "RPC_CM_RECALL_APP"}, _ac_type_of_database_rpcs);
+    // DATABASE - KMetadata
+    register_rpc_access_type(access_type::KMetadata,
+                             {"RPC_CM_QUERY_BACKUP_STATUS",
+                              "RPC_CM_QUERY_RESTORE_STATUS",
+                              "RPC_CM_QUERY_DUPLICATION",
+                              "RPC_CM_QUERY_PARTITION_SPLIT",
+                              "RPC_CM_QUERY_BULK_LOAD_STATUS",
+                              "RPC_CM_QUERY_MANUAL_COMPACT_STATUS",
+                              "RPC_CM_GET_MAX_REPLICA_COUNT"},
+                             _ac_type_of_database_rpcs);
+    // DATABASE - KControl
+    register_rpc_access_type(access_type::KControl,
+                             {"RPC_CM_START_BACKUP_APP",
+                              "RPC_CM_START_RESTORE",
+                              "RPC_CM_PROPOSE_BALANCER",
+                              "RPC_CM_ADD_DUPLICATION",
+                              "RPC_CM_MODIFY_DUPLICATION",
+                              "RPC_CM_UPDATE_APP_ENV",
+                              "RPC_CM_DDD_DIAGNOSE",
+                              "RPC_CM_START_PARTITION_SPLIT",
+                              "RPC_CM_CONTROL_PARTITION_SPLIT",
+                              "RPC_CM_START_BULK_LOAD",
+                              "RPC_CM_CONTROL_BULK_LOAD",
+                              "RPC_CM_CLEAR_BULK_LOAD",
+                              "RPC_CM_START_MANUAL_COMPACT",
+                              "RPC_CM_SET_MAX_REPLICA_COUNT",
+                              "RPC_CM_RENAME_APP"},
+                             _ac_type_of_database_rpcs);
+}
+} // namespace ranger
+} // namespace dsn

--- a/src/runtime/ranger/ranger_resource_policy_manager.h
+++ b/src/runtime/ranger/ranger_resource_policy_manager.h
@@ -50,13 +50,13 @@ private:
 
     replication::meta_service *_meta_svc;
 
-    // Save the rpc codes that match the global resources.
+    // The rpc codes that match the global resources.
     access_type_of_rpc_code _ac_type_of_global_rpcs;
 
-    // Save the rpc codes that match the database resources.
+    // The rpc codes that match the database resources.
     access_type_of_rpc_code _ac_type_of_database_rpcs;
 
-    // Record the Ranger policy version to determine whether to update.
+    // The Ranger policy version to determine whether to update.
     int _local_policy_version;
 };
 } // namespace ranger

--- a/src/runtime/ranger/ranger_resource_policy_manager.h
+++ b/src/runtime/ranger/ranger_resource_policy_manager.h
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "meta/meta_service.h"
+#include "ranger_resource_policy.h"
+#include "runtime/api_task.h"
+#include "utils/error_code.h"
+
+namespace dsn {
+
+namespace replication {
+class meta_service;
+}
+
+namespace ranger {
+
+// Range access type of rpc codes
+using access_type_of_rpc_code = std::unordered_map<int, ranger::access_type>;
+
+class ranger_resource_policy_manager
+{
+public:
+    ranger_resource_policy_manager(dsn::replication::meta_service *meta_svc);
+
+    ~ranger_resource_policy_manager() = default;
+
+private:
+    // The path where policies to be saved in remote storage.
+    std::string _ranger_policy_meta_root;
+
+    replication::meta_service *_meta_svc;
+
+    // Save the rpc codes that match the global resources.
+    access_type_of_rpc_code _ac_type_of_global_rpcs;
+
+    // Save the rpc codes that match the database resources.
+    access_type_of_rpc_code _ac_type_of_database_rpcs;
+
+    // Record the Ranger policy version to determine whether to update.
+    int _local_policy_version;
+};
+} // namespace ranger
+} // namespace dsn

--- a/src/runtime/ranger/ranger_resource_policy_manager.h
+++ b/src/runtime/ranger/ranger_resource_policy_manager.h
@@ -50,10 +50,10 @@ private:
 
     replication::meta_service *_meta_svc;
 
-    // The rpc codes that match the global resources.
+    // The access type of RPCs which access global level resources.
     access_type_of_rpc_code _ac_type_of_global_rpcs;
 
-    // The rpc codes that match the database resources.
+    // The access type of RPCs which access database level resources.
     access_type_of_rpc_code _ac_type_of_database_rpcs;
 
     // The Ranger policy version to determine whether to update.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1054

This patch aim to define ranger_resource_policy_manager:

- Define the ranger_resource_policy_manager data structure(currently, only some member variables are included).
- Implementation of constructor，it will classify and match resources according to the type of `rpc_code`.
