### PR TITLE
feat(Ranger): Support encode and decode Ranger policies

### DIFF
--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -347,8 +347,8 @@ inline bool json_decode(const JsonObject &in, dsn::ranger::access_type &t)
 {
     dverify(in.IsUint64());
     auto ans = in.GetUint64();
-    auto act_min = static_cast<uint64_t>(dsn::ranger::kAccessTypeMin);
-    auto act_max = static_cast<uint64_t>(dsn::ranger::kAccessTypeMax);
+    auto act_min = static_cast<uint64_t>(dsn::ranger::kAccessTypeNone);
+    auto act_max = static_cast<uint64_t>(dsn::ranger::kAccessTypeAll);
     dverify(ans >= act_min && ans <= act_max);
     t = static_cast<dsn::ranger::access_type>(ans);
     return true;

--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -25,14 +25,15 @@
  */
 #pragma once
 
-#include <vector>
+#include <cctype>
 #include <map>
-#include <unordered_map>
 #include <set>
 #include <sstream>
 #include <string>
 #include <type_traits>
-#include <cctype>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include <rapidjson/ostreamwrapper.h>
 #include <rapidjson/prettywriter.h>
@@ -57,6 +58,7 @@
 #include "consensus_types.h"
 #include "replica_admin_types.h"
 #include "common/replication_enums.h"
+#include "runtime/ranger/access_type.h"
 
 #define JSON_ENCODE_ENTRY(out, prefix, T)                                                          \
     out.Key(#T);                                                                                   \
@@ -335,6 +337,28 @@ INT_TYPE_SERIALIZATION(int16_t)
 INT_TYPE_SERIALIZATION(int32_t)
 INT_TYPE_SERIALIZATION(int64_t)
 
+template <typename Writer>
+inline void json_encode(Writer &out, dsn::ranger::access_type t)
+{
+    out.Uint64(static_cast<uint64_t>(t));
+}
+
+inline bool json_decode(const JsonObject &in, dsn::ranger::access_type &t)
+{
+    dverify(in.IsUint64());
+    int64_t ans = in.GetUint64();
+    int64_t act_min = static_cast<uint64_t>(dsn::ranger::access_type::KInvalid);
+    int64_t act_max = static_cast<uint64_t>(
+        dsn::ranger::access_type::KRead | dsn::ranger::access_type::KWrite |
+        dsn::ranger::access_type::KCreate | dsn::ranger::access_type::KDrop |
+        dsn::ranger::access_type::KList | dsn::ranger::access_type::KMetadata |
+        dsn::ranger::access_type::KControl);
+    dverify(ans >= act_min && ans <= act_max);
+    using act = std::underlying_type<dsn::ranger::access_type>::type;
+    t = (dsn::ranger::access_type) static_cast<act>(ans);
+    return true;
+}
+
 // json serialization for uint types
 #define UINT_TYPE_SERIALIZATION(TName)                                                             \
     template <typename Writer>                                                                     \
@@ -452,6 +476,19 @@ inline bool json_decode_map(const JsonObject &in, TMap &t)
     return true;
 }
 
+template <typename TSet>
+inline bool json_decode_set(const JsonObject &in, TSet &t)
+{
+    dverify(in.IsArray());
+    t.clear();
+    for (rapidjson::Value::ConstValueIterator it = in.Begin(); it != in.End(); ++it) {
+        typename TSet::value_type value;
+        dverify(json_forwarder<decltype(value)>::decode(*it, value));
+        dverify(t.emplace(std::move(value)).second);
+    }
+    return true;
+}
+
 template <typename T>
 inline void json_encode(JsonWriter &out, const std::vector<T> &t)
 {
@@ -482,15 +519,19 @@ inline void json_encode(JsonWriter &out, const std::set<T> &t)
 template <typename T>
 inline bool json_decode(const JsonObject &in, std::set<T> &t)
 {
-    dverify(in.IsArray());
-    t.clear();
+    return json_decode_set(in, t);
+}
 
-    for (rapidjson::Value::ConstValueIterator it = in.Begin(); it != in.End(); ++it) {
-        T value;
-        dverify(json_forwarder<T>::decode(*it, value));
-        dverify(t.emplace(std::move(value)).second);
-    }
-    return true;
+template <typename T>
+inline void json_encode(JsonWriter &out, const std::unordered_set<T> &t)
+{
+    json_encode_iterable(out, t);
+}
+
+template <typename T>
+inline bool json_decode(const JsonObject &in, std::unordered_set<T> &t)
+{
+    return json_decode_set(in, t);
 }
 
 template <typename T1, typename T2>

--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -347,15 +347,10 @@ inline bool json_decode(const JsonObject &in, dsn::ranger::access_type &t)
 {
     dverify(in.IsUint64());
     int64_t ans = in.GetUint64();
-    int64_t act_min = static_cast<uint64_t>(dsn::ranger::access_type::KInvalid);
-    int64_t act_max = static_cast<uint64_t>(
-        dsn::ranger::access_type::KRead | dsn::ranger::access_type::KWrite |
-        dsn::ranger::access_type::KCreate | dsn::ranger::access_type::KDrop |
-        dsn::ranger::access_type::KList | dsn::ranger::access_type::KMetadata |
-        dsn::ranger::access_type::KControl);
+    int64_t act_min = static_cast<uint64_t>(dsn::ranger::access_type_min);
+    int64_t act_max = static_cast<uint64_t>(dsn::ranger::access_type_max);
     dverify(ans >= act_min && ans <= act_max);
-    using act = std::underlying_type<dsn::ranger::access_type>::type;
-    t = (dsn::ranger::access_type) static_cast<act>(ans);
+    t = static_cast<dsn::ranger::access_type>(ans);
     return true;
 }
 

--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -347,9 +347,9 @@ inline bool json_decode(const JsonObject &in, dsn::ranger::access_type &t)
 {
     dverify(in.IsUint64());
     auto ans = in.GetUint64();
-    auto act_min = static_cast<uint64_t>(dsn::ranger::kAccessTypeNone);
-    auto act_max = static_cast<uint64_t>(dsn::ranger::kAccessTypeAll);
-    dverify(ans >= act_min && ans <= act_max);
+    auto act_none = static_cast<uint64_t>(dsn::ranger::kAccessTypeNone);
+    auto act_all = static_cast<uint64_t>(dsn::ranger::kAccessTypeAll);
+    dverify(ans >= act_none && ans <= act_all);
     t = static_cast<dsn::ranger::access_type>(ans);
     return true;
 }

--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -346,9 +346,9 @@ inline void json_encode(Writer &out, dsn::ranger::access_type t)
 inline bool json_decode(const JsonObject &in, dsn::ranger::access_type &t)
 {
     dverify(in.IsUint64());
-    int64_t ans = in.GetUint64();
-    int64_t act_min = static_cast<uint64_t>(dsn::ranger::access_type_min);
-    int64_t act_max = static_cast<uint64_t>(dsn::ranger::access_type_max);
+    auto ans = in.GetUint64();
+    auto act_min = static_cast<uint64_t>(dsn::ranger::access_type_min);
+    auto act_max = static_cast<uint64_t>(dsn::ranger::access_type_max);
     dverify(ans >= act_min && ans <= act_max);
     t = static_cast<dsn::ranger::access_type>(ans);
     return true;

--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -347,8 +347,8 @@ inline bool json_decode(const JsonObject &in, dsn::ranger::access_type &t)
 {
     dverify(in.IsUint64());
     auto ans = in.GetUint64();
-    auto act_min = static_cast<uint64_t>(dsn::ranger::access_type_min);
-    auto act_max = static_cast<uint64_t>(dsn::ranger::access_type_max);
+    auto act_min = static_cast<uint64_t>(dsn::ranger::kAccessTypeMin);
+    auto act_max = static_cast<uint64_t>(dsn::ranger::kAccessTypeMax);
     dverify(ans >= act_min && ans <= act_max);
     t = static_cast<dsn::ranger::access_type>(ans);
     return true;

--- a/src/runtime/ranger/access_type.cpp
+++ b/src/runtime/ranger/access_type.cpp
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <type_traits>
+
+#include "access_type.h"
+
+namespace dsn {
+namespace ranger {
+
+access_type operator|(access_type lhs, access_type rhs)
+{
+    using act = std::underlying_type<access_type>::type;
+    return access_type(static_cast<act>(lhs) | static_cast<act>(rhs));
+}
+
+access_type operator&(access_type lhs, access_type rhs)
+{
+    using act = std::underlying_type<access_type>::type;
+    return access_type(static_cast<act>(lhs) & static_cast<act>(rhs));
+}
+
+access_type &operator|=(access_type &lhs, access_type rhs) { return lhs = lhs | rhs; }
+
+} // namespace ranger
+} // namespace dsn

--- a/src/runtime/ranger/access_type.cpp
+++ b/src/runtime/ranger/access_type.cpp
@@ -24,13 +24,11 @@ namespace ranger {
 
 access_type operator|(access_type lhs, access_type rhs)
 {
-    using act = std::underlying_type<access_type>::type;
     return access_type(static_cast<act>(lhs) | static_cast<act>(rhs));
 }
 
 access_type operator&(access_type lhs, access_type rhs)
 {
-    using act = std::underlying_type<access_type>::type;
     return access_type(static_cast<act>(lhs) & static_cast<act>(rhs));
 }
 

--- a/src/runtime/ranger/access_type.h
+++ b/src/runtime/ranger/access_type.h
@@ -25,21 +25,28 @@ namespace ranger {
 // ACL type defined in Range service for RPC matching policy
 enum class access_type : uint8_t
 {
-    KInvalid = 0,
-    KRead = 1,
-    KWrite = 1 << 1,
-    KCreate = 1 << 2,
-    KDrop = 1 << 3,
-    KList = 1 << 4,
-    KMetadata = 1 << 5,
-    KControl = 1 << 6
+    kInvalid = 0,
+    kRead = 1,
+    kWrite = 1 << 1,
+    kCreate = 1 << 2,
+    kDrop = 1 << 3,
+    kList = 1 << 4,
+    kMetadata = 1 << 5,
+    kControl = 1 << 6
 };
+
+using act = std::underlying_type<access_type>::type;
 
 access_type operator|(access_type lhs, access_type rhs);
 
 access_type operator&(access_type lhs, access_type rhs);
 
 access_type &operator|=(access_type &lhs, access_type rhs);
+
+static access_type access_type_min = access_type::kInvalid;
+static access_type access_type_max =
+    access_type::kRead | access_type::kWrite | access_type::kCreate | access_type::kDrop |
+    access_type::kList | access_type::kMetadata | access_type::kControl;
 
 } // namespace ranger
 } // namespace dsn

--- a/src/runtime/ranger/access_type.h
+++ b/src/runtime/ranger/access_type.h
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace dsn {
+namespace ranger {
+
+// ACL type defined in Range service for RPC matching policy
+enum class access_type : uint8_t
+{
+    KInvalid = 0,
+    KRead = 1,
+    KWrite = 1 << 1,
+    KCreate = 1 << 2,
+    KDrop = 1 << 3,
+    KList = 1 << 4,
+    KMetadata = 1 << 5,
+    KControl = 1 << 6
+};
+
+access_type operator|(access_type lhs, access_type rhs);
+
+access_type operator&(access_type lhs, access_type rhs);
+
+access_type &operator|=(access_type &lhs, access_type rhs);
+
+} // namespace ranger
+} // namespace dsn

--- a/src/runtime/ranger/access_type.h
+++ b/src/runtime/ranger/access_type.h
@@ -43,8 +43,8 @@ access_type operator&(access_type lhs, access_type rhs);
 
 access_type &operator|=(access_type &lhs, access_type rhs);
 
-const access_type kAccessTypeMin = access_type::kInvalid;
-const access_type kAccessTypeMax = access_type::kRead | access_type::kWrite | access_type::kCreate |
+const access_type kAccessTypeNone = access_type::kInvalid;
+const access_type kAccessTypeAll = access_type::kRead | access_type::kWrite | access_type::kCreate |
                                    access_type::kDrop | access_type::kList |
                                    access_type::kMetadata | access_type::kControl;
 

--- a/src/runtime/ranger/access_type.h
+++ b/src/runtime/ranger/access_type.h
@@ -43,10 +43,10 @@ access_type operator&(access_type lhs, access_type rhs);
 
 access_type &operator|=(access_type &lhs, access_type rhs);
 
-static access_type access_type_min = access_type::kInvalid;
-static access_type access_type_max =
-    access_type::kRead | access_type::kWrite | access_type::kCreate | access_type::kDrop |
-    access_type::kList | access_type::kMetadata | access_type::kControl;
+const access_type kAccessTypeMin = access_type::kInvalid;
+const access_type kAccessTypeMax = access_type::kRead | access_type::kWrite | access_type::kCreate |
+                                   access_type::kDrop | access_type::kList |
+                                   access_type::kMetadata | access_type::kControl;
 
 } // namespace ranger
 } // namespace dsn

--- a/src/runtime/ranger/ranger_resource_policy.cpp
+++ b/src/runtime/ranger/ranger_resource_policy.cpp
@@ -20,18 +20,6 @@
 namespace dsn {
 namespace ranger {
 
-/*extern*/ access_type operator|(access_type lhs, access_type rhs)
-{
-    using act = std::underlying_type<access_type>::type;
-    return access_type(static_cast<act>(lhs) | static_cast<act>(rhs));
-}
-
-/*extern*/ access_type operator&(access_type lhs, access_type rhs)
-{
-    using act = std::underlying_type<access_type>::type;
-    return access_type(static_cast<act>(lhs) & static_cast<act>(rhs));
-}
-
 bool policy_item::match(const access_type &ac_type, const std::string &user_name) const
 {
     return static_cast<bool>(access_types & ac_type) && users.count(user_name) != 0;

--- a/src/runtime/ranger/ranger_resource_policy.h
+++ b/src/runtime/ranger/ranger_resource_policy.h
@@ -34,7 +34,7 @@ namespace ranger {
 // Ranger policy data structure
 struct policy_item
 {
-    access_type access_types = access_type::KInvalid;
+    access_type access_types = access_type::kInvalid;
     std::unordered_set<std::string> users;
 
     DEFINE_JSON_SERIALIZATION(access_types, users);

--- a/src/runtime/ranger/ranger_resource_policy.h
+++ b/src/runtime/ranger/ranger_resource_policy.h
@@ -24,33 +24,20 @@
 
 #include <rapidjson/document.h>
 
+#include "access_type.h"
 #include "common/json_helper.h"
 #include "utils/fmt_logging.h"
 
 namespace dsn {
 namespace ranger {
 
-// ACL type defined in Range service for RPC matching policy
-enum class access_type : uint8_t
-{
-    KRead = 1,
-    KWrite = 1 << 1,
-    KCreate = 1 << 2,
-    KDrop = 1 << 3,
-    KList = 1 << 4,
-    KMetadata = 1 << 5,
-    KControl = 1 << 6
-};
-
-extern access_type operator|(access_type lhs, access_type rhs);
-
-extern access_type operator&(access_type lhs, access_type rhs);
-
 // Ranger policy data structure
 struct policy_item
 {
-    access_type access_types;
+    access_type access_types = access_type::KInvalid;
     std::unordered_set<std::string> users;
+
+    DEFINE_JSON_SERIALIZATION(access_types, users);
 
     // Check if the 'acl_type' - 'user_name' pair is matched to the policy.
     // Return true if it is matched, otherwise return false.
@@ -68,6 +55,11 @@ struct acl_policies
     std::vector<policy_item> deny_policies;
     std::vector<policy_item> deny_policies_exclude;
 
+    DEFINE_JSON_SERIALIZATION(allow_policies,
+                              allow_policies_exclude,
+                              deny_policies,
+                              deny_policies_exclude);
+
     // Check whether the 'user_name' is allowed to access the resource by type of 'ac_type'.
     bool allowed(const access_type &ac_type, const std::string &user_name) const;
 };
@@ -79,6 +71,8 @@ struct ranger_resource_policy
     std::unordered_set<std::string> database_names;
     std::unordered_set<std::string> table_names;
     acl_policies policies;
+
+    DEFINE_JSON_SERIALIZATION(name, database_names, table_names, policies)
 };
 
 } // namespace ranger

--- a/src/runtime/ranger/ranger_resource_policy_manager.cpp
+++ b/src/runtime/ranger/ranger_resource_policy_manager.cpp
@@ -66,13 +66,13 @@ void register_rpc_access_type(access_type ac_type,
 }
 
 // Used to map access_type matched resources policies json string.
-std::map<std::string, access_type> access_type_maping({{"READ", access_type::KRead},
-                                                       {"WRITE", access_type::KWrite},
-                                                       {"CREATE", access_type::KCreate},
-                                                       {"DROP", access_type::KDrop},
-                                                       {"LIST", access_type::KList},
-                                                       {"METADATA", access_type::KMetadata},
-                                                       {"CONTROL", access_type::KControl}});
+std::map<std::string, access_type> access_type_maping({{"READ", access_type::kRead},
+                                                       {"WRITE", access_type::kWrite},
+                                                       {"CREATE", access_type::kCreate},
+                                                       {"DROP", access_type::kDrop},
+                                                       {"LIST", access_type::kList},
+                                                       {"METADATA", access_type::kMetadata},
+                                                       {"CONTROL", access_type::kControl}});
 } // anonymous namespace
 
 ranger_resource_policy_manager::ranger_resource_policy_manager(
@@ -84,11 +84,11 @@ ranger_resource_policy_manager::ranger_resource_policy_manager(
 
     // GLOBAL - KMetadata
     register_rpc_access_type(
-        access_type::KMetadata,
+        access_type::kMetadata,
         {"RPC_CM_LIST_NODES", "RPC_CM_CLUSTER_INFO", "RPC_CM_LIST_APPS", "RPC_QUERY_DISK_INFO"},
         _ac_type_of_global_rpcs);
     // GLOBAL - KControl
-    register_rpc_access_type(access_type::KControl,
+    register_rpc_access_type(access_type::kControl,
                              {"RPC_HTTP_SERVICE",
                               "RPC_CM_CONTROL_META",
                               "RPC_CM_START_RECOVERY",
@@ -98,15 +98,15 @@ ranger_resource_policy_manager::ranger_resource_policy_manager(
                               "RPC_CLI_CLI_CALL_ACK"},
                              _ac_type_of_global_rpcs);
     // DATABASE - KList
-    register_rpc_access_type(access_type::KList, {"RPC_CM_LIST_APPS"}, _ac_type_of_database_rpcs);
+    register_rpc_access_type(access_type::kList, {"RPC_CM_LIST_APPS"}, _ac_type_of_database_rpcs);
     // DATABASE - KCreate
     register_rpc_access_type(
-        access_type::KCreate, {"RPC_CM_CREATE_APP"}, _ac_type_of_database_rpcs);
+        access_type::kCreate, {"RPC_CM_CREATE_APP"}, _ac_type_of_database_rpcs);
     // DATABASE - KDrop
     register_rpc_access_type(
-        access_type::KDrop, {"RPC_CM_DROP_APP", "RPC_CM_RECALL_APP"}, _ac_type_of_database_rpcs);
+        access_type::kDrop, {"RPC_CM_DROP_APP", "RPC_CM_RECALL_APP"}, _ac_type_of_database_rpcs);
     // DATABASE - KMetadata
-    register_rpc_access_type(access_type::KMetadata,
+    register_rpc_access_type(access_type::kMetadata,
                              {"RPC_CM_QUERY_BACKUP_STATUS",
                               "RPC_CM_QUERY_RESTORE_STATUS",
                               "RPC_CM_QUERY_DUPLICATION",
@@ -116,7 +116,7 @@ ranger_resource_policy_manager::ranger_resource_policy_manager(
                               "RPC_CM_GET_MAX_REPLICA_COUNT"},
                              _ac_type_of_database_rpcs);
     // DATABASE - KControl
-    register_rpc_access_type(access_type::KControl,
+    register_rpc_access_type(access_type::kControl,
                              {"RPC_CM_START_BACKUP_APP",
                               "RPC_CM_START_RESTORE",
                               "RPC_CM_PROPOSE_BALANCER",

--- a/src/runtime/ranger/ranger_resource_policy_manager.cpp
+++ b/src/runtime/ranger/ranger_resource_policy_manager.cpp
@@ -66,13 +66,13 @@ void register_rpc_access_type(access_type ac_type,
 }
 
 // Used to map access_type matched resources policies json string.
-std::map<std::string, access_type> access_type_maping({{"READ", access_type::kRead},
-                                                       {"WRITE", access_type::kWrite},
-                                                       {"CREATE", access_type::kCreate},
-                                                       {"DROP", access_type::kDrop},
-                                                       {"LIST", access_type::kList},
-                                                       {"METADATA", access_type::kMetadata},
-                                                       {"CONTROL", access_type::kControl}});
+const std::map<std::string, access_type> kAccessTypeMaping({{"READ", access_type::kRead},
+                                                            {"WRITE", access_type::kWrite},
+                                                            {"CREATE", access_type::kCreate},
+                                                            {"DROP", access_type::kDrop},
+                                                            {"LIST", access_type::kList},
+                                                            {"METADATA", access_type::kMetadata},
+                                                            {"CONTROL", access_type::kControl}});
 } // anonymous namespace
 
 ranger_resource_policy_manager::ranger_resource_policy_manager(
@@ -149,7 +149,11 @@ void ranger_resource_policy_manager::parse_policies_from_json(const rapidjson::V
             if (access["isAllowed"].GetBool()) {
                 std::string type = access["type"].GetString();
                 std::transform(type.begin(), type.end(), type.begin(), toupper);
-                pi.access_types |= access_type_maping[type];
+                const auto &at = kAccessTypeMaping.find(type);
+                // ignore invalid access_type
+                if (kAccessTypeMaping.end() != at) {
+                    pi.access_types |= at->second;
+                }
             }
         }
         CONTINUE_IF_MISSING_MEMBER(item, "users");

--- a/src/runtime/ranger/ranger_resource_policy_manager.h
+++ b/src/runtime/ranger/ranger_resource_policy_manager.h
@@ -32,8 +32,28 @@ namespace replication {
 class meta_service;
 }
 
+enum class resource_type
+{
+    KGlobal = 0,
+    Kdatabase,
+    KDatabaseTable,
+    KUnknown,
+};
+
+ENUM_BEGIN(resource_type, resource_type::KUnknown)
+ENUM_REG(resource_type::KGlobal)
+ENUM_REG(resource_type::Kdatabase)
+ENUM_REG(resource_type::KDatabaseTable)
+ENUM_END(resource_type)
+
+ENUM_TYPE_SERIALIZATION(resource_type, resource_type::KUnknown)
+
 namespace ranger {
 
+// Policies corresponding to a resource
+using resource_policies = std::vector<ranger_resource_policy>;
+// Policies corresponding to all resources
+using all_resource_policies = std::map<std::string, resource_policies>;
 // Range access type of rpc codes
 using access_type_of_rpc_code = std::unordered_map<int, ranger::access_type>;
 
@@ -43,6 +63,11 @@ public:
     ranger_resource_policy_manager(dsn::replication::meta_service *meta_svc);
 
     ~ranger_resource_policy_manager() = default;
+
+private:
+    // Parse Ranger ACL policies in JSON format 'data' into 'policies'.
+    static void parse_policies_from_json(const rapidjson::Value &data,
+                                         std::vector<policy_item> &policies);
 
 private:
     // The path where policies to be saved in remote storage.
@@ -58,6 +83,13 @@ private:
 
     // The Ranger policy version to determine whether to update.
     //    int _local_policy_version;
+
+    // All Ranger ACL policies.
+    all_resource_policies _all_resource_policies;
+
+    DEFINE_JSON_SERIALIZATION(_all_resource_policies);
+
+    FRIEND_TEST(ranger_resource_policy_manager_test, parse_policies_from_json_for_test);
 };
 } // namespace ranger
 } // namespace dsn

--- a/src/runtime/ranger/ranger_resource_policy_manager.h
+++ b/src/runtime/ranger/ranger_resource_policy_manager.h
@@ -35,14 +35,14 @@ class meta_service;
 enum class resource_type
 {
     kGlobal = 0,
-    kdatabase,
+    kDatabase,
     kDatabaseTable,
     kUnknown,
 };
 
 ENUM_BEGIN(resource_type, resource_type::kUnknown)
 ENUM_REG(resource_type::kGlobal)
-ENUM_REG(resource_type::kdatabase)
+ENUM_REG(resource_type::kDatabase)
 ENUM_REG(resource_type::kDatabaseTable)
 ENUM_END(resource_type)
 

--- a/src/runtime/ranger/ranger_resource_policy_manager.h
+++ b/src/runtime/ranger/ranger_resource_policy_manager.h
@@ -34,19 +34,19 @@ class meta_service;
 
 enum class resource_type
 {
-    KGlobal = 0,
-    Kdatabase,
-    KDatabaseTable,
-    KUnknown,
+    kGlobal = 0,
+    kdatabase,
+    kDatabaseTable,
+    kUnknown,
 };
 
-ENUM_BEGIN(resource_type, resource_type::KUnknown)
-ENUM_REG(resource_type::KGlobal)
-ENUM_REG(resource_type::Kdatabase)
-ENUM_REG(resource_type::KDatabaseTable)
+ENUM_BEGIN(resource_type, resource_type::kUnknown)
+ENUM_REG(resource_type::kGlobal)
+ENUM_REG(resource_type::kdatabase)
+ENUM_REG(resource_type::kDatabaseTable)
 ENUM_END(resource_type)
 
-ENUM_TYPE_SERIALIZATION(resource_type, resource_type::KUnknown)
+ENUM_TYPE_SERIALIZATION(resource_type, resource_type::kUnknown)
 
 namespace ranger {
 
@@ -65,7 +65,7 @@ public:
     ~ranger_resource_policy_manager() = default;
 
 private:
-    // Parse Ranger ACL policies in JSON format 'data' into 'policies'.
+    // Parse Ranger ACL policies from 'data' in JSON format into 'policies'.
     static void parse_policies_from_json(const rapidjson::Value &data,
                                          std::vector<policy_item> &policies);
 

--- a/src/runtime/test/CMakeLists.txt
+++ b/src/runtime/test/CMakeLists.txt
@@ -32,6 +32,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 set(MY_PROJ_LIBS gtest
                  dsn_runtime
                  dsn_aio
+                 dsn_meta_server
                  )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/runtime/test/ranger_resource_policy_manager_test.cpp
+++ b/src/runtime/test/ranger_resource_policy_manager_test.cpp
@@ -42,6 +42,12 @@ TEST(ranger_resource_policy_manager_test, parse_policies_from_json_for_test)
 	        }, {
 		        "type": "list",
 		        "isAllowed": true
+	        }, {
+		        "type": "fake",
+		        "isAllowed": true
+	        }, {
+		        "type": "read",
+		        "isAllowed": false
 	        }],
 	        "users": ["user1", "user2"],
 	        "groups": [],
@@ -120,8 +126,10 @@ TEST(ranger_resource_policy_manager_test, parse_policies_from_json_for_test)
     }
 }
 
+// Check whether 'all_resource_policies' can correctly decode and encode
 TEST(ranger_resource_policy_manager_test, ranger_resource_policy_serialized_test)
 {
+    // 1. Create a fake resource policies data in 'fake_all_resource_policies'
     acl_policies fake_policy;
     fake_policy.allow_policies = {{access_type::kRead | access_type::kWrite | access_type::kList,
                                    {"user1", "user2", "user3", "user4"}}};
@@ -138,15 +146,18 @@ TEST(ranger_resource_policy_manager_test, ranger_resource_policy_serialized_test
     std::string resource_type_name = enum_to_string(resource_type::kDatabaseTable);
     all_resource_policies fake_all_resource_policies{
         {resource_type_name, {fake_ranger_resource_policy}}};
-
+    // 2.Encode 'fake_all_resource_policies' into a string 'value'
     dsn::blob value =
         json::json_forwarder<all_resource_policies>::encode(fake_all_resource_policies);
     std::string fake_all_resource_policies_str = value.to_string();
     all_resource_policies fake_all_resource_policies_serialized;
+    // 3. Decode the string 'value' into 'fake_all_resource_policies_serialized'
     dsn::json::json_forwarder<all_resource_policies>::decode(
         dsn::blob::create_from_bytes(std::move(fake_all_resource_policies_str)),
         fake_all_resource_policies_serialized);
 
+    // 4. Verify the correctness of serialization by checking the data content of
+    // 'fake_all_resource_policies' and 'fake_all_resource_policies_serialized'
     EXPECT_EQ(1, fake_all_resource_policies.count(resource_type_name));
     EXPECT_EQ(1, fake_all_resource_policies_serialized.count(resource_type_name));
     ranger_resource_policy policy = fake_all_resource_policies[resource_type_name][0];

--- a/src/runtime/test/ranger_resource_policy_manager_test.cpp
+++ b/src/runtime/test/ranger_resource_policy_manager_test.cpp
@@ -72,11 +72,11 @@ TEST(ranger_resource_policy_manager_test, parse_policies_from_json_for_test)
 
     EXPECT_EQ(2, fake_policies.size());
 
-    ASSERT_EQ(access_type::KCreate | access_type::KDrop | access_type::KList |
-                  access_type::KMetadata | access_type::KControl,
+    ASSERT_EQ(access_type::kCreate | access_type::kDrop | access_type::kList |
+                  access_type::kMetadata | access_type::kControl,
               fake_policies[0].access_types);
 
-    ASSERT_EQ(access_type::KRead | access_type::KWrite, fake_policies[1].access_types);
+    ASSERT_EQ(access_type::kRead | access_type::kWrite, fake_policies[1].access_types);
 
     struct test_case
     {
@@ -84,36 +84,36 @@ TEST(ranger_resource_policy_manager_test, parse_policies_from_json_for_test)
         access_type ac_type;
         std::string user_name;
         bool expected_result;
-    } tests[] = {{fake_policies[0], access_type::KRead, "", false},
-                 {fake_policies[0], access_type::KRead, "user", false},
-                 {fake_policies[0], access_type::KRead, "user1", false},
-                 {fake_policies[0], access_type::KWrite, "user1", false},
-                 {fake_policies[0], access_type::KCreate, "user1", true},
-                 {fake_policies[0], access_type::KDrop, "user1", true},
-                 {fake_policies[0], access_type::KList, "user1", true},
-                 {fake_policies[0], access_type::KMetadata, "user1", true},
-                 {fake_policies[0], access_type::KControl, "user1", true},
-                 {fake_policies[0], access_type::KRead, "user2", false},
-                 {fake_policies[0], access_type::KWrite, "user2", false},
-                 {fake_policies[0], access_type::KCreate, "user2", true},
-                 {fake_policies[0], access_type::KDrop, "user2", true},
-                 {fake_policies[0], access_type::KList, "user2", true},
-                 {fake_policies[0], access_type::KMetadata, "user2", true},
-                 {fake_policies[0], access_type::KControl, "user2", true},
-                 {fake_policies[1], access_type::KRead, "user1", false},
-                 {fake_policies[1], access_type::KWrite, "user1", false},
-                 {fake_policies[1], access_type::KCreate, "user1", false},
-                 {fake_policies[1], access_type::KDrop, "user1", false},
-                 {fake_policies[1], access_type::KList, "user1", false},
-                 {fake_policies[1], access_type::KMetadata, "user1", false},
-                 {fake_policies[1], access_type::KControl, "user1", false},
-                 {fake_policies[1], access_type::KRead, "user2", true},
-                 {fake_policies[1], access_type::KWrite, "user2", true},
-                 {fake_policies[1], access_type::KCreate, "user2", false},
-                 {fake_policies[1], access_type::KDrop, "user2", false},
-                 {fake_policies[1], access_type::KList, "user2", false},
-                 {fake_policies[1], access_type::KMetadata, "user2", false},
-                 {fake_policies[1], access_type::KControl, "user2", false}};
+    } tests[] = {{fake_policies[0], access_type::kRead, "", false},
+                 {fake_policies[0], access_type::kRead, "user", false},
+                 {fake_policies[0], access_type::kRead, "user1", false},
+                 {fake_policies[0], access_type::kWrite, "user1", false},
+                 {fake_policies[0], access_type::kCreate, "user1", true},
+                 {fake_policies[0], access_type::kDrop, "user1", true},
+                 {fake_policies[0], access_type::kList, "user1", true},
+                 {fake_policies[0], access_type::kMetadata, "user1", true},
+                 {fake_policies[0], access_type::kControl, "user1", true},
+                 {fake_policies[0], access_type::kRead, "user2", false},
+                 {fake_policies[0], access_type::kWrite, "user2", false},
+                 {fake_policies[0], access_type::kCreate, "user2", true},
+                 {fake_policies[0], access_type::kDrop, "user2", true},
+                 {fake_policies[0], access_type::kList, "user2", true},
+                 {fake_policies[0], access_type::kMetadata, "user2", true},
+                 {fake_policies[0], access_type::kControl, "user2", true},
+                 {fake_policies[1], access_type::kRead, "user1", false},
+                 {fake_policies[1], access_type::kWrite, "user1", false},
+                 {fake_policies[1], access_type::kCreate, "user1", false},
+                 {fake_policies[1], access_type::kDrop, "user1", false},
+                 {fake_policies[1], access_type::kList, "user1", false},
+                 {fake_policies[1], access_type::kMetadata, "user1", false},
+                 {fake_policies[1], access_type::kControl, "user1", false},
+                 {fake_policies[1], access_type::kRead, "user2", true},
+                 {fake_policies[1], access_type::kWrite, "user2", true},
+                 {fake_policies[1], access_type::kCreate, "user2", false},
+                 {fake_policies[1], access_type::kDrop, "user2", false},
+                 {fake_policies[1], access_type::kList, "user2", false},
+                 {fake_policies[1], access_type::kMetadata, "user2", false},
+                 {fake_policies[1], access_type::kControl, "user2", false}};
     for (const auto &test : tests) {
         auto actual_result = test.item.match(test.ac_type, test.user_name);
         EXPECT_EQ(test.expected_result, actual_result);
@@ -123,11 +123,11 @@ TEST(ranger_resource_policy_manager_test, parse_policies_from_json_for_test)
 TEST(ranger_resource_policy_manager_test, ranger_resource_policy_serialized_test)
 {
     acl_policies fake_policy;
-    fake_policy.allow_policies = {{access_type::KRead | access_type::KWrite | access_type::KList,
+    fake_policy.allow_policies = {{access_type::kRead | access_type::kWrite | access_type::kList,
                                    {"user1", "user2", "user3", "user4"}}};
-    fake_policy.allow_policies_exclude = {{access_type::KWrite | access_type::KCreate, {"user2"}}};
-    fake_policy.deny_policies = {{access_type::KRead | access_type::KWrite, {"user3", "user4"}}};
-    fake_policy.deny_policies_exclude = {{access_type::KRead | access_type::KList, {"user4"}}};
+    fake_policy.allow_policies_exclude = {{access_type::kWrite | access_type::kCreate, {"user2"}}};
+    fake_policy.deny_policies = {{access_type::kRead | access_type::kWrite, {"user3", "user4"}}};
+    fake_policy.deny_policies_exclude = {{access_type::kRead | access_type::kList, {"user4"}}};
 
     ranger_resource_policy fake_ranger_resource_policy;
     fake_ranger_resource_policy.name = "pegasus_ranger_test";
@@ -135,7 +135,7 @@ TEST(ranger_resource_policy_manager_test, ranger_resource_policy_serialized_test
     fake_ranger_resource_policy.table_names = {"database1_table", "database2_table"};
     fake_ranger_resource_policy.policies = fake_policy;
 
-    std::string resource_type_name = enum_to_string(resource_type::KDatabaseTable);
+    std::string resource_type_name = enum_to_string(resource_type::kDatabaseTable);
     all_resource_policies fake_all_resource_policies{
         {resource_type_name, {fake_ranger_resource_policy}}};
 
@@ -169,21 +169,21 @@ TEST(ranger_resource_policy_manager_test, ranger_resource_policy_serialized_test
         access_type ac_type;
         std::string user_name;
         bool expected_result;
-    } tests[] = {{access_type::KRead, "user", false},      {access_type::KRead, "user1", true},
-                 {access_type::KWrite, "user1", true},     {access_type::KCreate, "user1", false},
-                 {access_type::KDrop, "user1", false},     {access_type::KList, "user1", true},
-                 {access_type::KMetadata, "user1", false}, {access_type::KControl, "user1", false},
-                 {access_type::KRead, "user2", true},      {access_type::KWrite, "user2", false},
-                 {access_type::KCreate, "user2", false},   {access_type::KDrop, "user2", false},
-                 {access_type::KList, "user2", true},      {access_type::KMetadata, "user2", false},
-                 {access_type::KControl, "user2", false},  {access_type::KRead, "user3", false},
-                 {access_type::KWrite, "user3", false},    {access_type::KCreate, "user3", false},
-                 {access_type::KDrop, "user3", false},     {access_type::KList, "user3", true},
-                 {access_type::KMetadata, "user3", false}, {access_type::KControl, "user3", false},
-                 {access_type::KRead, "user4", true},      {access_type::KWrite, "user4", false},
-                 {access_type::KCreate, "user4", false},   {access_type::KDrop, "user4", false},
-                 {access_type::KList, "user4", true},      {access_type::KMetadata, "user4", false},
-                 {access_type::KControl, "user4", false}};
+    } tests[] = {{access_type::kRead, "user", false},      {access_type::kRead, "user1", true},
+                 {access_type::kWrite, "user1", true},     {access_type::kCreate, "user1", false},
+                 {access_type::kDrop, "user1", false},     {access_type::kList, "user1", true},
+                 {access_type::kMetadata, "user1", false}, {access_type::kControl, "user1", false},
+                 {access_type::kRead, "user2", true},      {access_type::kWrite, "user2", false},
+                 {access_type::kCreate, "user2", false},   {access_type::kDrop, "user2", false},
+                 {access_type::kList, "user2", true},      {access_type::kMetadata, "user2", false},
+                 {access_type::kControl, "user2", false},  {access_type::kRead, "user3", false},
+                 {access_type::kWrite, "user3", false},    {access_type::kCreate, "user3", false},
+                 {access_type::kDrop, "user3", false},     {access_type::kList, "user3", true},
+                 {access_type::kMetadata, "user3", false}, {access_type::kControl, "user3", false},
+                 {access_type::kRead, "user4", true},      {access_type::kWrite, "user4", false},
+                 {access_type::kCreate, "user4", false},   {access_type::kDrop, "user4", false},
+                 {access_type::kList, "user4", true},      {access_type::kMetadata, "user4", false},
+                 {access_type::kControl, "user4", false}};
     for (const auto &test : tests) {
         auto actual_result = policy.policies.allowed(test.ac_type, test.user_name);
         EXPECT_EQ(test.expected_result, actual_result);

--- a/src/runtime/test/ranger_resource_policy_manager_test.cpp
+++ b/src/runtime/test/ranger_resource_policy_manager_test.cpp
@@ -1,0 +1,195 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "runtime/ranger/ranger_resource_policy.h"
+#include "runtime/ranger/ranger_resource_policy_manager.h"
+
+namespace dsn {
+namespace ranger {
+
+TEST(ranger_resource_policy_manager_test, parse_policies_from_json_for_test)
+{
+    std::string data = R"(
+        [{
+	        "accesses": [{
+		        "type": "create",
+		        "isAllowed": true
+	        }, {
+		        "type": "drop",
+		        "isAllowed": true
+	        }, {
+		        "type": "control",
+		        "isAllowed": true
+	        }, {
+		        "type": "metadata",
+		        "isAllowed": true
+	        }, {
+		        "type": "list",
+		        "isAllowed": true
+	        }],
+	        "users": ["user1", "user2"],
+	        "groups": [],
+	        "roles": [],
+	        "conditions": [],
+	        "delegateAdmin": true
+        }, {
+	        "accesses": [{
+		        "type": "read",
+		        "isAllowed": true
+	        }, {
+		        "type": "write",
+		        "isAllowed": true
+	        }],
+	        "users": ["user2"],
+	        "groups": [],
+	        "roles": [],
+	        "conditions": [],
+	        "delegateAdmin": true
+        }]
+    )";
+
+    std::vector<policy_item> fake_policies;
+
+    rapidjson::Document fake_doc;
+    fake_doc.Parse(data.c_str());
+    ranger_resource_policy_manager::parse_policies_from_json(fake_doc, fake_policies);
+
+    EXPECT_EQ(2, fake_policies.size());
+
+    ASSERT_EQ(access_type::KCreate | access_type::KDrop | access_type::KList |
+                  access_type::KMetadata | access_type::KControl,
+              fake_policies[0].access_types);
+
+    ASSERT_EQ(access_type::KRead | access_type::KWrite, fake_policies[1].access_types);
+
+    struct test_case
+    {
+        policy_item item;
+        access_type ac_type;
+        std::string user_name;
+        bool expected_result;
+    } tests[] = {{fake_policies[0], access_type::KRead, "", false},
+                 {fake_policies[0], access_type::KRead, "user", false},
+                 {fake_policies[0], access_type::KRead, "user1", false},
+                 {fake_policies[0], access_type::KWrite, "user1", false},
+                 {fake_policies[0], access_type::KCreate, "user1", true},
+                 {fake_policies[0], access_type::KDrop, "user1", true},
+                 {fake_policies[0], access_type::KList, "user1", true},
+                 {fake_policies[0], access_type::KMetadata, "user1", true},
+                 {fake_policies[0], access_type::KControl, "user1", true},
+                 {fake_policies[0], access_type::KRead, "user2", false},
+                 {fake_policies[0], access_type::KWrite, "user2", false},
+                 {fake_policies[0], access_type::KCreate, "user2", true},
+                 {fake_policies[0], access_type::KDrop, "user2", true},
+                 {fake_policies[0], access_type::KList, "user2", true},
+                 {fake_policies[0], access_type::KMetadata, "user2", true},
+                 {fake_policies[0], access_type::KControl, "user2", true},
+                 {fake_policies[1], access_type::KRead, "user1", false},
+                 {fake_policies[1], access_type::KWrite, "user1", false},
+                 {fake_policies[1], access_type::KCreate, "user1", false},
+                 {fake_policies[1], access_type::KDrop, "user1", false},
+                 {fake_policies[1], access_type::KList, "user1", false},
+                 {fake_policies[1], access_type::KMetadata, "user1", false},
+                 {fake_policies[1], access_type::KControl, "user1", false},
+                 {fake_policies[1], access_type::KRead, "user2", true},
+                 {fake_policies[1], access_type::KWrite, "user2", true},
+                 {fake_policies[1], access_type::KCreate, "user2", false},
+                 {fake_policies[1], access_type::KDrop, "user2", false},
+                 {fake_policies[1], access_type::KList, "user2", false},
+                 {fake_policies[1], access_type::KMetadata, "user2", false},
+                 {fake_policies[1], access_type::KControl, "user2", false}};
+    for (const auto &test : tests) {
+        auto actual_result = test.item.match(test.ac_type, test.user_name);
+        EXPECT_EQ(test.expected_result, actual_result);
+    }
+}
+
+TEST(ranger_resource_policy_manager_test, ranger_resource_policy_serialized_test)
+{
+    acl_policies fake_policy;
+    fake_policy.allow_policies = {{access_type::KRead | access_type::KWrite | access_type::KList,
+                                   {"user1", "user2", "user3", "user4"}}};
+    fake_policy.allow_policies_exclude = {{access_type::KWrite | access_type::KCreate, {"user2"}}};
+    fake_policy.deny_policies = {{access_type::KRead | access_type::KWrite, {"user3", "user4"}}};
+    fake_policy.deny_policies_exclude = {{access_type::KRead | access_type::KList, {"user4"}}};
+
+    ranger_resource_policy fake_ranger_resource_policy;
+    fake_ranger_resource_policy.name = "pegasus_ranger_test";
+    fake_ranger_resource_policy.database_names = {"database1", "database2"};
+    fake_ranger_resource_policy.table_names = {"database1_table", "database2_table"};
+    fake_ranger_resource_policy.policies = fake_policy;
+
+    std::string resource_type_name = enum_to_string(resource_type::KDatabaseTable);
+    all_resource_policies fake_all_resource_policies{
+        {resource_type_name, {fake_ranger_resource_policy}}};
+
+    dsn::blob value =
+        json::json_forwarder<all_resource_policies>::encode(fake_all_resource_policies);
+    std::string fake_all_resource_policies_str = value.to_string();
+    all_resource_policies fake_all_resource_policies_serialized;
+    dsn::json::json_forwarder<all_resource_policies>::decode(
+        dsn::blob::create_from_bytes(std::move(fake_all_resource_policies_str)),
+        fake_all_resource_policies_serialized);
+
+    EXPECT_EQ(1, fake_all_resource_policies.count(resource_type_name));
+    EXPECT_EQ(1, fake_all_resource_policies_serialized.count(resource_type_name));
+    ranger_resource_policy policy = fake_all_resource_policies[resource_type_name][0];
+    ranger_resource_policy policy_serialized =
+        fake_all_resource_policies_serialized[resource_type_name][0];
+    ASSERT_EQ(policy.name, policy_serialized.name);
+    for (const auto &database_name : policy.database_names) {
+        auto it = find(policy_serialized.database_names.begin(),
+                       policy_serialized.database_names.end(),
+                       database_name);
+        ASSERT_NE(it, policy_serialized.database_names.end());
+    }
+    for (const auto &table_name : policy.table_names) {
+        auto it = find(
+            policy_serialized.table_names.begin(), policy_serialized.table_names.end(), table_name);
+        ASSERT_NE(it, policy_serialized.table_names.end());
+    }
+    struct test_case
+    {
+        access_type ac_type;
+        std::string user_name;
+        bool expected_result;
+    } tests[] = {{access_type::KRead, "user", false},      {access_type::KRead, "user1", true},
+                 {access_type::KWrite, "user1", true},     {access_type::KCreate, "user1", false},
+                 {access_type::KDrop, "user1", false},     {access_type::KList, "user1", true},
+                 {access_type::KMetadata, "user1", false}, {access_type::KControl, "user1", false},
+                 {access_type::KRead, "user2", true},      {access_type::KWrite, "user2", false},
+                 {access_type::KCreate, "user2", false},   {access_type::KDrop, "user2", false},
+                 {access_type::KList, "user2", true},      {access_type::KMetadata, "user2", false},
+                 {access_type::KControl, "user2", false},  {access_type::KRead, "user3", false},
+                 {access_type::KWrite, "user3", false},    {access_type::KCreate, "user3", false},
+                 {access_type::KDrop, "user3", false},     {access_type::KList, "user3", true},
+                 {access_type::KMetadata, "user3", false}, {access_type::KControl, "user3", false},
+                 {access_type::KRead, "user4", true},      {access_type::KWrite, "user4", false},
+                 {access_type::KCreate, "user4", false},   {access_type::KDrop, "user4", false},
+                 {access_type::KList, "user4", true},      {access_type::KMetadata, "user4", false},
+                 {access_type::KControl, "user4", false}};
+    for (const auto &test : tests) {
+        auto actual_result = policy.policies.allowed(test.ac_type, test.user_name);
+        EXPECT_EQ(test.expected_result, actual_result);
+        actual_result = policy_serialized.policies.allowed(test.ac_type, test.user_name);
+        EXPECT_EQ(test.expected_result, actual_result);
+    }
+}
+} // namespace ranger
+} // namespace dsn

--- a/src/runtime/test/ranger_resource_policy_test.cpp
+++ b/src/runtime/test/ranger_resource_policy_test.cpp
@@ -24,23 +24,23 @@ namespace ranger {
 
 TEST(ranger_resource_policy_test, policy_item_match)
 {
-    policy_item item = {access_type::KRead | access_type::KWrite | access_type::KCreate,
+    policy_item item = {access_type::kRead | access_type::kWrite | access_type::kCreate,
                         {"user1", "user2"}};
     struct test_case
     {
         access_type ac_type;
         std::string user_name;
         bool expected_result;
-    } tests[] = {{access_type::KRead, "", false},
-                 {access_type::KRead, "user", false},
-                 {access_type::KRead, "user1", true},
-                 {access_type::KWrite, "user1", true},
-                 {access_type::KCreate, "user1", true},
-                 {access_type::KDrop, "user1", false},
-                 {access_type::KList, "user1", false},
-                 {access_type::KMetadata, "user1", false},
-                 {access_type::KControl, "user1", false},
-                 {access_type::KWrite, "user2", true}};
+    } tests[] = {{access_type::kRead, "", false},
+                 {access_type::kRead, "user", false},
+                 {access_type::kRead, "user1", true},
+                 {access_type::kWrite, "user1", true},
+                 {access_type::kCreate, "user1", true},
+                 {access_type::kDrop, "user1", false},
+                 {access_type::kList, "user1", false},
+                 {access_type::kMetadata, "user1", false},
+                 {access_type::kControl, "user1", false},
+                 {access_type::kWrite, "user2", true}};
     for (const auto &test : tests) {
         auto actual_result = item.match(test.ac_type, test.user_name);
         EXPECT_EQ(test.expected_result, actual_result);
@@ -50,27 +50,27 @@ TEST(ranger_resource_policy_test, policy_item_match)
 TEST(ranger_resource_policy_test, acl_policies_allowed)
 {
     acl_policies policy;
-    policy.allow_policies = {{access_type::KRead | access_type::KWrite | access_type::KCreate,
+    policy.allow_policies = {{access_type::kRead | access_type::kWrite | access_type::kCreate,
                               {"user1", "user2", "user3", "user4"}}};
-    policy.allow_policies_exclude = {{access_type::KWrite | access_type::KCreate, {"user2"}}};
-    policy.deny_policies = {{access_type::KRead | access_type::KWrite, {"user3", "user4"}}};
-    policy.deny_policies_exclude = {{access_type::KRead, {"user4"}}};
+    policy.allow_policies_exclude = {{access_type::kWrite | access_type::kCreate, {"user2"}}};
+    policy.deny_policies = {{access_type::kRead | access_type::kWrite, {"user3", "user4"}}};
+    policy.deny_policies_exclude = {{access_type::kRead, {"user4"}}};
     struct test_case
     {
         access_type ac_type;
         std::string user_name;
         bool expected_result;
-    } tests[] = {{access_type::KRead, "user", false},      {access_type::KRead, "user1", true},
-                 {access_type::KWrite, "user1", true},     {access_type::KCreate, "user1", true},
-                 {access_type::KDrop, "user1", false},     {access_type::KList, "user1", false},
-                 {access_type::KMetadata, "user1", false}, {access_type::KControl, "user1", false},
-                 {access_type::KRead, "user2", true},      {access_type::KWrite, "user2", false},
-                 {access_type::KCreate, "user2", false},   {access_type::KDrop, "user2", false},
-                 {access_type::KList, "user2", false},     {access_type::KMetadata, "user2", false},
-                 {access_type::KControl, "user2", false},  {access_type::KRead, "user3", false},
-                 {access_type::KCreate, "user3", true},    {access_type::KList, "user3", false},
-                 {access_type::KRead, "user4", true},      {access_type::KWrite, "user4", false},
-                 {access_type::KCreate, "user4", true},    {access_type::KList, "user4", false}};
+    } tests[] = {{access_type::kRead, "user", false},      {access_type::kRead, "user1", true},
+                 {access_type::kWrite, "user1", true},     {access_type::kCreate, "user1", true},
+                 {access_type::kDrop, "user1", false},     {access_type::kList, "user1", false},
+                 {access_type::kMetadata, "user1", false}, {access_type::kControl, "user1", false},
+                 {access_type::kRead, "user2", true},      {access_type::kWrite, "user2", false},
+                 {access_type::kCreate, "user2", false},   {access_type::kDrop, "user2", false},
+                 {access_type::kList, "user2", false},     {access_type::kMetadata, "user2", false},
+                 {access_type::kControl, "user2", false},  {access_type::kRead, "user3", false},
+                 {access_type::kCreate, "user3", true},    {access_type::kList, "user3", false},
+                 {access_type::kRead, "user4", true},      {access_type::kWrite, "user4", false},
+                 {access_type::kCreate, "user4", true},    {access_type::kList, "user4", false}};
     for (const auto &test : tests) {
         auto actual_result = policy.allowed(test.ac_type, test.user_name);
         EXPECT_EQ(test.expected_result, actual_result);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1054

This patch is to prepare for parse policies and dump policies:
- 'DEFINE_JSON_SERIALIZATION' for data structure.
- Preparations for json parsing
- add unit test for 'parse_policies_from_json'
