### PR TITLE
refactor: minor refactor on replica module

### DIFF
--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -160,8 +160,9 @@ fs_manager::fs_manager(bool for_test)
     }
 }
 
-dir_node *fs_manager::get_dir_node(const std::string &subdir)
+dir_node *fs_manager::get_dir_node(const std::string &subdir) const
 {
+    zauto_read_lock l(_lock);
     std::string norm_subdir;
     utils::filesystem::get_normalized_path(subdir, norm_subdir);
     for (auto &n : _dir_nodes) {

--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -115,7 +115,7 @@ private:
         _status_updated_dir_nodes.clear();
     }
 
-    dir_node *get_dir_node(const std::string &subdir);
+    dir_node *get_dir_node(const std::string &subdir) const;
 
     // when visit the tag/storage of the _dir_nodes map, there's no need to protect by the lock.
     // but when visit the holding_replicas, you must take care.

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -42,7 +42,7 @@ public:
                     int max_count,
                     mutation_committer committer);
 
-    void commit(decree d, commit_type ct);
+    void commit(decree d, commit_type ct) override;
 
 private:
     perf_counter_wrapper _counter_dulication_mutation_loss_count;

--- a/src/replica/prepare_list.h
+++ b/src/replica/prepare_list.h
@@ -70,8 +70,9 @@ public:
     //
     // if pop_all_committed_mutations = true, pop all committed mutations, will only used during
     // bulk load ingestion
-    // if secondary_commit = true, and status is secondary or protential secondary, previous logs
+    // if secondary_commit = true, and status is secondary or potential secondary, previous logs
     // will be committed
+    // TODO(yingchun): should check return values for all callers by adding WARN_UNUSED_RESULT.
     error_code prepare(mutation_ptr &mu,
                        partition_status::type status,
                        bool pop_all_committed_mutations = false,

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -826,8 +826,8 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     }
 }
 
-void replica_stub::initialize_fs_manager(std::vector<std::string> &data_dirs,
-                                         std::vector<std::string> &data_dir_tags)
+void replica_stub::initialize_fs_manager(const std::vector<std::string> &data_dirs,
+                                         const std::vector<std::string> &data_dir_tags)
 {
     std::string cdir;
     std::string err_msg;
@@ -835,7 +835,7 @@ void replica_stub::initialize_fs_manager(std::vector<std::string> &data_dirs,
     std::vector<std::string> available_dirs;
     std::vector<std::string> available_dir_tags;
     for (auto i = 0; i < data_dir_tags.size(); ++i) {
-        std::string &dir = data_dirs[i];
+        const auto &dir = data_dirs[i];
         if (dsn_unlikely(!utils::filesystem::create_directory(dir, cdir, err_msg) ||
                          !utils::filesystem::check_dir_rw(dir, err_msg))) {
             if (FLAGS_ignore_broken_disk) {
@@ -1345,7 +1345,7 @@ void replica_stub::on_add_learner(const group_check_request &request)
         return;
     }
 
-    LOG_INFO("{}@{}: received add learner, primary = {}, ballot ={}, status = {}, "
+    LOG_INFO("{}@{}: received add learner, primary = {}, ballot = {}, status = {}, "
              "last_committed_decree = {}",
              request.config.pid,
              _primary_address_str,
@@ -1629,6 +1629,10 @@ void replica_stub::on_node_query_reply_scatter2(replica_stub_ptr this_, gpid id)
 void replica_stub::remove_replica_on_meta_server(const app_info &info,
                                                  const partition_configuration &config)
 {
+    if (FLAGS_fd_disabled) {
+        return;
+    }
+
     dsn::message_ex *msg = dsn::message_ex::create_request(RPC_CM_UPDATE_PARTITION_CONFIGURATION);
 
     std::shared_ptr<configuration_update_request> request(new configuration_update_request);
@@ -2818,24 +2822,10 @@ void replica_stub::close()
         _mem_release_timer_task = nullptr;
     }
 
+    wait_closing_replicas_finished();
+
     {
         zauto_write_lock l(_replicas_lock);
-        while (!_closing_replicas.empty()) {
-            task_ptr task = std::get<0>(_closing_replicas.begin()->second);
-            gpid tmp_gpid = _closing_replicas.begin()->first;
-            _replicas_lock.unlock_write();
-
-            task->wait();
-
-            _replicas_lock.lock_write();
-            // task will automatically remove this replica from _closing_replicas
-            if (!_closing_replicas.empty()) {
-                CHECK_NE_MSG(tmp_gpid,
-                             _closing_replicas.begin()->first,
-                             "this replica '{}' should has been removed",
-                             tmp_gpid.to_string());
-            }
-        }
 
         while (!_opening_replicas.empty()) {
             task_ptr task = _opening_replicas.begin()->second;
@@ -3198,6 +3188,28 @@ void replica_stub::update_config(const std::string &name)
     // The new value has been validated and FLAGS_* has been updated, it's safety to use it
     // directly.
     UPDATE_CONFIG(_config_sync_timer_task->update_interval, config_sync_interval_ms, name);
+}
+
+void replica_stub::wait_closing_replicas_finished()
+{
+    zauto_write_lock l(_replicas_lock);
+    while (!_closing_replicas.empty()) {
+        auto task = std::get<0>(_closing_replicas.begin()->second);
+        auto first_gpid = _closing_replicas.begin()->first;
+
+        // TODO(yingchun): improve the code
+        _replicas_lock.unlock_write();
+        task->wait();
+        _replicas_lock.lock_write();
+
+        // task will automatically remove this replica from '_closing_replicas'
+        if (!_closing_replicas.empty()) {
+            CHECK_NE_MSG(first_gpid,
+                         _closing_replicas.begin()->first,
+                         "this replica '{}' should has been removed",
+                         first_gpid);
+        }
+    }
 }
 
 } // namespace replication

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -131,8 +131,8 @@ public:
     //
     void initialize(const replication_options &opts, bool clear = false);
     void initialize(bool clear = false);
-    void initialize_fs_manager(std::vector<std::string> &data_dirs,
-                               std::vector<std::string> &data_dir_tags);
+    void initialize_fs_manager(const std::vector<std::string> &data_dirs,
+                               const std::vector<std::string> &data_dir_tags);
     void set_options(const replication_options &opts) { _options = opts; }
     void open_service();
     void close();
@@ -264,6 +264,8 @@ public:
 
     void update_config(const std::string &name);
 
+    fs_manager *get_fs_manager() { return &_fs_manager; }
+
 private:
     enum replica_node_state
     {
@@ -356,6 +358,9 @@ private:
     void register_jemalloc_ctrl_command();
 #endif
 
+    // Wait all replicas in closing state to be finished.
+    void wait_closing_replicas_finished();
+
 private:
     friend class ::dsn::replication::test::test_checker;
     friend class ::dsn::replication::replica;
@@ -381,7 +386,7 @@ private:
     friend class replica_follower;
     friend class replica_follower_test;
     friend class replica_http_service_test;
-    FRIEND_TEST(replica_test, test_clear_on_failer);
+    FRIEND_TEST(replica_test, test_clear_on_failure);
 
     typedef std::unordered_map<gpid, ::dsn::task_ptr> opening_replicas;
     typedef std::unordered_map<gpid, std::tuple<task_ptr, replica_ptr, app_info, replica_info>>

--- a/src/replica/replication_app_base.h
+++ b/src/replica/replication_app_base.h
@@ -135,6 +135,10 @@ public:
     error_code close(bool clear_state);
 
     error_code apply_checkpoint(chkpt_apply_mode mode, const learn_state &state);
+
+    // Return code:
+    //   - ERR_OK: everything is OK.
+    //   - ERR_LOCAL_APP_FAILURE: other type of errors.
     error_code apply_mutation(const mutation *mu);
 
     // methods need to implement on storage engine side

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -427,15 +427,17 @@ replica_split_manager::child_apply_private_logs(std::vector<std::string> plog_fi
     error_code ec;
     int64_t offset;
     // temp prepare_list used for apply states
-    prepare_list plist(_replica,
-                       _replica->_app->last_committed_decree(),
-                       FLAGS_max_mutation_count_in_prepare_list,
-                       [this](mutation_ptr &mu) {
-                           if (mu->data.header.decree ==
-                               _replica->_app->last_committed_decree() + 1) {
-                               _replica->_app->apply_mutation(mu);
-                           }
-                       });
+    prepare_list plist(
+        _replica,
+        _replica->_app->last_committed_decree(),
+        FLAGS_max_mutation_count_in_prepare_list,
+        [this](mutation_ptr &mu) {
+            if (mu->data.header.decree != _replica->_app->last_committed_decree() + 1) {
+                return;
+            }
+
+            _replica->_app->apply_mutation(mu);
+        });
 
     // replay private log
     ec = mutation_log::replay(plog_files,

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -427,17 +427,17 @@ replica_split_manager::child_apply_private_logs(std::vector<std::string> plog_fi
     error_code ec;
     int64_t offset;
     // temp prepare_list used for apply states
-    prepare_list plist(
-        _replica,
-        _replica->_app->last_committed_decree(),
-        FLAGS_max_mutation_count_in_prepare_list,
-        [this](mutation_ptr &mu) {
-            if (mu->data.header.decree != _replica->_app->last_committed_decree() + 1) {
-                return;
-            }
+    prepare_list plist(_replica,
+                       _replica->_app->last_committed_decree(),
+                       FLAGS_max_mutation_count_in_prepare_list,
+                       [this](mutation_ptr &mu) {
+                           if (mu->data.header.decree !=
+                               _replica->_app->last_committed_decree() + 1) {
+                               return;
+                           }
 
-            _replica->_app->apply_mutation(mu);
-        });
+                           _replica->_app->apply_mutation(mu);
+                       });
 
     // replay private log
     ec = mutation_log::replay(plog_files,

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -313,10 +313,11 @@ public:
         config.pid = pid;
         config.status = status;
 
-        auto data_dirs = std::vector<std::string>{"./"};
-        auto data_dirs_tag = std::vector<std::string>{"tag"};
-        initialize_fs_manager(data_dirs, data_dirs_tag);
-        auto *rep = new mock_replica(this, pid, info, "./", need_restore, is_duplication_follower);
+        // TODO(yingchun): should refactor to move to cstor or initializer.
+        initialize_fs_manager({"./"}, {"tag"});
+        std::string dir = get_replica_dir("test", pid);
+        auto *rep =
+            new mock_replica(this, pid, info, dir.c_str(), need_restore, is_duplication_follower);
         rep->set_replica_config(config);
         return rep;
     }

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -62,6 +62,7 @@
 
 namespace dsn {
 namespace replication {
+DSN_DECLARE_bool(fd_disabled);
 DSN_DECLARE_string(cold_backup_root);
 
 class replica_test : public replica_test_base
@@ -462,13 +463,15 @@ TEST_F(replica_test, test_query_last_checkpoint_info)
     ASSERT_EQ(resp.base_local_dir, "./data/checkpoint.100");
 }
 
-TEST_F(replica_test, test_clear_on_failer)
+TEST_F(replica_test, test_clear_on_failure)
 {
+    // Disable failure detector to avoid connecting with meta server which is not started.
+    FLAGS_fd_disabled = true;
+
     replica *rep =
         stub->generate_replica(_app_info, pid, partition_status::PS_PRIMARY, 1, false, true);
-    auto path = stub->get_replica_dir(_app_info.app_type.c_str(), pid);
+    auto path = rep->dir();
     dsn::utils::filesystem::create_directory(path);
-    ASSERT_TRUE(dsn::utils::filesystem::path_exists(path));
     ASSERT_TRUE(has_gpid(pid));
 
     stub->clear_on_failure(rep, path, pid);


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1383

This patch fix some minor issues includes:
- short return id `FLAGS_fd_disabled` is true in `remove_replica_on_meta_server`
  to avoid running meaningless logic
- encapsulate a new function `wait_closing_replicas_finished()` in `replica_stub`
- marks some functions as `const` or `override`
- marks some parameters or variables as `const`
- adds missing lock
- fixes some typos
- use short-circuit return style