### PR TITLE
feat(new_metrics): add disk-level metric entity and migrate disk-level metrics for fs_manager

### DIFF
--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -41,7 +41,7 @@
 
 #include "common/gpid.h"
 #include "common/replication_enums.h"
-#include "perf_counter/perf_counter.h"
+#include "fmt/core.h"
 #include "runtime/api_layer1.h"
 #include "runtime/rpc/rpc_address.h"
 #include "utils/fail_point.h"

--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -80,25 +80,22 @@ DSN_TAG_VARIABLE(disk_min_available_space_ratio, FT_MUTABLE);
 
 namespace {
 
-metric_entity_ptr instantiate_disk_metric_entity(const std::string &tag, const std::string &data_dir)
+metric_entity_ptr instantiate_disk_metric_entity(const std::string &tag,
+                                                 const std::string &data_dir)
 {
     auto entity_id = fmt::format("disk_{}", tag);
 
-    return METRIC_ENTITY_disk.instantiate(
-        entity_id,
-        {{"tag", tag},
-         {"data_dir", data_dir}});
+    return METRIC_ENTITY_disk.instantiate(entity_id, {{"tag", tag}, {"data_dir", data_dir}});
 }
 
 } // anonymous namespace
 
 disk_capacity_metrics::disk_capacity_metrics(const std::string &tag, const std::string &data_dir)
     : _disk_metric_entity(instantiate_disk_metric_entity(tag, data_dir)),
-    METRIC_VAR_INIT_disk(total_disk_capacity_mb),
-    METRIC_VAR_INIT_disk(avail_disk_capacity_mb),
-    METRIC_VAR_INIT_disk(avail_disk_capacity_percentage)
+      METRIC_VAR_INIT_disk(total_disk_capacity_mb),
+      METRIC_VAR_INIT_disk(avail_disk_capacity_mb),
+      METRIC_VAR_INIT_disk(avail_disk_capacity_percentage)
 {
-
 }
 
 const metric_entity_ptr &disk_capacity_metrics::disk_metric_entity() const
@@ -157,9 +154,9 @@ bool dir_node::update_disk_stat(const bool update_disk_status)
     disk_available_ratio = static_cast<int>(
         disk_capacity_mb == 0 ? 0 : std::round(disk_available_mb * 100.0 / disk_capacity_mb));
 
-    METRIC_VAR_SET(total_disk_capacity_mb, disk_capacity_mb);
-    METRIC_VAR_SET(avail_disk_capacity_mb, disk_available_mb);
-    METRIC_VAR_SET(avail_disk_capacity_percentage, disk_available_ratio);
+    METRIC_CALL_SET_METHOD(disk_capacity, total_disk_capacity_mb, disk_capacity_mb);
+    METRIC_CALL_SET_METHOD(disk_capacity, avail_disk_capacity_mb, disk_available_mb);
+    METRIC_CALL_SET_METHOD(disk_capacity, avail_disk_capacity_percentage, disk_available_ratio);
 
     if (!update_disk_status) {
         LOG_INFO("update disk space succeed: dir = {}, capacity_mb = {}, available_mb = {}, "

--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -54,17 +54,12 @@ METRIC_DEFINE_entity(disk);
 METRIC_DEFINE_gauge_int64(disk,
                           total_disk_capacity_mb,
                           dsn::metric_unit::kMegaBytes,
-                          "The total disk capacity in MB");
+                          "The total disk capacity");
 
 METRIC_DEFINE_gauge_int64(disk,
                           avail_disk_capacity_mb,
                           dsn::metric_unit::kMegaBytes,
-                          "The available disk capacity in MB");
-
-METRIC_DEFINE_gauge_int64(disk,
-                          avail_disk_capacity_percentage,
-                          dsn::metric_unit::kPercent,
-                          "The percentage of available disk capacity");
+                          "The available disk capacity");
 
 namespace dsn {
 namespace replication {
@@ -93,8 +88,7 @@ metric_entity_ptr instantiate_disk_metric_entity(const std::string &tag,
 disk_capacity_metrics::disk_capacity_metrics(const std::string &tag, const std::string &data_dir)
     : _disk_metric_entity(instantiate_disk_metric_entity(tag, data_dir)),
       METRIC_VAR_INIT_disk(total_disk_capacity_mb),
-      METRIC_VAR_INIT_disk(avail_disk_capacity_mb),
-      METRIC_VAR_INIT_disk(avail_disk_capacity_percentage)
+      METRIC_VAR_INIT_disk(avail_disk_capacity_mb)
 {
 }
 
@@ -156,7 +150,6 @@ bool dir_node::update_disk_stat(const bool update_disk_status)
 
     METRIC_CALL_SET_METHOD(disk_capacity, total_disk_capacity_mb, disk_capacity_mb);
     METRIC_CALL_SET_METHOD(disk_capacity, avail_disk_capacity_mb, disk_available_mb);
-    METRIC_CALL_SET_METHOD(disk_capacity, avail_disk_capacity_percentage, disk_available_ratio);
 
     if (!update_disk_status) {
         LOG_INFO("update disk space succeed: dir = {}, capacity_mb = {}, available_mb = {}, "

--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -52,13 +52,11 @@ public:
 
     METRIC_DEFINE_SET_METHOD(total_disk_capacity_mb, int64_t)
     METRIC_DEFINE_SET_METHOD(avail_disk_capacity_mb, int64_t)
-    METRIC_DEFINE_SET_METHOD(avail_disk_capacity_percentage, int64_t)
 
 private:
     const metric_entity_ptr _disk_metric_entity;
     METRIC_VAR_DECLARE_gauge_int64(total_disk_capacity_mb);
     METRIC_VAR_DECLARE_gauge_int64(avail_disk_capacity_mb);
-    METRIC_VAR_DECLARE_gauge_int64(avail_disk_capacity_percentage);
 
     DISALLOW_COPY_AND_ASSIGN(disk_capacity_metrics);
 };

--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -27,10 +27,11 @@
 
 #include "common/replication_other_types.h"
 #include "metadata_types.h"
-#include "perf_counter/perf_counter_wrapper.h"
+#include "utils/autoref_ptr.h"
 #include "utils/error_code.h"
 #include "utils/flags.h"
 #include "utils/metrics.h"
+#include "utils/ports.h"
 #include "utils/zlocks.h"
 
 namespace dsn {

--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -30,6 +30,7 @@
 #include "perf_counter/perf_counter_wrapper.h"
 #include "utils/error_code.h"
 #include "utils/flags.h"
+#include "utils/metrics.h"
 #include "utils/zlocks.h"
 
 namespace dsn {
@@ -73,6 +74,21 @@ public:
     bool has(const dsn::gpid &pid) const;
     unsigned remove(const dsn::gpid &pid);
     bool update_disk_stat(const bool update_disk_status);
+};
+
+class disk_capacity
+{
+public:
+    disk_capacity(const std::string &tag, const std::string &data_dir);
+
+    const metric_entity_ptr &disk_metric_entity() const;
+
+private:
+    const metric_entity_ptr _disk_metric_entity;
+    METRIC_VAR_DECLARE_gauge_int64(total_disk_capacity_mb);
+    METRIC_VAR_DECLARE_gauge_int64(avail_disk_capacity_mb);
+
+    DISALLOW_COPY_AND_ASSIGN(disk_capacity);
 };
 
 class fs_manager
@@ -134,6 +150,8 @@ private:
     // disk status will be updated periodically, this vector record nodes whose disk_status changed
     // in this round
     std::vector<std::shared_ptr<dir_node>> _status_updated_dir_nodes;
+
+    std::vector<std::unique_ptr<disk_capacity>> _disk_capacities;
 
     perf_counter_wrapper _counter_total_capacity_mb;
     perf_counter_wrapper _counter_total_available_mb;

--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -134,9 +134,10 @@ public:
 private:
     dir_node *get_dir_node(const std::string &subdir);
 
-    // TODO(wangdan): _dir_nodes should be protected by lock since
-    // when visit the tag/storage of the _dir_nodes map, there's no need to protect by the lock.
-    // but when visit the holding_replicas, you must take care.
+    // TODO(wangdan): _dir_nodes should be protected by lock since add_new_disk are supported:
+    // it might be updated arbitrarily at any time.
+    //
+    // Especially when visiting the holding_replicas, you must take care.
     mutable zrwlock_nr _lock;
 
     int64_t _total_capacity_mb = 0;

--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -49,10 +49,15 @@ public:
 
     const metric_entity_ptr &disk_metric_entity() const;
 
+    METRIC_DEFINE_SET_METHOD(total_disk_capacity_mb, int64_t)
+    METRIC_DEFINE_SET_METHOD(avail_disk_capacity_mb, int64_t)
+    METRIC_DEFINE_SET_METHOD(avail_disk_capacity_percentage, int64_t)
+
 private:
     const metric_entity_ptr _disk_metric_entity;
     METRIC_VAR_DECLARE_gauge_int64(total_disk_capacity_mb);
     METRIC_VAR_DECLARE_gauge_int64(avail_disk_capacity_mb);
+    METRIC_VAR_DECLARE_gauge_int64(avail_disk_capacity_percentage);
 
     DISALLOW_COPY_AND_ASSIGN(disk_capacity_metrics);
 };
@@ -71,7 +76,7 @@ public:
     std::map<app_id, std::set<gpid>> holding_secondary_replicas;
 
 private:
-    std::unique_ptr<disk_capacity_metrics> disk_capacity;
+    disk_capacity_metrics disk_capacity;
 
 public:
     dir_node(const std::string &tag_,
@@ -86,7 +91,7 @@ public:
           disk_available_mb(disk_available_mb_),
           disk_available_ratio(disk_available_ratio_),
           status(status_),
-          disk_capacity(std::make_unique(tag_, dir_))
+          disk_capacity(tag_, dir_)
     {
     }
     unsigned replicas_count(app_id id) const;
@@ -128,6 +133,7 @@ public:
 private:
     dir_node *get_dir_node(const std::string &subdir);
 
+    // TODO(wangdan): _dir_nodes should be protected by lock since
     // when visit the tag/storage of the _dir_nodes map, there's no need to protect by the lock.
     // but when visit the holding_replicas, you must take care.
     mutable zrwlock_nr _lock;

--- a/src/common/test/CMakeLists.txt
+++ b/src/common/test/CMakeLists.txt
@@ -27,6 +27,7 @@ set(MY_PROJ_NAME dsn_replication_common_test)
 set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS
+        dsn_http
         dsn_replication_common
         dsn_runtime
         gtest

--- a/src/meta/test/misc/misc.cpp
+++ b/src/meta/test/misc/misc.cpp
@@ -203,7 +203,7 @@ void generate_node_fs_manager(const app_mapper &apps,
     for (const auto &kv : nodes) {
         const node_state &ns = kv.second;
         if (nfm.find(ns.addr()) == nfm.end()) {
-            nfm.emplace(ns.addr(), std::make_shared<fs_manager>(true));
+            nfm.emplace(ns.addr(), std::make_shared<fs_manager>());
         }
         fs_manager &manager = *(nfm.find(ns.addr())->second);
         manager.initialize(data_dirs, tags, true);

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -194,7 +194,6 @@ replica_stub::replica_stub(replica_state_subscriber subscriber /*= nullptr*/,
       _mem_release_max_reserved_mem_percentage(10),
       _max_concurrent_bulk_load_downloading_count(5),
       _learn_app_concurrent_count(0),
-      _fs_manager(false),
       _bulk_load_downloading_count(0),
       _manual_emergency_checkpointing_count(0),
       _is_running(false)

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -615,6 +615,7 @@ enum class metric_unit : size_t
     kBytes,
     kMegaBytes,
     kCapacityUnits,
+    kPercent,
     kRequests,
     kSeeks,
     kPointLookups,

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -165,6 +165,7 @@ class error_code;
     _##name(METRIC_##name.instantiate(entity##_metric_entity(), ##__VA_ARGS__))
 #define METRIC_VAR_INIT_replica(name, ...) METRIC_VAR_INIT(name, replica, ##__VA_ARGS__)
 #define METRIC_VAR_INIT_server(name, ...) METRIC_VAR_INIT(name, server, ##__VA_ARGS__)
+#define METRIC_VAR_INIT_disk(name, ...) METRIC_VAR_INIT(name, disk, ##__VA_ARGS__)
 
 // Perform increment-related operations on metrics including gauge and counter.
 #define METRIC_VAR_INCREMENT_BY(name, x)                                                           \

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -195,6 +195,11 @@ class error_code;
 
 #define METRIC_VAR_AUTO_LATENCY_DURATION_NS(name) __##name##_auto_latency.duration_ns()
 
+#define METRIC_DEFINE_SET_METHOD(name, value_type)                                                 \
+    void set_##name(value_type value) { METRIC_VAR_SET(name, value); }
+
+#define METRIC_CALL_SET_METHOD(obj, name, value) obj.set_##name(value)
+
 namespace dsn {
 class metric;                  // IWYU pragma: keep
 class metric_entity_prototype; // IWYU pragma: keep


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1425

In perf counters, all metrics of `fs_manager` are server-level. For example,
the total capacity and the available capacity of all disks where there are
data of pegasus.

However, sometimes the capacity and the available capacity of each disk
seem more important: no space left on the disk will lead to serious problems.
Therefore, after being migrated to new framework, the server-level metrics
of perf counters become disk-level, including the capacity and the available
capacity of a disk. As for another disk-level metric -- the available percentage
of each disk used by a replica server, just use division operator.

Once server-level metrics are needed, just aggregate on the disk-level ones.
To compute another 2 server-level metrics -- the minimal/maximal available
percentage among all disks used by a replica server in a node, for example,
just use min/max operators over disk-level ones for Prometheus.

To implement disk-level metrics, disk-level metric entity are also added.