### PR TITLE
chore(github): remove directories and tarballs after packing server and tools for github actions in case of running out of disk space

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -147,9 +147,13 @@ jobs:
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release
           ccache -s
       - name: Pack Server
-        run: ./run.sh pack_server
+        run: |
+          ./run.sh pack_server
+          rm -rf pegasus-server-*
       - name: Pack Tools
-        run: ./run.sh pack_tools
+        run: |
+          ./run.sh pack_tools
+          rm -rf pegasus-tools-*
       - name: Tar files
         run: |
           mv thirdparty/hadoop-bin ./


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1485

Github actions `Build Release` and `Build with jemalloc` failed for the branch
`migrate-metrics-dev` due to running out of disk space. Both failed jobs would
pack servers and tools while another successful job `Build ASAN` would never
do.

After packaging, generated directories and tarballs would consume 2.7GB disk
space. Therefore, we could drop the generated directories and tarballs to spare
more disk space after packaging, though this problem has not been found for
master branch.

This problem is also tracked by another PR: https://github.com/apache/incubator-pegasus/pull/1484