### PR TITLE
fix(java-client): add missing elements that will lead to misalignment and IndexOutOfBoundsException for resultMapList in batchGetByPartitions

### DIFF
--- a/java-client/src/main/java/org/apache/pegasus/client/PegasusTable.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/PegasusTable.java
@@ -1234,6 +1234,8 @@ public class PegasusTable implements PegasusTableInterface {
         Throwable cause = fu.cause();
         partitionToPException.set(
             i, new PException("Get value of keys[" + i + "] failed: " + cause.getMessage(), cause));
+        Map<Pair<String, String>, byte[]> emptyMap = new HashMap<>();
+        resultMapList.add(emptyMap);
       }
     }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1410

In batchGetByPartitions, once some exception happens (such as timeout), resultMapList
will miss element which will lead to misalignment and IndexOutOfBoundsException. Just
add an empty element for resultMapList to align it while exception happens.