### PR TITLE
feat(new_metrics): migrate replica-level metrics for pegasus_event_listener

### DIFF
--- a/src/server/pegasus_event_listener.cpp
+++ b/src/server/pegasus_event_listener.cpp
@@ -35,44 +35,47 @@ class DB;
 } // namespace rocksdb
 
 METRIC_DEFINE_counter(replica,
-                          rdb_flush_completed_count,
-                          dsn::metric_unit::kFlushes,
-                          "The number of completed rocksdb flushes");
+                      rdb_flush_completed_count,
+                      dsn::metric_unit::kFlushes,
+                      "The number of completed rocksdb flushes");
 
 METRIC_DEFINE_counter(replica,
-                          rdb_flush_output_bytes,
-                          dsn::metric_unit::kBytes,
-                          "The size of rocksdb flush output in bytes");
+                      rdb_flush_output_bytes,
+                      dsn::metric_unit::kBytes,
+                      "The size of rocksdb flush output in bytes");
 
 METRIC_DEFINE_counter(replica,
-                          rdb_compaction_completed_count,
-                          dsn::metric_unit::kCompactions,
-                          "The number of completed rocksdb compactions");
+                      rdb_compaction_completed_count,
+                      dsn::metric_unit::kCompactions,
+                      "The number of completed rocksdb compactions");
 
 METRIC_DEFINE_counter(replica,
-                          rdb_compaction_input_bytes,
-                          dsn::metric_unit::kBytes,
-                          "The size of rocksdb compaction input in bytes");
+                      rdb_compaction_input_bytes,
+                      dsn::metric_unit::kBytes,
+                      "The size of rocksdb compaction input in bytes");
 
 METRIC_DEFINE_counter(replica,
-                          rdb_compaction_output_bytes,
-                          dsn::metric_unit::kBytes,
-                          "The size of rocksdb compaction output in bytes");
+                      rdb_compaction_output_bytes,
+                      dsn::metric_unit::kBytes,
+                      "The size of rocksdb compaction output in bytes");
 
-METRIC_DEFINE_counter(replica,
-                          rdb_changed_delayed_writes,
-                          dsn::metric_unit::kWrites,
-                          "The number of rocksdb delayed writes changed from another write stall condition");
+METRIC_DEFINE_counter(
+    replica,
+    rdb_changed_delayed_writes,
+    dsn::metric_unit::kWrites,
+    "The number of rocksdb delayed writes changed from another write stall condition");
 
-METRIC_DEFINE_counter(replica,
-                          rdb_changed_stopped_writes,
-                          dsn::metric_unit::kWrites,
-                          "The number of rocksdb stopped writes changed from another write stall condition");
+METRIC_DEFINE_counter(
+    replica,
+    rdb_changed_stopped_writes,
+    dsn::metric_unit::kWrites,
+    "The number of rocksdb stopped writes changed from another write stall condition");
 
 namespace pegasus {
 namespace server {
 
-pegasus_event_listener::pegasus_event_listener(replica_base *r) : replica_base(r),
+pegasus_event_listener::pegasus_event_listener(replica_base *r)
+    : replica_base(r),
       METRIC_VAR_INIT_replica(rdb_flush_completed_count),
       METRIC_VAR_INIT_replica(rdb_flush_output_bytes),
       METRIC_VAR_INIT_replica(rdb_compaction_completed_count),
@@ -83,8 +86,7 @@ pegasus_event_listener::pegasus_event_listener(replica_base *r) : replica_base(r
 {
 }
 
-void pegasus_event_listener::OnFlushCompleted(rocksdb::DB *db,
-                                              const rocksdb::FlushJobInfo &info)
+void pegasus_event_listener::OnFlushCompleted(rocksdb::DB *db, const rocksdb::FlushJobInfo &info)
 {
     METRIC_VAR_INCREMENT(rdb_flush_completed_count);
     METRIC_VAR_INCREMENT_BY(rdb_flush_output_bytes, info.table_properties.data_size);

--- a/src/server/pegasus_event_listener.cpp
+++ b/src/server/pegasus_event_listener.cpp
@@ -19,16 +19,12 @@
 
 #include "pegasus_event_listener.h"
 
-#include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <rocksdb/compaction_job_stats.h>
 #include <rocksdb/table_properties.h>
-#include <iosfwd>
-#include <string>
 
-#include "common/gpid.h"
-#include "perf_counter/perf_counter.h"
+#include "utils/autoref_ptr.h"
 #include "utils/fmt_logging.h"
+#include "utils/string_view.h"
 
 namespace rocksdb {
 class DB;

--- a/src/server/pegasus_event_listener.h
+++ b/src/server/pegasus_event_listener.h
@@ -37,24 +37,22 @@ public:
     explicit pegasus_event_listener(replica_base *r);
     ~pegasus_event_listener() override = default;
 
-    void OnFlushCompleted(rocksdb::DB *db, const rocksdb::FlushJobInfo &flush_job_info) override;
+    void OnFlushCompleted(rocksdb::DB *db, const rocksdb::FlushJobInfo &info) override;
 
-    void OnCompactionCompleted(rocksdb::DB *db, const rocksdb::CompactionJobInfo &ci) override;
+    void OnCompactionCompleted(rocksdb::DB *db, const rocksdb::CompactionJobInfo &info) override;
 
     void OnStallConditionsChanged(const rocksdb::WriteStallInfo &info) override;
 
 private:
-    ::dsn::perf_counter_wrapper _pfc_recent_flush_completed_count;
-    ::dsn::perf_counter_wrapper _pfc_recent_flush_output_bytes;
-    ::dsn::perf_counter_wrapper _pfc_recent_compaction_completed_count;
-    ::dsn::perf_counter_wrapper _pfc_recent_compaction_input_bytes;
-    ::dsn::perf_counter_wrapper _pfc_recent_compaction_output_bytes;
-    ::dsn::perf_counter_wrapper _pfc_recent_write_change_delayed_count;
-    ::dsn::perf_counter_wrapper _pfc_recent_write_change_stopped_count;
+    METRIC_VAR_DECLARE_counter(rdb_flush_completed_count);
+    METRIC_VAR_DECLARE_counter(rdb_flush_output_bytes);
 
-    // replica-level perfcounter
-    ::dsn::perf_counter_wrapper _pfc_recent_rdb_compaction_input_bytes;
-    ::dsn::perf_counter_wrapper _pfc_recent_rdb_compaction_output_bytes;
+    METRIC_VAR_DECLARE_counter(rdb_compaction_completed_count);
+    METRIC_VAR_DECLARE_counter(rdb_compaction_input_bytes);
+    METRIC_VAR_DECLARE_counter(rdb_compaction_output_bytes);
+
+    METRIC_VAR_DECLARE_counter(rdb_changed_delayed_writes);
+    METRIC_VAR_DECLARE_counter(rdb_changed_stopped_writes);
 };
 
 } // namespace server

--- a/src/server/pegasus_event_listener.h
+++ b/src/server/pegasus_event_listener.h
@@ -21,8 +21,8 @@
 
 #include <rocksdb/listener.h>
 
-#include "perf_counter/perf_counter_wrapper.h"
 #include "replica/replica_base.h"
+#include "utils/metrics.h"
 
 namespace rocksdb {
 class DB;

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -620,6 +620,9 @@ enum class metric_unit : size_t
     kKeys,
     kFiles,
     kAmplification,
+    kFlushes,
+    kCompactions,
+    kWrites,
     kInvalidUnit,
 };
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1343

Migrate replica-level metrics in pegasus_event_listener class to new framework, all of which
are rocksdb-related, including the number of completed flushes/compactions, the size of
flush output in bytes, the size of compaction input/output in bytes.

Note that in old perf counters there are just 2 replica-level metrics for pegasus_event_listener
while all of others are server-level. Migrated to new framework all of the metrics have become
replica-level; once server-level metrics are needed, just aggregate on replica-level ones.