### PR TITLE
feat(new_metrics): migrate replica-level metrics for pegasus_server_impl (part 2)

### DIFF
--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1798,8 +1798,8 @@ void pegasus_server_impl::cancel_background_work(bool wait)
             LOG_ERROR_PREFIX("rmdir {} failed when stop app", data_dir());
             return ::dsn::ERR_FILE_OPERATION_FAILED;
         }
-        _pfc_rdb_sst_count->set(0);
-        _pfc_rdb_sst_size->set(0);
+        METRIC_VAR_SET(rdb_total_sst_files, 0);
+        METRIC_VAR_SET(rdb_total_sst_size_mb, 0);
         _pfc_rdb_block_cache_hit_count->set(0);
         _pfc_rdb_block_cache_total_count->set(0);
         _pfc_rdb_block_cache_mem_usage->set(0);
@@ -2371,7 +2371,7 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
     std::string str_val;
     uint64_t val = 0;
 
-    // Update _pfc_rdb_sst_count
+    // Update rdb_total_sst_files
     for (int i = 0; i < _data_cf_opts.num_levels; ++i) {
         int cur_level_count = 0;
         if (_db->GetProperty(rocksdb::DB::Properties::kNumFilesAtLevelPrefix + std::to_string(i),
@@ -2380,15 +2380,15 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
             val += cur_level_count;
         }
     }
-    _pfc_rdb_sst_count->set(val);
-    LOG_DEBUG_PREFIX("_pfc_rdb_sst_count: {}", val);
+    METRIC_VAR_SET(rdb_total_sst_files, val);
+    LOG_DEBUG_PREFIX("rdb_total_sst_files: {}", val);
 
-    // Update _pfc_rdb_sst_size
+    // Update rdb_total_sst_size_mb
     if (_db->GetProperty(_data_cf, rocksdb::DB::Properties::kTotalSstFilesSize, &str_val) &&
         dsn::buf2uint64(str_val, val)) {
         static uint64_t bytes_per_mb = 1U << 20U;
-        _pfc_rdb_sst_size->set(val / bytes_per_mb);
-        LOG_DEBUG_PREFIX("_pfc_rdb_sst_size: {} bytes", val);
+        METRIC_VAR_SET(rdb_total_sst_size_mb, val / bytes_per_mb);
+        LOG_DEBUG_PREFIX("rdb_total_sst_size_mb: {}", val);
     }
 
     // Update _pfc_rdb_write_amplification

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2366,7 +2366,7 @@ range_iteration_state pegasus_server_impl::append_key_value_for_multi_get(
     return range_iteration_state::kNormal;
 }
 
-#define GET_TICKER_COUNT_AND_SET_METRIC(ticker_name, metirc_name)                                  \
+#define GET_TICKER_COUNT_AND_SET_METRIC(ticker_name, metric_name)                                  \
     do {                                                                                           \
         auto value = _statistics->getTickerCount(rocksdb::ticker_name);                            \
         METRIC_VAR_SET(metric_name, value);                                                        \

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1800,11 +1800,11 @@ void pegasus_server_impl::cancel_background_work(bool wait)
         }
         METRIC_VAR_SET(rdb_total_sst_files, 0);
         METRIC_VAR_SET(rdb_total_sst_size_mb, 0);
-        _pfc_rdb_block_cache_hit_count->set(0);
-        _pfc_rdb_block_cache_total_count->set(0);
-        _pfc_rdb_block_cache_mem_usage->set(0);
         METRIC_VAR_SET(rdb_index_and_filter_blocks_mem_usage_bytes, 0);
         METRIC_VAR_SET(rdb_memtable_mem_usage_bytes, 0);
+        METRIC_VAR_SET(rdb_block_cache_hit_count, 0);
+        METRIC_VAR_SET(rdb_block_cache_total_count, 0);
+        _pfc_rdb_block_cache_mem_usage->set(0);
     }
 
     LOG_INFO_PREFIX("close app succeed, clear_state = {}", clear_state ? "true" : "false");
@@ -2451,31 +2451,32 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
         }
     }
 
-    // Update rdb_bf_seek_negatives
-    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_PREFIX_USEFUL, rdb_bf_seek_negatives);
+    // Update rdb_bloom_filter_seek_negatives
+    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_PREFIX_USEFUL, rdb_bloom_filter_seek_negatives);
 
-    // Update rdb_bf_seek_total
-    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_PREFIX_CHECKED, rdb_bf_seek_total);
+    // Update rdb_bloom_filter_seek_total
+    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_PREFIX_CHECKED, rdb_bloom_filter_seek_total);
 
-    // Update rdb_bf_point_lookup_negatives
-    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_USEFUL, rdb_bf_point_lookup_negatives);
+    // Update rdb_bloom_filter_point_lookup_negatives
+    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_USEFUL, rdb_bloom_filter_point_lookup_negatives);
 
-    // Update rdb_bf_point_lookup_positives
-    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_FULL_POSITIVE, rdb_bf_point_lookup_positives);
+    // Update rdb_bloom_filter_point_lookup_positives
+    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_FULL_POSITIVE,
+                                    rdb_bloom_filter_point_lookup_positives);
 
-    // Update rdb_bf_point_lookup_true_positives
+    // Update rdb_bloom_filter_point_lookup_true_positives
     GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_FULL_TRUE_POSITIVE,
-                                    rdb_bf_point_lookup_true_positives);
+                                    rdb_bloom_filter_point_lookup_true_positives);
 
-    // Update _pfc_rdb_block_cache_hit_count and _pfc_rdb_block_cache_total_count
+    // Update rdb_block_cache_hit_count and rdb_block_cache_total_count
     auto block_cache_hit = _statistics->getTickerCount(rocksdb::BLOCK_CACHE_HIT);
-    _pfc_rdb_block_cache_hit_count->set(block_cache_hit);
-    LOG_DEBUG_PREFIX("_pfc_rdb_block_cache_hit_count: {}", block_cache_hit);
+    METRIC_VAR_SET(rdb_block_cache_hit_count, block_cache_hit);
+    LOG_DEBUG_PREFIX("rdb_block_cache_hit_count: {}", block_cache_hit);
 
     auto block_cache_miss = _statistics->getTickerCount(rocksdb::BLOCK_CACHE_MISS);
     auto block_cache_total = block_cache_hit + block_cache_miss;
-    _pfc_rdb_block_cache_total_count->set(block_cache_total);
-    LOG_DEBUG_PREFIX("_pfc_rdb_block_cache_total_count: {}", block_cache_total);
+    METRIC_VAR_SET(rdb_block_cache_total_count, block_cache_total);
+    LOG_DEBUG_PREFIX("rdb_block_cache_total_count: {}", block_cache_total);
 
     // update block memtable/l0/l1/l2andup hit rate under block cache up level
     auto memtable_hit_count = _statistics->getTickerCount(rocksdb::MEMTABLE_HIT);

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1803,8 +1803,8 @@ void pegasus_server_impl::cancel_background_work(bool wait)
         _pfc_rdb_block_cache_hit_count->set(0);
         _pfc_rdb_block_cache_total_count->set(0);
         _pfc_rdb_block_cache_mem_usage->set(0);
-        _pfc_rdb_index_and_filter_blocks_mem_usage->set(0);
-        _pfc_rdb_memtable_mem_usage->set(0);
+        METRIC_VAR_SET(rdb_index_and_filter_blocks_mem_usage_bytes, 0);
+        METRIC_VAR_SET(rdb_memtable_mem_usage_bytes, 0);
     }
 
     LOG_INFO_PREFIX("close app succeed, clear_state = {}", clear_state ? "true" : "false");
@@ -2402,27 +2402,27 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
         LOG_DEBUG_PREFIX("_pfc_rdb_write_amplification: {}", write_amplification);
     }
 
-    // Update _pfc_rdb_index_and_filter_blocks_mem_usage
+    // Update rdb_index_and_filter_blocks_mem_usage_bytes
     if (_db->GetProperty(_data_cf, rocksdb::DB::Properties::kEstimateTableReadersMem, &str_val) &&
         dsn::buf2uint64(str_val, val)) {
-        _pfc_rdb_index_and_filter_blocks_mem_usage->set(val);
-        LOG_DEBUG_PREFIX("_pfc_rdb_index_and_filter_blocks_mem_usage: {} bytes", val);
+        METRIC_VAR_SET(rdb_index_and_filter_blocks_mem_usage_bytes, val);
+        LOG_DEBUG_PREFIX("rdb_index_and_filter_blocks_mem_usage_bytes: {}", val);
     }
 
-    // Update _pfc_rdb_memtable_mem_usage
+    // Update rdb_memtable_mem_usage_bytes
     if (_db->GetProperty(_data_cf, rocksdb::DB::Properties::kCurSizeAllMemTables, &str_val) &&
         dsn::buf2uint64(str_val, val)) {
-        _pfc_rdb_memtable_mem_usage->set(val);
-        LOG_DEBUG_PREFIX("_pfc_rdb_memtable_mem_usage: {} bytes", val);
+        METRIC_VAR_SET(rdb_memtable_mem_usage_bytes, val);
+        LOG_DEBUG_PREFIX("rdb_memtable_mem_usage_bytes: {}", val);
     }
 
-    // Update _pfc_rdb_estimate_num_keys
+    // Update rdb_estimated_keys
     // NOTE: for the same n kv pairs, kEstimateNumKeys will be counted n times, you need compaction
     // to remove duplicate
     if (_db->GetProperty(_data_cf, rocksdb::DB::Properties::kEstimateNumKeys, &str_val) &&
         dsn::buf2uint64(str_val, val)) {
-        _pfc_rdb_estimate_num_keys->set(val);
-        LOG_DEBUG_PREFIX("_pfc_rdb_estimate_num_keys: {}", val);
+        METRIC_VAR_SET(rdb_estimated_keys, val);
+        LOG_DEBUG_PREFIX("rdb_estimated_keys: {}", val);
     }
 
     // the follow stats is related to `read`, so only primary need update it，ignore

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2366,11 +2366,11 @@ range_iteration_state pegasus_server_impl::append_key_value_for_multi_get(
     return range_iteration_state::kNormal;
 }
 
-#define GET_TICKER_COUNT_AND_SET_METRIC(ticker_name, metirc_name) \
-    do { \
-    auto value = _statistics->getTickerCount(rocksdb::ticker_name); \
-    METRIC_VAR_SET(metric_name, value); \
-    LOG_DEBUG_PREFIX("" #metric_name ": {}", value);\
+#define GET_TICKER_COUNT_AND_SET_METRIC(ticker_name, metirc_name)                                  \
+    do {                                                                                           \
+        auto value = _statistics->getTickerCount(rocksdb::ticker_name);                            \
+        METRIC_VAR_SET(metric_name, value);                                                        \
+        LOG_DEBUG_PREFIX("" #metric_name ": {}", value);                                           \
     } while (0)
 
 void pegasus_server_impl::update_replica_rocksdb_statistics()
@@ -2464,7 +2464,8 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
     GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_FULL_POSITIVE, rdb_bf_point_lookup_positives);
 
     // Update rdb_bf_point_lookup_true_positives
-    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_FULL_TRUE_POSITIVE, rdb_bf_point_lookup_true_positives);
+    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_FULL_TRUE_POSITIVE,
+                                    rdb_bf_point_lookup_true_positives);
 
     // Update _pfc_rdb_block_cache_hit_count and _pfc_rdb_block_cache_total_count
     auto block_cache_hit = _statistics->getTickerCount(rocksdb::BLOCK_CACHE_HIT);

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2366,6 +2366,13 @@ range_iteration_state pegasus_server_impl::append_key_value_for_multi_get(
     return range_iteration_state::kNormal;
 }
 
+#define GET_TICKER_COUNT_AND_SET_METRIC(ticker_name, metirc_name) \
+    do { \
+    auto value = _statistics->getTickerCount(rocksdb::ticker_name); \
+    METRIC_VAR_SET(metric_name, value); \
+    LOG_DEBUG_PREFIX("" #metric_name ": {}", value);\
+    } while (0)
+
 void pegasus_server_impl::update_replica_rocksdb_statistics()
 {
     std::string str_val;
@@ -2444,31 +2451,20 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
         }
     }
 
-    // Update _pfc_rdb_bf_seek_negatives
-    auto bf_seek_negatives = _statistics->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_USEFUL);
-    _pfc_rdb_bf_seek_negatives->set(bf_seek_negatives);
-    LOG_DEBUG_PREFIX("_pfc_rdb_bf_seek_negatives: {}", bf_seek_negatives);
+    // Update rdb_bf_seek_negatives
+    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_PREFIX_USEFUL, rdb_bf_seek_negatives);
 
-    // Update _pfc_rdb_bf_seek_total
-    auto bf_seek_total = _statistics->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_CHECKED);
-    _pfc_rdb_bf_seek_total->set(bf_seek_total);
-    LOG_DEBUG_PREFIX("_pfc_rdb_bf_seek_total: {}", bf_seek_total);
+    // Update rdb_bf_seek_total
+    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_PREFIX_CHECKED, rdb_bf_seek_total);
 
-    // Update _pfc_rdb_bf_point_positive_true
-    auto bf_point_positive_true =
-        _statistics->getTickerCount(rocksdb::BLOOM_FILTER_FULL_TRUE_POSITIVE);
-    _pfc_rdb_bf_point_positive_true->set(bf_point_positive_true);
-    LOG_DEBUG_PREFIX("_pfc_rdb_bf_point_positive_true: {}", bf_point_positive_true);
+    // Update rdb_bf_point_lookup_negatives
+    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_USEFUL, rdb_bf_point_lookup_negatives);
 
-    // Update _pfc_rdb_bf_point_positive_total
-    auto bf_point_positive_total = _statistics->getTickerCount(rocksdb::BLOOM_FILTER_FULL_POSITIVE);
-    _pfc_rdb_bf_point_positive_total->set(bf_point_positive_total);
-    LOG_DEBUG_PREFIX("_pfc_rdb_bf_point_positive_total: {}", bf_point_positive_total);
+    // Update rdb_bf_point_lookup_positives
+    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_FULL_POSITIVE, rdb_bf_point_lookup_positives);
 
-    // Update _pfc_rdb_bf_point_negatives
-    auto bf_point_negatives = _statistics->getTickerCount(rocksdb::BLOOM_FILTER_USEFUL);
-    _pfc_rdb_bf_point_negatives->set(bf_point_negatives);
-    LOG_DEBUG_PREFIX("_pfc_rdb_bf_point_negatives: {}", bf_point_negatives);
+    // Update rdb_bf_point_lookup_true_positives
+    GET_TICKER_COUNT_AND_SET_METRIC(BLOOM_FILTER_FULL_TRUE_POSITIVE, rdb_bf_point_lookup_true_positives);
 
     // Update _pfc_rdb_block_cache_hit_count and _pfc_rdb_block_cache_total_count
     auto block_cache_hit = _statistics->getTickerCount(rocksdb::BLOCK_CACHE_HIT);

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -516,17 +516,19 @@ private:
     // Replica-level metrics for rocksdb.
     METRIC_VAR_DECLARE_gauge_int64(rdb_total_sst_files);
     METRIC_VAR_DECLARE_gauge_int64(rdb_total_sst_size_mb);
-    METRIC_VAR_DECLARE_gauge_int64(rdb_index_and_filter_blocks_mem_usage_bytes);
-    METRIC_VAR_DECLARE_gauge_int64(rdb_memtable_mem_usage_bytes);
     METRIC_VAR_DECLARE_gauge_int64(rdb_estimated_keys);
 
-    METRIC_VAR_DECLARE_gauge_int64(rdb_bf_seek_negatives);
-    METRIC_VAR_DECLARE_gauge_int64(rdb_bf_seek_total);
-    METRIC_VAR_DECLARE_gauge_int64(rdb_bf_point_lookup_negatives);
-    METRIC_VAR_DECLARE_gauge_int64(rdb_bf_point_lookup_positives);
-    METRIC_VAR_DECLARE_gauge_int64(rdb_bf_point_lookup_true_positives);
-    dsn::perf_counter_wrapper _pfc_rdb_block_cache_hit_count;
-    dsn::perf_counter_wrapper _pfc_rdb_block_cache_total_count;
+    METRIC_VAR_DECLARE_gauge_int64(rdb_index_and_filter_blocks_mem_usage_bytes);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_memtable_mem_usage_bytes);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_block_cache_hit_count);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_block_cache_total_count);
+
+    METRIC_VAR_DECLARE_gauge_int64(rdb_bloom_filter_seek_negatives);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_bloom_filter_seek_total);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_bloom_filter_point_lookup_negatives);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_bloom_filter_point_lookup_positives);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_bloom_filter_point_lookup_true_positives);
+
     dsn::perf_counter_wrapper _pfc_rdb_write_amplification;
     dsn::perf_counter_wrapper _pfc_rdb_read_amplification;
     dsn::perf_counter_wrapper _pfc_rdb_memtable_hit_count;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -512,9 +512,10 @@ private:
     // server level
     static ::dsn::perf_counter_wrapper _pfc_rdb_write_limiter_rate_bytes;
     static ::dsn::perf_counter_wrapper _pfc_rdb_block_cache_mem_usage;
-    // replica level
-    dsn::perf_counter_wrapper _pfc_rdb_sst_count;
-    dsn::perf_counter_wrapper _pfc_rdb_sst_size;
+
+    // Replica-level metrics for rocksdb.
+    METRIC_VAR_DECLARE_gauge_int64(rdb_total_sst_files);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_total_sst_size_mb);
     dsn::perf_counter_wrapper _pfc_rdb_index_and_filter_blocks_mem_usage;
     dsn::perf_counter_wrapper _pfc_rdb_memtable_mem_usage;
     dsn::perf_counter_wrapper _pfc_rdb_estimate_num_keys;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -507,6 +507,7 @@ private:
     METRIC_VAR_DECLARE_counter(read_expired_values);
     METRIC_VAR_DECLARE_counter(read_filtered_values);
     METRIC_VAR_DECLARE_counter(abnormal_read_requests);
+    METRIC_VAR_DECLARE_counter(throttling_rejected_read_requests);
 
     // rocksdb internal statistics
     // server level
@@ -522,22 +523,20 @@ private:
     METRIC_VAR_DECLARE_gauge_int64(rdb_memtable_mem_usage_bytes);
     METRIC_VAR_DECLARE_gauge_int64(rdb_block_cache_hit_count);
     METRIC_VAR_DECLARE_gauge_int64(rdb_block_cache_total_count);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_memtable_hit_count);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_memtable_total_count);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_l0_hit_count);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_l1_hit_count);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_l2_and_up_hit_count);
+
+    METRIC_VAR_DECLARE_gauge_int64(rdb_write_amplification);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_read_amplification);
 
     METRIC_VAR_DECLARE_gauge_int64(rdb_bloom_filter_seek_negatives);
     METRIC_VAR_DECLARE_gauge_int64(rdb_bloom_filter_seek_total);
     METRIC_VAR_DECLARE_gauge_int64(rdb_bloom_filter_point_lookup_negatives);
     METRIC_VAR_DECLARE_gauge_int64(rdb_bloom_filter_point_lookup_positives);
     METRIC_VAR_DECLARE_gauge_int64(rdb_bloom_filter_point_lookup_true_positives);
-
-    dsn::perf_counter_wrapper _pfc_rdb_write_amplification;
-    dsn::perf_counter_wrapper _pfc_rdb_read_amplification;
-    dsn::perf_counter_wrapper _pfc_rdb_memtable_hit_count;
-    dsn::perf_counter_wrapper _pfc_rdb_memtable_total_count;
-    dsn::perf_counter_wrapper _pfc_rdb_l0_hit_count;
-    dsn::perf_counter_wrapper _pfc_rdb_l1_hit_count;
-    dsn::perf_counter_wrapper _pfc_rdb_l2andup_hit_count;
-
-    dsn::perf_counter_wrapper _counter_recent_read_throttling_reject_count;
 };
 
 } // namespace server

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -516,9 +516,9 @@ private:
     // Replica-level metrics for rocksdb.
     METRIC_VAR_DECLARE_gauge_int64(rdb_total_sst_files);
     METRIC_VAR_DECLARE_gauge_int64(rdb_total_sst_size_mb);
-    dsn::perf_counter_wrapper _pfc_rdb_index_and_filter_blocks_mem_usage;
-    dsn::perf_counter_wrapper _pfc_rdb_memtable_mem_usage;
-    dsn::perf_counter_wrapper _pfc_rdb_estimate_num_keys;
+    METRIC_VAR_DECLARE_gauge_int64(rdb_index_and_filter_blocks_mem_usage_bytes);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_memtable_mem_usage_bytes);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_estimated_keys);
 
     dsn::perf_counter_wrapper _pfc_rdb_bf_seek_negatives;
     dsn::perf_counter_wrapper _pfc_rdb_bf_seek_total;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -520,11 +520,11 @@ private:
     METRIC_VAR_DECLARE_gauge_int64(rdb_memtable_mem_usage_bytes);
     METRIC_VAR_DECLARE_gauge_int64(rdb_estimated_keys);
 
-    dsn::perf_counter_wrapper _pfc_rdb_bf_seek_negatives;
-    dsn::perf_counter_wrapper _pfc_rdb_bf_seek_total;
-    dsn::perf_counter_wrapper _pfc_rdb_bf_point_positive_true;
-    dsn::perf_counter_wrapper _pfc_rdb_bf_point_positive_total;
-    dsn::perf_counter_wrapper _pfc_rdb_bf_point_negatives;
+    METRIC_VAR_DECLARE_gauge_int64(rdb_bf_seek_negatives);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_bf_seek_total);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_bf_point_lookup_negatives);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_bf_point_lookup_positives);
+    METRIC_VAR_DECLARE_gauge_int64(rdb_bf_point_lookup_true_positives);
     dsn::perf_counter_wrapper _pfc_rdb_block_cache_hit_count;
     dsn::perf_counter_wrapper _pfc_rdb_block_cache_total_count;
     dsn::perf_counter_wrapper _pfc_rdb_write_amplification;

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -96,10 +96,11 @@ METRIC_DEFINE_gauge_int64(replica,
                           dsn::metric_unit::kMegaBytes,
                           "The total size of rocksdb sst files in MB for each replica");
 
-METRIC_DEFINE_gauge_int64(replica,
-                          rdb_index_and_filter_blocks_mem_usage_bytes,
-                          dsn::metric_unit::kBytes,
-                          "The memory usage of rocksdb index and filter blocks in bytes for each replica");
+METRIC_DEFINE_gauge_int64(
+    replica,
+    rdb_index_and_filter_blocks_mem_usage_bytes,
+    dsn::metric_unit::kBytes,
+    "The memory usage of rocksdb index and filter blocks in bytes for each replica");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_memtable_mem_usage_bytes,

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -96,6 +96,21 @@ METRIC_DEFINE_gauge_int64(replica,
                           dsn::metric_unit::kMegaBytes,
                           "The total size of rocksdb sst files in MB for each replica");
 
+METRIC_DEFINE_gauge_int64(replica,
+                          rdb_index_and_filter_blocks_mem_usage_bytes,
+                          dsn::metric_unit::kBytes,
+                          "The memory usage of rocksdb index and filter blocks in bytes for each replica");
+
+METRIC_DEFINE_gauge_int64(replica,
+                          rdb_memtable_mem_usage_bytes,
+                          dsn::metric_unit::kBytes,
+                          "The memory usage of rocksdb memtables in bytes for each replica");
+
+METRIC_DEFINE_gauge_int64(replica,
+                          rdb_estimated_keys,
+                          dsn::metric_unit::kKeys,
+                          "The estimated number of rocksdb keys for each replica");
+
 namespace pegasus {
 namespace server {
 
@@ -273,7 +288,10 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
       METRIC_VAR_INIT_replica(read_filtered_values),
       METRIC_VAR_INIT_replica(abnormal_read_requests),
       METRIC_VAR_INIT_replica(rdb_total_sst_files),
-      METRIC_VAR_INIT_replica(rdb_total_sst_size_mb)
+      METRIC_VAR_INIT_replica(rdb_total_sst_size_mb),
+      METRIC_VAR_INIT_replica(rdb_index_and_filter_blocks_mem_usage_bytes),
+      METRIC_VAR_INIT_replica(rdb_memtable_mem_usage_bytes),
+      METRIC_VAR_INIT_replica(rdb_estimated_keys)
 {
     _primary_address = dsn::rpc_address(dsn_primary_address()).to_string();
     _gpid = get_gpid();
@@ -736,24 +754,6 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
             COUNTER_TYPE_NUMBER,
             "statistic the through bytes of rocksdb write rate limiter");
     });
-
-    snprintf(name, 255, "rdb.index_and_filter_blocks.memory_usage@%s", str_gpid.c_str());
-    _pfc_rdb_index_and_filter_blocks_mem_usage.init_app_counter(
-        "app.pegasus",
-        name,
-        COUNTER_TYPE_NUMBER,
-        "statistic the memory usage of rocksdb index and filter blocks");
-
-    snprintf(name, 255, "rdb.memtable.memory_usage@%s", str_gpid.c_str());
-    _pfc_rdb_memtable_mem_usage.init_app_counter(
-        "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistic the memory usage of rocksdb memtable");
-
-    snprintf(name, 255, "rdb.estimate_num_keys@%s", str_gpid.c_str());
-    _pfc_rdb_estimate_num_keys.init_app_counter(
-        "app.pegasus",
-        name,
-        COUNTER_TYPE_NUMBER,
-        "statistics the estimated number of keys inside the rocksdb");
 
     snprintf(name, 255, "rdb.bf_seek_negatives@%s", str_gpid.c_str());
     _pfc_rdb_bf_seek_negatives.init_app_counter("app.pegasus",

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -86,6 +86,16 @@ METRIC_DEFINE_counter(replica,
                       dsn::metric_unit::kRequests,
                       "The number of abnormal read requests for each replica");
 
+METRIC_DEFINE_gauge_int64(replica,
+                      rdb_total_sst_files,
+                      dsn::metric_unit::kFiles,
+                      "The total number of rocksdb sst files for each replica");
+
+METRIC_DEFINE_gauge_int64(replica,
+                      rdb_total_sst_size_mb,
+                      dsn::metric_unit::kMegaBytes,
+                      "The total size of rocksdb sst files in MB for each replica");
+
 namespace pegasus {
 namespace server {
 
@@ -261,7 +271,9 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
       METRIC_VAR_INIT_replica(scan_latency_ns),
       METRIC_VAR_INIT_replica(read_expired_values),
       METRIC_VAR_INIT_replica(read_filtered_values),
-      METRIC_VAR_INIT_replica(abnormal_read_requests)
+      METRIC_VAR_INIT_replica(abnormal_read_requests),
+      METRIC_VAR_INIT_replica(rdb_total_sst_files),
+      METRIC_VAR_INIT_replica(rdb_total_sst_size_mb)
 {
     _primary_address = dsn::rpc_address(dsn_primary_address()).to_string();
     _gpid = get_gpid();
@@ -667,14 +679,6 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     char name[256];
 
     // register the perf counters
-    snprintf(name, 255, "disk.storage.sst.count@%s", str_gpid.c_str());
-    _pfc_rdb_sst_count.init_app_counter(
-        "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistic the count of sstable files");
-
-    snprintf(name, 255, "disk.storage.sst(MB)@%s", str_gpid.c_str());
-    _pfc_rdb_sst_size.init_app_counter(
-        "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistic the size of sstable files");
-
     snprintf(name, 255, "rdb.block_cache.hit_count@%s", str_gpid.c_str());
     _pfc_rdb_block_cache_hit_count.init_app_counter(
         "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistic the hit count of rocksdb block cache");

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -34,133 +34,132 @@
 METRIC_DEFINE_counter(replica,
                       get_requests,
                       dsn::metric_unit::kRequests,
-                      "The number of GET requests for each replica");
+                      "The number of GET requests");
 
 METRIC_DEFINE_counter(replica,
                       multi_get_requests,
                       dsn::metric_unit::kRequests,
-                      "The number of MULTI_GET requests for each replica");
+                      "The number of MULTI_GET requests");
 
 METRIC_DEFINE_counter(replica,
                       batch_get_requests,
                       dsn::metric_unit::kRequests,
-                      "The number of BATCH_GET requests for each replica");
+                      "The number of BATCH_GET requests");
 
 METRIC_DEFINE_counter(replica,
                       scan_requests,
                       dsn::metric_unit::kRequests,
-                      "The number of SCAN requests for each replica");
+                      "The number of SCAN requests");
 
 METRIC_DEFINE_percentile_int64(replica,
                                get_latency_ns,
                                dsn::metric_unit::kNanoSeconds,
-                               "The latency of GET requests for each replica");
+                               "The latency of GET requests");
 
 METRIC_DEFINE_percentile_int64(replica,
                                multi_get_latency_ns,
                                dsn::metric_unit::kNanoSeconds,
-                               "The latency of MULTI_GET requests for each replica");
+                               "The latency of MULTI_GET requests");
 
 METRIC_DEFINE_percentile_int64(replica,
                                batch_get_latency_ns,
                                dsn::metric_unit::kNanoSeconds,
-                               "The latency of BATCH_GET requests for each replica");
+                               "The latency of BATCH_GET requests");
 
 METRIC_DEFINE_percentile_int64(replica,
                                scan_latency_ns,
                                dsn::metric_unit::kNanoSeconds,
-                               "The latency of SCAN requests for each replica");
+                               "The latency of SCAN requests");
 
 METRIC_DEFINE_counter(replica,
                       read_expired_values,
                       dsn::metric_unit::kValues,
-                      "The number of expired values read for each replica");
+                      "The number of expired values read");
 
 METRIC_DEFINE_counter(replica,
                       read_filtered_values,
                       dsn::metric_unit::kValues,
-                      "The number of filtered values read for each replica");
+                      "The number of filtered values read");
 
 METRIC_DEFINE_counter(replica,
                       abnormal_read_requests,
                       dsn::metric_unit::kRequests,
-                      "The number of abnormal read requests for each replica");
+                      "The number of abnormal read requests");
 
 METRIC_DEFINE_counter(replica,
                       throttling_rejected_read_requests,
                       dsn::metric_unit::kRequests,
-                      "The number of rejected read requests by throttling for each replica");
+                      "The number of rejected read requests by throttling");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_total_sst_files,
                           dsn::metric_unit::kFiles,
-                          "The total number of rocksdb sst files for each replica");
+                          "The total number of rocksdb sst files");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_total_sst_size_mb,
                           dsn::metric_unit::kMegaBytes,
-                          "The total size of rocksdb sst files in MB for each replica");
+                          "The total size of rocksdb sst files in MB");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_estimated_keys,
                           dsn::metric_unit::kKeys,
-                          "The estimated number of rocksdb keys for each replica");
+                          "The estimated number of rocksdb keys");
 
-METRIC_DEFINE_gauge_int64(
-    replica,
-    rdb_index_and_filter_blocks_mem_usage_bytes,
-    dsn::metric_unit::kBytes,
-    "The memory usage of rocksdb index and filter blocks in bytes for each replica");
+METRIC_DEFINE_gauge_int64(replica,
+                          rdb_index_and_filter_blocks_mem_usage_bytes,
+                          dsn::metric_unit::kBytes,
+                          "The memory usage of rocksdb index and filter blocks in bytes");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_memtable_mem_usage_bytes,
                           dsn::metric_unit::kBytes,
-                          "The memory usage of rocksdb memtables in bytes for each replica");
+                          "The memory usage of rocksdb memtables in bytes");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_block_cache_hit_count,
                           dsn::metric_unit::kPointLookups,
-                          "The hit number of lookups on rocksdb block cache for each replica");
+                          "The hit number of lookups on rocksdb block cache");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_block_cache_total_count,
                           dsn::metric_unit::kPointLookups,
-                          "The total number of lookups on rocksdb block cache for each replica");
+                          "The total number of lookups on rocksdb block cache");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_memtable_hit_count,
                           dsn::metric_unit::kPointLookups,
-                          "The hit number of lookups on rocksdb memtable for each replica");
+                          "The hit number of lookups on rocksdb memtable");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_memtable_total_count,
                           dsn::metric_unit::kPointLookups,
-                          "The total number of lookups on rocksdb memtable for each replica");
+                          "The total number of lookups on rocksdb memtable");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_l0_hit_count,
                           dsn::metric_unit::kPointLookups,
-                          "The number of lookups served by rocksdb L0 for each replica");
+                          "The number of lookups served by rocksdb L0");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_l1_hit_count,
                           dsn::metric_unit::kPointLookups,
-                          "The number of lookups served by rocksdb L1 for each replica");
+                          "The number of lookups served by rocksdb L1");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_l2_and_up_hit_count,
                           dsn::metric_unit::kPointLookups,
-                          "The number of lookups served by rocksdb L2 and up for each replica");
+                          "The number of lookups served by rocksdb L2 and up");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_write_amplification,
                           dsn::metric_unit::kAmplification,
-                          "The write amplification of rocksdb for each replica");
+                          "The write amplification of rocksdb");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_read_amplification,
                           dsn::metric_unit::kAmplification,
-                          "The read amplification of rocksdb for each replica");
+                          "The read amplification of rocksdb");
 
 // Following metrics are rocksdb statistics that are related to bloom filters.
 //
@@ -189,25 +188,25 @@ METRIC_DEFINE_gauge_int64(replica,
                           rdb_bloom_filter_seek_total,
                           dsn::metric_unit::kSeeks,
                           "The number of times prefix bloom filter was checked before creating "
-                          "iterator on a file, used by rocksdb for each replica");
+                          "iterator on a file, used by rocksdb");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_bloom_filter_point_lookup_negatives,
                           dsn::metric_unit::kPointLookups,
                           "The number of times full bloom filter has avoided file reads (i.e., "
-                          "negatives), used by rocksdb for each replica");
+                          "negatives), used by rocksdb");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_bloom_filter_point_lookup_positives,
                           dsn::metric_unit::kPointLookups,
                           "The number of times full bloom filter has not avoided the reads, used "
-                          "by rocksdb for each replica");
+                          "by rocksdb");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_bloom_filter_point_lookup_true_positives,
                           dsn::metric_unit::kPointLookups,
                           "The number of times full bloom filter has not avoided the reads and "
-                          "data actually exist, used by rocksdb for each replica");
+                          "data actually exist, used by rocksdb");
 
 namespace pegasus {
 namespace server {

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -112,6 +112,8 @@ METRIC_DEFINE_gauge_int64(replica,
                           dsn::metric_unit::kKeys,
                           "The estimated number of rocksdb keys for each replica");
 
+// https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter
+//
 namespace pegasus {
 namespace server {
 

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -114,11 +114,14 @@ METRIC_DEFINE_gauge_int64(replica,
 
 // Following metrics are rocksdb statistics that are related to bloom filters.
 //
-// To measure prefix bloom filters, these metrics are updated after each ::Seek and ::SeekForPrev if prefix is enabled and check_filter is set:
+// To measure prefix bloom filters, these metrics are updated after each ::Seek and ::SeekForPrev if
+// prefix is enabled and check_filter is set:
 // * rdb_bf_seek_negatives: seek_negatives
 // * rdb_bf_seek_total: seek_negatives + seek_positives
 //
-// To measure full bloom filters, these metrics are updated after each point lookup. If whole_key_filtering is set, this is the result of checking the bloom of the whole key, otherwise this is the result of checking the bloom of the prefix:
+// To measure full bloom filters, these metrics are updated after each point lookup. If
+// whole_key_filtering is set, this is the result of checking the bloom of the whole key, otherwise
+// this is the result of checking the bloom of the prefix:
 // * rdb_bf_point_lookup_negatives: [true] negatives
 // * rdb_bf_point_lookup_positives: positives
 // * rdb_bf_point_lookup_true_positives: true positives
@@ -128,27 +131,33 @@ METRIC_DEFINE_gauge_int64(replica,
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_bf_seek_negatives,
                           dsn::metric_unit::kSeeks,
-                          "The number of times the check for prefix bloom filter was useful in avoiding iterator creation (and thus likely IOPs), used by rocksdb for each replica");
+                          "The number of times the check for prefix bloom filter was useful in "
+                          "avoiding iterator creation (and thus likely IOPs), used by rocksdb for "
+                          "each replica");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_bf_seek_total,
                           dsn::metric_unit::kSeeks,
-                          "The number of times prefix bloom filter was checked before creating iterator on a file, used by rocksdb for each replica");
+                          "The number of times prefix bloom filter was checked before creating "
+                          "iterator on a file, used by rocksdb for each replica");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_bf_point_lookup_negatives,
                           dsn::metric_unit::kPointLookups,
-                          "The number of times full bloom filter has avoided file reads (i.e., negatives), used by rocksdb for each replica");
+                          "The number of times full bloom filter has avoided file reads (i.e., "
+                          "negatives), used by rocksdb for each replica");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_bf_point_lookup_positives,
                           dsn::metric_unit::kPointLookups,
-                          "The number of times full bloom filter has not avoided the reads, used by rocksdb for each replica");
+                          "The number of times full bloom filter has not avoided the reads, used "
+                          "by rocksdb for each replica");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_bf_point_lookup_true_positives,
                           dsn::metric_unit::kPointLookups,
-                          "The number of times full bloom filter has not avoided the reads and data actually exist, used by rocksdb for each replica");
+                          "The number of times full bloom filter has not avoided the reads and "
+                          "data actually exist, used by rocksdb for each replica");
 
 namespace pegasus {
 namespace server {

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -87,14 +87,14 @@ METRIC_DEFINE_counter(replica,
                       "The number of abnormal read requests for each replica");
 
 METRIC_DEFINE_gauge_int64(replica,
-                      rdb_total_sst_files,
-                      dsn::metric_unit::kFiles,
-                      "The total number of rocksdb sst files for each replica");
+                          rdb_total_sst_files,
+                          dsn::metric_unit::kFiles,
+                          "The total number of rocksdb sst files for each replica");
 
 METRIC_DEFINE_gauge_int64(replica,
-                      rdb_total_sst_size_mb,
-                      dsn::metric_unit::kMegaBytes,
-                      "The total size of rocksdb sst files in MB for each replica");
+                          rdb_total_sst_size_mb,
+                          dsn::metric_unit::kMegaBytes,
+                          "The total size of rocksdb sst files in MB for each replica");
 
 namespace pegasus {
 namespace server {

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -599,9 +599,11 @@ enum class metric_unit : size_t
     kMicroSeconds,
     kMilliSeconds,
     kSeconds,
+    kBytes,
     kMegaBytes,
     kRequests,
     kValues,
+    kKeys,
     kFiles,
     kInvalidUnit,
 };

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -599,8 +599,10 @@ enum class metric_unit : size_t
     kMicroSeconds,
     kMilliSeconds,
     kSeconds,
+    kMegaBytes,
     kRequests,
     kValues,
+    kFiles,
     kInvalidUnit,
 };
 

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -153,8 +153,9 @@
     METRIC_VAR_DECLARE(name, dsn::percentile_ptr<int64_t>)
 
 // Initialize a metric variable in user class.
-#define METRIC_VAR_INIT(name, entity) _##name(METRIC_##name.instantiate(entity##_metric_entity()))
-#define METRIC_VAR_INIT_replica(name) METRIC_VAR_INIT(name, replica)
+#define METRIC_VAR_INIT(name, entity, ...)                                                         \
+    _##name(METRIC_##name.instantiate(entity##_metric_entity(), ##__VA_ARGS__))
+#define METRIC_VAR_INIT_replica(name, ...) METRIC_VAR_INIT(name, replica, ##__VA_ARGS__)
 
 // Perform increment-related operations on metrics including gauge and counter.
 #define METRIC_VAR_INCREMENT_BY(name, x)                                                           \

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -608,6 +608,7 @@ enum class metric_unit : size_t
     kValues,
     kKeys,
     kFiles,
+    kAmplification,
     kInvalidUnit,
 };
 

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -603,6 +603,8 @@ enum class metric_unit : size_t
     kBytes,
     kMegaBytes,
     kRequests,
+    kSeeks,
+    kPointLookups,
     kValues,
     kKeys,
     kFiles,


### PR DESCRIPTION
This PR is to migrate replica-level metrics of pegasus_server_impl to new framework, 
2nd part, for https://github.com/apache/incubator-pegasus/issues/1333.

This PR focuses on migrating all rocksdb-related metrics for each replica, including
total number and size of sst files, estimated number of keys, memory usage and hit
rate, write/read amplification, negatives/positives of bloom filters.