### PR TITLE
feat(new_metrics): add server-level metric entity

### DIFF
--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -32,6 +32,12 @@
 
 METRIC_DEFINE_entity(server);
 
+dsn::metric_entity_ptr server_metric_entity()
+{
+    static auto entity = METRIC_ENTITY_server.instantiate("server");
+    return entity;
+}
+
 namespace dsn {
 
 DSN_DEFINE_uint64(metrics,
@@ -197,12 +203,6 @@ bool metric_entity::is_stale() const
     // This entity is considered stale once there is only one reference for it kept in the
     // registry.
     return get_count() == 1;
-}
-
-metric_entity_ptr server_metric_entity()
-{
-    static auto entity = METRIC_ENTITY_server.instantiate("server");
-    return entity;
 }
 
 void metric_filters::extract_entity_metrics(const metric_entity::metric_map &candidates,

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -30,6 +30,8 @@
 #include "utils/string_conv.h"
 #include "utils/strings.h"
 
+METRIC_DEFINE_entity(server);
+
 namespace dsn {
 
 DSN_DEFINE_uint64(metrics,
@@ -195,6 +197,12 @@ bool metric_entity::is_stale() const
     // This entity is considered stale once there is only one reference for it kept in the
     // registry.
     return get_count() == 1;
+}
+
+metric_entity_ptr server_metric_entity()
+{
+    static auto entity = METRIC_ENTITY_server.instantiate("server");
+    return entity;
 }
 
 void metric_filters::extract_entity_metrics(const metric_entity::metric_map &candidates,

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -289,8 +289,6 @@ private:
 
 using metric_entity_ptr = ref_ptr<metric_entity>;
 
-metric_entity_ptr server_metric_entity();
-
 // This struct includes a set of filters for both entities and metrics requested by client.
 struct metric_filters
 {
@@ -1448,3 +1446,9 @@ private:
 };
 
 } // namespace dsn
+
+// Since server_metric_entity() will be called in macros such as METRIC_VAR_INIT_server(), its
+// declaration should be put outside any namespace (for example dsn). server_metric_entity()
+// will not be qualified with any namespace. Once it was qualified with some namespace, its name
+// would not be resolved in any other namespace.
+dsn::metric_entity_ptr server_metric_entity();

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -164,6 +164,7 @@ class error_code;
 #define METRIC_VAR_INIT(name, entity, ...)                                                         \
     _##name(METRIC_##name.instantiate(entity##_metric_entity(), ##__VA_ARGS__))
 #define METRIC_VAR_INIT_replica(name, ...) METRIC_VAR_INIT(name, replica, ##__VA_ARGS__)
+#define METRIC_VAR_INIT_server(name, ...) METRIC_VAR_INIT(name, server, ##__VA_ARGS__)
 
 // Perform increment-related operations on metrics including gauge and counter.
 #define METRIC_VAR_INCREMENT_BY(name, x)                                                           \
@@ -287,6 +288,8 @@ private:
 };
 
 using metric_entity_ptr = ref_ptr<metric_entity>;
+
+metric_entity_ptr server_metric_entity();
 
 // This struct includes a set of filters for both entities and metrics requested by client.
 struct metric_filters


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1414

Add server-level metric entity, including:
- Define server-level entity prototype in metrics.cpp;
- Implement getter to acquire the (only) instance of server entity;
- Provide convenient macros to simplify operations for server entity.