### PR TITLE
feat(Ranger): remove ACL of RPC_CM_LIST_APPS from global resource

### DIFF
--- a/src/runtime/ranger/ranger_resource_policy_manager.cpp
+++ b/src/runtime/ranger/ranger_resource_policy_manager.cpp
@@ -147,10 +147,9 @@ ranger_resource_policy_manager::ranger_resource_policy_manager(
     : _meta_svc(meta_svc), _local_policy_version(-1)
 {
     // GLOBAL - kMetadata
-    register_rpc_access_type(
-        access_type::kMetadata,
-        {"RPC_CM_LIST_NODES", "RPC_CM_CLUSTER_INFO", "RPC_CM_LIST_APPS", "RPC_QUERY_DISK_INFO"},
-        _ac_type_of_global_rpcs);
+    register_rpc_access_type(access_type::kMetadata,
+                             {"RPC_CM_LIST_NODES", "RPC_CM_CLUSTER_INFO", "RPC_QUERY_DISK_INFO"},
+                             _ac_type_of_global_rpcs);
     // GLOBAL - kControl
     register_rpc_access_type(access_type::kControl,
                              {"RPC_HTTP_SERVICE",
@@ -231,12 +230,8 @@ bool ranger_resource_policy_manager::allowed(const int rpc_code,
             }
         }
 
-        // It's not allowed to access except list_app.
-        // list_app rpc code is in both GLOBAL and DATABASE policies, check the DATABASE policies
-        // later.
-        if (rpc_code != RPC_CM_LIST_APPS.code()) {
-            return false;
-        }
+        // The check that does not match any GLOBAL policy returns false.
+        return false;
     } while (false);
 
     do {

--- a/src/runtime/test/ranger_resource_policy_manager_test.cpp
+++ b/src/runtime/test/ranger_resource_policy_manager_test.cpp
@@ -338,7 +338,8 @@ TEST_F(ranger_resource_policy_manager_function_test, allowed)
                  {"TASK_CODE_INVALID", "user7", "database3", false},
                  {"RPC_CM_LIST_NODES", "user7", "database3", true},
                  {"RPC_CM_LIST_NODES", "user8", "database3", false},
-                 {"RPC_CM_LIST_APPS", "user7", "database3", true},
+                 // RPC_CM_LIST_APPS has been removed from global resources.
+                 {"RPC_CM_LIST_APPS", "user7", "database3", false},
                  {"RPC_CM_LIST_APPS", "user8", "database3", false},
                  {"TASK_CODE_INVALID", "user9", "database4", false},
                  {"RPC_CM_LIST_NODES", "user9", "database4", false},


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1054

### What is changed and how does it work?
- The access control management of RPC RPC_CM_LIST_APPS is removed from the global level resource, which is managed by the database resource.