### PR TITLE
feat(FQDN): Implemention of struct dns_resolver

### DIFF
--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -58,9 +58,10 @@ error_s dns_resolver::resolve_addresses(const host_port &hp, std::vector<rpc_add
     {
         utils::auto_write_lock l(_lock);
         if (resolved_addresses.size() > 1) {
-            LOG_WARNING("host_port '{}' resolves to {} different addresses, using the first one {}.",
+            LOG_DEBUGING("host_port '{}' resolves to {} different addresses {}, using the first one {}.",
                         hp,
                         resolved_addresses.size(),
+                        fmt::join(resolved_addresses, ","),
                         resolved_addresses[0]);
         }
         _dsn_cache.insert(std::make_pair(hp, resolved_addresses[0]));

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -58,11 +58,12 @@ error_s dns_resolver::resolve_addresses(const host_port &hp, std::vector<rpc_add
     {
         utils::auto_write_lock l(_lock);
         if (resolved_addresses.size() > 1) {
-            LOG_DEBUGING("host_port '{}' resolves to {} different addresses {}, using the first one {}.",
-                        hp,
-                        resolved_addresses.size(),
-                        fmt::join(resolved_addresses, ","),
-                        resolved_addresses[0]);
+            LOG_DEBUG(
+                "host_port '{}' resolves to {} different addresses {}, using the first one {}.",
+                hp,
+                resolved_addresses.size(),
+                fmt::join(resolved_addresses, ","),
+                resolved_addresses[0]);
         }
         _dsn_cache.insert(std::make_pair(hp, resolved_addresses[0]));
     }

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -19,6 +19,12 @@
 
 #include "runtime/rpc/dns_resolver.h"
 
+#include <utility>
+
+#include "runtime/rpc/group_address.h"
+#include "runtime/rpc/group_host_port.h"
+#include "utils/fmt_logging.h"
+
 namespace dsn {
 
 void dns_resolver::add_item(const host_port &hp, const rpc_address &addr)

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -58,7 +58,7 @@ error_s dns_resolver::resolve_addresses(const host_port &hp, std::vector<rpc_add
     {
         utils::auto_write_lock l(_lock);
         if (resolved_addresses.size() > 1) {
-            LOG_WARNING("host_port '{}' resolves to {} different addresses, using {}.",
+            LOG_WARNING("host_port '{}' resolves to {} different addresses, using the first one {}.",
                         hp,
                         resolved_addresses.size(),
                         resolved_addresses[0]);

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -92,7 +92,7 @@ rpc_address dns_resolver::resolve_address(const host_port &hp)
         CHECK(!addresses.empty(), "host_port '{}' can not be resolved to any address", hp);
 
         if (addresses.size() > 1) {
-            LOG_WARNING("host_port '{}' resolves to {} different addresses, using {}",
+            LOG_WARNING("host_port '{}' resolves to {} different addresses, using the first one {}",
                         hp,
                         addresses.size(),
                         addresses[0]);

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-#include "runtime/rpc/dns_resolver.h"
-
 #include <utility>
 
+#include "fmt/format.h"
+#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/group_address.h"
 #include "runtime/rpc/group_host_port.h"
 #include "utils/fmt_logging.h"

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -34,7 +34,7 @@ void dns_resolver::add_item(const host_port &hp, const rpc_address &addr)
     _dsn_cache.insert(std::make_pair(hp, addr));
 }
 
-bool dns_resolver::get_cached_addresses(const host_port &hp, std::vector<rpc_address> addresses)
+bool dns_resolver::get_cached_addresses(const host_port &hp, std::vector<rpc_address> &addresses)
 {
     utils::auto_read_lock l(_lock);
     const auto &found = _dsn_cache.find(hp);
@@ -46,7 +46,7 @@ bool dns_resolver::get_cached_addresses(const host_port &hp, std::vector<rpc_add
     return true;
 }
 
-error_s dns_resolver::resolve_addresses(const host_port &hp, std::vector<rpc_address> addresses)
+error_s dns_resolver::resolve_addresses(const host_port &hp, std::vector<rpc_address> &addresses)
 {
     CHECK(addresses.empty(), "invalid addresses, not empty");
     if (get_cached_addresses(hp, addresses)) {

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -1,27 +1,20 @@
 /*
- * The MIT License (MIT)
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (c) 2015 Microsoft Corporation
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * -=- Robust Distributed System Nucleus (rDSN) -=-
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 #include "runtime/rpc/dns_resolver.h"

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <algorithm>
 #include <utility>
 
 #include "fmt/format.h"

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -1,0 +1,108 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "runtime/rpc/dns_resolver.h"
+
+namespace dsn {
+
+void dns_resolver::add_item(const host_port &hp, const rpc_address &addr)
+{
+    utils::auto_write_lock l(_lock);
+    _dsn_cache.insert(std::make_pair(hp, addr));
+}
+
+bool dns_resolver::get_cached_addresses(const host_port &hp, std::vector<rpc_address> addresses)
+{
+    utils::auto_read_lock l(_lock);
+    const auto &found = _dsn_cache.find(hp);
+    if (found == _dsn_cache.end()) {
+        return false;
+    }
+
+    addresses = {found->second};
+    return true;
+}
+
+error_s dns_resolver::resolve_addresses(const host_port &hp, std::vector<rpc_address> addresses)
+{
+    CHECK(addresses.empty(), "invalid addresses, not empty");
+    if (get_cached_addresses(hp, addresses)) {
+        return error_s::ok();
+    }
+
+    std::vector<rpc_address> resolved_addresses;
+    RETURN_NOT_OK(hp.resolve_addresses(resolved_addresses));
+
+    {
+        utils::auto_write_lock l(_lock);
+        if (resolved_addresses.size() > 1) {
+            LOG_WARNING("host_port '{}' resolves to {} different addresses, using {}.",
+                        hp,
+                        resolved_addresses.size(),
+                        resolved_addresses[0]);
+        }
+        _dsn_cache.insert(std::make_pair(hp, resolved_addresses[0]));
+    }
+
+    addresses = std::move(resolved_addresses);
+    return error_s::ok();
+}
+
+rpc_address dns_resolver::resolve_address(const host_port &hp)
+{
+    switch (hp.type()) {
+    case HOST_TYPE_GROUP: {
+        rpc_address addr;
+        auto group_address = hp.group_host_port();
+        addr.assign_group(group_address->name());
+
+        for (const auto &hp : group_address->members()) {
+            CHECK_TRUE(addr.group_address()->add(resolve_address(hp)));
+        }
+        addr.group_address()->set_update_leader_automatically(
+            group_address->is_update_leader_automatically());
+        addr.group_address()->set_leader(resolve_address(group_address->leader()));
+        return addr;
+    }
+    case HOST_TYPE_IPV4: {
+        std::vector<rpc_address> addresses;
+        CHECK_OK(resolve_addresses(hp, addresses), "host_port '{}' can not be resolved", hp);
+        CHECK(!addresses.empty(), "host_port '{}' can not be resolved to any address", hp);
+
+        if (addresses.size() > 1) {
+            LOG_WARNING("host_port '{}' resolves to {} different addresses, using {}",
+                        hp,
+                        addresses.size(),
+                        addresses[0]);
+        }
+        return addresses[0];
+    }
+    default:
+        return rpc_address();
+    }
+}
+
+} // namespace dsn

--- a/src/runtime/rpc/dns_resolver.h
+++ b/src/runtime/rpc/dns_resolver.h
@@ -1,27 +1,20 @@
 /*
- * The MIT License (MIT)
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (c) 2015 Microsoft Corporation
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * -=- Robust Distributed System Nucleus (rDSN) -=-
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 #pragma once

--- a/src/runtime/rpc/dns_resolver.h
+++ b/src/runtime/rpc/dns_resolver.h
@@ -37,7 +37,7 @@ public:
 
     void add_item(const host_port &hp, const rpc_address &addr);
 
-    // Transfer host_port to unique rpc_address.
+    // Resolve this host_port to an unique rpc_address.
     rpc_address resolve_address(const host_port &hp);
 
 private:

--- a/src/runtime/rpc/dns_resolver.h
+++ b/src/runtime/rpc/dns_resolver.h
@@ -19,11 +19,9 @@
 
 #pragma once
 
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
-#include "runtime/rpc/group_address.h"
-#include "runtime/rpc/group_host_port.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/errors.h"

--- a/src/runtime/rpc/dns_resolver.h
+++ b/src/runtime/rpc/dns_resolver.h
@@ -29,7 +29,7 @@
 
 namespace dsn {
 
-// This class provider way transfer host_port to rpc_address.
+// This class provide a way to resolve host_port to rpc_address.
 class dns_resolver
 {
 public:

--- a/src/runtime/rpc/dns_resolver.h
+++ b/src/runtime/rpc/dns_resolver.h
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <vector>
+#include <unordered_map>
+
+#include "runtime/rpc/group_address.h"
+#include "runtime/rpc/group_host_port.h"
+#include "runtime/rpc/rpc_address.h"
+#include "runtime/rpc/rpc_host_port.h"
+#include "utils/errors.h"
+#include "utils/synchronize.h"
+
+namespace dsn {
+
+class dns_resolver
+{
+public:
+    explicit dns_resolver() = default;
+
+    void add_item(const host_port &hp, const rpc_address &addr);
+
+    rpc_address resolve_address(const host_port &hp);
+
+private:
+    bool get_cached_addresses(const host_port &hp, std::vector<rpc_address> &addresses);
+
+    error_s resolve_addresses(const host_port &hp, std::vector<rpc_address> &addresses);
+
+    error_s do_resolution(const host_port &hp, std::vector<rpc_address> &addresses);
+
+    mutable utils::rw_lock_nr _lock;
+    std::unordered_map<host_port, rpc_address> _dsn_cache;
+};
+
+} // namespace dsn

--- a/src/runtime/rpc/dns_resolver.h
+++ b/src/runtime/rpc/dns_resolver.h
@@ -31,6 +31,7 @@
 
 namespace dsn {
 
+// This class provider way transfer host_port to rpc_address.
 class dns_resolver
 {
 public:
@@ -38,6 +39,7 @@ public:
 
     void add_item(const host_port &hp, const rpc_address &addr);
 
+    // Transfer host_port to unique rpc_address.
     rpc_address resolve_address(const host_port &hp);
 
 private:

--- a/src/runtime/rpc/rpc_address.cpp
+++ b/src/runtime/rpc/rpc_address.cpp
@@ -240,4 +240,13 @@ const char *rpc_address::to_string() const
 
     return (const char *)p;
 }
+
+rpc_address::rpc_address(const struct sockaddr_in &addr)
+{
+    set_invalid();
+    _addr.v4.type = HOST_TYPE_IPV4;
+    _addr.v4.ip = static_cast<uint32_t>(ntohl(addr.sin_addr.s_addr));
+    _addr.v4.port = ntohs(addr.sin_port);
+}
+
 } // namespace dsn

--- a/src/runtime/rpc/rpc_address.h
+++ b/src/runtime/rpc/rpc_address.h
@@ -32,6 +32,8 @@
 #include <sstream>
 #include <string>
 
+#include <arpa/inet.h>
+
 namespace apache {
 namespace thrift {
 namespace protocol {
@@ -77,6 +79,8 @@ public:
     }
 
     rpc_address(const char *host, uint16_t port) { assign_ipv4(host, port); }
+
+    explicit rpc_address(const struct sockaddr_in &addr);
 
     void assign_ipv4(uint32_t ip, uint16_t port)
     {

--- a/src/runtime/rpc/rpc_address.h
+++ b/src/runtime/rpc/rpc_address.h
@@ -26,13 +26,13 @@
 
 #pragma once
 
+#include <arpa/inet.h> // IWYU pragma: keep
+
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <sstream>
 #include <string>
-
-#include <arpa/inet.h>
 
 namespace apache {
 namespace thrift {

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -17,15 +17,19 @@
  * under the License.
  */
 
-#include <netinet/in.h>
+#include <errno.h>
 #include <netdb.h>
+#include <netinet/in.h>
+#include <string.h>
 #include <sys/socket.h>
+#include <memory>
 #include <unordered_set>
 #include <utility>
 
 #include "fmt/core.h"
 #include "runtime/rpc/group_host_port.h"
 #include "runtime/rpc/rpc_host_port.h"
+#include "utils/error_code.h"
 #include "utils/safe_strerror_posix.h"
 #include "utils/utils.h"
 

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -188,6 +188,11 @@ error_s host_port::resolve_addresses(std::vector<rpc_address> &addresses) const
             result_addresses.emplace_back(rpc_addr);
         }
     }
+    
+    if (result_addresses.empty()) {
+        return error_s::make(dsn::ERR_NETWORK_FAILURE, fmt::format("can not resolve host_port {}.", to_string()));
+    }
+
     addresses = std::move(result_addresses);
     return error_s::ok();
 }

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -188,9 +188,10 @@ error_s host_port::resolve_addresses(std::vector<rpc_address> &addresses) const
             result_addresses.emplace_back(rpc_addr);
         }
     }
-    
+
     if (result_addresses.empty()) {
-        return error_s::make(dsn::ERR_NETWORK_FAILURE, fmt::format("can not resolve host_port {}.", to_string()));
+        return error_s::make(dsn::ERR_NETWORK_FAILURE,
+                             fmt::format("can not resolve host_port {}.", to_string()));
     }
 
     addresses = std::move(result_addresses);

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -145,11 +145,18 @@ void host_port::assign_group(const char *name)
 error_s host_port::resolve_addresses(std::vector<rpc_address> &addresses) const
 {
     CHECK(addresses.empty(), "");
-    if (type() != HOST_TYPE_IPV4) {
-        return error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type");
+
+    switch (type()) {
+    case HOST_TYPE_INVALID:
+        return error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type: HOST_TYPE_INVALID");
+    case HOST_TYPE_GROUP:
+        return error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type: HOST_TYPE_GROUP");
+    case HOST_TYPE_IPV4:
+        break;
     }
 
     rpc_address rpc_addr;
+    // Transfer hostname like "local" & "192.168.0.1".
     if (rpc_addr.from_string_ipv4(this->to_string().c_str())) {
         addresses.emplace_back(rpc_addr);
         return error_s::ok();

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -146,7 +146,7 @@ error_s host_port::resolve_addresses(std::vector<rpc_address> &addresses) const
 {
     CHECK(addresses.empty(), "invalid addresses, not empty");
     if (type() != HOST_TYPE_IPV4) {
-        return std::move(error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type"));
+        return error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type");
     }
 
     rpc_address rpc_addr;

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -144,7 +144,7 @@ void host_port::assign_group(const char *name)
 
 error_s host_port::resolve_addresses(std::vector<rpc_address> &addresses) const
 {
-    CHECK(addresses.empty(), "invalid addresses, not empty");
+    CHECK(addresses.empty(), "");
     if (type() != HOST_TYPE_IPV4) {
         return error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type");
     }

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -160,7 +160,7 @@ error_s host_port::resolve_addresses(std::vector<rpc_address> &addresses) const
     }
 
     rpc_address rpc_addr;
-    // Transfer hostname like "local" & "192.168.0.1".
+    // Resolve hostname like "localhost:80" or "192.168.0.1:8080".
     if (rpc_addr.from_string_ipv4(this->to_string().c_str())) {
         addresses.emplace_back(rpc_addr);
         return error_s::ok();

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -29,7 +29,6 @@
 #include "utils/safe_strerror_posix.h"
 #include "utils/utils.h"
 
-
 namespace dsn {
 
 const host_port host_port::s_invalid_host_port;

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -71,7 +71,7 @@ public:
     void assign_group(const char *name);
 
     // Transfer host_port to rpc_addresses.
-    // Trere could be multi rpc_address for one host_port.
+    // Trere may be multiple rpc_addresses for one host_port.
     error_s resolve_addresses(std::vector<rpc_address> &addresses) const;
 
 private:

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -69,6 +69,8 @@ public:
     }
     void assign_group(const char *name);
 
+    // Transfer host_port to rpc_addresses.
+    // Trere could be multi rpc_address for one host_port.
     error_s resolve_addresses(std::vector<rpc_address> &addresses) const;
 
 private:

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -70,7 +70,7 @@ public:
     }
     void assign_group(const char *name);
 
-    // Transfer host_port to rpc_addresses.
+    // Resolve host_port to rpc_addresses.
     // Trere may be multiple rpc_addresses for one host_port.
     error_s resolve_addresses(std::vector<rpc_address> &addresses) const;
 

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -68,6 +68,8 @@ public:
     }
     void assign_group(const char *name);
 
+    error_s resolve_addresses(std::vector<rpc_address> &addresses) const;
+
 private:
     std::string _host;
     uint16_t _port = 0;

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -25,6 +25,7 @@
 #include <functional>
 #include <iosfwd>
 #include <string>
+#include <vector>
 
 #include "runtime/rpc/rpc_address.h"
 #include "utils/autoref_ptr.h"

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -28,6 +28,7 @@
 
 #include "runtime/rpc/rpc_address.h"
 #include "utils/autoref_ptr.h"
+#include "utils/errors.h"
 #include "utils/fmt_logging.h"
 
 namespace dsn {

--- a/src/runtime/test/host_port_test.cpp
+++ b/src/runtime/test/host_port_test.cpp
@@ -20,14 +20,17 @@
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
-#include <string>
 #include <string.h>
+#include <string>
 #include <vector>
 
 #include "runtime/rpc/dns_resolver.h"
+#include "runtime/rpc/group_address.h"
 #include "runtime/rpc/group_host_port.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
+#include "utils/error_code.h"
+#include "utils/errors.h"
 
 namespace dsn {
 

--- a/src/runtime/test/host_port_test.cpp
+++ b/src/runtime/test/host_port_test.cpp
@@ -187,12 +187,14 @@ TEST(host_port_test, dns_resolver)
         host_port hp2("localhost", 8081);
         g->set_leader(hp2);
 
-        auto addr_grp  = resolver.resolve_address(hp_grp);
+        auto addr_grp = resolver.resolve_address(hp_grp);
 
-        ASSERT_EQ(addr_grp.group_address()->is_update_leader_automatically(), hp_grp.group_host_port()->is_update_leader_automatically());
+        ASSERT_EQ(addr_grp.group_address()->is_update_leader_automatically(),
+                  hp_grp.group_host_port()->is_update_leader_automatically());
         ASSERT_EQ(strcmp(addr_grp.group_address()->name(), hp_grp.group_host_port()->name()), 0);
         ASSERT_EQ(addr_grp.group_address()->count(), hp_grp.group_host_port()->count());
-        ASSERT_EQ(host_port(addr_grp.group_address()->leader()), hp_grp.group_host_port()->leader());
+        ASSERT_EQ(host_port(addr_grp.group_address()->leader()),
+                  hp_grp.group_host_port()->leader());
     }
 }
 

--- a/src/runtime/test/host_port_test.cpp
+++ b/src/runtime/test/host_port_test.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 #include <string>
+#include <string.h>
 #include <vector>
 
 #include "runtime/rpc/dns_resolver.h"
@@ -168,12 +169,12 @@ TEST(host_port_test, transfer_rpc_address)
 
 TEST(host_port_test, dns_resolver)
 {
-    std::unique_ptr<dns_resolver> resolver = new dns_resolver();
+    dns_resolver resolver;
     {
         host_port hp("localhost", 8080);
         auto addr = resolver.resolve_address(hp);
-        ASSERT_TRUE(rpc_address("127.0.0.1", 8080) == hp ||
-                    rpc_address("127.0.1.1", 8080) == hp);
+        ASSERT_TRUE(rpc_address("127.0.0.1", 8080) == addr ||
+                    rpc_address("127.0.1.1", 8080) == addr);
     }
 
     {
@@ -188,11 +189,10 @@ TEST(host_port_test, dns_resolver)
 
         auto addr_grp  = resolver.resolve_address(hp_grp);
 
-        ASSERT_EQ(addr_grp.name(), hp_grp.name());
-        ASSERT_EQ(addr_grp.is_update_leader_automatically(), hp_grp.is_update_leader_automatically());
-        ASSERT_EQ(addr_grp.name(), hp_grp.name());
-        ASSERT_EQ(addr_grp.count(), hp_grp.count());
-        ASSERT_EQ(host_port(addr_grp.leader()), hp_grp.leader());
+        ASSERT_EQ(addr_grp.group_address()->is_update_leader_automatically(), hp_grp.group_host_port()->is_update_leader_automatically());
+        ASSERT_EQ(strcmp(addr_grp.group_address()->name(), hp_grp.group_host_port()->name()), 0);
+        ASSERT_EQ(addr_grp.group_address()->count(), hp_grp.group_host_port()->count());
+        ASSERT_EQ(host_port(addr_grp.group_address()->leader()), hp_grp.group_host_port()->leader());
     }
 }
 

--- a/src/runtime/test/host_port_test.cpp
+++ b/src/runtime/test/host_port_test.cpp
@@ -161,12 +161,13 @@ TEST(host_port_test, transfer_rpc_address)
         std::vector<rpc_address> addresses;
         host_port hp;
         hp.resolve_addresses(addresses);
-        ASSERT_EQ(hp.resolve_addresses(addresses),
-                  error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type"));
+        ASSERT_EQ(
+            hp.resolve_addresses(addresses),
+            error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type: HOST_TYPE_INVALID"));
 
         hp.assign_group("test_group");
         ASSERT_EQ(hp.resolve_addresses(addresses),
-                  error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type"));
+                  error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type: HOST_TYPE_GROUP"));
     }
 }
 


### PR DESCRIPTION
issue: https://github.com/apache/incubator-pegasus/issues/1404

Implement of struct `dns_resolver ` in order to transfer 'host_port' to 'rpc_address'.
`rpc_address` is used to rpc communication.