### PR TITLE
fix: fix a crash bug when open an incomplete created RocksDB instance

### DIFF
--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -44,29 +44,30 @@ meta_store::meta_store(pegasus_server_impl *server,
     _wt_opts.disableWAL = true;
 }
 
-uint64_t meta_store::get_last_flushed_decree() const
+dsn::error_code meta_store::get_last_flushed_decree(uint64_t *decree) const
 {
-    uint64_t last_flushed_decree = 0;
-    auto ec = get_value_from_meta_cf(true, LAST_FLUSHED_DECREE, &last_flushed_decree);
-    CHECK_EQ_PREFIX(::dsn::ERR_OK, ec);
-    return last_flushed_decree;
+    LOG_AND_RETURN_NOT_OK(ERROR_PREFIX,
+                          get_value_from_meta_cf(true, LAST_FLUSHED_DECREE, decree),
+                          "get_value_from_meta_cf failed");
+    return dsn::ERR_OK;
 }
 
-uint32_t meta_store::get_data_version() const
+dsn::error_code meta_store::get_data_version(uint32_t *version) const
 {
     uint64_t pegasus_data_version = 0;
-    auto ec = get_value_from_meta_cf(false, DATA_VERSION, &pegasus_data_version);
-    CHECK_EQ_PREFIX(::dsn::ERR_OK, ec);
-    return static_cast<uint32_t>(pegasus_data_version);
+    LOG_AND_RETURN_NOT_OK(ERROR_PREFIX,
+                          get_value_from_meta_cf(false, DATA_VERSION, &pegasus_data_version),
+                          "get_value_from_meta_cf failed");
+    *version = static_cast<uint32_t>(pegasus_data_version);
+    return dsn::ERR_OK;
 }
 
-uint64_t meta_store::get_last_manual_compact_finish_time() const
+dsn::error_code meta_store::get_last_manual_compact_finish_time(uint64_t *ts) const
 {
-    uint64_t last_manual_compact_finish_time = 0;
-    auto ec = get_value_from_meta_cf(
-        false, LAST_MANUAL_COMPACT_FINISH_TIME, &last_manual_compact_finish_time);
-    CHECK_EQ_PREFIX(::dsn::ERR_OK, ec);
-    return last_manual_compact_finish_time;
+    LOG_AND_RETURN_NOT_OK(ERROR_PREFIX,
+                          get_value_from_meta_cf(false, LAST_MANUAL_COMPACT_FINISH_TIME, ts),
+                          "get_value_from_meta_cf failed");
+    return dsn::ERR_OK;
 }
 
 uint64_t meta_store::get_decree_from_readonly_db(rocksdb::DB *db,

--- a/src/server/meta_store.h
+++ b/src/server/meta_store.h
@@ -45,11 +45,11 @@ class meta_store : public dsn::replication::replica_base
 public:
     meta_store(pegasus_server_impl *server, rocksdb::DB *db, rocksdb::ColumnFamilyHandle *meta_cf);
 
-    uint64_t get_last_flushed_decree() const;
+    dsn::error_code get_last_flushed_decree(uint64_t *decree) const;
     uint64_t get_decree_from_readonly_db(rocksdb::DB *db,
                                          rocksdb::ColumnFamilyHandle *meta_cf) const;
-    uint32_t get_data_version() const;
-    uint64_t get_last_manual_compact_finish_time() const;
+    dsn::error_code get_data_version(uint32_t *version) const;
+    dsn::error_code get_last_manual_compact_finish_time(uint64_t *ts) const;
     std::string get_usage_scenario() const;
 
     void set_last_flushed_decree(uint64_t decree) const;

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -3186,7 +3186,6 @@ bool pegasus_server_impl::set_options(
     }
 
     for (const auto &column_family : column_families) {
-        LOG_ERROR_PREFIX("column family name: {}", column_family);
         if (column_family == META_COLUMN_FAMILY_NAME) {
             *missing_meta_cf = false;
         } else if (column_family == DATA_COLUMN_FAMILY_NAME) {

--- a/src/test/function_test/base_api_test/integration_test.cpp
+++ b/src/test/function_test/base_api_test/integration_test.cpp
@@ -29,7 +29,7 @@
 #include "test/function_test/utils/test_util.h"
 #include "test_util/test_util.h"
 #include "utils/flags.h"
-#include "base/pegasus_utils.h"
+#include "utils/fmt_logging.h"
 
 namespace dsn {
 namespace replication {

--- a/src/test/function_test/base_api_test/integration_test.cpp
+++ b/src/test/function_test/base_api_test/integration_test.cpp
@@ -28,15 +28,6 @@
 #include "pegasus/error.h"
 #include "test/function_test/utils/test_util.h"
 #include "test_util/test_util.h"
-#include "utils/flags.h"
-#include "utils/fmt_logging.h"
-
-namespace dsn {
-namespace replication {
-DSN_DECLARE_int32(fd_check_interval_seconds);
-DSN_DECLARE_int32(fd_grace_seconds);
-} // namespace replication
-} // namespace dsn
 
 using namespace ::pegasus;
 
@@ -111,8 +102,7 @@ TEST_F(integration_test, write_corrupt_db)
               << std::endl;
 
     // Make effort to get a trustable alive replica server count.
-    KEEP_COND_FOR_TIME([&] { return get_alive_replica_server_count() == 3; }, 30);
-    LOG_WARNING("get_alive_replica_server_count: {}", get_alive_replica_server_count());
+    WAIT_IN_TIME([&] { return get_alive_replica_server_count() != 3; }, 30);
     // Now only 2 RSs left, or RS-1 has no leader replicas.
     ASSERT_IN_TIME(
         [&] {
@@ -136,7 +126,7 @@ TEST_F(integration_test, write_corrupt_db)
     ASSERT_NO_FATAL_FAILURE(
         run_cmd_from_project_root("echo 'set_meta_level lively' | ./run.sh shell"));
     // Make sure RS-1 has some primaries of table 'temp'.
-    ASSERT_IN_TIME([&] { ASSERT_GT(get_leader_count("temp", 1), 0); }, 60);
+    ASSERT_IN_TIME([&] { ASSERT_GT(get_leader_count("temp", 1), 0); }, 120);
 
     for (int i = 0; i < 1000; i++) {
         std::string hkey = fmt::format("hkey2_{}", i);

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -35,9 +35,11 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-logging_start_level = LOG_LEVEL_DEBUG
+
+logging_start_level = LOG_LEVEL_INFO
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
+
 enable_default_app_mimic = true
 
 [tools.simple_logger]

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -35,11 +35,9 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-
-logging_start_level = LOG_LEVEL_INFO
+logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
-
 enable_default_app_mimic = true
 
 [tools.simple_logger]

--- a/src/test/function_test/utils/global_env.cpp
+++ b/src/test/function_test/utils/global_env.cpp
@@ -45,12 +45,12 @@ global_env::global_env()
 void global_env::get_dirs()
 {
     std::string output1;
-    ASSERT_NO_FATAL_FAILURE(run_cmd(
+    ASSERT_NO_FATAL_FAILURE(run_cmd_no_error(
         "ps aux | grep '/meta1/pegasus_server' | grep -v grep | awk '{print $2}'", &output1));
 
     // get the dir of a process in onebox, say: $PEGASUS/onebox/meta1
     std::string output2;
-    ASSERT_NO_FATAL_FAILURE(run_cmd("readlink /proc/" + output1 + "/cwd", &output2));
+    ASSERT_NO_FATAL_FAILURE(run_cmd_no_error("readlink /proc/" + output1 + "/cwd", &output2));
 
     _pegasus_root = dirname(dirname((char *)output2.c_str()));
     std::cout << "Pegasus project root: " << _pegasus_root << std::endl;

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -21,6 +21,7 @@
 
 #include <nlohmann/json.hpp>
 #include <unistd.h>
+#include <algorithm>
 #include <fstream>
 #include <initializer_list>
 #include <utility>
@@ -42,9 +43,7 @@
 #include "utils/defer.h"
 #include "utils/error_code.h"
 #include "utils/filesystem.h"
-#include "utils/fmt_logging.h"
 #include "utils/rand.h"
-#include "utils/string_conv.h"
 
 using dsn::partition_configuration;
 using dsn::replication::replica_helper;

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -50,12 +50,13 @@ using dsn::replication::replica_helper;
 using dsn::replication::replication_ddl_client;
 using dsn::rpc_address;
 using nlohmann::json;
+using std::map;
 using std::string;
 using std::vector;
 
 namespace pegasus {
 
-test_util::test_util(std::map<string, string> create_envs)
+test_util::test_util(map<string, string> create_envs)
     : cluster_name_("mycluster"), app_name_("temp"), create_envs_(std::move(create_envs))
 {
 }

--- a/src/test/function_test/utils/utils.h
+++ b/src/test/function_test/utils/utils.h
@@ -206,14 +206,24 @@ inline void compare(const T &expect, const U &actual)
     }
 }
 
-inline void run_cmd(const std::string &cmd, std::string *output = nullptr)
+inline int run_cmd(const std::string &cmd, std::string *output = nullptr)
 {
     std::stringstream ss;
     int ret = dsn::utils::pipe_execute(cmd.c_str(), ss);
-    ASSERT_TRUE(ret == 0 || ret == 256) << "ret: " << ret << std::endl
-                                        << "cmd: " << cmd << std::endl
-                                        << "output: " << ss.str();
     if (output) {
         *output = dsn::utils::trim_string((char *)ss.str().c_str());
+    }
+    return ret;
+}
+
+inline void run_cmd_no_error(const std::string &cmd, std::string *output = nullptr)
+{
+    std::string tmp;
+    int ret = run_cmd(cmd, &tmp);
+    ASSERT_TRUE(ret == 0 || ret == 256) << "ret: " << ret << std::endl
+                                        << "cmd: " << cmd << std::endl
+                                        << "output: " << tmp;
+    if (output) {
+        *output = tmp;
     }
 }

--- a/src/test_util/test_util.cpp
+++ b/src/test_util/test_util.cpp
@@ -32,7 +32,7 @@
 
 namespace pegasus {
 
-void AssertEventually(const std::function<void(void)> &f, int timeout_sec, AssertBackoff backoff)
+void AssertEventually(const std::function<void(void)> &f, int timeout_sec, WaitBackoff backoff)
 {
     // TODO(yingchun): should use mono time
     uint64_t deadline = dsn_now_s() + timeout_sec;
@@ -69,10 +69,10 @@ void AssertEventually(const std::function<void(void)> &f, int timeout_sec, Asser
             // If they had failures, sleep and try again.
             int sleep_ms = 0;
             switch (backoff) {
-            case AssertBackoff::EXPONENTIAL:
+            case WaitBackoff::EXPONENTIAL:
                 sleep_ms = (attempts < 10) ? (1 << attempts) : 1000;
                 break;
-            case AssertBackoff::NONE:
+            case WaitBackoff::NONE:
                 sleep_ms = 1000;
                 break;
             default:
@@ -93,21 +93,19 @@ void AssertEventually(const std::function<void(void)> &f, int timeout_sec, Asser
     }
 }
 
-void KeepConditionForTime(const std::function<bool(void)> &f,
-                          int timeout_sec,
-                          AssertBackoff backoff)
+void WaitCondition(const std::function<bool(void)> &f, int timeout_sec, WaitBackoff backoff)
 {
     uint64_t deadline = dsn_now_s() + timeout_sec;
     for (int attempts = 0; dsn_now_s() < deadline; attempts++) {
-        if (!f()) {
+        if (f()) {
             break;
         }
         int sleep_ms = 0;
         switch (backoff) {
-        case AssertBackoff::EXPONENTIAL:
+        case WaitBackoff::EXPONENTIAL:
             sleep_ms = (attempts < 10) ? (1 << attempts) : 1000;
             break;
-        case AssertBackoff::NONE:
+        case WaitBackoff::NONE:
             sleep_ms = 1000;
             break;
         default:

--- a/src/test_util/test_util.h
+++ b/src/test_util/test_util.h
@@ -43,6 +43,12 @@ namespace pegasus {
         NO_PENDING_FATALS();                                                                       \
     } while (0)
 
+#define KEEP_COND_FOR_TIME(expr, sec)                                                              \
+    do {                                                                                           \
+        KeepConditionForTime(expr, sec);                                                           \
+        NO_PENDING_FATALS();                                                                       \
+    } while (0)
+
 // Wait until 'f()' succeeds without adding any GTest 'fatal failures'.
 // For example:
 //
@@ -66,5 +72,7 @@ enum class AssertBackoff
 void AssertEventually(const std::function<void(void)> &f,
                       int timeout_sec = 30,
                       AssertBackoff backoff = AssertBackoff::EXPONENTIAL);
-
+void KeepConditionForTime(const std::function<bool(void)> &f,
+                          int timeout_sec = 30,
+                          AssertBackoff backoff = AssertBackoff::EXPONENTIAL);
 } // namespace pegasus

--- a/src/test_util/test_util.h
+++ b/src/test_util/test_util.h
@@ -39,13 +39,13 @@ namespace pegasus {
 
 #define ASSERT_IN_TIME_WITH_FIXED_INTERVAL(expr, sec)                                              \
     do {                                                                                           \
-        AssertEventually(expr, sec, AssertBackoff::NONE);                                          \
+        AssertEventually(expr, sec, WaitBackoff::NONE);                                            \
         NO_PENDING_FATALS();                                                                       \
     } while (0)
 
-#define KEEP_COND_FOR_TIME(expr, sec)                                                              \
+#define WAIT_IN_TIME(expr, sec)                                                                    \
     do {                                                                                           \
-        KeepConditionForTime(expr, sec);                                                           \
+        WaitCondition(expr, sec);                                                                  \
         NO_PENDING_FATALS();                                                                       \
     } while (0)
 
@@ -61,7 +61,7 @@ namespace pegasus {
 // To check whether AssertEventually() eventually succeeded, call
 // NO_PENDING_FATALS() afterward, or use ASSERT_EVENTUALLY() which performs
 // this check automatically.
-enum class AssertBackoff
+enum class WaitBackoff
 {
     // Use exponential back-off while looping, capped at one second.
     EXPONENTIAL,
@@ -71,8 +71,11 @@ enum class AssertBackoff
 };
 void AssertEventually(const std::function<void(void)> &f,
                       int timeout_sec = 30,
-                      AssertBackoff backoff = AssertBackoff::EXPONENTIAL);
-void KeepConditionForTime(const std::function<bool(void)> &f,
-                          int timeout_sec = 30,
-                          AssertBackoff backoff = AssertBackoff::EXPONENTIAL);
+                      WaitBackoff backoff = WaitBackoff::EXPONENTIAL);
+
+// Wait until 'f()' succeeds or timeout, there is no GTest 'fatal failures'
+// regardless failed or timeout.
+void WaitCondition(const std::function<bool(void)> &f,
+                   int timeout_sec = 30,
+                   WaitBackoff backoff = WaitBackoff::EXPONENTIAL);
 } // namespace pegasus

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -254,6 +254,7 @@ inline const char *null_str_printer(const char *s) { return s == nullptr ? "(nul
 #define CHECK_LE_PREFIX(var1, var2) CHECK_LE_PREFIX_MSG(var1, var2, "")
 #define CHECK_GT_PREFIX(var1, var2) CHECK_GT_PREFIX_MSG(var1, var2, "")
 #define CHECK_LT_PREFIX(var1, var2) CHECK_LT_PREFIX_MSG(var1, var2, "")
+#define CHECK_OK_PREFIX(x) CHECK_EQ_PREFIX_MSG(x, ::dsn::ERR_OK, "")
 
 // Return the given status if condition is not true.
 #define LOG_AND_RETURN_NOT_TRUE(level, s, err, ...)                                                \


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1450

If replica server attempt to open an incomplete RocksDB instance (maybe caused
by a previous crash), it will crash before moving the incomplete path to ".err"
trash path, and it will crash again if restart the server.

This patch avoid to crash before moving the incomplete RocksDB path to ".err" path,
thus the replica has an opportunity to recovery automatically without move the
incomplete RocksDB path manually.