### PR TITLE
chore(CI): Use Ubuntu 22.04 as the default test platform

### DIFF
--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -47,7 +47,7 @@ jobs:
           - centos7
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -27,7 +27,7 @@ jobs:
     name: Module Labeler
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Assign GitHub labels
         uses: actions/labeler@main
         with:

--- a/.github/workflows/lint_and_test_admin-cli.yml
+++ b/.github/workflows/lint_and_test_admin-cli.yml
@@ -40,9 +40,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -58,9 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -188,9 +188,15 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
+      - name: Setup cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            /github/home/.ccache
+          key: asan_ccache
       - uses: dorny/paths-filter@v2
         id: changes
         with:
@@ -218,7 +224,10 @@ jobs:
           ../scripts/download_zk.sh zookeeper-bin
       - name: Compilation
         run: |
+          ccache -p
+          ccache -z
           ./run.sh build --test --sanitizer address --skip_thirdparty --disable_gperf -j $(nproc)
+          ccache -s
       - name: Tar files
         run: |
           mv thirdparty/hadoop-bin ./
@@ -275,7 +284,7 @@ jobs:
     needs: build_ASAN
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v3
@@ -306,7 +315,7 @@ jobs:
 #    needs: cpp_clang_format_linter
 #    runs-on: ubuntu-latest
 #    container:
-#      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
+#      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
 #    steps:
 #      - uses: actions/checkout@v3
 #      - name: Setup cache
@@ -398,7 +407,7 @@ jobs:
 #    needs: build_UBSAN
 #    runs-on: ubuntu-latest
 #    container:
-#      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
+#      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
 #      options: --cap-add=SYS_PTRACE
 #    steps:
 #      - uses: actions/checkout@v3

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -88,10 +88,12 @@ jobs:
       - name: Rebuild third-parties
         if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
+        # Build thirdparties and leave some necessary libraries and source
         run: |
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
           cmake --build build/ -j $(nproc)
+          rm -rf build/Build build/Download/[a-y]* build/Source/[a-g]* build/Source/[i-q]* build/Source/[s-z]*
           ../scripts/download_hadoop.sh hadoop-bin
           ../scripts/download_zk.sh zookeeper-bin
       - name: Compilation
@@ -212,10 +214,12 @@ jobs:
       - name: Rebuild third-parties
         if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
+        # Build thirdparties and leave some necessary libraries and source
         run: |
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
           cmake --build build/ -j $(nproc)
+          rm -rf build/Build build/Download/[a-y]* build/Source/[a-g]* build/Source/[i-q]* build/Source/[s-z]*
           ../scripts/download_hadoop.sh hadoop-bin
           ../scripts/download_zk.sh zookeeper-bin
       - name: Compilation
@@ -337,10 +341,12 @@ jobs:
 #      - name: Rebuild third-parties
 #        if: steps.changes.outputs.thirdparty == 'true'
 #        working-directory: thirdparty
+#        # Build thirdparties and leave some necessary libraries and source
 #        run: |
 #          mkdir build
 #          cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
 #          cmake --build build/ -j $(nproc)
+#          rm -rf build/Build build/Download/[a-y]* build/Source/[a-g]* build/Source/[i-q]* build/Source/[s-z]*
 #          ../scripts/download_hadoop.sh hadoop-bin
 #          ../scripts/download_zk.sh zookeeper-bin
 #      - name: Compilation
@@ -455,10 +461,12 @@ jobs:
       - name: Rebuild third-parties
         if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
+        # Build thirdparties and leave some necessary libraries and source
         run: |
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -DUSE_JEMALLOC=ON -B build/
           cmake --build build/ -j $(nproc)
+          rm -rf build/Build build/Download/[a-y]* build/Source/[a-g]* build/Source/[i-q]* build/Source/[s-z]*
           ../scripts/download_hadoop.sh hadoop-bin
           ../scripts/download_zk.sh zookeeper-bin
       - name: Compilation

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -53,10 +53,7 @@ jobs:
     container:
       image: apache/pegasus:clang-format-3.9
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          submodules: true
+      - uses: actions/checkout@v3
       - name: clang-format
         run: ./scripts/run-clang-format.py --clang-format-executable clang-format-3.9 -e ./src/shell/linenoise -e ./src/shell/sds -e ./thirdparty -r .
 
@@ -65,9 +62,9 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup cache
         uses: actions/cache@v3
         with:
@@ -85,7 +82,9 @@ jobs:
               - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
-        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+        run: |
+          unzip /root/thirdparties-bin.zip -d ./thirdparty
+          rm -f /root/thirdparties-bin.zip
       - name: Rebuild third-parties
         if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
@@ -110,7 +109,7 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          tar -zcvhf release__builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin --exclude='*CMakeFiles*'
+          tar --exclude='*CMakeFiles*' -zcvhf release__builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -159,12 +158,14 @@ jobs:
     needs: build_Release
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Unpack prebuilt third-parties
-        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+        run: |
+          unzip /root/thirdparties-bin.zip -d ./thirdparty
+          rm -f /root/thirdparties-bin.zip
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:
@@ -185,9 +186,9 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup cache
         uses: actions/cache@v3
         with:
@@ -205,7 +206,9 @@ jobs:
               - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
-        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+        run: |
+          unzip /root/thirdparties-bin.zip -d ./thirdparty
+          rm -f /root/thirdparties-bin.zip
       - name: Rebuild third-parties
         if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
@@ -226,7 +229,7 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          tar -zcvhf release_address_builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin --exclude='*CMakeFiles*'
+          tar --exclude='*CMakeFiles*' -zcvhf release_address_builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -277,12 +280,14 @@ jobs:
     needs: build_ASAN
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Unpack prebuilt third-parties
-        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+        run: |
+          unzip /root/thirdparties-bin.zip -d ./thirdparty
+          rm -f /root/thirdparties-bin.zip
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:
@@ -306,9 +311,9 @@ jobs:
 #    needs: cpp_clang_format_linter
 #    runs-on: ubuntu-latest
 #    container:
-#      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+#      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v3
 #      - name: Setup cache
 #        uses: actions/cache@v3
 #        with:
@@ -326,7 +331,9 @@ jobs:
 #              - 'thirdparty/**'
 #      - name: Unpack prebuilt third-parties
 #        if: steps.changes.outputs.thirdparty == 'false'
-#        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+#        run: |
+#          unzip /root/thirdparties-bin.zip -d ./thirdparty
+#          rm -f /root/thirdparties-bin.zip
 #      - name: Rebuild third-parties
 #        if: steps.changes.outputs.thirdparty == 'true'
 #        working-directory: thirdparty
@@ -347,7 +354,7 @@ jobs:
 #          mv thirdparty/hadoop-bin ./
 #          mv thirdparty/zookeeper-bin ./
 #          rm -rf thirdparty
-#          tar -zcvhf release_undefined_builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin --exclude='*CMakeFiles*'
+#          tar --exclude='*CMakeFiles*' -zcvhf release_undefined_builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin
 #      - name: Upload Artifact
 #        uses: actions/upload-artifact@v3
 #        with:
@@ -394,12 +401,14 @@ jobs:
 #    needs: build_UBSAN
 #    runs-on: ubuntu-latest
 #    container:
-#      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+#      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
 #      options: --cap-add=SYS_PTRACE
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v3
 #      - name: Unpack prebuilt third-parties
-#        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+#        run: |
+#          unzip /root/thirdparties-bin.zip -d ./thirdparty
+#          rm -f /root/thirdparties-bin.zip
 #      - name: Download Artifact
 #        uses: actions/download-artifact@v3
 #        with:
@@ -420,9 +429,9 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-jemallc-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-jemallc-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup cache
         uses: actions/cache@v3
         with:
@@ -440,7 +449,9 @@ jobs:
               - 'thirdparty/**'
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
-        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+        run: |
+          unzip /root/thirdparties-bin.zip -d ./thirdparty
+          rm -f /root/thirdparties-bin.zip
       - name: Rebuild third-parties
         if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
@@ -465,7 +476,7 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          tar -zcvhf release_jemalloc_builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin --exclude='*CMakeFiles*'
+          tar --exclude='*CMakeFiles*' -zcvhf release_jemalloc_builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -482,12 +493,14 @@ jobs:
     needs: build_with_jemalloc
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-jemallc-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-jemallc-ubuntu2204-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Unpack prebuilt third-parties
-        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+        run: |
+          unzip /root/thirdparties-bin.zip -d ./thirdparty
+          rm -f /root/thirdparties-bin.zip
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:
@@ -518,7 +531,7 @@ jobs:
           brew install lz4
           brew install zstd
           brew install openssl@1.1
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -191,12 +191,6 @@ jobs:
       image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            /github/home/.ccache
-          key: asan_ccache
       - uses: dorny/paths-filter@v2
         id: changes
         with:
@@ -224,10 +218,7 @@ jobs:
           ../scripts/download_zk.sh zookeeper-bin
       - name: Compilation
         run: |
-          ccache -p
-          ccache -z
           ./run.sh build --test --sanitizer address --skip_thirdparty --disable_gperf -j $(nproc)
-          ccache -s
       - name: Tar files
         run: |
           mv thirdparty/hadoop-bin ./

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -45,9 +45,7 @@ jobs:
       # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
       run: sudo apt-get install -y thrift-compiler
     - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      uses: actions/checkout@v3
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/lint_and_test_pegic.yml
+++ b/.github/workflows/lint_and_test_pegic.yml
@@ -40,9 +40,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -54,9 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -41,10 +41,7 @@ jobs:
     container:
       image: apache/pegasus:clang-format-3.9
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          submodules: true
+      - uses: actions/checkout@v3
       - name: clang-format
         run: ./scripts/run-clang-format.py --clang-format-executable clang-format-3.9 -e ./src/shell/linenoise -e ./src/shell/sds -e ./thirdparty -r .
 
@@ -84,7 +81,9 @@ jobs:
         run: |
           git clone -b ${{ github.ref_name }} --depth=1 https://github.com/apache/incubator-pegasus.git
       - name: Unpack prebuilt third-parties
-        run: unzip /root/thirdparties-bin.zip -d ./thirdparty
+        run: |
+          unzip /root/thirdparties-bin.zip -d ./thirdparty
+          rm -f /root/thirdparties-bin.zip
       - name: Compilation Pegasus on GCC
         if: ${{ matrix.compiler-family == 'gcc' }}
         run: ./run.sh build -c --skip_thirdparty
@@ -105,9 +104,7 @@ jobs:
         # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
         run: sudo apt-get install -y thrift-compiler
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -150,7 +147,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}

--- a/.github/workflows/standardization_lint.yaml
+++ b/.github/workflows/standardization_lint.yaml
@@ -47,7 +47,7 @@ jobs:
     name: Check Markdown links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
 
   related_issue:
@@ -66,7 +66,7 @@ jobs:
     name: Lint Dockerfile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@v3.1.0
         with:
           recursive: true
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check License Header
         uses: apache/skywalking-eyes@main
         env:

--- a/.github/workflows/test_java-client.yml
+++ b/.github/workflows/test_java-client.yml
@@ -48,7 +48,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}

--- a/.github/workflows/test_scala-client.yml
+++ b/.github/workflows/test_scala-client.yml
@@ -46,7 +46,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -41,7 +41,7 @@ jobs:
   build_push_src_docker_images:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -78,7 +78,7 @@ jobs:
           - centos6
           - centos7
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -116,7 +116,7 @@ jobs:
           - centos6
           - centos7
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -148,9 +148,9 @@ jobs:
       fail-fast: false
       matrix:
         osversion:
-          - ubuntu1804
+          - ubuntu2204
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -184,9 +184,9 @@ jobs:
       fail-fast: false
       matrix:
         osversion:
-          - ubuntu1804
+          - ubuntu2204
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -28,6 +28,7 @@
 #include "runtime/tool_api.h"
 #include "uri_decoder.h"
 #include "utils/output_utils.h"
+#include "utils/strings.h"
 #include "utils/time_utils.h"
 
 namespace dsn {
@@ -200,7 +201,7 @@ void http_server::serve(message_ex *msg)
 
     // parse path
     std::vector<std::string> args;
-    boost::split(args, unresolved_path, boost::is_any_of("/"));
+    dsn::utils::split_args(unresolved_path.c_str(), args, '/');
     std::vector<std::string> real_args;
     for (std::string &arg : args) {
         if (!arg.empty()) {
@@ -221,7 +222,7 @@ void http_server::serve(message_ex *msg)
     // find if there are method args (<ip>:<port>/<service>/<method>?<arg>=<val>&<arg>=<val>)
     if (!unresolved_query.empty()) {
         std::vector<std::string> method_arg_val;
-        boost::split(method_arg_val, unresolved_query, boost::is_any_of("&"));
+        dsn::utils::split_args(unresolved_query.c_str(), method_arg_val, '&');
         for (const std::string &arg_val : method_arg_val) {
             size_t sep = arg_val.find_first_of('=');
             if (sep == std::string::npos) {

--- a/src/replica/duplication/replica_follower.cpp
+++ b/src/replica/duplication/replica_follower.cpp
@@ -26,6 +26,7 @@
 #include "runtime/rpc/group_address.h"
 #include "nfs/nfs_node.h"
 #include "utils/fail_point.h"
+#include "utils/strings.h"
 
 namespace dsn {
 namespace replication {
@@ -54,7 +55,7 @@ void replica_follower::init_master_info()
 
     const auto &meta_list_str = envs.at(duplication_constants::kDuplicationEnvMasterMetasKey);
     std::vector<std::string> metas;
-    boost::split(metas, meta_list_str, boost::is_any_of(","));
+    dsn::utils::split_args(meta_list_str.c_str(), metas, ',');
     CHECK(!metas.empty(), "master cluster meta list is invalid!");
     for (const auto &meta : metas) {
         dsn::rpc_address node;

--- a/src/runtime/ranger/ranger_resource_policy_manager.cpp
+++ b/src/runtime/ranger/ranger_resource_policy_manager.cpp
@@ -40,7 +40,7 @@ void register_rpc_access_type(access_type ac_type,
 
 ranger_resource_policy_manager::ranger_resource_policy_manager(
     dsn::replication::meta_service *meta_svc)
-    : _meta_svc(meta_svc), _local_policy_version(0)
+    : _meta_svc(meta_svc) //, _local_policy_version(0)
 {
     _ranger_policy_meta_root = dsn::replication::meta_options::concat_path_unix_style(
         _meta_svc->cluster_root(), "ranger_policy_meta_root");

--- a/src/runtime/ranger/ranger_resource_policy_manager.h
+++ b/src/runtime/ranger/ranger_resource_policy_manager.h
@@ -57,7 +57,7 @@ private:
     access_type_of_rpc_code _ac_type_of_database_rpcs;
 
     // The Ranger policy version to determine whether to update.
-    int _local_policy_version;
+    //    int _local_policy_version;
 };
 } // namespace ranger
 } // namespace dsn

--- a/src/utils/string_conv.h
+++ b/src/utils/string_conv.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <climits>
 #include <cmath>
+#include <limits>
 
 #include "string_view.h"
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1349

Now we have introduced Ubuntu 22.04 (with GCC 11.3.0) Dockerfile, and use it for daily regular build workflow, but the workflow for pull requests is using Ubuntu 18.04 (with GCC 7.5.0). Some warnings or errors will be reported in daily regular build workflow lately. GCC 11.3.0 has more default CXXFLAGS to check hidden code troubles, so I suggest using Ubuntu 22.04 (with GCC 11.3.0) for pull requests.
This patch also includes some other improvements, including:
- upgrade `actions/checkout@v2` to `actions/checkout@v3`
- remove `fetch-depth` option since the default is `1` which is which we need
- remove `submodules` option since it's meaningless now
- remove `/root/thirdparties-bin.zip` after it has been unzipped
- move `--exclude` to the beginning of `tar` ti make it effective