### PR TITLE
refactor(new_metrics): refactor enum definition for metric types and units

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -156,14 +156,11 @@ jobs:
           rm -rf pegasus-tools-*
       - name: Tar files
         run: |
-          mv build/latest/src/server/test/config.ini ./
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          rm -rf build/latest/src/*
-          mkdir -p build/latest/src/server/test
-          mv config.ini build/latest/src/server/test/
-          tar --exclude='*CMakeFiles*' -zcvhf release__builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
+          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
+          tar -zcvhf release__builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -289,14 +286,11 @@ jobs:
           ccache -s
       - name: Tar files
         run: |
-          mv build/latest/src/server/test/config.ini ./
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          rm -rf build/latest/src/*
-          mkdir -p build/latest/src/server/test
-          mv config.ini build/latest/src/server/test/
-          tar --exclude='*CMakeFiles*' -zcvhf release_address_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
+          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
+          tar -zcvhf release_address_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -562,14 +556,11 @@ jobs:
           rm -rf pegasus-tools-*
       - name: Tar files
         run: |
-          mv build/latest/src/server/test/config.ini ./
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          rm -rf build/latest/src/*
-          mkdir -p build/latest/src/server/test
-          mv config.ini build/latest/src/server/test/
-          tar --exclude='*CMakeFiles*' -zcvhf release_jemalloc_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
+          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
+          tar -zcvhf release_jemalloc_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -156,9 +156,13 @@ jobs:
           rm -rf pegasus-tools-*
       - name: Tar files
         run: |
+          mv build/latest/src/server/test/config.ini ./
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
+          rm -rf build/latest/src
+          mkdir -p build/latest/src/server/test
+          mv config.ini build/latest/src/server/test/
           tar --exclude='*CMakeFiles*' -zcvhf release__builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
@@ -285,9 +289,13 @@ jobs:
           ccache -s
       - name: Tar files
         run: |
+          mv build/latest/src/server/test/config.ini ./
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
+          rm -rf build/latest/src
+          mkdir -p build/latest/src/server/test
+          mv config.ini build/latest/src/server/test/
           tar --exclude='*CMakeFiles*' -zcvhf release_address_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
@@ -554,9 +562,13 @@ jobs:
           rm -rf pegasus-tools-*
       - name: Tar files
         run: |
+          mv build/latest/src/server/test/config.ini ./
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
+          rm -rf build/latest/src
+          mkdir -p build/latest/src/server/test
+          mv config.ini build/latest/src/server/test/
           tar --exclude='*CMakeFiles*' -zcvhf release_jemalloc_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -160,7 +160,7 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          rm -rf build/latest/src
+          rm -rf build/latest/src/*
           mkdir -p build/latest/src/server/test
           mv config.ini build/latest/src/server/test/
           tar --exclude='*CMakeFiles*' -zcvhf release__builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
@@ -293,7 +293,7 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          rm -rf build/latest/src
+          rm -rf build/latest/src/*
           mkdir -p build/latest/src/server/test
           mv config.ini build/latest/src/server/test/
           tar --exclude='*CMakeFiles*' -zcvhf release_address_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
@@ -566,7 +566,7 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          rm -rf build/latest/src
+          rm -rf build/latest/src/*
           mkdir -p build/latest/src/server/test
           mv config.ini build/latest/src/server/test/
           tar --exclude='*CMakeFiles*' -zcvhf release_jemalloc_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin

--- a/src/replica/test/replica_disk_test_base.h
+++ b/src/replica/test/replica_disk_test_base.h
@@ -57,7 +57,6 @@ public:
         generate_mock_app_info();
 
         stub->_fs_manager._dir_nodes.clear();
-        // stub->_fs_manager.reset_disk_stat();
         generate_mock_dir_nodes(dir_nodes_count);
         generate_mock_empty_dir_node(empty_dir_nodes_count);
 

--- a/src/replica/test/replica_disk_test_base.h
+++ b/src/replica/test/replica_disk_test_base.h
@@ -57,7 +57,7 @@ public:
         generate_mock_app_info();
 
         stub->_fs_manager._dir_nodes.clear();
-        stub->_fs_manager.reset_disk_stat();
+        // stub->_fs_manager.reset_disk_stat();
         generate_mock_dir_nodes(dir_nodes_count);
         generate_mock_empty_dir_node(empty_dir_nodes_count);
 

--- a/src/runtime/task/task_queue.cpp
+++ b/src/runtime/task/task_queue.cpp
@@ -55,7 +55,7 @@ METRIC_DEFINE_counter(queue,
 METRIC_DEFINE_counter(queue,
                       queue_rejected_tasks,
                       dsn::metric_unit::kTasks,
-                      "The accumulative number of rejeced tasks by throttling before enqueue");
+                      "The accumulative number of rejected tasks by throttling before enqueue");
 
 namespace dsn {
 

--- a/src/utils/enum_helper.h
+++ b/src/utils/enum_helper.h
@@ -66,6 +66,10 @@
 
 #define ENUM_END(type) ENUM_END2(type, type)
 
+#define ENUM_CONST(str) k##str
+#define ENUM_CONST_DEF(str) ENUM_CONST(str),
+#define ENUM_CONST_REG_STR(enum_class, str) helper->register_enum(#str, enum_class::ENUM_CONST(str));
+
 namespace dsn {
 
 template <typename TEnum>

--- a/src/utils/enum_helper.h
+++ b/src/utils/enum_helper.h
@@ -36,9 +36,14 @@
 #pragma once
 
 #include <map>
-#include <string>
-#include <mutex>
 #include <memory>
+#include <mutex>
+#include <string>
+
+namespace dsn {
+template <typename TEnum>
+class enum_helper_xxx;
+} // namespace dsn
 
 // an invalid enum value must be provided so as to be the default value when parsing failed
 #define ENUM_BEGIN2(type, name, invalid_value)                                                     \
@@ -68,7 +73,53 @@
 
 #define ENUM_END(type) ENUM_END2(type, type)
 
-// UpperCamelCase
+// Google Style (https://google.github.io/styleguide/cppguide.html#Enumerator_Names) has recommended
+// using k-prefixed camelCase to name an enumerator instead of MACRO_CASE. That is, use kEnumName,
+// rather than ENUM_NAME.
+//
+// On the other hand, the string representation for an enumerator is often needed. After declaring
+// the enumerator, ENUM_REG* macros would also be used to register the string representation, which
+// has some drawbacks:
+// * the enumerator has to appear again, leading to redundant code;
+// * once there are numerous enumerators, ENUM_REG* tend to be forgotten and the registers for the
+// string representation would be missing.
+//
+// To solve these problems, ENUM_CONST* macros are introduced:
+// * firstly, naming for the string representation should be UpperCamelCase style (namely EnumName);
+// * ENUM_CONST() could be used to generate the enumerators according to the string representation;
+// * only support `enum class` declarations;
+// * ENUM_CONST_DEF() could be used to declare enumerators in the enum class;
+// * ENUM_CONST_REG_STR could be used to register the string representation.
+//
+// The usage of these macros would be described as below. For example, Status::code of rocksdb
+// (include/rocksdb/status.h) could be defined by ENUM_CONST* as following steps:
+//
+// 1. List string representation for each enumerator by a user-defined macro:
+// --------------------------------------------------------------------------
+/*
+ * #define ENUM_FOREACH_STATUS_CODE(DEF)    \
+ *    DEF(Ok)                               \
+ *    DEF(NotFound)                         \
+ *    DEF(Corruption)                       \
+ *    DEF(IOError)
+ */
+// 2. Declare an enum class by above user-defined macro, with an Invalid and an Count enumerator if
+// necessary:
+// ------------------------------------------------------------------------------------------------
+// enum class status_code
+// {
+//     ENUM_FOREACH_STATUS_CODE(ENUM_CONST_DEF) kCount, kInvalidCode,
+// };
+//
+// 3. Define another user-defined macro to register string representations:
+// ------------------------------------------------------------------------
+// #define ENUM_CONST_REG_STR_STATUS_CODE(str) ENUM_CONST_REG_STR(status_code, str)
+//
+// 4. Define enum helper class:
+// ----------------------------
+// ENUM_BEGIN(status_code, status_code::kInvalidCode)
+// ENUM_FOREACH_STATUS_CODE(ENUM_CONST_REG_STR_STATUS_CODE)
+// ENUM_END(status_code)
 #define ENUM_CONST(str) k##str
 #define ENUM_CONST_DEF(str) ENUM_CONST(str),
 #define ENUM_CONST_REG_STR(enum_class, str)                                                        \

--- a/src/utils/enum_helper.h
+++ b/src/utils/enum_helper.h
@@ -68,7 +68,8 @@
 
 #define ENUM_CONST(str) k##str
 #define ENUM_CONST_DEF(str) ENUM_CONST(str),
-#define ENUM_CONST_REG_STR(enum_class, str) helper->register_enum(#str, enum_class::ENUM_CONST(str));
+#define ENUM_CONST_REG_STR(enum_class, str)                                                        \
+    helper->register_enum(#str, enum_class::ENUM_CONST(str));
 
 namespace dsn {
 

--- a/src/utils/enum_helper.h
+++ b/src/utils/enum_helper.h
@@ -52,6 +52,8 @@
 #define ENUM_REG_WITH_CUSTOM_NAME(type, name) helper->register_enum(#name, type);
 #define ENUM_REG(e) helper->register_enum(#e, e);
 
+// Argument `type invalid_value` for enum_from_string, albeit unused, has to be provided due to
+// overloading.
 #define ENUM_END2(type, name)                                                                      \
     return helper;                                                                                 \
     }                                                                                              \
@@ -66,6 +68,7 @@
 
 #define ENUM_END(type) ENUM_END2(type, type)
 
+// UpperCamelCase
 #define ENUM_CONST(str) k##str
 #define ENUM_CONST_DEF(str) ENUM_CONST(str),
 #define ENUM_CONST_REG_STR(enum_class, str)                                                        \

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -644,20 +644,21 @@ private:
 // On the other hand, it is also needed when some special operation should be done
 // for a metric type. For example, percentile should be closed while it's no longer
 // used.
+#define FOREACH_metric_type(def) \
+        def(Gauge)   \
+        def(Counter)  \
+        def(VolatileCounter)   \
+        def(Percentile)  
+
 enum class metric_type
 {
-    kGauge,
-    kCounter,
-    kVolatileCounter,
-    kPercentile,
-    kInvalidUnit,
+    FOREACH_metric_type(ENUM_CONST_DEF)
+    kInvalidType,
 };
 
-ENUM_BEGIN(metric_type, metric_type::kInvalidUnit)
-ENUM_REG_WITH_CUSTOM_NAME(metric_type::kGauge, gauge)
-ENUM_REG_WITH_CUSTOM_NAME(metric_type::kCounter, counter)
-ENUM_REG_WITH_CUSTOM_NAME(metric_type::kVolatileCounter, volatile_counter)
-ENUM_REG_WITH_CUSTOM_NAME(metric_type::kPercentile, percentile)
+#define ENUM_CONST_REG_STR_metric_type(str) ENUM_CONST_REG_STR(metric_type, str)
+ENUM_BEGIN(metric_type, metric_type::kInvalidType)
+FOREACH_metric_type(ENUM_CONST_REG_STR_metric_type)
 ENUM_END(metric_type)
 
 enum class metric_unit : size_t

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -644,63 +644,65 @@ private:
 // On the other hand, it is also needed when some special operation should be done
 // for a metric type. For example, percentile should be closed while it's no longer
 // used.
-#define FOREACH_metric_type(def) \
-        def(Gauge)   \
-        def(Counter)  \
-        def(VolatileCounter)   \
-        def(Percentile)  
+#define ENUM_FOREACH_METRIC_TYPE(DEF)                                                              \
+    DEF(Gauge)                                                                                     \
+    DEF(Counter)                                                                                   \
+    DEF(VolatileCounter)                                                                           \
+    DEF(Percentile)
 
 enum class metric_type
 {
-    FOREACH_metric_type(ENUM_CONST_DEF)
-    kInvalidType,
+    ENUM_FOREACH_METRIC_TYPE(ENUM_CONST_DEF) kInvalidType,
 };
 
-#define ENUM_CONST_REG_STR_metric_type(str) ENUM_CONST_REG_STR(metric_type, str)
+#define ENUM_CONST_REG_STR_METRIC_TYPE(str) ENUM_CONST_REG_STR(metric_type, str)
+
 ENUM_BEGIN(metric_type, metric_type::kInvalidType)
-FOREACH_metric_type(ENUM_CONST_REG_STR_metric_type)
+ENUM_FOREACH_METRIC_TYPE(ENUM_CONST_REG_STR_METRIC_TYPE)
 ENUM_END(metric_type)
+
+#define ENUM_FOREACH_METRIC_UNIT(DEF)                                                              \
+    DEF(NanoSeconds)                                                                               \
+    DEF(MicroSeconds)                                                                              \
+    DEF(MilliSeconds)                                                                              \
+    DEF(Seconds)                                                                                   \
+    DEF(Bytes)                                                                                     \
+    DEF(MegaBytes)                                                                                 \
+    DEF(CapacityUnits)                                                                             \
+    DEF(Percent)                                                                                   \
+    DEF(Replicas)                                                                                  \
+    DEF(Partitions)                                                                                \
+    DEF(PartitionSplittings)                                                                       \
+    DEF(Servers)                                                                                   \
+    DEF(Requests)                                                                                  \
+    DEF(Responses)                                                                                 \
+    DEF(Seeks)                                                                                     \
+    DEF(PointLookups)                                                                              \
+    DEF(Values)                                                                                    \
+    DEF(Keys)                                                                                      \
+    DEF(Files)                                                                                     \
+    DEF(Dirs)                                                                                      \
+    DEF(Amplification)                                                                             \
+    DEF(Checkpoints)                                                                               \
+    DEF(Flushes)                                                                                   \
+    DEF(Compactions)                                                                               \
+    DEF(Mutations)                                                                                 \
+    DEF(Writes)                                                                                    \
+    DEF(Changes)                                                                                   \
+    DEF(Operations)                                                                                \
+    DEF(Tasks)                                                                                     \
+    DEF(Disconnections)                                                                            \
+    DEF(Learns)                                                                                    \
+    DEF(Rounds)                                                                                    \
+    DEF(Resets)                                                                                    \
+    DEF(Backups)                                                                                   \
+    DEF(FileLoads)                                                                                 \
+    DEF(FileUploads)                                                                               \
+    DEF(BulkLoads)
 
 enum class metric_unit : size_t
 {
-    kNanoSeconds,
-    kMicroSeconds,
-    kMilliSeconds,
-    kSeconds,
-    kBytes,
-    kMegaBytes,
-    kCapacityUnits,
-    kPercent,
-    kReplicas,
-    kPartitions,
-    kPartitionSplittings,
-    kServers,
-    kRequests,
-    kResponses,
-    kSeeks,
-    kPointLookups,
-    kValues,
-    kKeys,
-    kFiles,
-    kDirs,
-    kAmplification,
-    kCheckpoints,
-    kFlushes,
-    kCompactions,
-    kMutations,
-    kWrites,
-    kChanges,
-    kOperations,
-    kTasks,
-    kDisconnections,
-    kLearns,
-    kRounds,
-    kResets,
-    kBackups,
-    kFileLoads,
-    kFileUploads,
-    kBulkLoads,
-    kInvalidUnit,
+    ENUM_FOREACH_METRIC_UNIT(ENUM_CONST_DEF) kInvalidUnit,
 };
 
 #define METRIC_ASSERT_UNIT_LATENCY(unit, index)                                                    \
@@ -728,12 +730,10 @@ inline uint64_t convert_metric_latency_from_ns(uint64_t latency_ns, metric_unit 
     return latency_ns / kMetricLatencyConverterFromNS[index];
 }
 
+#define ENUM_CONST_REG_STR_METRIC_UNIT(str) ENUM_CONST_REG_STR(metric_unit, str)
+
 ENUM_BEGIN(metric_unit, metric_unit::kInvalidUnit)
-ENUM_REG_WITH_CUSTOM_NAME(metric_unit::kNanoSeconds, nanoseconds)
-ENUM_REG_WITH_CUSTOM_NAME(metric_unit::kMicroSeconds, microseconds)
-ENUM_REG_WITH_CUSTOM_NAME(metric_unit::kMilliSeconds, milliseconds)
-ENUM_REG_WITH_CUSTOM_NAME(metric_unit::kSeconds, seconds)
-ENUM_REG_WITH_CUSTOM_NAME(metric_unit::kRequests, requests)
+ENUM_FOREACH_METRIC_UNIT(ENUM_CONST_REG_STR_METRIC_UNIT)
 ENUM_END(metric_unit)
 
 class metric_prototype

--- a/src/utils/test/enum_helper_test.cpp
+++ b/src/utils/test/enum_helper_test.cpp
@@ -17,62 +17,82 @@
 
 #include "utils/enum_helper.h"
 
+// IWYU pragma: no_include <gtest/gtest-message.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
+// IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <vector>
 
 namespace dsn {
 
-#define ENUM_FOREACH_TEST_TYPE(DEF)                                                                \
-    DEF(EnumeratorOne)                                                                             \
-    DEF(EnumeratorTwo)                                                                             \
-    DEF(EnumeratorThree)
-
-enum class test_enum_const_type
+enum class command_type
 {
-    ENUM_FOREACH_TEST_TYPE(ENUM_CONST_DEF) kInvalidType,
+    START,
+    RESTART,
+    STOP,
+    COUNT,
+    INVALID_TYPE,
 };
 
-#define ENUM_CONST_REG_STR_TEST_TYPE(str) ENUM_CONST_REG_STR(test_enum_const_type, str)
+ENUM_BEGIN(command_type, command_type::INVALID_TYPE)
+ENUM_REG2(command_type, START)
+ENUM_REG_WITH_CUSTOM_NAME(command_type::RESTART, restart)
+ENUM_REG(command_type::STOP)
+ENUM_END(command_type)
 
-ENUM_BEGIN(test_enum_const_type, test_enum_const_type::kInvalidType)
-ENUM_FOREACH_TEST_TYPE(ENUM_CONST_REG_STR_TEST_TYPE)
-ENUM_END(test_enum_const_type)
+using command_type_enum_from_string_case = std::tuple<std::string, command_type>;
 
-using enum_const_from_string_case = std::tuple<std::string, test_enum_const_type>;
-
-class EnumConstFromStringTest : public testing::TestWithParam<enum_const_from_string_case>
+class CommandTypeEnumFromStringTest
+    : public testing::TestWithParam<command_type_enum_from_string_case>
 {
 };
 
-TEST_P(EnumConstFromStringTest, EnumFromString)
+TEST_P(CommandTypeEnumFromStringTest, EnumFromString)
 {
     std::string str;
-    test_enum_const_type expected_type;
+    command_type expected_type;
     std::tie(str, expected_type) = GetParam();
 
-    auto actual_type = enum_from_string(str.c_str(), test_enum_const_type::kInvalidType);
+    auto actual_type = enum_from_string(str.c_str(), command_type::INVALID_TYPE);
     EXPECT_EQ(expected_type, actual_type);
 }
 
-const std::vector<enum_const_from_string_case> enum_const_from_string_tests = {
-    {"EnumeratorOne", test_enum_const_type::kEnumeratorOne},
-    {"EnumeratorTwo", test_enum_const_type::kEnumeratorTwo},
-    {"EnumeratorThree", test_enum_const_type::kEnumeratorThree},
-    {"EnumeratorUndefined", test_enum_const_type::kInvalidType},
+const std::vector<command_type_enum_from_string_case> command_type_enum_from_string_tests = {
+    {"START", command_type::START},
+    {"Start", command_type::INVALID_TYPE},
+    {"start", command_type::INVALID_TYPE},
+    {"command_type::START", command_type::INVALID_TYPE},
+    {"command_type::Start", command_type::INVALID_TYPE},
+    {"command_type::start", command_type::INVALID_TYPE},
+    {"RESTART", command_type::INVALID_TYPE},
+    {"Restart", command_type::INVALID_TYPE},
+    {"restart", command_type::RESTART},
+    {"command_type::RESTART", command_type::INVALID_TYPE},
+    {"command_type::Restart", command_type::INVALID_TYPE},
+    {"command_type::restart", command_type::INVALID_TYPE},
+    {"STOP", command_type::INVALID_TYPE},
+    {"Stop", command_type::INVALID_TYPE},
+    {"stop", command_type::INVALID_TYPE},
+    {"command_type::STOP", command_type::STOP},
+    {"command_type::Stop", command_type::INVALID_TYPE},
+    {"command_type::stop", command_type::INVALID_TYPE},
+    {"COUNT", command_type::INVALID_TYPE}, // Since COUNT was not registered with specified string
+    {"UNDEFINE_TYPE", command_type::INVALID_TYPE},
 };
 
 INSTANTIATE_TEST_CASE_P(EnumHelperTest,
-                        EnumConstFromStringTest,
-                        testing::ValuesIn(enum_const_from_string_tests));
+                        CommandTypeEnumFromStringTest,
+                        testing::ValuesIn(command_type_enum_from_string_tests));
 
-using enum_const_to_string_case = std::tuple<test_enum_const_type, std::string>;
+using command_type_enum_to_string_case = std::tuple<command_type, std::string>;
 
-class EnumConstToStringTest : public testing::TestWithParam<enum_const_to_string_case>
+class CommandTypeEnumToStringTest : public testing::TestWithParam<command_type_enum_to_string_case>
 {
 };
 
-TEST_P(EnumConstToStringTest, EnumToString)
+TEST_P(CommandTypeEnumToStringTest, EnumToString)
 {
-    test_enum_const_type type;
+    command_type type;
     std::string expected_str;
     std::tie(type, expected_str) = GetParam();
 
@@ -80,15 +100,113 @@ TEST_P(EnumConstToStringTest, EnumToString)
     EXPECT_EQ(expected_str, actual_str);
 }
 
-const std::vector<enum_const_to_string_case> enum_const_to_string_tests = {
-    {test_enum_const_type::kEnumeratorOne, "EnumeratorOne"},
-    {test_enum_const_type::kEnumeratorTwo, "EnumeratorTwo"},
-    {test_enum_const_type::kEnumeratorThree, "EnumeratorThree"},
-    {test_enum_const_type::kInvalidType, "Unknown"},
+const std::vector<command_type_enum_to_string_case> command_type_enum_to_string_tests = {
+    {command_type::START, "START"},
+    {command_type::RESTART, "restart"},
+    {command_type::STOP, "command_type::STOP"},
+    {command_type::COUNT, "Unknown"}, // Since COUNT was not registered with specified string
+    {command_type::INVALID_TYPE, "Unknown"},
 };
 
 INSTANTIATE_TEST_CASE_P(EnumHelperTest,
-                        EnumConstToStringTest,
-                        testing::ValuesIn(enum_const_to_string_tests));
+                        CommandTypeEnumToStringTest,
+                        testing::ValuesIn(command_type_enum_to_string_tests));
+
+#define ENUM_FOREACH_STATUS_CODE(DEF)                                                              \
+    DEF(Ok)                                                                                        \
+    DEF(NotFound)                                                                                  \
+    DEF(Corruption)                                                                                \
+    DEF(IOError)
+
+enum class status_code
+{
+    ENUM_FOREACH_STATUS_CODE(ENUM_CONST_DEF) kCount,
+    kInvalidCode,
+};
+
+#define ENUM_CONST_REG_STR_STATUS_CODE(str) ENUM_CONST_REG_STR(status_code, str)
+
+ENUM_BEGIN(status_code, status_code::kInvalidCode)
+ENUM_FOREACH_STATUS_CODE(ENUM_CONST_REG_STR_STATUS_CODE)
+ENUM_END(status_code)
+
+using status_code_enum_from_string_case = std::tuple<std::string, status_code>;
+
+class StatusCodeEnumFromStringTest
+    : public testing::TestWithParam<status_code_enum_from_string_case>
+{
+};
+
+TEST_P(StatusCodeEnumFromStringTest, EnumFromString)
+{
+    std::string str;
+    status_code expected_code;
+    std::tie(str, expected_code) = GetParam();
+
+    auto actual_code = enum_from_string(str.c_str(), status_code::kInvalidCode);
+    EXPECT_EQ(expected_code, actual_code);
+}
+
+const std::vector<status_code_enum_from_string_case> status_code_enum_from_string_tests = {
+    {"OK", status_code::kInvalidCode},
+    {"Ok", status_code::kOk},
+    {"ok", status_code::kInvalidCode},
+    {"status_code::OK", status_code::kInvalidCode},
+    {"status_code::Ok", status_code::kInvalidCode},
+    {"status_code::ok", status_code::kInvalidCode},
+    {"NOTFOUND", status_code::kInvalidCode},
+    {"NotFound", status_code::kNotFound},
+    {"notfound", status_code::kInvalidCode},
+    {"status_code::NOTFOUND", status_code::kInvalidCode},
+    {"status_code::NotFound", status_code::kInvalidCode},
+    {"status_code::notfound", status_code::kInvalidCode},
+    {"CORRUPTION", status_code::kInvalidCode},
+    {"Corruption", status_code::kCorruption},
+    {"corruption", status_code::kInvalidCode},
+    {"status_code::CORRUPTION", status_code::kInvalidCode},
+    {"status_code::Corruption", status_code::kInvalidCode},
+    {"status_code::corruption", status_code::kInvalidCode},
+    {"IOERROR", status_code::kInvalidCode},
+    {"IOError", status_code::kIOError},
+    {"ioerror", status_code::kInvalidCode},
+    {"status_code::IOERROR", status_code::kInvalidCode},
+    {"status_code::IOError", status_code::kInvalidCode},
+    {"status_code::ioerror", status_code::kInvalidCode},
+    {"Count", status_code::kInvalidCode}, // Since kCount was not registered with specified string
+    {"UndefinedCode", status_code::kInvalidCode},
+};
+
+INSTANTIATE_TEST_CASE_P(EnumHelperTest,
+                        StatusCodeEnumFromStringTest,
+                        testing::ValuesIn(status_code_enum_from_string_tests));
+
+using status_code_enum_to_string_case = std::tuple<status_code, std::string>;
+
+class StatusCodeEnumToStringTest : public testing::TestWithParam<status_code_enum_to_string_case>
+{
+};
+
+TEST_P(StatusCodeEnumToStringTest, EnumToString)
+{
+    status_code code;
+    std::string expected_str;
+    std::tie(code, expected_str) = GetParam();
+
+    std::string actual_str(enum_to_string(code));
+    EXPECT_EQ(expected_str, actual_str);
+}
+
+const std::vector<status_code_enum_to_string_case> status_code_enum_to_string_tests = {
+    {status_code::kOk, "Ok"},
+    {status_code::kNotFound, "NotFound"},
+    {status_code::kCorruption, "Corruption"},
+    {status_code::kIOError, "IOError"},
+    {status_code::kCount, "Unknown"}, // Since kCount was not registered with specified string
+    {status_code::kInvalidCode, "Unknown"},
+};
+
+INSTANTIATE_TEST_CASE_P(EnumHelperTest,
+                        StatusCodeEnumToStringTest,
+                        testing::ValuesIn(status_code_enum_to_string_tests));
 
 } // namespace dsn

--- a/src/utils/test/enum_helper_test.cpp
+++ b/src/utils/test/enum_helper_test.cpp
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "utils/enum_helper.h"
+
+#include <gtest/gtest.h>
+
+namespace dsn {
+
+#define ENUM_FOREACH_TEST_TYPE(DEF)                                                                \
+    DEF(EnumeratorOne)                                                                             \
+    DEF(EnumeratorTwo)                                                                             \
+    DEF(EnumeratorThree)
+
+enum class test_enum_const_type
+{
+    ENUM_FOREACH_TEST_TYPE(ENUM_CONST_DEF) kInvalidType,
+};
+
+#define ENUM_CONST_REG_STR_TEST_TYPE(str) ENUM_CONST_REG_STR(test_enum_const_type, str)
+
+ENUM_BEGIN(test_enum_const_type, test_enum_const_type::kInvalidType)
+ENUM_FOREACH_TEST_TYPE(ENUM_CONST_REG_STR_TEST_TYPE)
+ENUM_END(test_enum_const_type)
+
+using enum_const_from_string_case = std::tuple<std::string, test_enum_const_type>;
+
+class EnumConstFromStringTest : public testing::TestWithParam<enum_const_from_string_case>
+{
+};
+
+TEST_P(EnumConstFromStringTest, EnumFromString)
+{
+    std::string str;
+    test_enum_const_type expected_type;
+    std::tie(str, expected_type) = GetParam();
+
+    auto actual_type = enum_from_string(str.c_str(), test_enum_const_type::kInvalidType);
+    EXPECT_EQ(expected_type, actual_type);
+}
+
+const std::vector<enum_const_from_string_case> enum_const_from_string_tests = {
+    {"EnumeratorOne", test_enum_const_type::kEnumeratorOne},
+    {"EnumeratorTwo", test_enum_const_type::kEnumeratorTwo},
+    {"EnumeratorThree", test_enum_const_type::kEnumeratorThree},
+    {"EnumeratorUndefined", test_enum_const_type::kInvalidType},
+};
+
+INSTANTIATE_TEST_CASE_P(EnumHelperTest,
+                        EnumConstFromStringTest,
+                        testing::ValuesIn(enum_const_from_string_tests));
+
+using enum_const_to_string_case = std::tuple<test_enum_const_type, std::string>;
+
+class EnumConstToStringTest : public testing::TestWithParam<enum_const_to_string_case>
+{
+};
+
+TEST_P(EnumConstToStringTest, EnumToString)
+{
+    test_enum_const_type type;
+    std::string expected_str;
+    std::tie(type, expected_str) = GetParam();
+
+    std::string actual_str(enum_to_string(type));
+    EXPECT_EQ(expected_str, actual_str);
+}
+
+const std::vector<enum_const_to_string_case> enum_const_to_string_tests = {
+    {test_enum_const_type::kEnumeratorOne, "EnumeratorOne"},
+    {test_enum_const_type::kEnumeratorTwo, "EnumeratorTwo"},
+    {test_enum_const_type::kEnumeratorThree, "EnumeratorThree"},
+    {test_enum_const_type::kInvalidType, "Unknown"},
+};
+
+INSTANTIATE_TEST_CASE_P(EnumHelperTest,
+                        EnumConstToStringTest,
+                        testing::ValuesIn(enum_const_to_string_tests));
+
+} // namespace dsn


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1490

For the enum classes, such as metric type and unit, in addition to the declaration
of all enumerators, extra code is needed to implement `enum_to_string` for each
enumerator. However, the "extra code" tended to be forgotten, just as what has
been said in the above issue #1490.

Therefore, we should find a way that could share all the enumerators between
the declaration and `enum_to_string`. Each enumerator would be written only
once, and there is no need to remember to add `enum_to_string` for each
enumerator.

We could implement the "sharing" by function-like macros. They have the names
of all the enumerators, and accept an argument to perform custom actions over
the names to implement the "sharing". Both metric types and units would be
refactored in this way.

While building ASAN Github actions failed due to running out of disk space.
This problem is resolved by dropping all directories of `CMakeFiles`, which is
also tracked another issue: 
        https://github.com/apache/incubator-pegasus/issues/1497