### PR TITLE
feat(new_metrics): migrate server-level metrics for nfs

### DIFF
--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -39,25 +39,26 @@
 #include "utils/fmt_logging.h"
 #include "utils/ports.h"
 #include "utils/string_conv.h"
+#include "utils/string_view.h"
 #include "utils/token_buckets.h"
 
-METRIC_DEFINE_counter(replica,
+METRIC_DEFINE_counter(server,
                       nfs_client_copy_bytes,
                       dsn::metric_unit::kBytes,
                       "The accumulated data size in bytes requested by client during nfs copy");
 
-METRIC_DEFINE_counter(replica,
+METRIC_DEFINE_counter(server,
                       nfs_client_failed_copy_requests,
                       dsn::metric_unit::kRequests,
                       "The number of failed nfs copy requests (requested by client)");
 
 METRIC_DEFINE_counter(
-    replica,
+    server,
     nfs_client_write_bytes,
     dsn::metric_unit::kBytes,
     "The accumulated data size in bytes that are written to local file in client");
 
-METRIC_DEFINE_counter(replica,
+METRIC_DEFINE_counter(server,
                       nfs_client_failed_writes,
                       dsn::metric_unit::kWrites,
                       "The number of failed writes to local file in client");

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -51,10 +51,11 @@ METRIC_DEFINE_counter(replica,
                       dsn::metric_unit::kRequests,
                       "The number of failed nfs copy requests (requested by client)");
 
-METRIC_DEFINE_counter(replica,
-                      nfs_client_write_bytes,
-                      dsn::metric_unit::kBytes,
-                      "The accumulated data size in bytes that are written to local file in client");
+METRIC_DEFINE_counter(
+    replica,
+    nfs_client_write_bytes,
+    dsn::metric_unit::kBytes,
+    "The accumulated data size in bytes that are written to local file in client");
 
 METRIC_DEFINE_counter(replica,
                       nfs_client_failed_writes,
@@ -118,10 +119,10 @@ nfs_client_impl::nfs_client_impl()
       _buffered_local_write_count(0),
       _copy_requests_low(FLAGS_max_file_copy_request_count_per_file),
       _high_priority_remaining_time(FLAGS_high_priority_speed_rate),
-    METRIC_VAR_INIT_server(nfs_client_copy_bytes),
-    METRIC_VAR_INIT_server(nfs_client_failed_copy_requests),
-    METRIC_VAR_INIT_server(nfs_client_write_bytes),
-    METRIC_VAR_INIT_server(nfs_client_failed_writes)
+      METRIC_VAR_INIT_server(nfs_client_copy_bytes),
+      METRIC_VAR_INIT_server(nfs_client_failed_copy_requests),
+      METRIC_VAR_INIT_server(nfs_client_write_bytes),
+      METRIC_VAR_INIT_server(nfs_client_failed_writes)
 {
     _copy_token_buckets = std::make_unique<utils::token_buckets>();
 

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -32,7 +32,6 @@
 
 #include "nfs/nfs_code_definition.h"
 #include "nfs/nfs_node.h"
-#include "perf_counter/perf_counter.h"
 #include "utils/blob.h"
 #include "utils/command_manager.h"
 #include "utils/filesystem.h"
@@ -41,6 +40,26 @@
 #include "utils/ports.h"
 #include "utils/string_conv.h"
 #include "utils/token_buckets.h"
+
+METRIC_DEFINE_counter(replica,
+                      nfs_client_copy_bytes,
+                      dsn::metric_unit::kBytes,
+                      "The accumulated data size in bytes requested by client during nfs copy");
+
+METRIC_DEFINE_counter(replica,
+                      nfs_client_failed_copy_requests,
+                      dsn::metric_unit::kRequests,
+                      "The number of failed nfs copy requests (requested by client)");
+
+METRIC_DEFINE_counter(replica,
+                      nfs_client_write_bytes,
+                      dsn::metric_unit::kBytes,
+                      "The accumulated data size in bytes that are written to local file in client");
+
+METRIC_DEFINE_counter(replica,
+                      nfs_client_failed_writes,
+                      dsn::metric_unit::kWrites,
+                      "The number of failed writes to local file in client");
 
 namespace dsn {
 namespace service {
@@ -98,27 +117,12 @@ nfs_client_impl::nfs_client_impl()
       _concurrent_local_write_count(0),
       _buffered_local_write_count(0),
       _copy_requests_low(FLAGS_max_file_copy_request_count_per_file),
-      _high_priority_remaining_time(FLAGS_high_priority_speed_rate)
+      _high_priority_remaining_time(FLAGS_high_priority_speed_rate),
+    METRIC_VAR_INIT_server(nfs_client_copy_bytes),
+    METRIC_VAR_INIT_server(nfs_client_failed_copy_requests),
+    METRIC_VAR_INIT_server(nfs_client_write_bytes),
+    METRIC_VAR_INIT_server(nfs_client_failed_writes)
 {
-    _recent_copy_data_size.init_app_counter("eon.nfs_client",
-                                            "recent_copy_data_size",
-                                            COUNTER_TYPE_VOLATILE_NUMBER,
-                                            "nfs client copy data size in the recent period");
-    _recent_copy_fail_count.init_app_counter(
-        "eon.nfs_client",
-        "recent_copy_fail_count",
-        COUNTER_TYPE_VOLATILE_NUMBER,
-        "nfs client copy fail count count in the recent period");
-    _recent_write_data_size.init_app_counter("eon.nfs_client",
-                                             "recent_write_data_size",
-                                             COUNTER_TYPE_VOLATILE_NUMBER,
-                                             "nfs client write data size in the recent period");
-    _recent_write_fail_count.init_app_counter(
-        "eon.nfs_client",
-        "recent_write_fail_count",
-        COUNTER_TYPE_VOLATILE_NUMBER,
-        "nfs client write fail count count in the recent period");
-
     _copy_token_buckets = std::make_unique<utils::token_buckets>();
 
     register_cli_commands();
@@ -337,7 +341,7 @@ void nfs_client_impl::end_copy(::dsn::error_code err,
     }
 
     if (err != ::dsn::ERR_OK) {
-        _recent_copy_fail_count->increment();
+        METRIC_VAR_INCREMENT(nfs_client_failed_copy_requests);
 
         if (!fc->user_req->is_finished) {
             if (reqc->retry_count > 0) {
@@ -373,7 +377,7 @@ void nfs_client_impl::end_copy(::dsn::error_code err,
     }
 
     else {
-        _recent_copy_data_size->add(resp.size);
+        METRIC_VAR_INCREMENT_BY(nfs_client_copy_bytes, resp.size);
 
         reqc->response = resp;
         reqc->is_ready_for_write = true;
@@ -504,7 +508,7 @@ void nfs_client_impl::end_write(error_code err, size_t sz, const copy_request_ex
 
     bool completed = false;
     if (err != ERR_OK) {
-        _recent_write_fail_count->increment();
+        METRIC_VAR_INCREMENT(nfs_client_failed_writes);
 
         LOG_ERROR("[nfs_service] local write failed, dir = {}, file = {}, err = {}",
                   fc->user_req->file_size_req.dst_dir,
@@ -512,7 +516,7 @@ void nfs_client_impl::end_write(error_code err, size_t sz, const copy_request_ex
                   err);
         completed = true;
     } else {
-        _recent_write_data_size->add(sz);
+        METRIC_VAR_INCREMENT_BY(nfs_client_write_bytes, sz);
 
         file_wrapper_ptr temp_holder;
         zauto_lock l(fc->user_req->user_req_lock);

--- a/src/nfs/nfs_client_impl.h
+++ b/src/nfs/nfs_client_impl.h
@@ -311,9 +311,9 @@ private:
     zlock _local_writes_lock;
     std::deque<copy_request_ex_ptr> _local_writes;
 
-    METRIC_VAR_DECLARE_counte(nfs_client_copy_bytes);
-    METRIC_VAR_DECLARE_counte(nfs_client_failed_copy_requests);
-    METRIC_VAR_DECLARE_counte(nfs_client_write_bytes);
+    METRIC_VAR_DECLARE_counter(nfs_client_copy_bytes);
+    METRIC_VAR_DECLARE_counter(nfs_client_failed_copy_requests);
+    METRIC_VAR_DECLARE_counter(nfs_client_write_bytes);
     METRIC_VAR_DECLARE_counter(nfs_client_failed_writes);
 
     std::unique_ptr<command_deregister> _nfs_max_copy_rate_megabytes_cmd;

--- a/src/nfs/nfs_client_impl.h
+++ b/src/nfs/nfs_client_impl.h
@@ -41,7 +41,6 @@
 #include "aio/file_io.h"
 #include "nfs_code_definition.h"
 #include "nfs_types.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/task/async_calls.h"
 #include "runtime/task/task.h"
@@ -50,6 +49,7 @@
 #include "utils/autoref_ptr.h"
 #include "utils/error_code.h"
 #include "utils/fmt_logging.h"
+#include "utils/metrics.h"
 #include "utils/zlocks.h"
 
 namespace dsn {
@@ -311,10 +311,10 @@ private:
     zlock _local_writes_lock;
     std::deque<copy_request_ex_ptr> _local_writes;
 
-    perf_counter_wrapper _recent_copy_data_size;
-    perf_counter_wrapper _recent_copy_fail_count;
-    perf_counter_wrapper _recent_write_data_size;
-    perf_counter_wrapper _recent_write_fail_count;
+    METRIC_VAR_DECLARE_counte(nfs_client_copy_bytes);
+    METRIC_VAR_DECLARE_counte(nfs_client_failed_copy_requests);
+    METRIC_VAR_DECLARE_counte(nfs_client_write_bytes);
+    METRIC_VAR_DECLARE_counter(nfs_client_failed_writes);
 
     std::unique_ptr<command_deregister> _nfs_max_copy_rate_megabytes_cmd;
 

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -45,15 +45,17 @@
 #include "utils/string_conv.h"
 #include "utils/utils.h"
 
-METRIC_DEFINE_counter(replica,
-                      nfs_server_copy_bytes,
-                      dsn::metric_unit::kBytes,
-                      "The accumulated data size in bytes that are read from local file in server during nfs copy");
+METRIC_DEFINE_counter(
+    replica,
+    nfs_server_copy_bytes,
+    dsn::metric_unit::kBytes,
+    "The accumulated data size in bytes that are read from local file in server during nfs copy");
 
-METRIC_DEFINE_counter(replica,
-                      nfs_server_failed_copy_requests,
-                      dsn::metric_unit::kRequests,
-                      "The number of nfs copy requests (received by server) that fail to read local file in server");
+METRIC_DEFINE_counter(
+    replica,
+    nfs_server_failed_copy_requests,
+    dsn::metric_unit::kRequests,
+    "The number of nfs copy requests (received by server) that fail to read local file in server");
 
 namespace dsn {
 class disk_file;
@@ -70,9 +72,10 @@ DSN_TAG_VARIABLE(max_send_rate_megabytes_per_disk, FT_MUTABLE);
 DSN_DECLARE_int32(file_close_timer_interval_ms_on_server);
 DSN_DECLARE_int32(file_close_expire_time_ms);
 
-nfs_service_impl::nfs_service_impl() : ::dsn::serverlet<nfs_service_impl>("nfs"),
-    METRIC_VAR_INIT_server(nfs_server_copy_bytes),
-    METRIC_VAR_INIT_server(nfs_server_failed_copy_requests)
+nfs_service_impl::nfs_service_impl()
+    : ::dsn::serverlet<nfs_service_impl>("nfs"),
+      METRIC_VAR_INIT_server(nfs_server_copy_bytes),
+      METRIC_VAR_INIT_server(nfs_server_failed_copy_requests)
 {
     _file_close_timer = ::dsn::tasking::enqueue_timer(
         LPC_NFS_FILE_CLOSE_TIMER,

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -38,21 +38,23 @@
 #include "runtime/api_layer1.h"
 #include "runtime/task/async_calls.h"
 #include "utils/TokenBucket.h"
+#include "utils/autoref_ptr.h"
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/ports.h"
 #include "utils/safe_strerror_posix.h"
 #include "utils/string_conv.h"
+#include "utils/string_view.h"
 #include "utils/utils.h"
 
 METRIC_DEFINE_counter(
-    replica,
+    server,
     nfs_server_copy_bytes,
     dsn::metric_unit::kBytes,
     "The accumulated data size in bytes that are read from local file in server during nfs copy");
 
 METRIC_DEFINE_counter(
-    replica,
+    server,
     nfs_server_failed_copy_requests,
     dsn::metric_unit::kRequests,
     "The number of nfs copy requests (received by server) that fail to read local file in server");

--- a/src/nfs/nfs_server_impl.h
+++ b/src/nfs/nfs_server_impl.h
@@ -35,7 +35,6 @@
 #include "aio/file_io.h"
 #include "nfs_code_definition.h"
 #include "nfs_types.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "runtime/serverlet.h"
 #include "runtime/task/task.h"
 #include "runtime/task/task_tracker.h"
@@ -43,6 +42,7 @@
 #include "utils/command_manager.h"
 #include "utils/error_code.h"
 #include "utils/fmt_logging.h"
+#include "utils/metrics.h"
 #include "utils/token_buckets.h"
 #include "utils/zlocks.h"
 
@@ -137,8 +137,8 @@ private:
     std::unique_ptr<dsn::utils::token_buckets>
         _send_token_buckets; // rate limiter of send to remote
 
-    perf_counter_wrapper _recent_copy_data_size;
-    perf_counter_wrapper _recent_copy_fail_count;
+    METRIC_VAR_DECLARE_counter(nfs_server_copy_bytes);
+    METRIC_VAR_DECLARE_counter(nfs_server_failed_copy_requests);
 
     std::unique_ptr<command_deregister> _nfs_max_send_rate_megabytes_cmd;
 

--- a/src/nfs/test/CMakeLists.txt
+++ b/src/nfs/test/CMakeLists.txt
@@ -33,7 +33,7 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_LIBS dsn_nfs dsn_runtime gtest dsn_aio)
+set(MY_PROJ_LIBS dsn_nfs dsn_runtime gtest dsn_aio dsn_http)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
 

--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <rocksdb/status.h>
-#include <stdio.h>
 #include <thrift/transport/TTransportException.h>
 #include <algorithm>
 #include <utility>


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1329

Migrate server-level metrics to new framework for both server/client sides
of nfs, including the data size in bytes that are requested by client or read
from local file in server, the number of nfs copy requests that fail for client
or server, the data size in bytes that are written to local file in client, the
number of failed writes to local file in client.

The old type in perf counters of all these metrics are volatile counter, while
all of them become accumulated counter for new metrics.