### PR TITLE
feat(util): add cancel() for class defer

### DIFF
--- a/src/utils/defer.h
+++ b/src/utils/defer.h
@@ -50,8 +50,16 @@ template <typename Func>
 struct deferred_action
 {
     explicit deferred_action(Func &&func) noexcept : _func(std::move(func)) {}
-    ~deferred_action() { _func(); }
+    void cancel() { _cancelled = true; }
+    ~deferred_action()
+    {
+        if (!_cancelled) {
+            _func();
+        }
+    }
+
 private:
+    bool _cancelled = false;
     Func _func;
 };
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/887

Add function cancel() for class defer to cancel the callback, it's useful
if using defer to short circuit failures and cancel it after all conditions
passed.

For example:
```c++
auto cleanup = dsn::defer([this]() { release_db(); });
RETURN_NOT_OK(a);
RETURN_NOT_OK(b);
RETURN_NOT_OK(c);
cleanup.cancel();
```