### PR TITLE
feat(new_metrics): migrate metrics for network

### DIFF
--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -33,7 +33,6 @@
 #include <utility>
 
 #include "message_parser_manager.h"
-#include "perf_counter/perf_counter.h"
 #include "runtime/api_task.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_engine.h"
@@ -45,8 +44,19 @@
 #include "utils/fmt_logging.h"
 #include "utils/ports.h"
 #include "utils/safe_strerror_posix.h"
+#include "utils/string_view.h"
 #include "utils/strings.h"
 #include "utils/threadpool_code.h"
+
+METRIC_DEFINE_gauge_int64(server,
+                          network_client_sessions,
+                          dsn::metric_unit::kSessions,
+                          "The number of sessions from client side");
+
+METRIC_DEFINE_gauge_int64(server,
+                          network_server_sessions,
+                          dsn::metric_unit::kSessions,
+                          "The number of sessions from server side");
 
 namespace dsn {
 DSN_DEFINE_uint32(network,
@@ -590,13 +600,10 @@ uint32_t network::get_local_ipv4()
 }
 
 connection_oriented_network::connection_oriented_network(rpc_engine *srv, network *inner_provider)
-    : network(srv, inner_provider)
+    : network(srv, inner_provider),
+    METRIC_VAR_INIT_server(network_client_sessions),
+    METRIC_VAR_INIT_server(network_server_sessions)
 {
-    _client_session_count.init_global_counter("server",
-                                              "network",
-                                              "client_session_count",
-                                              COUNTER_TYPE_NUMBER,
-                                              "current session count on server");
 }
 
 void connection_oriented_network::inject_drop_message(message_ex *msg, bool is_send)
@@ -654,7 +661,7 @@ void connection_oriented_network::send_message(message_ex *request)
         LOG_INFO("client session created, remote_server = {}, current_count = {}",
                  client->remote_address(),
                  ip_count);
-        _client_session_count->set(ip_count);
+        METRIC_VAR_SET(network_client_sessions, ip_count);
         client->connect();
     }
 
@@ -702,7 +709,7 @@ void connection_oriented_network::on_server_session_accepted(rpc_session_ptr &s)
              s->remote_address(),
              ip_conn_count);
 
-    _client_session_count->set(ip_count);
+    METRIC_VAR_SET(network_server_sessions, ip_count);
 }
 
 void connection_oriented_network::on_server_session_disconnected(rpc_session_ptr &s)
@@ -738,7 +745,7 @@ void connection_oriented_network::on_server_session_disconnected(rpc_session_ptr
         LOG_INFO("session {} disconnected, the total client sessions count remains {}",
                  s->remote_address(),
                  ip_count);
-        _client_session_count->set(ip_count);
+        METRIC_VAR_SET(network_server_sessions, ip_count);
     }
 
     if (ip_conn_count == 0) {
@@ -800,7 +807,7 @@ void connection_oriented_network::on_client_session_connected(rpc_session_ptr &s
         LOG_INFO("client session connected, remote_server = {}, current_count = {}",
                  s->remote_address(),
                  ip_count);
-        _client_session_count->set(ip_count);
+        METRIC_VAR_SET(network_client_sessions, ip_count);
     }
 }
 
@@ -822,7 +829,7 @@ void connection_oriented_network::on_client_session_disconnected(rpc_session_ptr
         LOG_INFO("client session disconnected, remote_server = {}, current_count = {}",
                  s->remote_address(),
                  ip_count);
-        _client_session_count->set(ip_count);
+        METRIC_VAR_SET(network_client_sessions, ip_count);
     }
 }
 

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -601,8 +601,8 @@ uint32_t network::get_local_ipv4()
 
 connection_oriented_network::connection_oriented_network(rpc_engine *srv, network *inner_provider)
     : network(srv, inner_provider),
-    METRIC_VAR_INIT_server(network_client_sessions),
-    METRIC_VAR_INIT_server(network_server_sessions)
+      METRIC_VAR_INIT_server(network_client_sessions),
+      METRIC_VAR_INIT_server(network_server_sessions)
 {
 }
 

--- a/src/runtime/rpc/network.h
+++ b/src/runtime/rpc/network.h
@@ -32,7 +32,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "perf_counter/perf_counter_wrapper.h"
 #include "rpc_address.h"
 #include "runtime/rpc/message_parser.h"
 #include "runtime/rpc/rpc_message.h"
@@ -41,6 +40,7 @@
 #include "utils/error_code.h"
 #include "utils/join_point.h"
 #include "utils/link.h"
+#include "utils/metrics.h"
 #include "utils/synchronize.h"
 
 namespace dsn {
@@ -191,7 +191,8 @@ protected:
     ip_connection_count _ip_conn_count; // from_ip => connection count
     utils::rw_lock_nr _servers_lock;
 
-    perf_counter_wrapper _client_session_count;
+    METRIC_VAR_DECLARE_gauge_int64(network_client_sessions);
+    METRIC_VAR_DECLARE_gauge_int64(network_server_sessions);
 };
 
 /*!

--- a/src/runtime/rpc/rpc_message.cpp
+++ b/src/runtime/rpc/rpc_message.cpp
@@ -40,7 +40,7 @@
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/join_point.h"
-#include "utils/singleton.h"
+#include "utils/strings.h"
 #include "utils/utils.h"
 
 using namespace dsn::utils;

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -692,6 +692,7 @@ ENUM_END(metric_type)
     DEF(Operations)                                                                                \
     DEF(Tasks)                                                                                     \
     DEF(Disconnections)                                                                            \
+    DEF(Sessions)                                                                            \
     DEF(Learns)                                                                                    \
     DEF(Rounds)                                                                                    \
     DEF(Resets)                                                                                    \

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -692,7 +692,7 @@ ENUM_END(metric_type)
     DEF(Operations)                                                                                \
     DEF(Tasks)                                                                                     \
     DEF(Disconnections)                                                                            \
-    DEF(Sessions)                                                                            \
+    DEF(Sessions)                                                                                  \
     DEF(Learns)                                                                                    \
     DEF(Rounds)                                                                                    \
     DEF(Resets)                                                                                    \


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1503

The only server-level gauge of network is split into 2 gauges, and migrated
to the new framework. The only gauge is a metric about TCP connections:
from client side, the network could connect to different remote servers;
while from server side, it could receive connections from remote clients.

In the past, the only gauge has been used to measure either the number of
different remote servers from client side, or the number of different remote
clients from server side, which might result in confusion. Therefore, it's better
to split the only gauge into 2 individual ones.