### PR TITLE
feat(new_metrics): migrate metrics for failure detector

### DIFF
--- a/src/failure_detector/failure_detector.cpp
+++ b/src/failure_detector/failure_detector.cpp
@@ -52,7 +52,7 @@ METRIC_DEFINE_counter(server,
 namespace dsn {
 namespace fd {
 
-failure_detector::failure_detector(): METRIC_VAR_INIT_server(beacon_failed_count)
+failure_detector::failure_detector() : METRIC_VAR_INIT_server(beacon_failed_count)
 {
     dsn::threadpool_code pool = task_spec::get(LPC_BEACON_CHECK.code())->pool_code;
     task_spec::get(RPC_FD_FAILURE_DETECTOR_PING.code())->pool_code = pool;

--- a/src/failure_detector/failure_detector.cpp
+++ b/src/failure_detector/failure_detector.cpp
@@ -43,6 +43,7 @@
 #include "utils/command_manager.h"
 #include "utils/fmt_logging.h"
 #include "utils/process_utils.h"
+#include "utils/string_view.h"
 
 METRIC_DEFINE_counter(server,
                       beacon_failed_count,

--- a/src/failure_detector/failure_detector.h
+++ b/src/failure_detector/failure_detector.h
@@ -70,12 +70,12 @@
 
 #include "failure_detector/fd.client.h"
 #include "failure_detector/fd.server.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/task/task.h"
 #include "runtime/task/task_code.h"
 #include "runtime/task/task_tracker.h"
 #include "utils/error_code.h"
+#include "utils/metrics.h"
 #include "utils/threadpool_code.h"
 #include "utils/zlocks.h"
 
@@ -238,7 +238,7 @@ private:
     bool _use_allow_list;
     allow_list _allow_list;
 
-    perf_counter_wrapper _recent_beacon_fail_count;
+    METRIC_VAR_DECLARE_counter(beacon_failed_count);
 
     std::unique_ptr<command_deregister> _get_allow_list;
 

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -698,7 +698,8 @@ ENUM_END(metric_type)
     DEF(Backups)                                                                                   \
     DEF(FileLoads)                                                                                 \
     DEF(FileUploads)                                                                               \
-    DEF(BulkLoads)
+    DEF(BulkLoads) \
+    DEF(Beacons) 
 
 enum class metric_unit : size_t
 {

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -698,8 +698,8 @@ ENUM_END(metric_type)
     DEF(Backups)                                                                                   \
     DEF(FileLoads)                                                                                 \
     DEF(FileUploads)                                                                               \
-    DEF(BulkLoads) \
-    DEF(Beacons) 
+    DEF(BulkLoads)                                                                                 \
+    DEF(Beacons)
 
 enum class metric_unit : size_t
 {


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1501

The only server-level metric of failure detector is migrated to the new framework,
i.e. the number of failed beacons sent by failure detector.