### PR TITLE
fix: undeclared names that are reported while building alloc.h in debug mode

### DIFF
--- a/src/utils/alloc.cpp
+++ b/src/utils/alloc.cpp
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#ifdef CACHELINE_SIZE
+
 #include "utils/alloc.h"
 
 #include <cstdlib>
@@ -23,8 +25,6 @@
 #include "utils/safe_strerror_posix.h"
 
 namespace dsn {
-
-#ifdef CACHELINE_SIZE
 
 /* extern */ void *cacheline_aligned_alloc(size_t size)
 {
@@ -50,6 +50,6 @@ namespace dsn {
 
 /* extern */ void cacheline_aligned_free(void *mem_block) { free(mem_block); }
 
-#endif
-
 } // namespace dsn
+
+#endif

--- a/src/utils/alloc.h
+++ b/src/utils/alloc.h
@@ -17,17 +17,21 @@
 
 #pragma once
 
+#ifdef CACHELINE_SIZE
+
 #include <stddef.h>
 #include <algorithm>
 #include <functional>
 #include <memory>
 #include <new>
 
+#ifndef NDEBUG
+#include "utils/fmt_logging.h"
+#endif
+
 #include "utils/ports.h"
 
 namespace dsn {
-
-#ifdef CACHELINE_SIZE
 
 extern void *cacheline_aligned_alloc(size_t size);
 
@@ -79,6 +83,6 @@ cacheline_aligned_ptr<T> cacheline_aligned_alloc_array(size_t len, const T &val)
     return array;
 }
 
-#endif
-
 } // namespace dsn
+
+#endif


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1391