### PR TITLE
chore(build): make build dir standalone and speedup re-build

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -98,8 +98,8 @@ jobs:
         run: |
           PWD=`pwd`
           ./run.sh build --test --compiler clang-14,clang++-14 -j $(nproc) -t release --iwyu ${PWD}/iwyu/build/bin/include-what-you-use --skip_thirdparty
-          python3 iwyu/include-what-you-use/fix_includes.py --blank_lines --reorder --nocomments --nosafe_headers --separate_project_includes="<tld>" --ignore_re="release__builder|rrdb_types|layer2_types|metrics_test.cpp" --dry_run < src/builder/iwyu.out
-          python3 iwyu/include-what-you-use/fix_includes.py --blank_lines --reorder --nocomments --nosafe_headers --separate_project_includes="<tld>" --ignore_re="release__builder|rrdb_types|layer2_types|metrics_test.cpp" --dry_run < src/builder/iwyu.out | egrep "IWYU edited 0 files on your behalf"
+          python3 iwyu/include-what-you-use/fix_includes.py --blank_lines --reorder --nocomments --nosafe_headers --separate_project_includes="<tld>" --ignore_re="thrift-gen|rrdb_types|layer2_types|metrics_test.cpp" --dry_run < build/latest/iwyu.out
+          python3 iwyu/include-what-you-use/fix_includes.py --blank_lines --reorder --nocomments --nosafe_headers --separate_project_includes="<tld>" --ignore_re="thrift-gen|rrdb_types|layer2_types|metrics_test.cpp" --dry_run < build/latest/iwyu.out | egrep "IWYU edited 0 files on your behalf"
 
   build_Release:
     name: Build Release
@@ -155,7 +155,7 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          tar --exclude='*CMakeFiles*' -zcvhf release__builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin
+          tar --exclude='*CMakeFiles*' -zcvhf release__builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -277,7 +277,7 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          tar --exclude='*CMakeFiles*' -zcvhf release_address_builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin
+          tar --exclude='*CMakeFiles*' -zcvhf release_address_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -404,7 +404,7 @@ jobs:
 #          mv thirdparty/hadoop-bin ./
 #          mv thirdparty/zookeeper-bin ./
 #          rm -rf thirdparty
-#          tar --exclude='*CMakeFiles*' -zcvhf release_undefined_builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin
+#          tar --exclude='*CMakeFiles*' -zcvhf release_undefined_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
 #      - name: Upload Artifact
 #        uses: actions/upload-artifact@v3
 #        with:
@@ -528,7 +528,7 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          tar --exclude='*CMakeFiles*' -zcvhf release_jemalloc_builder.tar src/builder/output src/builder/bin src/builder/src/server/test/config.ini hadoop-bin zookeeper-bin
+          tar --exclude='*CMakeFiles*' -zcvhf release_jemalloc_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ src/base/rrdb_types.cpp
 src/include/rrdb/rrdb_types.h
 src/common/serialization_helper/dsn.layer2_types.h
 src/runtime/dsn.layer2_types.cpp
-src/*builder
 
 onebox/
 .zk_install/

--- a/run.sh
+++ b/run.sh
@@ -21,10 +21,11 @@ set -e
 LOCAL_HOSTNAME=`hostname -f`
 PID=$$
 ROOT=`pwd`
-export BUILD_DIR=$ROOT/src/builder
+export BUILD_ROOT_DIR=${ROOT}/build
+export BUILD_LATEST_DIR=${BUILD_ROOT_DIR}/latest
 export REPORT_DIR="$ROOT/test_report"
 export THIRDPARTY_ROOT=$ROOT/thirdparty
-export LD_LIBRARY_PATH=$BUILD_DIR/output/lib:$THIRDPARTY_ROOT/output/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$BUILD_ROOT_DIR/output/lib:$THIRDPARTY_ROOT/output/lib:$LD_LIBRARY_PATH
 
 function usage()
 {
@@ -253,17 +254,25 @@ function run_build()
     fi
 
     echo "INFO: start build Pegasus..."
-    BUILD_DIR="${ROOT}/src/${BUILD_TYPE}_${SANITIZER}_builder"
+    BUILD_DIR="${BUILD_ROOT_DIR}/${BUILD_TYPE}_${SANITIZER}"
+    BUILD_DIR=${BUILD_DIR%_*}
     if [ "$CLEAR" == "YES" ]; then
         echo "Clear $BUILD_DIR ..."
         rm -rf $BUILD_DIR
+        rm ${ROOT}/src/base/rrdb_types.cpp
+        rm ${ROOT}/src/include/rrdb/rrdb_types.h
+        rm ${ROOT}/src/common/serialization_helper/dsn.layer2_types.h
+        rm ${ROOT}/src/runtime/dsn.layer2_types.cpp
+        rm ${ROOT}/src/include/pegasus/git_commit.h
     fi
 
     pushd ${ROOT}
-    echo "Gen thrift"
-    # TODO(yingchun): should be optimized
-    python3 $ROOT/scripts/compile_thrift.py
-    sh ${ROOT}/scripts/recompile_thrift.sh
+    if [ ! -f "${ROOT}/src/common/serialization_helper/dsn.layer2_types.h" ]; then
+        echo "Gen thrift"
+        # TODO(yingchun): should be optimized
+        python3 $ROOT/scripts/compile_thrift.py
+        sh ${ROOT}/scripts/recompile_thrift.sh
+    fi
 
     if [ ! -d "$BUILD_DIR" ]; then
         mkdir -p $BUILD_DIR
@@ -274,25 +283,27 @@ function run_build()
             CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=${IWYU}"
         fi
         CMAKE_OPTIONS="${CMAKE_OPTIONS} -DBUILD_TEST=${BUILD_TEST}"
-        cmake ../.. -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/output $CMAKE_OPTIONS
+        cmake ${ROOT} -DCMAKE_INSTALL_PREFIX=$BUILD_DIR/output $CMAKE_OPTIONS
         exit_if_fail $?
     fi
 
-    echo "Gen git_commit.h ..."
-    pushd "$ROOT/src"
-    PEGASUS_GIT_COMMIT="non-git-repo"
-    if git rev-parse HEAD; then # this is a git repo
-        PEGASUS_GIT_COMMIT=$(git rev-parse HEAD)
-    fi
-    echo "PEGASUS_GIT_COMMIT=${PEGASUS_GIT_COMMIT}"
     GIT_COMMIT_FILE=$ROOT/src/include/pegasus/git_commit.h
-    echo "Generating $GIT_COMMIT_FILE..."
-    echo "#pragma once" >$GIT_COMMIT_FILE
-    echo "#define PEGASUS_GIT_COMMIT \"$PEGASUS_GIT_COMMIT\"" >>$GIT_COMMIT_FILE
+    if [ ! -f "${GIT_COMMIT_FILE}" ]; then
+        echo "Gen git_commit.h ..."
+        pushd "$ROOT/src"
+        PEGASUS_GIT_COMMIT="non-git-repo"
+        if git rev-parse HEAD; then # this is a git repo
+            PEGASUS_GIT_COMMIT=$(git rev-parse HEAD)
+        fi
+        echo "PEGASUS_GIT_COMMIT=${PEGASUS_GIT_COMMIT}"
+        echo "Generating $GIT_COMMIT_FILE..."
+        echo "#pragma once" >$GIT_COMMIT_FILE
+        echo "#define PEGASUS_GIT_COMMIT \"$PEGASUS_GIT_COMMIT\"" >>$GIT_COMMIT_FILE
+    fi
 
     # rebuild link
-    rm -f ${ROOT}/src/builder
-    ln -s ${BUILD_DIR} ${ROOT}/src/builder
+    rm -f ${BUILD_LATEST_DIR}
+    ln -s ${BUILD_DIR} ${BUILD_LATEST_DIR}
 
     echo "[$(date)] Building Pegasus ..."
     pushd $BUILD_DIR
@@ -393,7 +404,6 @@ function run_test()
         mkdir -p $REPORT_DIR
     fi
 
-    BUILD_DIR=$ROOT/src/builder
     if [ "$test_modules" == "" ]; then
         test_modules=$(IFS=,; echo "${all_tests[*]}")
     fi
@@ -441,12 +451,12 @@ function run_test()
                 exit 1
             fi
             # TODO(yingchun): remove it?
-            sed -i "s/@LOCAL_HOSTNAME@/${LOCAL_HOSTNAME}/g"  $ROOT/src/builder/src/server/test/config.ini
+            sed -i "s/@LOCAL_HOSTNAME@/${LOCAL_HOSTNAME}/g"  ${BUILD_LATEST_DIR}/src/server/test/config.ini
         else
             run_stop_zk
             run_start_zk
         fi
-        pushd $ROOT/src/builder/bin/$module
+        pushd ${BUILD_LATEST_DIR}/bin/$module
         REPORT_DIR=$REPORT_DIR TEST_BIN=$module ./run.sh
         if [ $? != 0 ]; then
             echo "run test \"$module\" in `pwd` failed"
@@ -472,8 +482,8 @@ function run_test()
         mkdir -p "$ROOT/gcov_report"
 
         echo "Running gcovr to produce HTML code coverage report."
-        $BUILD_DIR
-        gcovr --html --html-details -r $ROOT --object-directory=$BUILD_DIR \
+        $BUILD_LATEST_DIR
+        gcovr --html --html-details -r $ROOT --object-directory=$BUILD_LATEST_DIR \
               -o $GCOV_DIR/index.html
         if [ $? -ne 0 ]; then
             exit 1
@@ -644,7 +654,7 @@ function usage_start_onebox()
     echo "   -w|--wait_healthy"
     echo "                     wait cluster to become healthy, default not wait"
     echo "   -s|--server_path <str>"
-    echo "                     server binary path, default is ${BUILD_DIR}/output/bin/pegasus_server"
+    echo "                     server binary path, default is ${BUILD_LATEST_DIR}/output/bin/pegasus_server"
     echo "   --config_path"
     echo "                     specify the config template path, default is ./src/server/config.min.ini in non-production env"
     echo "                                                                  ./src/server/config.ini in production env"
@@ -662,7 +672,7 @@ function run_start_onebox()
     APP_NAME=temp
     PARTITION_COUNT=8
     WAIT_HEALTHY=false
-    SERVER_PATH=${BUILD_DIR}/output/bin/pegasus_server
+    SERVER_PATH=${BUILD_LATEST_DIR}/output/bin/pegasus_server
     CONFIG_FILE=""
     USE_PRODUCT_CONFIG=false
     OPTS=""
@@ -1280,7 +1290,7 @@ s+@ONEBOX_RUN_PATH@+`pwd`+g" ${ROOT}/src/test/kill_test/config.ini >$CONFIG
 
     # start verifier
     mkdir -p onebox/verifier && cd onebox/verifier
-    ln -s -f ${BUILD_DIR}/output/bin/pegasus_kill_test/pegasus_kill_test
+    ln -s -f ${BUILD_LATEST_DIR}/output/bin/pegasus_kill_test/pegasus_kill_test
     ln -s -f ${ROOT}/$CONFIG config.ini
     echo "$PWD/pegasus_kill_test config.ini verifier &>/dev/null &"
     $PWD/pegasus_kill_test config.ini verifier &>/dev/null &
@@ -1291,7 +1301,7 @@ s+@ONEBOX_RUN_PATH@+`pwd`+g" ${ROOT}/src/test/kill_test/config.ini >$CONFIG
 
     #start killer
     mkdir -p onebox/killer && cd onebox/killer
-    ln -s -f ${BUILD_DIR}/output/bin/pegasus_kill_test/pegasus_kill_test
+    ln -s -f ${BUILD_LATEST_DIR}/output/bin/pegasus_kill_test/pegasus_kill_test
     ln -s -f ${ROOT}/$CONFIG config.ini
     echo "$PWD/pegasus_kill_test config.ini $KILLER_TYPE &>/dev/null &"
     $PWD/pegasus_kill_test config.ini $KILLER_TYPE &>/dev/null &
@@ -1516,9 +1526,9 @@ function run_bench()
         shift
     done
     cd ${ROOT}
-    cp ${BUILD_DIR}/output/bin/pegasus_bench/config.ini ./config-bench.ini
+    cp ${BUILD_LATEST_DIR}/output/bin/pegasus_bench/config.ini ./config-bench.ini
     fill_bench_config
-    ln -s -f ${BUILD_DIR}/output/bin/pegasus_bench/pegasus_bench
+    ln -s -f ${BUILD_LATEST_DIR}/output/bin/pegasus_bench/pegasus_bench
     ./pegasus_bench ./config-bench.ini
     rm -f ./config-bench.ini
 }
@@ -1645,7 +1655,7 @@ function run_shell()
     fi
 
     cd ${ROOT}
-    ln -s -f ${BUILD_DIR}/output/bin/pegasus_shell/pegasus_shell
+    ln -s -f ${BUILD_LATEST_DIR}/output/bin/pegasus_shell/pegasus_shell
     ./pegasus_shell ${CONFIG} $CLUSTER_NAME
     # because pegasus shell will catch 'Ctrl-C' signal, so the following commands will be executed
     # even user inputs 'Ctrl-C', so that the temporary config file will be cleared when exit shell.

--- a/run.sh
+++ b/run.sh
@@ -25,7 +25,7 @@ export BUILD_ROOT_DIR=${ROOT}/build
 export BUILD_LATEST_DIR=${BUILD_ROOT_DIR}/latest
 export REPORT_DIR="$ROOT/test_report"
 export THIRDPARTY_ROOT=$ROOT/thirdparty
-export LD_LIBRARY_PATH=$BUILD_ROOT_DIR/output/lib:$THIRDPARTY_ROOT/output/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${BUILD_LATEST_DIR}/output/lib:${THIRDPARTY_ROOT}/output/lib:${LD_LIBRARY_PATH}
 
 function usage()
 {

--- a/scripts/pack_client.sh
+++ b/scripts/pack_client.sh
@@ -39,19 +39,19 @@ then
     exit 1
 fi
 
-if [ ! -f ${BUILD_DIR}/output/bin/pegasus_server/pegasus_server ]
+if [ ! -f ${BUILD_LATEST_DIR}/output/bin/pegasus_server/pegasus_server ]
 then
-    echo "ERROR: ${BUILD_DIR}/output/bin/pegasus_server/pegasus_server not found"
+    echo "ERROR: ${BUILD_LATEST_DIR}/output/bin/pegasus_server/pegasus_server not found"
     exit 1
 fi
 
-if [ ! -f src/builder/CMakeCache.txt ]
+if [ ! -f ${BUILD_LATEST_DIR}/CMakeCache.txt ]
 then
-    echo "ERROR: src/builder/CMakeCache.txt not found"
+    echo "ERROR: ${BUILD_LATEST_DIR}/CMakeCache.txt not found"
     exit 1
 fi
 
-if egrep -i "CMAKE_BUILD_TYPE:STRING\=debug" src/builder/CMakeCache.txt;
+if egrep -i "CMAKE_BUILD_TYPE:STRING\=debug" ${BUILD_LATEST_DIR}/CMakeCache.txt;
 then
     build_type=debug
 else
@@ -106,9 +106,9 @@ while [[ $# > 0 ]]; do
 done
 
 mkdir -p ${pack}/lib
-copy_file ${BUILD_DIR}/output/lib/libpegasus_client_static.a ${pack}/lib
+copy_file ${BUILD_LATEST_DIR}/output/lib/libpegasus_client_static.a ${pack}/lib
 # TODO(yingchun): make sure shared lib works well too
-# copy_file ${BUILD_DIR}/output/lib/libpegasus_client_shared.so ${pack}/lib
+# copy_file ${BUILD_LATEST_DIR}/output/lib/libpegasus_client_shared.so ${pack}/lib
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/lib
 ln -sf `ls ${pack}/lib | grep libboost_system` ${pack}/lib/libboost_system.so
 ln -sf `ls ${pack}/lib | grep libboost_filesystem` ${pack}/lib/libboost_filesystem.so

--- a/scripts/pack_common.sh
+++ b/scripts/pack_common.sh
@@ -20,7 +20,7 @@ set -e
 
 function get_stdcpp_lib()
 {
-    libname=`ldd ${BUILD_DIR}/output/bin/pegasus_server/pegasus_server 2>/dev/null | grep libstdc++`
+    libname=`ldd ${BUILD_LATEST_DIR}/output/bin/pegasus_server/pegasus_server 2>/dev/null | grep libstdc++`
     libname=`echo $libname | cut -f1 -d" "`
     if [ $1 = "true" ]; then
         gcc_path=`which gcc`
@@ -40,7 +40,7 @@ function get_stdcpp_lib()
 # USAGE: get_system_lib server snappy
 function get_system_lib()
 {
-    libname=`ldd ${BUILD_DIR}/output/bin/pegasus_$1/pegasus_$1 2>/dev/null | grep "lib${2}\.so"`
+    libname=`ldd ${BUILD_LATEST_DIR}/output/bin/pegasus_$1/pegasus_$1 2>/dev/null | grep "lib${2}\.so"`
     libname=`echo $libname | cut -f1 -d" "`
     libs=(`ldconfig -p|grep $libname|awk '{print $NF}'`)
 
@@ -53,7 +53,7 @@ function get_system_lib()
     done;
 
     # if get failed by ldconfig, then just extract lib from ldd result
-    libname=`ldd ${BUILD_DIR}/output/bin/pegasus_$1/pegasus_$1 2>/dev/null | grep "lib${2}\.so"`
+    libname=`ldd ${BUILD_LATEST_DIR}/output/bin/pegasus_$1/pegasus_$1 2>/dev/null | grep "lib${2}\.so"`
     libname=`echo $libname | cut -f3 -d" "`
     if echo "$libname" | grep -q "lib${2}\.so"; then
         echo "$libname"
@@ -63,7 +63,7 @@ function get_system_lib()
 # USAGE: get_system_libname server snappy
 function get_system_libname()
 {
-    libname=`ldd ${BUILD_DIR}/output/bin/pegasus_$1/pegasus_$1 2>/dev/null | grep "lib${2}\.so"`
+    libname=`ldd ${BUILD_LATEST_DIR}/output/bin/pegasus_$1/pegasus_$1 2>/dev/null | grep "lib${2}\.so"`
     libname=`echo $libname | cut -f1 -d" "`
     echo "$libname"
 }
@@ -104,7 +104,7 @@ function check_bit()
 
 function need_system_lib() {
     # return if system libname is not empty, if false, it means this library is not a dependency
-    libname=$(ldd ${BUILD_DIR}/output/bin/pegasus_"$1"/pegasus_"$1" 2>/dev/null | grep "lib${2}\.so")
+    libname=$(ldd ${BUILD_LATEST_DIR}/output/bin/pegasus_"$1"/pegasus_"$1" 2>/dev/null | grep "lib${2}\.so")
     [ -n "${libname}" ]
 }
 

--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -39,17 +39,17 @@ if [ ! -f src/include/pegasus/git_commit.h ]; then
     exit 1
 fi
 
-if [ ! -f ${BUILD_DIR}/output/bin/pegasus_server/pegasus_server ]; then
-    echo "ERROR: ${BUILD_DIR}/output/bin/pegasus_server/pegasus_server not found"
+if [ ! -f ${BUILD_LATEST_DIR}/output/bin/pegasus_server/pegasus_server ]; then
+    echo "ERROR: ${BUILD_LATEST_DIR}/output/bin/pegasus_server/pegasus_server not found"
     exit 1
 fi
 
-if [ ! -f src/builder/CMakeCache.txt ]; then
-    echo "ERROR: src/builder/CMakeCache.txt not found"
+if [ ! -f ${BUILD_LATEST_DIR}/CMakeCache.txt ]; then
+    echo "ERROR: ${BUILD_LATEST_DIR}/CMakeCache.txt not found"
     exit 1
 fi
 
-if egrep -i "CMAKE_BUILD_TYPE:STRING\=debug" src/builder/CMakeCache.txt; then
+if egrep -i "CMAKE_BUILD_TYPE:STRING\=debug" ${BUILD_LATEST_DIR}/CMakeCache.txt; then
     build_type=debug
 else
     build_type=release
@@ -110,10 +110,10 @@ while [[ $# > 0 ]]; do
 done
 
 mkdir -p ${pack}/bin
-copy_file ${BUILD_DIR}/output/bin/pegasus_server/pegasus_server ${pack}/bin
-copy_file ${BUILD_DIR}/output/lib/libdsn_meta_server.so ${pack}/bin
-copy_file ${BUILD_DIR}/output/lib/libdsn_replica_server.so ${pack}/bin
-copy_file ${BUILD_DIR}/output/lib/libdsn_utils.so ${pack}/bin
+copy_file ${BUILD_LATEST_DIR}/output/bin/pegasus_server/pegasus_server ${pack}/bin
+copy_file ${BUILD_LATEST_DIR}/output/lib/libdsn_meta_server.so ${pack}/bin
+copy_file ${BUILD_LATEST_DIR}/output/lib/libdsn_replica_server.so ${pack}/bin
+copy_file ${BUILD_LATEST_DIR}/output/lib/libdsn_utils.so ${pack}/bin
 copy_file ./thirdparty/output/lib/libPoco*.so.* ${pack}/bin
 
 if [ "$use_jemalloc" == "on" ]; then

--- a/scripts/pack_tools.sh
+++ b/scripts/pack_tools.sh
@@ -40,19 +40,19 @@ then
     exit 1
 fi
 
-if [ ! -f ${BUILD_DIR}/output/bin/pegasus_shell/pegasus_shell ]
+if [ ! -f ${BUILD_LATEST_DIR}/output/bin/pegasus_shell/pegasus_shell ]
 then
-    echo "ERROR: ${BUILD_DIR}/output/bin/pegasus_shell/pegasus_shell not found"
+    echo "ERROR: ${BUILD_LATEST_DIR}/output/bin/pegasus_shell/pegasus_shell not found"
     exit 1
 fi
 
-if [ ! -f src/builder/CMakeCache.txt ]
+if [ ! -f ${BUILD_LATEST_DIR}/CMakeCache.txt ]
 then
-    echo "ERROR: src/builder/CMakeCache.txt not found"
+    echo "ERROR: ${BUILD_LATEST_DIR}/CMakeCache.txt not found"
     exit 1
 fi
 
-if egrep -i "CMAKE_BUILD_TYPE:STRING\=debug" src/builder/CMakeCache.txt;
+if egrep -i "CMAKE_BUILD_TYPE:STRING\=debug" ${BUILD_LATEST_DIR}/CMakeCache.txt;
 then
     build_type=debug
 else
@@ -114,15 +114,15 @@ mkdir -p ${pack}
 copy_file ./run.sh ${pack}/
 
 mkdir -p ${pack}/bin
-cp -v -r ${BUILD_DIR}/output/bin/pegasus_server ${pack}/bin/
-cp -v -r ${BUILD_DIR}/output/bin/pegasus_shell ${pack}/bin/
-cp -v -r ${BUILD_DIR}/output/bin/pegasus_bench ${pack}/bin/
-cp -v -r ${BUILD_DIR}/output/bin/pegasus_kill_test ${pack}/bin/
-cp -v -r ${BUILD_DIR}/output/bin/pegasus_rproxy ${pack}/bin/
-cp -v -r ${BUILD_DIR}/output/bin/pegasus_pressureclient ${pack}/bin/
+cp -v -r ${BUILD_LATEST_DIR}/output/bin/pegasus_server ${pack}/bin/
+cp -v -r ${BUILD_LATEST_DIR}/output/bin/pegasus_shell ${pack}/bin/
+cp -v -r ${BUILD_LATEST_DIR}/output/bin/pegasus_bench ${pack}/bin/
+cp -v -r ${BUILD_LATEST_DIR}/output/bin/pegasus_kill_test ${pack}/bin/
+cp -v -r ${BUILD_LATEST_DIR}/output/bin/pegasus_rproxy ${pack}/bin/
+cp -v -r ${BUILD_LATEST_DIR}/output/bin/pegasus_pressureclient ${pack}/bin/
 
 mkdir -p ${pack}/lib
-copy_file ${BUILD_DIR}/output/lib/*.so* ${pack}/lib/
+copy_file ${BUILD_LATEST_DIR}/output/lib/*.so* ${pack}/lib/
 copy_file ./thirdparty/output/lib/libPoco*.so.* ${pack}/lib/
 
 if [ "$use_jemalloc" == "on" ]; then


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1400

- Move cmake build directory from `./src/builder/` to a standalone
  directory in `./build/`
- Avoid to re-generate thrift and git commit header files to speedup
  re-build the project