### PR TITLE
feat(new_metrics): migrate server-level metrics for meta_service

### DIFF
--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -70,11 +70,10 @@
 #include "utils/string_conv.h"
 #include "utils/strings.h"
 
-METRIC_DEFINE_counter(
-    server,
-    replica_server_disconnections,
-    dsn::metric_unit::kDisconnections,
-    "The number of disconnections with replica servers");
+METRIC_DEFINE_counter(server,
+                      replica_server_disconnections,
+                      dsn::metric_unit::kDisconnections,
+                      "The number of disconnections with replica servers");
 
 METRIC_DEFINE_gauge_int64(server,
                           unalive_replica_servers,
@@ -158,10 +157,13 @@ DSN_DECLARE_string(cold_backup_root);
     } while (0)
 
 meta_service::meta_service()
-    : serverlet("meta_service"), _failure_detector(nullptr), _started(false), _recovering(false),
-    METRIC_VAR_INIT_server(replica_server_disconnections),
-    METRIC_VAR_INIT_server(unalive_replica_servers),
-    METRIC_VAR_INIT_server(alive_replica_servers)
+    : serverlet("meta_service"),
+      _failure_detector(nullptr),
+      _started(false),
+      _recovering(false),
+      METRIC_VAR_INIT_server(replica_server_disconnections),
+      METRIC_VAR_INIT_server(unalive_replica_servers),
+      METRIC_VAR_INIT_server(alive_replica_servers)
 {
     _opts.initialize();
     _meta_opts.initialize();

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -66,7 +66,6 @@
 #include "utils/factory_store.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
-#include "utils/metrics.h"
 #include "utils/string_conv.h"
 #include "utils/strings.h"
 

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -67,6 +67,7 @@
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/string_conv.h"
+#include "utils/string_view.h"
 #include "utils/strings.h"
 
 METRIC_DEFINE_counter(server,

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -55,7 +55,6 @@
 #include "meta_service.h"
 #include "meta_split_service.h"
 #include "partition_split_types.h"
-#include "perf_counter/perf_counter.h"
 #include "remote_cmd/remote_command.h"
 #include "runtime/ranger/ranger_resource_policy_manager.h"
 #include "runtime/rpc/rpc_holder.h"
@@ -67,8 +66,25 @@
 #include "utils/factory_store.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
+#include "utils/metrics.h"
 #include "utils/string_conv.h"
 #include "utils/strings.h"
+
+METRIC_DEFINE_counter(
+    server,
+    replica_server_disconnections,
+    dsn::metric_unit::kDisconnections,
+    "The number of disconnections with replica servers");
+
+METRIC_DEFINE_gauge_int64(server,
+                          unalive_replica_servers,
+                          dsn::metric_unit::kServers,
+                          "The number of unalive replica servers");
+
+METRIC_DEFINE_gauge_int64(server,
+                          alive_replica_servers,
+                          dsn::metric_unit::kServers,
+                          "The number of alive replica servers");
 
 namespace dsn {
 namespace dist {
@@ -142,7 +158,10 @@ DSN_DECLARE_string(cold_backup_root);
     } while (0)
 
 meta_service::meta_service()
-    : serverlet("meta_service"), _failure_detector(nullptr), _started(false), _recovering(false)
+    : serverlet("meta_service"), _failure_detector(nullptr), _started(false), _recovering(false),
+    METRIC_VAR_INIT_server(replica_server_disconnections),
+    METRIC_VAR_INIT_server(unalive_replica_servers),
+    METRIC_VAR_INIT_server(alive_replica_servers)
 {
     _opts.initialize();
     _meta_opts.initialize();
@@ -157,16 +176,6 @@ meta_service::meta_service()
             _function_level.store(meta_function_level::fl_steady);
         }
     }
-
-    _recent_disconnect_count.init_app_counter(
-        "eon.meta_service",
-        "recent_disconnect_count",
-        COUNTER_TYPE_VOLATILE_NUMBER,
-        "replica server disconnect count in the recent period");
-    _unalive_nodes_count.init_app_counter(
-        "eon.meta_service", "unalive_nodes", COUNTER_TYPE_NUMBER, "current count of unalive nodes");
-    _alive_nodes_count.init_app_counter(
-        "eon.meta_service", "alive_nodes", COUNTER_TYPE_NUMBER, "current count of alive nodes");
 
     _meta_op_status.store(meta_op_status::FREE);
 }
@@ -242,9 +251,9 @@ void meta_service::set_node_state(const std::vector<rpc_address> &nodes, bool is
         }
     }
 
-    _recent_disconnect_count->add(is_alive ? 0 : nodes.size());
-    _unalive_nodes_count->set(_dead_set.size());
-    _alive_nodes_count->set(_alive_set.size());
+    METRIC_VAR_INCREMENT_BY(replica_server_disconnections, is_alive ? 0 : nodes.size());
+    METRIC_VAR_SET(unalive_replica_servers, _dead_set.size());
+    METRIC_VAR_SET(alive_replica_servers, _alive_set.size());
 
     if (!_started) {
         return;
@@ -327,7 +336,7 @@ void meta_service::start_service()
             _alive_set.insert(kv.first);
     }
 
-    _alive_nodes_count->set(_alive_set.size());
+    METRIC_VAR_SET(alive_replica_servers, _alive_set.size());
 
     for (const dsn::rpc_address &node : _alive_set) {
         // sync alive set and the failure_detector

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -69,6 +69,7 @@
 #include "utils/enum_helper.h"
 #include "utils/error_code.h"
 #include "utils/fmt_logging.h"
+#include "utils/metrics.h"
 #include "utils/threadpool_code.h"
 #include "utils/zlocks.h"
 

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -55,7 +55,6 @@
 #include "meta_options.h"
 #include "meta_rpc_types.h"
 #include "meta_server_failure_detector.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "runtime/api_layer1.h"
 #include "runtime/rpc/network.h"
 #include "runtime/rpc/rpc_address.h"
@@ -383,9 +382,9 @@ private:
 
     std::string _cluster_root;
 
-    perf_counter_wrapper _recent_disconnect_count;
-    perf_counter_wrapper _unalive_nodes_count;
-    perf_counter_wrapper _alive_nodes_count;
+    METRIC_VAR_DECLARE_counter(replica_server_disconnections);
+    METRIC_VAR_DECLARE_gauge_int64(unalive_replica_servers);
+    METRIC_VAR_DECLARE_gauge_int64(alive_replica_servers);
 
     dsn::task_tracker _tracker;
 

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -649,6 +649,8 @@ enum class metric_unit : size_t
     kWrites,
     kChanges,
     kOperations,
+    kDisconnections,
+    kServers,
     kInvalidUnit,
 };
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1331

Migrate metrics to new framework for meta_service, including the number
of disconnections with replica servers, and the number of unalive and alive
replica servers. All of these metrics are server-level, maintained in meta
server.

The old type in perf counters of the number of disconnections is volatile
counter, which would be changed to non-volatile, while another 2 metrics
would keep the type of gauge.