### PR TITLE
feat(new_metrics): migrate metrics for some duplication class

### DIFF
--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -30,6 +30,7 @@
 #include "utils/autoref_ptr.h"
 #include "utils/errors.h"
 #include "utils/fmt_logging.h"
+#include "utils/string_view.h"
 
 METRIC_DEFINE_counter(replica,
                       dup_shipped_bytes,
@@ -37,7 +38,6 @@ METRIC_DEFINE_counter(replica,
                       "The shipped size of private log for dup");
 
 namespace dsn {
-class string_view;
 
 namespace replication {
 

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -32,9 +32,9 @@
 #include "utils/fmt_logging.h"
 
 METRIC_DEFINE_counter(replica,
-                          dup_shipped_bytes,
-                          dsn::metric_unit::kBytes,
-                          "The shipped size of private log for dup");
+                      dup_shipped_bytes,
+                      dsn::metric_unit::kBytes,
+                      "The shipped size of private log for dup");
 
 namespace dsn {
 class string_view;

--- a/src/replica/duplication/duplication_pipeline.h
+++ b/src/replica/duplication/duplication_pipeline.h
@@ -20,11 +20,11 @@
 #include <memory>
 
 #include "common/replication_other_types.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "replica/duplication/mutation_duplicator.h"
 #include "replica/replica_base.h"
 #include "runtime/pipeline.h"
 #include "utils/chrono_literals.h"
+#include "utils/metrics.h"
 
 namespace dsn {
 namespace replication {
@@ -90,7 +90,7 @@ private:
 
     decree _last_decree{invalid_decree};
 
-    perf_counter_wrapper _counter_dup_shipped_bytes_rate;
+    METRIC_VAR_DECLARE_counter(dup_shipped_bytes);
 };
 
 } // namespace replication

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -36,6 +36,16 @@
 #include "utils/string_view.h"
 
 METRIC_DEFINE_counter(replica,
+                          dup_log_file_load_failed_count,
+                          dsn::metric_unit::kFileLoads,
+                          "The number of times private log files have failed to be loaded during dup");
+
+METRIC_DEFINE_counter(replica,
+                          dup_log_file_load_skipped_bytes,
+                          dsn::metric_unit::kBytes,
+                          "The bytes of mutations that have been skipped due to failed loadings of private log files during dup");
+
+METRIC_DEFINE_counter(replica,
                           dup_log_read_bytes,
                           dsn::metric_unit::kBytes,
                           "The size read from private log for dup");
@@ -207,7 +217,7 @@ void load_from_private_log::replay_log_block()
                 err,
                 _current->path(),
                 _start_offset);
-            _counter_dup_load_file_failed_count->increment();
+            METRIC_VAR_INCREMENT(dup_log_file_load_failed_count);
             _err_file_repeats_num++;
             if (dsn_unlikely(will_fail_skip())) {
                 // skip this file
@@ -220,7 +230,7 @@ void load_from_private_log::replay_log_block()
                 if (switch_to_next_log_file()) {
                     // successfully skip to next file
                     auto skipped_bytes = _current_global_end_offset - prev_offset;
-                    _counter_dup_load_skipped_bytes_count->add(skipped_bytes);
+                    METRIC_VAR_INCREMENT_BY(dup_log_file_load_skipped_bytes, skipped_bytes);
                     repeat(_repeat_delay);
                     return;
                 }
@@ -263,19 +273,11 @@ load_from_private_log::load_from_private_log(replica *r, replica_duplicator *dup
       _duplicator(dup),
       _stub(r->get_replica_stub()),
       _mutation_batch(dup),
+      METRIC_VAR_INIT_replica(dup_log_file_load_failed_count),
+      METRIC_VAR_INIT_replica(dup_log_file_load_skipped_bytes),
       METRIC_VAR_INIT_replica(dup_log_read_bytes),
       METRIC_VAR_INIT_replica(dup_log_read_mutations)
 {
-    _counter_dup_load_file_failed_count.init_app_counter(
-        "eon.replica_stub",
-        "dup.load_file_failed_count",
-        COUNTER_TYPE_VOLATILE_NUMBER,
-        "the number of failures loading a private log file during duplication");
-    _counter_dup_load_skipped_bytes_count.init_app_counter(
-        "eon.replica_stub",
-        "dup.load_skipped_bytes_count",
-        COUNTER_TYPE_VOLATILE_NUMBER,
-        "bytes of mutations that were skipped because of failure during duplication");
 }
 
 void load_from_private_log::set_start_decree(decree start_decree)

--- a/src/replica/duplication/load_from_private_log.h
+++ b/src/replica/duplication/load_from_private_log.h
@@ -30,6 +30,7 @@
 #include "replica/mutation_log.h"
 #include "replica/replica_base.h"
 #include "runtime/pipeline.h"
+#include "utils/autoref_ptr.h"
 #include "utils/chrono_literals.h"
 #include "utils/metrics.h"
 

--- a/src/replica/duplication/load_from_private_log.h
+++ b/src/replica/duplication/load_from_private_log.h
@@ -77,6 +77,8 @@ public:
 
     void TEST_set_repeat_delay(std::chrono::milliseconds delay) { _repeat_delay = delay; }
 
+    METRIC_DEFINE_VALUE(dup_log_file_load_failed_count, int64_t)
+
     static constexpr int MAX_ALLOWED_BLOCK_REPEATS{3};
     static constexpr int MAX_ALLOWED_FILE_REPEATS{10};
 
@@ -104,8 +106,8 @@ private:
 
     decree _start_decree{0};
 
-    perf_counter_wrapper _counter_dup_load_file_failed_count;
-    perf_counter_wrapper _counter_dup_load_skipped_bytes_count;
+    METRIC_VAR_DECLARE_counter(dup_log_file_load_failed_count);
+    METRIC_VAR_DECLARE_counter(dup_log_file_load_skipped_bytes);
     METRIC_VAR_DECLARE_counter(dup_log_read_bytes);
     METRIC_VAR_DECLARE_counter(dup_log_read_mutations);
 

--- a/src/replica/duplication/load_from_private_log.h
+++ b/src/replica/duplication/load_from_private_log.h
@@ -32,6 +32,7 @@
 #include "replica/replica_base.h"
 #include "runtime/pipeline.h"
 #include "utils/chrono_literals.h"
+#include "utils/metrics.h"
 
 namespace dsn {
 namespace replication {
@@ -105,8 +106,8 @@ private:
 
     perf_counter_wrapper _counter_dup_load_file_failed_count;
     perf_counter_wrapper _counter_dup_load_skipped_bytes_count;
-    perf_counter_wrapper _counter_dup_log_read_bytes_rate;
-    perf_counter_wrapper _counter_dup_log_read_mutations_rate;
+    METRIC_VAR_DECLARE_counter(dup_log_read_bytes);
+    METRIC_VAR_DECLARE_counter(dup_log_read_mutations);
 
     std::chrono::milliseconds _repeat_delay{10_s};
 };

--- a/src/replica/duplication/load_from_private_log.h
+++ b/src/replica/duplication/load_from_private_log.h
@@ -25,7 +25,6 @@
 
 #include "common/replication_other_types.h"
 #include "mutation_batch.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "replica/duplication/mutation_duplicator.h"
 #include "replica/log_file.h"
 #include "replica/mutation_log.h"
@@ -78,6 +77,7 @@ public:
     void TEST_set_repeat_delay(std::chrono::milliseconds delay) { _repeat_delay = delay; }
 
     METRIC_DEFINE_VALUE(dup_log_file_load_failed_count, int64_t)
+    METRIC_DEFINE_VALUE(dup_log_file_load_skipped_bytes, int64_t)
 
     static constexpr int MAX_ALLOWED_BLOCK_REPEATS{3};
     static constexpr int MAX_ALLOWED_FILE_REPEATS{10};

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -15,16 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <functional>
-#include <iosfwd>
 #include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
 
-#include "common/gpid.h"
 #include "common/replication.codes.h"
 #include "consensus_types.h"
 #include "metadata_types.h"

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -54,7 +54,7 @@ mutation_buffer::mutation_buffer(replica_base *r,
                                  int max_count,
                                  mutation_committer committer)
     : prepare_list(r, init_decree, max_count, committer),
-    METRIC_VAR_INIT_replica(dup_recent_lost_mutations)
+      METRIC_VAR_INIT_replica(dup_recent_lost_mutations)
 {
 }
 

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -27,6 +27,7 @@
 #include "replica/prepare_list.h"
 #include "replica/replica_base.h"
 #include "utils/errors.h"
+#include "utils/metrics.h"
 
 namespace dsn {
 namespace replication {

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -22,7 +22,6 @@
 #include <memory>
 
 #include "common/replication_other_types.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "replica/duplication/mutation_duplicator.h"
 #include "replica/mutation.h"
 #include "replica/prepare_list.h"
@@ -45,7 +44,7 @@ public:
     void commit(decree d, commit_type ct) override;
 
 private:
-    perf_counter_wrapper _counter_dulication_mutation_loss_count;
+    METRIC_VAR_DECLARE_gauge_int64(dup_recent_lost_mutations);
 };
 
 // A sorted array of committed mutations that are ready for duplication.

--- a/src/replica/duplication/test/load_from_private_log_test.cpp
+++ b/src/replica/duplication/test/load_from_private_log_test.cpp
@@ -383,6 +383,8 @@ public:
         load = std::make_unique<load_from_private_log>(_replica.get(), duplicator.get());
         load->TEST_set_repeat_delay(0_ms); // no delay
         load->set_start_decree(duplicator->progress().last_decree + 1);
+        load->METRIC_VAR_NAME(dup_log_file_load_failed_count)->reset();
+        load->METRIC_VAR_NAME(dup_log_file_load_skipped_bytes)->reset();
         end_stage = std::make_unique<end_stage_t>(
             [this, num_entries](decree &&d, mutation_tuple_set &&mutations) {
                 load->set_start_decree(d + 1);
@@ -403,7 +405,7 @@ public:
 TEST_F(load_fail_mode_test, fail_skip)
 {
     duplicator->update_fail_mode(duplication_fail_mode::FAIL_SKIP);
-    ASSERT_EQ(load->_counter_dup_load_skipped_bytes_count->get_integer_value(), 0);
+    ASSERT_EQ(METRIC_VALUE(*load, dup_log_file_load_skipped_bytes), 0);
 
     // will trigger fail-skip and read the subsequent file, some mutations will be lost.
     auto repeats = load->MAX_ALLOWED_BLOCK_REPEATS * load->MAX_ALLOWED_FILE_REPEATS;
@@ -413,16 +415,16 @@ TEST_F(load_fail_mode_test, fail_skip)
     duplicator->wait_all();
     fail::teardown();
 
-    ASSERT_EQ(load->_counter_dup_load_file_failed_count->get_integer_value(),
+    ASSERT_EQ(METRIC_VALUE(*load, dup_log_file_load_failed_count),
               load_from_private_log::MAX_ALLOWED_FILE_REPEATS);
-    ASSERT_GT(load->_counter_dup_load_skipped_bytes_count->get_integer_value(), 0);
+    ASSERT_GT(METRIC_VALUE(*load, dup_log_file_load_skipped_bytes), 0);
 }
 
 TEST_F(load_fail_mode_test, fail_slow)
 {
     duplicator->update_fail_mode(duplication_fail_mode::FAIL_SLOW);
-    ASSERT_EQ(load->_counter_dup_load_skipped_bytes_count->get_integer_value(), 0);
-    ASSERT_EQ(load->_counter_dup_load_file_failed_count->get_integer_value(), 0);
+    ASSERT_EQ(METRIC_VALUE(*load, dup_log_file_load_skipped_bytes), 0);
+    ASSERT_EQ(METRIC_VALUE(*load, dup_log_file_load_failed_count), 0);
 
     // will trigger fail-slow and retry infinitely
     auto repeats = load->MAX_ALLOWED_BLOCK_REPEATS * load->MAX_ALLOWED_FILE_REPEATS;
@@ -432,9 +434,9 @@ TEST_F(load_fail_mode_test, fail_slow)
     duplicator->wait_all();
     fail::teardown();
 
-    ASSERT_EQ(load->_counter_dup_load_file_failed_count->get_integer_value(),
+    ASSERT_EQ(METRIC_VALUE(*load, dup_log_file_load_failed_count),
               load_from_private_log::MAX_ALLOWED_FILE_REPEATS);
-    ASSERT_EQ(load->_counter_dup_load_skipped_bytes_count->get_integer_value(), 0);
+    ASSERT_EQ(METRIC_VALUE(*load, dup_log_file_load_skipped_bytes), 0);
 }
 
 TEST_F(load_fail_mode_test, fail_skip_real_corrupted_file)
@@ -454,9 +456,9 @@ TEST_F(load_fail_mode_test, fail_skip_real_corrupted_file)
     duplicator->wait_all();
 
     // ensure the bad file will be skipped
-    ASSERT_EQ(load->_counter_dup_load_file_failed_count->get_integer_value(),
+    ASSERT_EQ(METRIC_VALUE(*load, dup_log_file_load_failed_count),
               load_from_private_log::MAX_ALLOWED_FILE_REPEATS);
-    ASSERT_GT(load->_counter_dup_load_skipped_bytes_count->get_integer_value(), 0);
+    ASSERT_GT(METRIC_VALUE(*load, dup_log_file_load_skipped_bytes), 0);
 }
 
 } // namespace replication

--- a/src/replica/duplication/test/load_from_private_log_test.cpp
+++ b/src/replica/duplication/test/load_from_private_log_test.cpp
@@ -29,8 +29,6 @@
 #include "common/replication_other_types.h"
 #include "consensus_types.h"
 #include "duplication_types.h"
-#include "perf_counter/perf_counter.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "replica/duplication/mutation_duplicator.h"
 #include "replica/duplication/replica_duplicator.h"
 #include "replica/log_file.h"
@@ -49,6 +47,7 @@
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
+#include "utils/metrics.h"
 
 #define BOOST_NO_CXX11_SCOPED_ENUMS
 #include <boost/filesystem/operations.hpp>

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -48,14 +48,14 @@
 #include "utils/rand.h"
 
 METRIC_DEFINE_counter(replica,
-                      mutation_dup_successful_requests,
+                      dup_shipped_successful_requests,
                       dsn::metric_unit::kRequests,
-                      "The number of successful DUPLICATE requests sent from mutation duplicator");
+                      "The number of successful DUPLICATE requests sent from client");
 
 METRIC_DEFINE_counter(replica,
-                      mutation_dup_failed_requests,
+                      dup_shipped_failed_requests,
                       dsn::metric_unit::kRequests,
-                      "The number of failed DUPLICATE requests sent from mutation duplicator");
+                      "The number of failed DUPLICATE requests sent from client");
 
 namespace dsn {
 namespace replication {
@@ -107,8 +107,8 @@ pegasus_mutation_duplicator::pegasus_mutation_duplicator(dsn::replication::repli
                                                          dsn::string_view app)
     : mutation_duplicator(r),
       _remote_cluster(remote_cluster),
-      METRIC_VAR_INIT_replica(mutation_dup_successful_requests),
-      METRIC_VAR_INIT_replica(mutation_dup_failed_requests)
+      METRIC_VAR_INIT_replica(dup_shipped_successful_requests),
+      METRIC_VAR_INIT_replica(dup_shipped_failed_requests)
 {
     // initialize pegasus-client when this class is first time used.
     static __attribute__((unused)) bool _dummy = pegasus_client_factory::initialize(nullptr);
@@ -162,7 +162,7 @@ void pegasus_mutation_duplicator::on_duplicate_reply(uint64_t hash,
     }
 
     if (perr != PERR_OK || err != dsn::ERR_OK) {
-        METRIC_VAR_INCREMENT(mutation_dup_failed_requests);
+        METRIC_VAR_INCREMENT(dup_shipped_failed_requests);
 
         // randomly log the 1% of the failed duplicate rpc, because minor number of
         // errors are acceptable.
@@ -175,7 +175,7 @@ void pegasus_mutation_duplicator::on_duplicate_reply(uint64_t hash,
         // duplicating an illegal write to server is unacceptable, fail fast.
         CHECK_NE_PREFIX_MSG(perr, PERR_INVALID_ARGUMENT, rpc.response().error_hint);
     } else {
-        METRIC_VAR_INCREMENT(mutation_dup_successful_requests);
+        METRIC_VAR_INCREMENT(dup_shipped_successful_requests);
         _total_shipped_size +=
             rpc.dsn_request()->header->body_length + rpc.dsn_request()->header->hdr_length;
     }

--- a/src/server/pegasus_mutation_duplicator.h
+++ b/src/server/pegasus_mutation_duplicator.h
@@ -89,8 +89,8 @@ private:
 
     size_t _total_shipped_size{0};
 
-    METRIC_VAR_DECLARE_counter(mutation_dup_successful_requests);
-    METRIC_VAR_DECLARE_counter(mutation_dup_failed_requests);
+    METRIC_VAR_DECLARE_counter(dup_shipped_successful_requests);
+    METRIC_VAR_DECLARE_counter(dup_shipped_failed_requests);
 };
 
 // Decodes the binary `request_data` into write request in thrift struct, and

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -686,6 +686,7 @@ enum class metric_unit : size_t
     kRounds,
     kResets,
     kBackups,
+    kFileLoads,
     kFileUploads,
     kBulkLoads,
     kInvalidUnit,


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1481

Some duplication-related classes, including `ship_mutation`, `mutation_buffer`,
`load_from_private_log`, are migrated to the new framework.

During this migration, there are 6 metrics which are changed from server-level
to replica-level, all of which are duplication-related, including the shipped size of
private log, the number of times private log files have failed to be loaded, the bytes
of mutations that have been skipped due to failed loadings of private log files, the
size read from private log, the number of mutations read from private log, the number
of lost mutations recently.

Another 2 metrics, the numbers of failed/successful DUPLICATE requests sent from
client, are renamed according to the new style of naming for duplication.