### PR TITLE
chore(CI): include cmath to fix ambiguous std::abs on ubuntu1604

### DIFF
--- a/src/utils/output_utils.h
+++ b/src/utils/output_utils.h
@@ -20,7 +20,7 @@
 // IWYU pragma: no_include <bits/std_abs.h>
 #include <rapidjson/ostreamwrapper.h>
 #include <stdlib.h>
-#include <cmath>
+#include <cmath> // IWYU pragma: keep
 #include <iomanip>
 // IWYU pragma: no_include <new>
 #include <sstream> // IWYU pragma: keep

--- a/src/utils/output_utils.h
+++ b/src/utils/output_utils.h
@@ -20,6 +20,7 @@
 // IWYU pragma: no_include <bits/std_abs.h>
 #include <rapidjson/ostreamwrapper.h>
 #include <stdlib.h>
+#include <cmath>
 #include <iomanip>
 // IWYU pragma: no_include <new>
 #include <sstream> // IWYU pragma: keep


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fixes #1394

### What is changed and how does it work?

Includes `<cmath>` in `src/utils/output_utils.h`.

### Checklist <!--REMOVE the items that are not applicable-->