### PR TITLE
refactor: improve the single-responsibility of class fs_manager

### DIFF
--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -301,7 +301,7 @@ dir_node *fs_manager::find_best_dir_for_new_replica(const gpid &pid) const
             }
         }
     }
-    if (selected) {
+    if (selected != nullptr) {
         LOG_INFO(
             "{}: put pid({}) to dir({}), which has {} replicas of current app, {} replicas totally",
             dsn_primary_address(),

--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -87,7 +87,7 @@ uint64_t dir_node::replicas_count(app_id id) const
     return iter->second.size();
 }
 
-std::string dir_node::replica_dir(const char *app_type, const dsn::gpid &pid) const
+std::string dir_node::replica_dir(dsn::string_view app_type, const dsn::gpid &pid) const
 {
     return utils::filesystem::path_combine(full_dir, fmt::format("{}.{}", pid, app_type));
 }
@@ -395,7 +395,7 @@ bool fs_manager::is_dir_node_available(const std::string &data_dir, const std::s
     return false;
 }
 
-dir_node *fs_manager::find_replica_dir(const char *app_type, gpid pid)
+dir_node *fs_manager::find_replica_dir(dsn::string_view app_type, gpid pid)
 {
     std::string replica_dir;
     dir_node *replica_dn = nullptr;
@@ -415,10 +415,10 @@ dir_node *fs_manager::find_replica_dir(const char *app_type, gpid pid)
     return replica_dn;
 }
 
-dir_node *fs_manager::create_replica_dir_if_necessary(const char *app_type, gpid pid)
+dir_node *fs_manager::create_replica_dir_if_necessary(dsn::string_view app_type, gpid pid)
 {
     // Try to find the replica directory.
-    dir_node *replica_dn = find_replica_dir(app_type, pid);
+    auto replica_dn = find_replica_dir(app_type, pid);
     if (replica_dn != nullptr) {
         return replica_dn;
     }
@@ -439,7 +439,7 @@ dir_node *fs_manager::create_replica_dir_if_necessary(const char *app_type, gpid
     return replica_dn;
 }
 
-dir_node *fs_manager::create_child_replica_dir(const char *app_type,
+dir_node *fs_manager::create_child_replica_dir(dsn::string_view app_type,
                                                gpid child_pid,
                                                const std::string &parent_dir)
 {

--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -31,6 +31,7 @@
 #include "perf_counter/perf_counter_wrapper.h"
 #include "utils/error_code.h"
 #include "utils/flags.h"
+#include "utils/string_view.h"
 #include "utils/zlocks.h"
 
 namespace dsn {
@@ -90,7 +91,9 @@ public:
     void initialize(const std::vector<std::string> &data_dirs,
                     const std::vector<std::string> &data_dir_tags);
     // Try to find the best dir_node to place the new replica. The less replica count the
-    // dir_node has, the higher opportunity it will be selected.
+    // dir_node has, which means the load is lower generally, the higher opportunity it
+    // will be selected.
+    // TODO(yingchun): consider the disk capacity and available space.
     // NOTE: the 'pid' must not exist in any dir_nodes.
     dir_node *find_best_dir_for_new_replica(const dsn::gpid &pid) const;
     dsn::error_code get_disk_tag(const std::string &dir, /*out*/ std::string &tag);

--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -74,7 +74,7 @@ public:
     uint64_t replicas_count() const;
     // Construct the replica dir for the given 'app_type' and 'pid'.
     // NOTE: Just construct the string, the directory will not be created.
-    std::string replica_dir(const char *app_type, const dsn::gpid &pid) const;
+    std::string replica_dir(dsn::string_view app_type, const dsn::gpid &pid) const;
     bool has(const dsn::gpid &pid) const;
     uint64_t remove(const dsn::gpid &pid);
     bool update_disk_stat(const bool update_disk_status);
@@ -96,15 +96,16 @@ public:
     dsn::error_code get_disk_tag(const std::string &dir, /*out*/ std::string &tag);
     void add_replica(const dsn::gpid &pid, const std::string &pid_dir);
     // Find the replica instance directory.
-    dir_node *find_replica_dir(const char *app_type, gpid pid);
+    dir_node *find_replica_dir(dsn::string_view app_type, gpid pid);
     // Similar to the above, but it will create a new directory if not found.
-    dir_node *create_replica_dir_if_necessary(const char *app_type, gpid pid);
+    dir_node *create_replica_dir_if_necessary(dsn::string_view app_type, gpid pid);
     // Similar to the above, and will create a directory for the child on the same dir_node
     // of parent.
     // During partition split, we should guarantee child replica and parent replica share the
     // same data dir.
-    dir_node *
-    create_child_replica_dir(const char *app_type, gpid child_pid, const std::string &parent_dir);
+    dir_node *create_child_replica_dir(dsn::string_view app_type,
+                                       gpid child_pid,
+                                       const std::string &parent_dir);
     void remove_replica(const dsn::gpid &pid);
     bool for_each_dir_node(const std::function<bool(const dir_node &)> &func) const;
     void update_disk_stat(bool check_status_changed = true);

--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -72,6 +72,9 @@ public:
     // and protected by the lock in fs_manager.
     uint64_t replicas_count(app_id id) const;
     uint64_t replicas_count() const;
+    // Construct the replica dir for the given 'app_type' and 'pid'.
+    // NOTE: Just construct the string, the directory will not be created.
+    std::string replica_dir(const char *app_type, const dsn::gpid &pid) const;
     bool has(const dsn::gpid &pid) const;
     uint64_t remove(const dsn::gpid &pid);
     bool update_disk_stat(const bool update_disk_status);
@@ -86,23 +89,33 @@ public:
     // NOTE: 'data_dirs' and 'data_dir_tags' must have the same size and in the same order.
     void initialize(const std::vector<std::string> &data_dirs,
                     const std::vector<std::string> &data_dir_tags);
-
+    // Try to find the best dir_node to place the new replica. The less replica count the
+    // dir_node has, the higher opportunity it will be selected.
+    // NOTE: the 'pid' must not exist in any dir_nodes.
+    dir_node *find_best_dir_for_new_replica(const dsn::gpid &pid) const;
     dsn::error_code get_disk_tag(const std::string &dir, /*out*/ std::string &tag);
-    void allocate_dir(const dsn::gpid &pid,
-                      const std::string &type,
-                      /*out*/ std::string &dir);
     void add_replica(const dsn::gpid &pid, const std::string &pid_dir);
+    // Find the replica instance directory.
+    dir_node *find_replica_dir(const char *app_type, gpid pid);
+    // Similar to the above, but it will create a new directory if not found.
+    dir_node *create_replica_dir_if_necessary(const char *app_type, gpid pid);
+    // Similar to the above, and will create a directory for the child on the same dir_node
+    // of parent.
+    // During partition split, we should guarantee child replica and parent replica share the
+    // same data dir.
+    dir_node *
+    create_child_replica_dir(const char *app_type, gpid child_pid, const std::string &parent_dir);
     void remove_replica(const dsn::gpid &pid);
     bool for_each_dir_node(const std::function<bool(const dir_node &)> &func) const;
     void update_disk_stat(bool check_status_changed = true);
 
     void add_new_dir_node(const std::string &data_dir, const std::string &tag);
-    bool is_dir_node_available(const std::string &data_dir, const std::string &tag) const;
-    const std::vector<std::string> &get_available_data_dirs() const
+    const std::vector<std::shared_ptr<dir_node>> &get_dir_nodes() const
     {
         zauto_read_lock l(_lock);
-        return _available_data_dirs;
+        return _dir_nodes;
     }
+    bool is_dir_node_available(const std::string &data_dir, const std::string &tag) const;
 
 private:
     void reset_disk_stat()
@@ -128,7 +141,6 @@ private:
     int _max_available_ratio = 0;
 
     std::vector<std::shared_ptr<dir_node>> _dir_nodes;
-    std::vector<std::string> _available_data_dirs;
 
     // Used for disk available space check
     // disk status will be updated periodically, this vector record nodes whose disk_status changed
@@ -147,7 +159,9 @@ private:
     friend class replica_disk_migrator;
     friend class replica_disk_test_base;
     friend class open_replica_test;
+    FRIEND_TEST(fs_manager, find_best_dir_for_new_replica);
     FRIEND_TEST(fs_manager, get_dir_node);
+    FRIEND_TEST(open_replica_test, open_replica_add_decree_and_ballot_check);
     FRIEND_TEST(replica_test, test_auto_trash);
 };
 } // replication

--- a/src/common/test/fs_manager_test.cpp
+++ b/src/common/test/fs_manager_test.cpp
@@ -17,18 +17,56 @@
  * under the License.
  */
 
+// IWYU pragma: no_include <ext/alloc_traits.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <stdint.h>
+#include <map>
 #include <memory>
+#include <ostream>
+#include <set>
 #include <string>
+#include <vector>
 
 #include "common/fs_manager.h"
+#include "common/gpid.h"
+#include "common/replication_other_types.h"
 #include "metadata_types.h"
 #include "utils/fail_point.h"
+#include "utils/filesystem.h"
+
+using namespace dsn::utils::filesystem;
 
 namespace dsn {
 namespace replication {
+
+TEST(dir_node, replica_dir)
+{
+    dir_node dn("tag", "path");
+    ASSERT_EQ("path/1.0.test", dn.replica_dir("test", gpid(1, 0)));
+}
+
+TEST(fs_manager, initialize)
+{
+    fail::setup();
+    struct broken_disk_test
+    {
+        std::string create_dir_ok;
+        std::string check_dir_rw_ok;
+        int32_t data_dir_size;
+    } tests[]{{"true", "true", 3}, {"true", "false", 2}, {"false", "false", 2}};
+    int i = 0;
+    for (const auto &test : tests) {
+        fail::cfg("filesystem_create_directory", "return(" + test.create_dir_ok + ")");
+        fail::cfg("filesystem_check_dir_rw", "return(" + test.check_dir_rw_ok + ")");
+        fs_manager fm;
+        fm.initialize({"disk1", "disk2", "disk3"}, {"tag1", "tag2", "tag3"});
+        ASSERT_EQ(test.data_dir_size, fm.get_dir_nodes().size()) << i;
+        i++;
+    }
+    fail::teardown();
+}
 
 TEST(fs_manager, dir_update_disk_status)
 {
@@ -64,19 +102,113 @@ TEST(fs_manager, dir_update_disk_status)
 TEST(fs_manager, get_dir_node)
 {
     fs_manager fm;
-    fm.initialize({"/data1"}, {"data1"});
+    fm.initialize({"./data1"}, {"data1"});
+    const auto &dns = fm.get_dir_nodes();
+    ASSERT_EQ(1, dns.size());
+    const auto &base_dir =
+        dns[0]->full_dir.substr(0, dns[0]->full_dir.size() - std::string("/data1").size());
 
     ASSERT_EQ(nullptr, fm.get_dir_node(""));
     ASSERT_EQ(nullptr, fm.get_dir_node("/"));
 
-    ASSERT_NE(nullptr, fm.get_dir_node("/data1"));
-    ASSERT_NE(nullptr, fm.get_dir_node("/data1/"));
-    ASSERT_NE(nullptr, fm.get_dir_node("/data1/replica1"));
+    ASSERT_NE(nullptr, fm.get_dir_node(base_dir + "/data1"));
+    ASSERT_NE(nullptr, fm.get_dir_node(base_dir + "/data1/"));
+    ASSERT_NE(nullptr, fm.get_dir_node(base_dir + "/data1/replica1"));
 
-    ASSERT_EQ(nullptr, fm.get_dir_node("/data2"));
-    ASSERT_EQ(nullptr, fm.get_dir_node("/data2/"));
-    ASSERT_EQ(nullptr, fm.get_dir_node("/data2/replica1"));
+    ASSERT_EQ(nullptr, fm.get_dir_node(base_dir + "/data2"));
+    ASSERT_EQ(nullptr, fm.get_dir_node(base_dir + "/data2/"));
+    ASSERT_EQ(nullptr, fm.get_dir_node(base_dir + "/data2/replica1"));
 }
 
+TEST(fs_manager, find_replica_dir)
+{
+    fs_manager fm;
+    fm.initialize({"./data1", "./data2", "./data3"}, {"data1", "data2", "data3"});
+
+    const char *app_type = "find_replica_dir";
+    gpid test_pid(1, 0);
+
+    // Clear up the remaining directories if exist.
+    for (const auto &dn : fm.get_dir_nodes()) {
+        remove_path(dn->replica_dir(app_type, test_pid));
+    }
+
+    ASSERT_EQ(nullptr, fm.find_replica_dir(app_type, test_pid));
+    dir_node *dn = fm.create_replica_dir_if_necessary(app_type, test_pid);
+    ASSERT_NE(nullptr, dn);
+    const auto dir = dn->replica_dir(app_type, test_pid);
+    ASSERT_TRUE(directory_exists(dir));
+    dir_node *dn1 = fm.find_replica_dir(app_type, test_pid);
+    ASSERT_EQ(dn, dn1);
+}
+
+TEST(fs_manager, create_replica_dir_if_necessary)
+{
+    fs_manager fm;
+
+    const char *app_type = "create_replica_dir_if_necessary";
+    gpid test_pid(1, 0);
+
+    // Could not find a valid dir_node.
+    ASSERT_EQ(nullptr, fm.create_replica_dir_if_necessary(app_type, test_pid));
+
+    // It's able to create a dir for the replica after a valid dir_node has been added.
+    fm.add_new_dir_node("./data1", "data1");
+    dir_node *dn = fm.create_replica_dir_if_necessary(app_type, test_pid);
+    ASSERT_NE(nullptr, dn);
+    ASSERT_EQ("data1", dn->tag);
+}
+
+TEST(fs_manager, create_child_replica_dir)
+{
+    fs_manager fm;
+    fm.initialize({"./data1", "./data2", "./data3"}, {"data1", "data2", "data3"});
+
+    const char *app_type = "create_child_replica_dir";
+    gpid test_pid(1, 0);
+    gpid test_child_pid(1, 0);
+
+    dir_node *dn = fm.create_replica_dir_if_necessary(app_type, test_pid);
+    ASSERT_NE(nullptr, dn);
+    const auto dir = dn->replica_dir(app_type, test_pid);
+
+    dir_node *child_dn = fm.create_child_replica_dir(app_type, test_child_pid, dir);
+    ASSERT_EQ(dn, child_dn);
+    const auto child_dir = child_dn->replica_dir(app_type, test_child_pid);
+    ASSERT_TRUE(directory_exists(child_dir));
+    ASSERT_EQ(dir, child_dir);
+}
+
+TEST(fs_manager, find_best_dir_for_new_replica)
+{
+    // dn1 | 1.0,  1.1 +1.6
+    // dn2 | 1.2,  1.3 +1.7   2.0
+    // dn3 | 1.4  +1.5 +1.7   2.1
+    auto dn1 = std::make_shared<dir_node>("./data1", "data1");
+    dn1->holding_replicas[1] = {gpid(1, 0), gpid(1, 1)};
+    auto dn2 = std::make_shared<dir_node>("./data2", "data2");
+    dn2->holding_replicas[1] = {gpid(1, 2), gpid(1, 3)};
+    dn2->holding_replicas[2] = {gpid(2, 0)};
+    auto dn3 = std::make_shared<dir_node>("./data3", "data3");
+    dn3->holding_replicas[1] = {gpid(1, 4)};
+    dn3->holding_replicas[2] = {gpid(2, 1)};
+    fs_manager fm;
+    fm._dir_nodes = {dn1, dn2, dn3};
+
+    gpid pid_1_5(1, 5);
+    dir_node *dn = fm.find_best_dir_for_new_replica(pid_1_5);
+    ASSERT_EQ(dn3.get(), dn);
+    dn->holding_replicas[pid_1_5.get_app_id()].emplace(pid_1_5);
+
+    gpid pid_1_6(1, 6);
+    dn = fm.find_best_dir_for_new_replica(pid_1_6);
+    ASSERT_EQ(dn1.get(), dn);
+    dn->holding_replicas[pid_1_6.get_app_id()].emplace(pid_1_6);
+
+    gpid pid_1_7(1, 7);
+    dn = fm.find_best_dir_for_new_replica(pid_1_7);
+    ASSERT_TRUE(dn == dn2.get() || dn == dn3.get());
+    dn->holding_replicas[pid_1_7.get_app_id()].emplace(pid_1_7);
+}
 } // namespace replication
 } // namespace dsn

--- a/src/common/test/fs_manager_test.cpp
+++ b/src/common/test/fs_manager_test.cpp
@@ -134,11 +134,11 @@ TEST(fs_manager, find_replica_dir)
     }
 
     ASSERT_EQ(nullptr, fm.find_replica_dir(app_type, test_pid));
-    dir_node *dn = fm.create_replica_dir_if_necessary(app_type, test_pid);
+    auto dn = fm.create_replica_dir_if_necessary(app_type, test_pid);
     ASSERT_NE(nullptr, dn);
     const auto dir = dn->replica_dir(app_type, test_pid);
     ASSERT_TRUE(directory_exists(dir));
-    dir_node *dn1 = fm.find_replica_dir(app_type, test_pid);
+    auto dn1 = fm.find_replica_dir(app_type, test_pid);
     ASSERT_EQ(dn, dn1);
 }
 
@@ -172,7 +172,7 @@ TEST(fs_manager, create_child_replica_dir)
     ASSERT_NE(nullptr, dn);
     const auto dir = dn->replica_dir(app_type, test_pid);
 
-    dir_node *child_dn = fm.create_child_replica_dir(app_type, test_child_pid, dir);
+    auto child_dn = fm.create_child_replica_dir(app_type, test_child_pid, dir);
     ASSERT_EQ(dn, child_dn);
     const auto child_dir = child_dn->replica_dir(app_type, test_child_pid);
     ASSERT_TRUE(directory_exists(child_dir));
@@ -196,7 +196,7 @@ TEST(fs_manager, find_best_dir_for_new_replica)
     fm._dir_nodes = {dn1, dn2, dn3};
 
     gpid pid_1_5(1, 5);
-    dir_node *dn = fm.find_best_dir_for_new_replica(pid_1_5);
+    auto dn = fm.find_best_dir_for_new_replica(pid_1_5);
     ASSERT_EQ(dn3.get(), dn);
     dn->holding_replicas[pid_1_5.get_app_id()].emplace(pid_1_5);
 

--- a/src/meta/test/misc/misc.cpp
+++ b/src/meta/test/misc/misc.cpp
@@ -34,6 +34,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <set>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -46,7 +47,6 @@
 #include "duplication_types.h"
 #include "meta_admin_types.h"
 #include "metadata_types.h"
-#include "utils/error_code.h"
 #include "utils/fmt_logging.h"
 #include "utils/rand.h"
 
@@ -240,19 +240,21 @@ void track_disk_info_check_and_apply(const dsn::replication::configuration_propo
     std::string dir;
     replica_info ri;
     switch (act.type) {
-    case config_type::CT_ASSIGN_PRIMARY:
-        target_manager->allocate_dir(pid, "test", dir);
-        CHECK_EQ(dsn::ERR_OK, target_manager->get_disk_tag(dir, ri.disk_tag));
+    case config_type::CT_ASSIGN_PRIMARY: {
+        auto selected = target_manager->find_best_dir_for_new_replica(pid);
+        CHECK_NOTNULL(selected, "");
+        selected->holding_replicas[pid.get_app_id()].emplace(pid);
         cc->collect_serving_replica(act.target, ri);
         break;
-
+    }
     case config_type::CT_ADD_SECONDARY:
-    case config_type::CT_ADD_SECONDARY_FOR_LB:
-        node_manager->allocate_dir(pid, "test", dir);
-        CHECK_EQ(dsn::ERR_OK, node_manager->get_disk_tag(dir, ri.disk_tag));
+    case config_type::CT_ADD_SECONDARY_FOR_LB: {
+        auto selected = node_manager->find_best_dir_for_new_replica(pid);
+        CHECK_NOTNULL(selected, "");
+        selected->holding_replicas[pid.get_app_id()].emplace(pid);
         cc->collect_serving_replica(act.node, ri);
         break;
-
+    }
     case config_type::CT_DOWNGRADE_TO_SECONDARY:
     case config_type::CT_UPGRADE_TO_PRIMARY:
         break;

--- a/src/replica/disk_cleaner.cpp
+++ b/src/replica/disk_cleaner.cpp
@@ -24,6 +24,7 @@
 #include <sys/types.h>
 #include <algorithm>
 
+#include "common/fs_manager.h"
 #include "runtime/api_layer1.h"
 #include "utils/error_code.h"
 #include "utils/filesystem.h"
@@ -67,14 +68,14 @@ const std::string kFolderSuffixBak = ".bak";
 const std::string kFolderSuffixOri = ".ori";
 const std::string kFolderSuffixTmp = ".tmp";
 
-error_s disk_remove_useless_dirs(const std::vector<std::string> &data_dirs,
+error_s disk_remove_useless_dirs(const std::vector<std::shared_ptr<dir_node>> &dir_nodes,
                                  /*output*/ disk_cleaning_report &report)
 {
     std::vector<std::string> sub_list;
-    for (auto &dir : data_dirs) {
+    for (const auto &dn : dir_nodes) {
         std::vector<std::string> tmp_list;
-        if (!dsn::utils::filesystem::get_subdirectories(dir, tmp_list, false)) {
-            LOG_WARNING("gc_disk: failed to get subdirectories in {}", dir);
+        if (!dsn::utils::filesystem::get_subdirectories(dn->full_dir, tmp_list, false)) {
+            LOG_WARNING("gc_disk: failed to get subdirectories in {}", dn->full_dir);
             return error_s::make(ERR_OBJECT_NOT_FOUND, "failed to get subdirectories");
         }
         sub_list.insert(sub_list.end(), tmp_list.begin(), tmp_list.end());

--- a/src/replica/disk_cleaner.h
+++ b/src/replica/disk_cleaner.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -26,6 +27,8 @@
 
 namespace dsn {
 namespace replication {
+struct dir_node;
+
 DSN_DECLARE_uint64(gc_disk_error_replica_interval_seconds);
 DSN_DECLARE_uint64(gc_disk_garbage_replica_interval_seconds);
 DSN_DECLARE_uint64(gc_disk_migration_tmp_replica_interval_seconds);
@@ -49,7 +52,7 @@ struct disk_cleaning_report
 };
 
 // Removes the useless data from data directories.
-extern error_s disk_remove_useless_dirs(const std::vector<std::string> &data_dirs,
+extern error_s disk_remove_useless_dirs(const std::vector<std::shared_ptr<dir_node>> &dir_nodes,
                                         /*output*/ disk_cleaning_report &report);
 
 inline bool is_data_dir_removable(const std::string &dir)

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -139,8 +139,6 @@ public:
     //
     void initialize(const replication_options &opts, bool clear = false);
     void initialize(bool clear = false);
-    void initialize_fs_manager(const std::vector<std::string> &data_dirs,
-                               const std::vector<std::string> &data_dir_tags);
     void set_options(const replication_options &opts) { _options = opts; }
     void open_service();
     void close();
@@ -201,12 +199,6 @@ public:
     bool is_connected() const { return NS_Connected == _state; }
     virtual rpc_address get_meta_server_address() const { return _failure_detector->get_servers(); }
     rpc_address primary_address() const { return _primary_address; }
-
-    std::string get_replica_dir(const char *app_type, gpid id, bool create_new = true);
-
-    // during partition split, we should gurantee child replica and parent replica share the
-    // same data dir
-    std::string get_child_dir(const char *app_type, gpid child_pid, const std::string &parent_dir);
 
     //
     // helper methods
@@ -341,7 +333,7 @@ private:
                       const std::shared_ptr<group_check_request> &req,
                       const std::shared_ptr<configuration_update_request> &req2);
     // Create a new replica according to the parameters.
-    // 'parent_dir' is used in partition split for get_child_dir().
+    // 'parent_dir' is used in partition split for create_child_replica_dir().
     replica *new_replica(gpid gpid,
                          const app_info &app,
                          bool restore_if_necessary,
@@ -427,6 +419,7 @@ private:
     friend class replica_follower;
     friend class replica_follower_test;
     friend class replica_http_service_test;
+    FRIEND_TEST(open_replica_test, open_replica_add_decree_and_ballot_check);
     FRIEND_TEST(replica_test, test_clear_on_failure);
     FRIEND_TEST(replica_test, test_auto_trash);
 

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -239,10 +239,10 @@ create_mock_replica(replica_stub *stub, int appid = 1, int partition_index = 1)
     app_info.app_type = "replica";
     app_info.app_name = "temp";
 
-    dir_node *dn =
-        stub->get_fs_manager()->create_replica_dir_if_necessary(app_info.app_type.c_str(), gpid);
+    const auto *const dn =
+        stub->get_fs_manager()->create_replica_dir_if_necessary(app_info.app_type, gpid);
     CHECK_NOTNULL(dn, "");
-    const auto replica_path = dn->replica_dir(app_info.app_type.c_str(), gpid);
+    const auto replica_path = dn->replica_dir(app_info.app_type, gpid);
     CHECK(
         dsn::utils::filesystem::directory_exists(replica_path), "dir({}) not exist", replica_path);
     return std::make_unique<mock_replica>(stub, gpid, app_info, replica_path.c_str());
@@ -317,9 +317,9 @@ public:
         config.pid = pid;
         config.status = status;
 
-        auto dn = _fs_manager.create_replica_dir_if_necessary(info.app_type.c_str(), pid);
+        auto dn = _fs_manager.create_replica_dir_if_necessary(info.app_type, pid);
         CHECK_NOTNULL(dn, "");
-        const auto &dir = dn->replica_dir(info.app_type.c_str(), pid);
+        const auto &dir = dn->replica_dir(info.app_type, pid);
         CHECK(dsn::utils::filesystem::directory_exists(dir), "dir({}) not exist", dir);
         auto *rep =
             new mock_replica(this, pid, info, dir.c_str(), need_restore, is_duplication_follower);

--- a/src/replica/test/mutation_log_test.cpp
+++ b/src/replica/test/mutation_log_test.cpp
@@ -297,7 +297,6 @@ public:
     {
         utils::filesystem::remove_path(_log_dir);
         utils::filesystem::create_directory(_log_dir);
-
         utils::filesystem::remove_path(_log_dir + ".test");
     }
 

--- a/src/replica/test/replica_disk_migrate_test.cpp
+++ b/src/replica/test/replica_disk_migrate_test.cpp
@@ -18,9 +18,11 @@
  */
 
 #include <fmt/core.h>
+#include <fmt/ostream.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <iosfwd>
 #include <map>
 #include <memory>
 #include <set>

--- a/src/replica/test/replica_disk_migrate_test.cpp
+++ b/src/replica/test/replica_disk_migrate_test.cpp
@@ -375,16 +375,14 @@ TEST_F(replica_disk_migrate_test, disk_migrate_replica_open)
     request.target_disk = "tag_empty_1";
 
     // Remove the gpid 1.4 dir which is created in constructor.
-    const std::string kReplicaOriginDir =
-        fmt::format("./{}/{}.replica", request.origin_disk, request.pid.to_string());
+    const auto kReplicaOriginDir = fmt::format("./{}/{}.replica", request.origin_disk, request.pid);
     utils::filesystem::remove_path(kReplicaOriginDir);
     stub->get_fs_manager()->remove_replica(test_pid);
 
     // Create the related dirs.
-    const std::string kReplicaOriginSuffixDir = fmt::format(
-        "./{}/{}.replica.disk.migrate.ori/", request.origin_disk, request.pid.to_string());
-    const std::string kReplicaNewDir =
-        fmt::format("./{}/{}.replica/", request.target_disk, request.pid.to_string());
+    const auto kReplicaOriginSuffixDir =
+        fmt::format("./{}/{}.replica.disk.migrate.ori/", request.origin_disk, request.pid);
+    const auto kReplicaNewDir = fmt::format("./{}/{}.replica/", request.target_disk, request.pid);
     utils::filesystem::create_directory(kReplicaOriginSuffixDir);
     utils::filesystem::create_directory(kReplicaNewDir);
 
@@ -394,8 +392,8 @@ TEST_F(replica_disk_migrate_test, disk_migrate_replica_open)
     open_replica(app_info_1, request.pid);
 
     // Check it works as expected.
-    const std::string kReplicaGarDir =
-        fmt::format("./{}/{}.replica.gar", request.target_disk, request.pid.to_string());
+    const auto kReplicaGarDir =
+        fmt::format("./{}/{}.replica.gar", request.target_disk, request.pid);
     ASSERT_TRUE(utils::filesystem::directory_exists(kReplicaOriginDir));
     ASSERT_TRUE(utils::filesystem::directory_exists(kReplicaGarDir));
 

--- a/src/replica/test/replica_disk_test_base.h
+++ b/src/replica/test/replica_disk_test_base.h
@@ -56,6 +56,8 @@ public:
         fail::cfg("update_disk_stat", "return()");
         generate_mock_app_info();
 
+        stub->_fs_manager._dir_nodes.clear();
+        stub->_fs_manager.reset_disk_stat();
         generate_mock_dir_nodes(dir_nodes_count);
         generate_mock_empty_dir_node(empty_dir_nodes_count);
 
@@ -73,8 +75,6 @@ public:
 
     void update_disks_status() { stub->update_disks_status(); }
 
-    std::vector<std::shared_ptr<dir_node>> get_dir_nodes() { return stub->_fs_manager._dir_nodes; }
-
     void generate_mock_dir_node(const app_info &app,
                                 const gpid pid,
                                 const std::string &tag,
@@ -83,7 +83,6 @@ public:
         dir_node *node_disk = new dir_node(tag, full_dir);
         node_disk->holding_replicas[app.app_id].emplace(pid);
         stub->_fs_manager._dir_nodes.emplace_back(node_disk);
-        stub->_fs_manager._available_data_dirs.emplace_back(full_dir);
     }
 
     void remove_mock_dir_node(const std::string &tag)
@@ -101,7 +100,7 @@ public:
     void
     mock_node_status(int32_t node_index, disk_status::type old_status, disk_status::type new_status)
     {
-        auto node = get_dir_nodes()[node_index];
+        auto node = stub->_fs_manager.get_dir_nodes()[node_index];
         for (const auto &kv : node->holding_replicas) {
             for (const auto &pid : kv.second) {
                 update_replica_disk_status(pid, old_status);
@@ -124,21 +123,6 @@ public:
         return ERR_OK;
     }
 
-    int32_t ignore_broken_disk_test(const std::string &mock_create_directory,
-                                    const std::string &mock_check_rw)
-    {
-        std::vector<std::string> data_dirs = {"disk1", "disk2", "disk3"};
-        std::vector<std::string> data_dir_tags = {"tag1", "tag2", "tag3"};
-        auto test_stub = std::make_unique<mock_replica_stub>();
-        fail::cfg("filesystem_create_directory", "return(" + mock_create_directory + ")");
-        fail::cfg("filesystem_check_dir_rw", "return(" + mock_check_rw + ")");
-        fail::cfg("update_disk_stat", "return()");
-        test_stub->initialize_fs_manager(data_dirs, data_dir_tags);
-        int32_t dir_size = test_stub->_fs_manager.get_available_data_dirs().size();
-        test_stub.reset();
-        return dir_size;
-    }
-
     void prepare_before_add_new_disk_test(const std::string &create_dir,
                                           const std::string &check_rw)
     {
@@ -153,7 +137,6 @@ public:
     void reset_after_add_new_disk_test()
     {
         stub->_fs_manager._dir_nodes.clear();
-        stub->_fs_manager._available_data_dirs.clear();
         dsn::utils::filesystem::remove_path("add_new_not_empty_disk");
     }
 
@@ -193,7 +176,6 @@ private:
             dir_node *node_disk =
                 new dir_node(fmt::format("tag_empty_{}", num), fmt::format("./tag_empty_{}", num));
             stub->_fs_manager._dir_nodes.emplace_back(node_disk);
-            stub->_fs_manager._available_data_dirs.emplace_back(node_disk->full_dir);
             utils::filesystem::create_directory(node_disk->full_dir);
             num--;
         }
@@ -239,7 +221,6 @@ private:
             }
 
             stub->_fs_manager._dir_nodes.emplace_back(node_disk);
-            stub->_fs_manager._available_data_dirs.emplace_back(node_disk->full_dir);
         }
     }
 

--- a/src/replica/test/replica_test_base.h
+++ b/src/replica/test/replica_test_base.h
@@ -53,9 +53,14 @@ class replica_test_base : public replica_stub_test_base
 {
 public:
     std::unique_ptr<mock_replica> _replica;
-    const std::string _log_dir{"./test-log"};
+    // TODO(yingchun): rename to _replica_dir, and consider to remove it totally.
+    std::string _log_dir;
 
-    replica_test_base() { _replica = create_mock_replica(stub.get(), 1, 1, _log_dir.c_str()); }
+    replica_test_base()
+    {
+        _replica = create_mock_replica(stub.get(), 1, 1);
+        _log_dir = _replica->dir();
+    }
 
     virtual mutation_ptr create_test_mutation(int64_t decree, const std::string &data)
     {

--- a/src/server/test/pegasus_server_test_base.h
+++ b/src/server/test/pegasus_server_test_base.h
@@ -46,6 +46,7 @@ public:
         // Remove rdb to prevent rocksdb recovery from last test.
         dsn::utils::filesystem::remove_path("./data/rdb");
         _replica_stub = new dsn::replication::replica_stub();
+        _replica_stub->get_fs_manager()->initialize({"./"}, {"test_tag"});
 
         _gpid = dsn::gpid(100, 1);
         dsn::app_info app_info;


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1383

This patch moves some functions to fs_manager which are more reasonable to be
responsibilities of class fs_manager rather than those of class replica_stub.