### PR TITLE
fix: fix start_onebox failed because of libjvm.so not found (#1494)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,7 @@ LOCAL_HOSTNAME=`hostname -f`
 export REPORT_DIR="$ROOT/test_report"
 export DSN_ROOT=$ROOT/DSN_ROOT
 export THIRDPARTY_ROOT=$ROOT/thirdparty
-export LD_LIBRARY_PATH=$DSN_ROOT/lib:$THIRDPARTY_ROOT/output/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/amd64/server:$DSN_ROOT/lib:$THIRDPARTY_ROOT/output/lib:$LD_LIBRARY_PATH
 
 function usage()
 {


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1493

This is a cherry-pick commit to branch v2.4.
Fix rhe bug of "pegasus_server: error while loading shared libraries: libdsn_replica_server.so: cannot open shared object file: No such file or directory". It's because that the libjvm.so is not added to $LD_LIBRARY_PATH.
