### PR TITLE
feat(java-client): add listApps interface

### DIFF
--- a/java-client/src/main/java/org/apache/pegasus/client/ListAppInfoType.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/ListAppInfoType.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pegasus.client;
+
+public enum ListAppInfoType {
+  LT_ONLY_GET_AVAILABLE_APPS(0),
+  LT_GET_ALL_APPS(1);
+
+  private final int value;
+
+  private ListAppInfoType(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+}

--- a/java-client/src/main/java/org/apache/pegasus/client/ListAppInfoType.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/ListAppInfoType.java
@@ -19,8 +19,8 @@
 package org.apache.pegasus.client;
 
 public enum ListAppInfoType {
-  LT_ONLY_GET_AVAILABLE_APPS(0),
-  LT_GET_ALL_APPS(1);
+  LT_AVAILABLE_APPS(0),
+  LT_ALL_APPS(1);
 
   private final int value;
 

--- a/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClient.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClient.java
@@ -234,17 +234,10 @@ public class PegasusAdminClient extends PegasusAbstractClient
   }
 
   @Override
-  public void listApps(ListAppInfoType listAppInfoType, List<app_info> appInfoList)
-      throws PException {
-    if (!appInfoList.isEmpty()) {
-      throw new PException(
-          new IllegalArgumentException(
-              String.format("listApps failed: output parameters 'appInfoList' is not empty.")));
-    }
-
+  public List<app_info> listApps(ListAppInfoType listAppInfoType) throws PException {
     configuration_list_apps_request request = new configuration_list_apps_request();
     request.setStatus(app_status.AS_AVAILABLE);
-    if (listAppInfoType = ListAppInfoType.GETALLAPPINFOS) {
+    if (listAppInfoType == ListAppInfoType.LT_GET_ALL_APPS) {
       request.setStatus(app_status.AS_INVALID);
     }
 
@@ -258,6 +251,7 @@ public class PegasusAdminClient extends PegasusAbstractClient
               request.getStatus(), error.toString()));
     }
 
-    appInfoList = response.infos;
+    configuration_list_apps_response response = app_operator.get_response();
+    return response.infos;
   }
 }

--- a/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClient.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClient.java
@@ -238,7 +238,7 @@ public class PegasusAdminClient extends PegasusAbstractClient
     if (!appInfoList.isEmpty()) {
       throw new PException(
           new IllegalArgumentException(
-              String.format("listApps failed: output parameters 'appList' not empty.")));
+              String.format("listApps failed: output parameters 'appInfoList' not empty.")));
     }
 
     configuration_list_apps_request request = new configuration_list_apps_request();

--- a/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClient.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClient.java
@@ -234,16 +234,17 @@ public class PegasusAdminClient extends PegasusAbstractClient
   }
 
   @Override
-  public void listApps(boolean onlyGetAvailableApps, List<app_info> appInfoList) throws PException {
+  public void listApps(ListAppInfoType listAppInfoType, List<app_info> appInfoList)
+      throws PException {
     if (!appInfoList.isEmpty()) {
       throw new PException(
           new IllegalArgumentException(
-              String.format("listApps failed: output parameters 'appInfoList' not empty.")));
+              String.format("listApps failed: output parameters 'appInfoList' is not empty.")));
     }
 
     configuration_list_apps_request request = new configuration_list_apps_request();
     request.setStatus(app_status.AS_AVAILABLE);
-    if (!onlyGetAvailableApps) {
+    if (listAppInfoType = ListAppInfoType.GETALLAPPINFOS) {
       request.setStatus(app_status.AS_INVALID);
     }
 
@@ -257,9 +258,6 @@ public class PegasusAdminClient extends PegasusAbstractClient
               request.getStatus(), error.toString()));
     }
 
-    configuration_list_apps_response response = app_operator.get_response();
-    for (int i = 0; i < response.infos.size(); i++) {
-      appInfoList.add(response.infos.get(i));
-    }
+    appInfoList = response.infos;
   }
 }

--- a/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClient.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClient.java
@@ -236,9 +236,16 @@ public class PegasusAdminClient extends PegasusAbstractClient
   @Override
   public List<app_info> listApps(ListAppInfoType listAppInfoType) throws PException {
     configuration_list_apps_request request = new configuration_list_apps_request();
-    request.setStatus(app_status.AS_AVAILABLE);
-    if (listAppInfoType == ListAppInfoType.LT_GET_ALL_APPS) {
+    if (listAppInfoType == ListAppInfoType.LT_AVAILABLE_APPS) {
+      // if set request.setStatus as 'AS_AVAILABLE', It will return 'app_info' of all available
+      // tables
+      request.setStatus(app_status.AS_AVAILABLE);
+    } else if (listAppInfoType == ListAppInfoType.LT_ALL_APPS) {
+      // if set request.setStatus as 'AS_INVALID', It will return app_info of all tables, including
+      // dropped but currently reserved tables
       request.setStatus(app_status.AS_INVALID);
+    } else {
+      throw new PException(String.format("List apps failed, unknown ListAppInfoType."));
     }
 
     list_apps_operator app_operator = new list_apps_operator(request);
@@ -247,7 +254,7 @@ public class PegasusAdminClient extends PegasusAbstractClient
     if (error != error_code.error_types.ERR_OK) {
       throw new PException(
           String.format(
-              "List apps failed, query status:%s, error:%s.",
+              "List apps failed, query status: %s, error: %s.",
               request.getStatus(), error.toString()));
     }
 

--- a/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClientInterface.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClientInterface.java
@@ -74,12 +74,11 @@ public interface PegasusAdminClientInterface extends Closeable {
   public void dropApp(String appName, int reserveSeconds) throws PException;
 
   /**
-   * Get all app names of the pegasus cluster
+   * Get app infos in the Pegasus cluster
    *
-   * @param onlyGetAvailableApps Whether to return all available tables, true means to return only
-   *     available tables, false means to return all tables, including dropped but currently
-   *     reserved tables
-   * @param appInfoList List of all 'app_info' in the pegasus cluster
+   * @param listAppInfoType 'LT_AVAILABLE_APPS' means to return only available tables, 'LT_ALL_APPS'
+   *     means to return all tables, including dropped but currently reserved tables
+   * @return List of 'app_info' in the Pegasus cluster
    * @throws PException
    */
   public List<app_info> listApps(ListAppInfoType listAppInfoType) throws PException;

--- a/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClientInterface.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClientInterface.java
@@ -19,10 +19,10 @@
 
 package org.apache.pegasus.client;
 
-import org.apache.pegasus.replication.app_info;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
+import org.apache.pegasus.replication.app_info;
 
 public interface PegasusAdminClientInterface extends Closeable {
   /**

--- a/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClientInterface.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClientInterface.java
@@ -24,6 +24,11 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pegasus.replication.app_info;
 
+public enum ListAppInfoType {
+  GETALLAPPINFOS,
+  ONLYGETAVAILABLEAPPS;
+}
+
 public interface PegasusAdminClientInterface extends Closeable {
   /**
    * Create A new pegasus app which is not stateless However the successful execution of the
@@ -77,11 +82,13 @@ public interface PegasusAdminClientInterface extends Closeable {
    * Get all app names of the pegasus cluster
    *
    * @param onlyGetAvailableApps Whether to return all available tables, true means to return only
-   *     available tables, false means to return all tables, including dropped tables
-   * @param appInfoList List of all table names in the pegasus cluster
+   *     available tables, false means to return all tables, including dropped but currently
+   *     reserved tables
+   * @param appInfoList List of all 'app_info' in the pegasus cluster
    * @throws PException
    */
-  public void listApps(boolean onlyGetAvailableApps, List<app_info> appInfoList) throws PException;
+  public void listApps(ListAppInfoType listAppInfoType, List<app_info> appInfoList)
+      throws PException;
 
   /** close the client */
   @Override

--- a/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClientInterface.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClientInterface.java
@@ -24,11 +24,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pegasus.replication.app_info;
 
-public enum ListAppInfoType {
-  GETALLAPPINFOS,
-  ONLYGETAVAILABLEAPPS;
-}
-
 public interface PegasusAdminClientInterface extends Closeable {
   /**
    * Create A new pegasus app which is not stateless However the successful execution of the
@@ -87,8 +82,7 @@ public interface PegasusAdminClientInterface extends Closeable {
    * @param appInfoList List of all 'app_info' in the pegasus cluster
    * @throws PException
    */
-  public void listApps(ListAppInfoType listAppInfoType, List<app_info> appInfoList)
-      throws PException;
+  public List<app_info> listApps(ListAppInfoType listAppInfoType) throws PException;
 
   /** close the client */
   @Override

--- a/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClientInterface.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/PegasusAdminClientInterface.java
@@ -19,7 +19,9 @@
 
 package org.apache.pegasus.client;
 
+import org.apache.pegasus.replication.app_info;
 import java.io.Closeable;
+import java.util.List;
 import java.util.Map;
 
 public interface PegasusAdminClientInterface extends Closeable {
@@ -70,6 +72,16 @@ public interface PegasusAdminClientInterface extends Closeable {
   public boolean isAppHealthy(String appName, int replicaCount) throws PException;
 
   public void dropApp(String appName, int reserveSeconds) throws PException;
+
+  /**
+   * Get all app names of the pegasus cluster
+   *
+   * @param onlyGetAvailableApps Whether to return all available tables, true means to return only
+   *     available tables, false means to return all tables, including dropped tables
+   * @param appInfoList List of all table names in the pegasus cluster
+   * @throws PException
+   */
+  public void listApps(boolean onlyGetAvailableApps, List<app_info> appInfoList) throws PException;
 
   /** close the client */
   @Override

--- a/java-client/src/main/java/org/apache/pegasus/operator/list_apps_operator.java
+++ b/java-client/src/main/java/org/apache/pegasus/operator/list_apps_operator.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pegasus.operator;
 
-import org.apache.pegasus.apps.meta.list_apps_args;
-import org.apache.pegasus.apps.meta.list_apps_result;
 import org.apache.pegasus.base.gpid;
+import org.apache.pegasus.replication.admin_client.list_apps_args;
+import org.apache.pegasus.replication.admin_client.list_apps_result;
 import org.apache.pegasus.replication.configuration_list_apps_request;
 import org.apache.pegasus.replication.configuration_list_apps_response;
 import org.apache.thrift.TException;
@@ -43,14 +43,14 @@ public class list_apps_operator extends client_operator {
   public void send_data(TProtocol oprot, int sequence_id) throws TException {
     TMessage msg = new TMessage("RPC_CM_LIST_APPS", TMessageType.CALL, sequence_id);
     oprot.writeMessageBegin(msg);
-    org.apache.pegasus.apps.meta.list_apps_args args = new list_apps_args(request);
+    org.apache.pegasus.replication.admin_client.list_apps_args args = new list_apps_args(request);
     args.write(oprot);
     oprot.writeMessageEnd();
   }
 
   @Override
   public void recv_data(TProtocol iprot) throws TException {
-    org.apache.pegasus.apps.meta.list_apps_result result = new list_apps_result();
+    org.apache.pegasus.replication.admin_client.list_apps_result result = new list_apps_result();
     result.read(iprot);
     if (result.isSetSuccess()) response = result.success;
     else

--- a/java-client/src/main/java/org/apache/pegasus/operator/list_apps_operator.java
+++ b/java-client/src/main/java/org/apache/pegasus/operator/list_apps_operator.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
- package org.apache.pegasus.operator;
+package org.apache.pegasus.operator;
 
 import org.apache.pegasus.apps.meta.list_apps_args;
 import org.apache.pegasus.apps.meta.list_apps_result;

--- a/java-client/src/main/java/org/apache/pegasus/operator/list_apps_operator.java
+++ b/java-client/src/main/java/org/apache/pegasus/operator/list_apps_operator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ package org.apache.pegasus.operator;
+
+import org.apache.pegasus.apps.meta.list_apps_args;
+import org.apache.pegasus.apps.meta.list_apps_result;
+import org.apache.pegasus.base.gpid;
+import org.apache.pegasus.replication.configuration_list_apps_request;
+import org.apache.pegasus.replication.configuration_list_apps_response;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TMessage;
+import org.apache.thrift.protocol.TMessageType;
+import org.apache.thrift.protocol.TProtocol;
+
+public class list_apps_operator extends client_operator {
+  public list_apps_operator(configuration_list_apps_request request) {
+    super(new gpid(), "", 0);
+    this.request = request;
+  }
+
+  @Override
+  public String name() {
+    return "list_apps_operator";
+  }
+
+  @Override
+  public void send_data(TProtocol oprot, int sequence_id) throws TException {
+    TMessage msg = new TMessage("RPC_CM_LIST_APPS", TMessageType.CALL, sequence_id);
+    oprot.writeMessageBegin(msg);
+    org.apache.pegasus.apps.meta.list_apps_args args = new list_apps_args(request);
+    args.write(oprot);
+    oprot.writeMessageEnd();
+  }
+
+  @Override
+  public void recv_data(TProtocol iprot) throws TException {
+    org.apache.pegasus.apps.meta.list_apps_result result = new list_apps_result();
+    result.read(iprot);
+    if (result.isSetSuccess()) response = result.success;
+    else
+      throw new org.apache.thrift.TApplicationException(
+          org.apache.thrift.TApplicationException.MISSING_RESULT,
+          "list apps failed: unknown result");
+  }
+
+  public configuration_list_apps_response get_response() {
+    return response;
+  }
+
+  private configuration_list_apps_request request;
+  private configuration_list_apps_response response;
+}

--- a/java-client/src/main/java/org/apache/pegasus/operator/list_apps_operator.java
+++ b/java-client/src/main/java/org/apache/pegasus/operator/list_apps_operator.java
@@ -43,14 +43,14 @@ public class list_apps_operator extends client_operator {
   public void send_data(TProtocol oprot, int sequence_id) throws TException {
     TMessage msg = new TMessage("RPC_CM_LIST_APPS", TMessageType.CALL, sequence_id);
     oprot.writeMessageBegin(msg);
-    org.apache.pegasus.replication.admin_client.list_apps_args args = new list_apps_args(request);
+    list_apps_args args = new list_apps_args(request);
     args.write(oprot);
     oprot.writeMessageEnd();
   }
 
   @Override
   public void recv_data(TProtocol iprot) throws TException {
-    org.apache.pegasus.replication.admin_client.list_apps_result result = new list_apps_result();
+    list_apps_result result = new list_apps_result();
     result.read(iprot);
     if (result.isSetSuccess()) response = result.success;
     else

--- a/java-client/src/main/java/org/apache/pegasus/rpc/async/MetaSession.java
+++ b/java-client/src/main/java/org/apache/pegasus/rpc/async/MetaSession.java
@@ -89,7 +89,7 @@ public class MetaSession extends HostNameResolver {
       return ((drop_app_operator) (metaQueryOp)).get_response().getErr().errno;
     } else if (metaQueryOp instanceof list_apps_operator) {
       return ((list_apps_operator) (metaQueryOp)).get_response().getErr().errno;
-    else {
+    } else {
       assert (false);
       return null;
     }

--- a/java-client/src/main/java/org/apache/pegasus/rpc/async/MetaSession.java
+++ b/java-client/src/main/java/org/apache/pegasus/rpc/async/MetaSession.java
@@ -35,6 +35,7 @@ import org.apache.pegasus.base.rpc_address;
 import org.apache.pegasus.operator.client_operator;
 import org.apache.pegasus.operator.create_app_operator;
 import org.apache.pegasus.operator.drop_app_operator;
+import org.apache.pegasus.operator.list_apps_operator;
 import org.apache.pegasus.operator.query_cfg_operator;
 import org.apache.pegasus.replication.partition_configuration;
 

--- a/java-client/src/main/java/org/apache/pegasus/rpc/async/MetaSession.java
+++ b/java-client/src/main/java/org/apache/pegasus/rpc/async/MetaSession.java
@@ -87,7 +87,9 @@ public class MetaSession extends HostNameResolver {
       return ((create_app_operator) (metaQueryOp)).get_response().getErr().errno;
     } else if (metaQueryOp instanceof drop_app_operator) {
       return ((drop_app_operator) (metaQueryOp)).get_response().getErr().errno;
-    } else {
+    } else if (metaQueryOp instanceof list_apps_operator) {
+      return ((list_apps_operator) (metaQueryOp)).get_response().getErr().errno;
+    else {
       assert (false);
       return null;
     }

--- a/java-client/src/test/java/org/apache/pegasus/client/TestAdminClient.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestAdminClient.java
@@ -22,7 +22,6 @@ package org.apache.pegasus.client;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -141,8 +140,7 @@ public class TestAdminClient {
   @Test
   public void testListApps() throws PException {
     String appName = "testListApps" + System.currentTimeMillis();
-    List<app_info> appInfoList = new ArrayList<>();
-    toolsClient.listApps(ListAppInfoType.ONLYGETAVAILABLEAPPS, appInfoList);
+    List<app_info> appInfoList = toolsClient.listApps(ListAppInfoType.LT_ONLY_GET_AVAILABLE_APPS);
     int size1 = appInfoList.size();
     toolsClient.createApp(
         appName,
@@ -154,17 +152,17 @@ public class TestAdminClient {
     Assert.assertTrue(isAppHealthy);
 
     appInfoList.clear();
-    toolsClient.listApps(ListAppInfoType.ONLYGETAVAILABLEAPPS, appInfoList);
+    appInfoList = toolsClient.listApps(ListAppInfoType.LT_ONLY_GET_AVAILABLE_APPS);
     Assert.assertEquals(size1 + 1, appInfoList.size());
     appInfoList.clear();
-    toolsClient.listApps(ListAppInfoType.GETALLAPPINFOS, appInfoList);
+    appInfoList = toolsClient.listApps(ListAppInfoType.LT_GET_ALL_APPS);
     int size2 = appInfoList.size();
     toolsClient.dropApp(appName, this.tableOpTimeoutMs);
     appInfoList.clear();
-    toolsClient.listApps(ListAppInfoType.ONLYGETAVAILABLEAPPS, appInfoList);
+    appInfoList = toolsClient.listApps(ListAppInfoType.LT_ONLY_GET_AVAILABLE_APPS);
     Assert.assertEquals(size1, appInfoList.size());
     appInfoList.clear();
-    toolsClient.listApps(ListAppInfoType.GETALLAPPINFOS, appInfoList);
+    appInfoList = toolsClient.listApps(ListAppInfoType.LT_GET_ALL_APPS);
     Assert.assertEquals(size2, appInfoList.size());
   }
 }

--- a/java-client/src/test/java/org/apache/pegasus/client/TestAdminClient.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestAdminClient.java
@@ -140,7 +140,7 @@ public class TestAdminClient {
   @Test
   public void testListApps() throws PException {
     String appName = "testListApps" + System.currentTimeMillis();
-    List<app_info> appInfoList = toolsClient.listApps(ListAppInfoType.LT_ONLY_GET_AVAILABLE_APPS);
+    List<app_info> appInfoList = toolsClient.listApps(ListAppInfoType.LT_AVAILABLE_APPS);
     int size1 = appInfoList.size();
     toolsClient.createApp(
         appName,
@@ -152,17 +152,17 @@ public class TestAdminClient {
     Assert.assertTrue(isAppHealthy);
 
     appInfoList.clear();
-    appInfoList = toolsClient.listApps(ListAppInfoType.LT_ONLY_GET_AVAILABLE_APPS);
+    appInfoList = toolsClient.listApps(ListAppInfoType.LT_AVAILABLE_APPS);
     Assert.assertEquals(size1 + 1, appInfoList.size());
     appInfoList.clear();
-    appInfoList = toolsClient.listApps(ListAppInfoType.LT_GET_ALL_APPS);
+    appInfoList = toolsClient.listApps(ListAppInfoType.LT_ALL_APPS);
     int size2 = appInfoList.size();
     toolsClient.dropApp(appName, this.tableOpTimeoutMs);
     appInfoList.clear();
-    appInfoList = toolsClient.listApps(ListAppInfoType.LT_ONLY_GET_AVAILABLE_APPS);
+    appInfoList = toolsClient.listApps(ListAppInfoType.LT_AVAILABLE_APPS);
     Assert.assertEquals(size1, appInfoList.size());
     appInfoList.clear();
-    appInfoList = toolsClient.listApps(ListAppInfoType.LT_GET_ALL_APPS);
+    appInfoList = toolsClient.listApps(ListAppInfoType.LT_ALL_APPS);
     Assert.assertEquals(size2, appInfoList.size());
   }
 }

--- a/java-client/src/test/java/org/apache/pegasus/client/TestAdminClient.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestAdminClient.java
@@ -160,7 +160,7 @@ public class TestAdminClient {
     appInfoList.clear();
     toolsClient.listApps(false, appInfoList);
     int size2 = appInfoList.size();
-    toolsClient.dropApp(appName);
+    toolsClient.dropApp(appName, this.tableOpTimeoutMs);
     appInfoList.clear();
     toolsClient.listApps(true, appInfoList);
     Assert.assertTrue(appInfoList.size() == size1);

--- a/java-client/src/test/java/org/apache/pegasus/client/TestAdminClient.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestAdminClient.java
@@ -142,7 +142,7 @@ public class TestAdminClient {
   public void testListApps() throws PException {
     String appName = "testListApps" + System.currentTimeMillis();
     List<app_info> appInfoList = new ArrayList<>();
-    toolsClient.listApps(true, appInfoList);
+    toolsClient.listApps(ListAppInfoType.ONLYGETAVAILABLEAPPS, appInfoList);
     int size1 = appInfoList.size();
     toolsClient.createApp(
         appName,
@@ -154,18 +154,17 @@ public class TestAdminClient {
     Assert.assertTrue(isAppHealthy);
 
     appInfoList.clear();
-    toolsClient.listApps(true, appInfoList);
-    Assert.assertTrue(appInfoList.size() == size1 + 1);
-
+    toolsClient.listApps(ListAppInfoType.ONLYGETAVAILABLEAPPS, appInfoList);
+    Assert.assertEquals(size1 + 1, appInfoList.size());
     appInfoList.clear();
-    toolsClient.listApps(false, appInfoList);
+    toolsClient.listApps(ListAppInfoType.GETALLAPPINFOS, appInfoList);
     int size2 = appInfoList.size();
     toolsClient.dropApp(appName, this.tableOpTimeoutMs);
     appInfoList.clear();
-    toolsClient.listApps(true, appInfoList);
-    Assert.assertTrue(appInfoList.size() == size1);
+    toolsClient.listApps(ListAppInfoType.ONLYGETAVAILABLEAPPS, appInfoList);
+    Assert.assertEquals(size1, appInfoList.size());
     appInfoList.clear();
-    toolsClient.listApps(false, appInfoList);
-    Assert.assertTrue(appInfoList.size() == size2);
+    toolsClient.listApps(ListAppInfoType.GETALLAPPINFOS, appInfoList);
+    Assert.assertEquals(size2, appInfoList.size());
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1470

### What is changed and how does it work?
add new interface `public List<app_info> listApps(ListAppInfoType listAppInfoType) throws PException` in `PegasusAdminClient.java` for get all app infos.
add ut `public void testListApps() throws PException` in `TestAdminClient.java`.

##### Tests <!-- At least one of them must be included. -->

- Unit test

