### PR TITLE
feat(Ranger): Use Apache Ranger for ACL when replica master-slave learn

### DIFF
--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -72,6 +72,7 @@
 #include "replica_disk_migrator.h"
 #include "replica_stub.h"
 #include "runtime/api_layer1.h"
+#include "runtime/ranger/access_type.h"
 #include "runtime/rpc/rpc_message.h"
 #include "runtime/rpc/serialization.h"
 #include "runtime/security/access_controller.h"


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1054

This patch add ACL to the learn action of replica. 

1. specifically, regard learn as a write action, and use the Ranger 
    policy to determine whether the master-slave can learn.
