### PR TITLE
fix(go-client): loopForRequest not return and retry forever

### DIFF
--- a/go-client/pegasus/table_connector.go
+++ b/go-client/pegasus/table_connector.go
@@ -724,6 +724,7 @@ func (p *pegasusTableConnector) handleReplicaError(err error, replica *session.R
 			err = errors.New(err.Error() + " Rate of requests exceeds the throughput limit")
 		case base.ERR_INVALID_STATE:
 			err = errors.New(err.Error() + " The target replica is not primary")
+			retry = false
 		case base.ERR_OBJECT_NOT_FOUND:
 			err = errors.New(err.Error() + " The replica server doesn't serve this partition")
 		case base.ERR_SPLITTING:

--- a/go-client/pegasus/table_connector_test.go
+++ b/go-client/pegasus/table_connector_test.go
@@ -261,7 +261,7 @@ func TestPegasusTableConnector_TriggerSelfUpdate(t *testing.T) {
 	<-ptb.confUpdateCh
 	assert.Error(t, err)
 	assert.True(t, confUpdate)
-	assert.True(t, retry)
+	assert.False(t, retry)
 
 	confUpdate, retry, err = ptb.handleReplicaError(base.ERR_PARENT_PARTITION_MISUSED, nil)
 	<-ptb.confUpdateCh


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #1385 

### What is changed and how does it work?
#### expected behavior: 
after replica server restart，The client should be able to reconnect with node without considering the client configuration update (reselecting the primary replica).

Actually, client configuration update is another issue we should talk about. I'd like to discuss that in another issue.

In this pr, we focus on why client cannot reconnect with restarted server.

1. SDK use several loop to monitor rpc.conn, when server is closed, `loopForDialing` will continue to retry dialling until connected with server(when server is restart),then,  two new loop `loopForRequest` & `loopForResponse`  will be created to handle request.
however,  `loopForRequest` will not return when correlative `loopForResponse`  returned because of IsNetworkClosed(EOF), since latter only return nil and will not shutdown tom.  thus, there will be more alive`loopForRequest` than `loopForResponse`  in this case.

2. SDK retried not on timeout err, however, we wrapped timeout err incorrectly in here https://github.com/apache/incubator-pegasus/blob/d16e65cd88b4fb6113d5e6a99234b5be527f28da/go-client/session/session.go#L338 ,thus every request like `multiset` will continue to do retry here since err we passed to outer is no longer timeout err
https://github.com/apache/incubator-pegasus/blob/d16e65cd88b4fb6113d5e6a99234b5be527f28da/go-client/pegasus/table_connector.go#L719





### Checklist <!--REMOVE the items that are not applicable-->
monitor capture based on this pr:
timeout is eliminated after server restart.
![image](https://user-images.githubusercontent.com/41042306/232466971-fab882cb-4bc4-4e69-a925-710eebd21688.png)


