### PR TITLE
feat(new_metrics): migrate replica-level metrics for pegasus_mutation_duplicator

### DIFF
--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -19,14 +19,11 @@
 
 #include "pegasus_mutation_duplicator.h"
 
-#include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <pegasus/error.h>
 #include <sys/types.h>
 #include <chrono>
 #include <cstdint>
 #include <functional>
-#include <iosfwd>
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -34,16 +31,15 @@
 
 #include "client_lib/pegasus_client_impl.h"
 #include "common/duplication_common.h"
-#include "common/gpid.h"
 #include "duplication_internal_types.h"
 #include "pegasus/client.h"
 #include "pegasus_key_schema.h"
-#include "perf_counter/perf_counter.h"
 #include "rrdb/rrdb.code.definition.h"
 #include "rrdb/rrdb_types.h"
 #include "runtime/message_utils.h"
 #include "runtime/rpc/rpc_message.h"
 #include "server/pegasus_write_service.h"
+#include "utils/autoref_ptr.h"
 #include "utils/blob.h"
 #include "utils/chrono_literals.h"
 #include "utils/error_code.h"

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -109,9 +109,10 @@ using namespace dsn::literals::chrono_literals;
 pegasus_mutation_duplicator::pegasus_mutation_duplicator(dsn::replication::replica_base *r,
                                                          dsn::string_view remote_cluster,
                                                          dsn::string_view app)
-    : mutation_duplicator(r), _remote_cluster(remote_cluster),
-    METRIC_VAR_INIT_replica(successful_mutation_dup_requests),
-    METRIC_VAR_INIT_replica(failed_mutation_dup_requests)
+    : mutation_duplicator(r),
+      _remote_cluster(remote_cluster),
+      METRIC_VAR_INIT_replica(successful_mutation_dup_requests),
+      METRIC_VAR_INIT_replica(failed_mutation_dup_requests)
 {
     // initialize pegasus-client when this class is first time used.
     static __attribute__((unused)) bool _dummy = pegasus_client_factory::initialize(nullptr);

--- a/src/server/pegasus_mutation_duplicator.h
+++ b/src/server/pegasus_mutation_duplicator.h
@@ -25,13 +25,13 @@
 #include <map>
 #include <string>
 
-#include "perf_counter/perf_counter_wrapper.h"
 #include "replica/duplication/mutation_duplicator.h"
 #include "rrdb/rrdb.client.h"
 #include "runtime/pipeline.h"
 #include "runtime/task/task_code.h"
 #include "runtime/task/task_tracker.h"
 #include "utils/chrono_literals.h"
+#include "utils/metrics.h"
 #include "utils/string_view.h"
 #include "utils/zlocks.h"
 
@@ -89,8 +89,8 @@ private:
 
     size_t _total_shipped_size{0};
 
-    dsn::perf_counter_wrapper _shipped_ops;
-    dsn::perf_counter_wrapper _failed_shipping_ops;
+    METRIC_VAR_DECLARE_counter(successful_mutation_dup_requests);
+    METRIC_VAR_DECLARE_counter(failed_mutation_dup_requests);
 };
 
 // Decodes the binary `request_data` into write request in thrift struct, and


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1412

Migrate replica-level metrics in pegasus_mutation_duplicator class to new
framework, including the numbers of successful/failed DUPLICATE requests
sent from mutation duplicator.