### PR TITLE
feat(new_metrics): migrate server-level metrics of rocksdb

### DIFF
--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -56,8 +56,6 @@
 #include "pegasus_const.h"
 #include "pegasus_rpc_types.h"
 #include "pegasus_server_write.h"
-#include "perf_counter/perf_counter.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "replica_admin_types.h"
 #include "rrdb/rrdb.code.definition.h"
 #include "rrdb/rrdb_types.h"
@@ -140,7 +138,7 @@ std::shared_ptr<rocksdb::Cache> pegasus_server_impl::_s_block_cache;
 std::shared_ptr<rocksdb::WriteBufferManager> pegasus_server_impl::_s_write_buffer_manager;
 ::dsn::task_ptr pegasus_server_impl::_update_server_rdb_stat;
 METRIC_VAR_DEFINE_gauge_int64(rdb_block_cache_mem_usage_bytes, pegasus_server_impl);
-::dsn::perf_counter_wrapper pegasus_server_impl::_pfc_rdb_write_limiter_rate_bytes;
+METRIC_VAR_DEFINE_gauge_int64(rdb_write_rate_limiter_through_bytes_per_sec, pegasus_server_impl);
 const std::string pegasus_server_impl::COMPRESSION_HEADER = "per_level:";
 const std::string pegasus_server_impl::DATA_COLUMN_FAMILY_NAME = "default";
 const std::string pegasus_server_impl::META_COLUMN_FAMILY_NAME = "pegasus_meta_cf";
@@ -2537,13 +2535,12 @@ void pegasus_server_impl::update_server_rocksdb_statistics()
         METRIC_VAR_SET(rdb_block_cache_mem_usage_bytes, val);
     }
 
-    // Update _pfc_rdb_write_limiter_rate_bytes
     if (_s_rate_limiter) {
         uint64_t current_total_through = _s_rate_limiter->GetTotalBytesThrough();
         uint64_t through_bytes_per_sec =
             (current_total_through - _rocksdb_limiter_last_total_through) /
             kServerStatUpdateTimeSec.count();
-        _pfc_rdb_write_limiter_rate_bytes->set(through_bytes_per_sec);
+        METRIC_VAR_SET(rdb_write_rate_limiter_through_bytes_per_sec, through_bytes_per_sec);
         _rocksdb_limiter_last_total_through = current_total_through;
     }
 }

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -139,7 +139,7 @@ int64_t pegasus_server_impl::_rocksdb_limiter_last_total_through;
 std::shared_ptr<rocksdb::Cache> pegasus_server_impl::_s_block_cache;
 std::shared_ptr<rocksdb::WriteBufferManager> pegasus_server_impl::_s_write_buffer_manager;
 ::dsn::task_ptr pegasus_server_impl::_update_server_rdb_stat;
-::dsn::perf_counter_wrapper pegasus_server_impl::_pfc_rdb_block_cache_mem_usage;
+METRIC_VAR_DEFINE_gauge_int64(rdb_block_cache_mem_usage_bytes, pegasus_server_impl);
 ::dsn::perf_counter_wrapper pegasus_server_impl::_pfc_rdb_write_limiter_rate_bytes;
 const std::string pegasus_server_impl::COMPRESSION_HEADER = "per_level:";
 const std::string pegasus_server_impl::DATA_COLUMN_FAMILY_NAME = "default";
@@ -1865,7 +1865,6 @@ void pegasus_server_impl::cancel_background_work(bool wait)
         METRIC_VAR_SET(rdb_memtable_mem_usage_bytes, 0);
         METRIC_VAR_SET(rdb_block_cache_hit_count, 0);
         METRIC_VAR_SET(rdb_block_cache_total_count, 0);
-        _pfc_rdb_block_cache_mem_usage->set(0);
     }
 
     LOG_INFO_PREFIX("close app succeed, clear_state = {}", clear_state ? "true" : "false");
@@ -2533,10 +2532,9 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
 
 void pegasus_server_impl::update_server_rocksdb_statistics()
 {
-    // Update _pfc_rdb_block_cache_mem_usage
     if (_s_block_cache) {
         uint64_t val = _s_block_cache->GetUsage();
-        _pfc_rdb_block_cache_mem_usage->set(val);
+        METRIC_VAR_SET(rdb_block_cache_mem_usage_bytes, val);
     }
 
     // Update _pfc_rdb_write_limiter_rate_bytes

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -544,10 +544,9 @@ private:
     METRIC_VAR_DECLARE_counter(abnormal_read_requests);
     METRIC_VAR_DECLARE_counter(throttling_rejected_read_requests);
 
-    // rocksdb internal statistics
-    // server level
+    // Server-level metrics for rocksdb.
+    METRIC_VAR_DECLARE_gauge_int64(rdb_block_cache_mem_usage_bytes, static);
     static ::dsn::perf_counter_wrapper _pfc_rdb_write_limiter_rate_bytes;
-    static ::dsn::perf_counter_wrapper _pfc_rdb_block_cache_mem_usage;
 
     // Replica-level metrics for rocksdb.
     METRIC_VAR_DECLARE_gauge_int64(rdb_total_sst_files);

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -69,7 +69,6 @@ class WriteBufferManager;
 namespace dsn {
 class blob;
 class message_ex;
-class perf_counter_wrapper;
 class rpc_address;
 
 namespace replication {
@@ -546,7 +545,7 @@ private:
 
     // Server-level metrics for rocksdb.
     METRIC_VAR_DECLARE_gauge_int64(rdb_block_cache_mem_usage_bytes, static);
-    static ::dsn::perf_counter_wrapper _pfc_rdb_write_limiter_rate_bytes;
+    METRIC_VAR_DECLARE_gauge_int64(rdb_write_rate_limiter_through_bytes_per_sec, static);
 
     // Replica-level metrics for rocksdb.
     METRIC_VAR_DECLARE_gauge_int64(rdb_total_sst_files);

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -129,7 +129,7 @@ METRIC_DEFINE_gauge_int64(replica,
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_total_sst_size_mb,
                           dsn::metric_unit::kMegaBytes,
-                          "The total size of rocksdb sst files in MB");
+                          "The total size of rocksdb sst files");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_estimated_keys,
@@ -139,12 +139,12 @@ METRIC_DEFINE_gauge_int64(replica,
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_index_and_filter_blocks_mem_usage_bytes,
                           dsn::metric_unit::kBytes,
-                          "The memory usage of rocksdb index and filter blocks in bytes");
+                          "The memory usage of rocksdb index and filter blocks");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_memtable_mem_usage_bytes,
                           dsn::metric_unit::kBytes,
-                          "The memory usage of rocksdb memtables in bytes");
+                          "The memory usage of rocksdb memtables");
 
 METRIC_DEFINE_gauge_int64(replica,
                           rdb_block_cache_hit_count,
@@ -237,6 +237,16 @@ METRIC_DEFINE_gauge_int64(replica,
                           dsn::metric_unit::kPointLookups,
                           "The number of times full bloom filter has not avoided the reads and "
                           "data actually exist, used by rocksdb");
+
+METRIC_DEFINE_gauge_int64(server,
+                          rdb_block_cache_mem_usage_bytes,
+                          dsn::metric_unit::kBytes,
+                          "The memory usage of rocksdb block cache");
+
+METRIC_DEFINE_gauge_int64(server,
+                          rdb_block_cache_mem_usage_bytes,
+                          dsn::metric_unit::kBytes,
+                          "The memory usage of rocksdb block cache");
 
 namespace pegasus {
 namespace server {
@@ -820,13 +830,6 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     // them only once.
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-        _pfc_rdb_block_cache_mem_usage.init_global_counter(
-            "replica",
-            "app.pegasus",
-            "rdb.block_cache.memory_usage",
-            COUNTER_TYPE_NUMBER,
-            "statistic the memory usage of rocksdb block cache");
-
         _pfc_rdb_write_limiter_rate_bytes.init_global_counter(
             "replica",
             "app.pegasus",

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -825,6 +825,7 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     // them only once.
     static std::once_flag flag;
     std::call_once(flag, [&]() {
+        METRIC_VAR_ASSIGN_server(rdb_block_cache_mem_usage_bytes);
         _pfc_rdb_write_limiter_rate_bytes.init_global_counter(
             "replica",
             "app.pegasus",

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -40,8 +40,6 @@
 #include "pegasus_event_listener.h"
 #include "pegasus_server_impl.h"
 #include "pegasus_value_schema.h"
-#include "perf_counter/perf_counter.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "replica_admin_types.h"
 #include "runtime/api_layer1.h"
 #include "runtime/rpc/rpc_address.h"
@@ -242,6 +240,12 @@ METRIC_DEFINE_gauge_int64(server,
                           rdb_block_cache_mem_usage_bytes,
                           dsn::metric_unit::kBytes,
                           "The memory usage of rocksdb block cache");
+
+METRIC_DEFINE_gauge_int64(server,
+                          rdb_write_rate_limiter_through_bytes_per_sec,
+                          dsn::metric_unit::kBytesPerSec,
+                          "The through bytes per second that go through the rate limiter which "
+                          "takes control of the write rate of flush and compaction of rocksdb");
 
 namespace pegasus {
 namespace server {
@@ -826,12 +830,7 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     static std::once_flag flag;
     std::call_once(flag, [&]() {
         METRIC_VAR_ASSIGN_server(rdb_block_cache_mem_usage_bytes);
-        _pfc_rdb_write_limiter_rate_bytes.init_global_counter(
-            "replica",
-            "app.pegasus",
-            "rdb.write_limiter_rate_bytes",
-            COUNTER_TYPE_NUMBER,
-            "statistic the through bytes of rocksdb write rate limiter");
+        METRIC_VAR_ASSIGN_server(rdb_write_rate_limiter_through_bytes_per_sec);
     });
 }
 

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -243,11 +243,6 @@ METRIC_DEFINE_gauge_int64(server,
                           dsn::metric_unit::kBytes,
                           "The memory usage of rocksdb block cache");
 
-METRIC_DEFINE_gauge_int64(server,
-                          rdb_block_cache_mem_usage_bytes,
-                          dsn::metric_unit::kBytes,
-                          "The memory usage of rocksdb block cache");
-
 namespace pegasus {
 namespace server {
 

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -682,6 +682,7 @@ ENUM_END(metric_type)
     DEF(Seconds)                                                                                   \
     DEF(Bytes)                                                                                     \
     DEF(MegaBytes)                                                                                 \
+    DEF(BytesPerSec)                                                                               \
     DEF(CapacityUnits)                                                                             \
     DEF(Percent)                                                                                   \
     DEF(Replicas)                                                                                  \

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -156,20 +156,20 @@ class error_code;
 #define METRIC_VAR_NAME(name) _metric_##name
 #define METRIC_VAR_DECLARE(name, ...) __VA_ARGS__ METRIC_VAR_NAME(name)
 #define METRIC_VAR_DECLARE_gauge_int64(name, ...)                                                  \
-    METRIC_VAR_DECLARE(name, ##__VA_ARGS__, dsn::gauge_ptr<int64_t>)
+    METRIC_VAR_DECLARE(name, __VA_ARGS__ dsn::gauge_ptr<int64_t>)
 #define METRIC_VAR_DECLARE_counter(name, ...)                                                      \
-    METRIC_VAR_DECLARE(name, ##__VA_ARGS__, dsn::counter_ptr<dsn::striped_long_adder, false>)
+    METRIC_VAR_DECLARE(name, __VA_ARGS__ dsn::counter_ptr<dsn::striped_long_adder, false>)
 #define METRIC_VAR_DECLARE_percentile_int64(name, ...)                                             \
-    METRIC_VAR_DECLARE(name, ##__VA_ARGS__, dsn::percentile_ptr<int64_t>)
+    METRIC_VAR_DECLARE(name, __VA_ARGS__ dsn::percentile_ptr<int64_t>)
 
 // Macro METRIC_VAR_DEFINE* are used for metrics as static members of classes.
 #define METRIC_VAR_DEFINE(name, clazz, ...) __VA_ARGS__ clazz::METRIC_VAR_NAME(name)
 #define METRIC_VAR_DEFINE_gauge_int64(name, clazz, ...)                                            \
-    METRIC_VAR_DEFINE(name, clazz, ##__VA_ARGS__, dsn::gauge_ptr<int64_t>)
+    METRIC_VAR_DEFINE(name, clazz, __VA_ARGS__ dsn::gauge_ptr<int64_t>)
 #define METRIC_VAR_DEFINE_counter(name, clazz, ...)                                                \
-    METRIC_VAR_DEFINE(name, clazz, ##__VA_ARGS__, dsn::counter_ptr<dsn::striped_long_adder, false>)
+    METRIC_VAR_DEFINE(name, clazz, __VA_ARGS__ dsn::counter_ptr<dsn::striped_long_adder, false>)
 #define METRIC_VAR_DEFINE_percentile_int64(name, clazz, ...)                                       \
-    METRIC_VAR_DEFINE(name, clazz, ##__VA_ARGS__, dsn::percentile_ptr<int64_t>)
+    METRIC_VAR_DEFINE(name, clazz, __VA_ARGS__ dsn::percentile_ptr<int64_t>)
 
 // Initialize a metric variable in user class.
 #define METRIC_VAR_INIT(name, entity, ...)                                                         \

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -155,11 +155,19 @@ class error_code;
 // instead of a single fixed argument to represent a type.
 #define METRIC_VAR_NAME(name) _metric_##name
 #define METRIC_VAR_DECLARE(name, ...) __VA_ARGS__ METRIC_VAR_NAME(name)
-#define METRIC_VAR_DECLARE_gauge_int64(name) METRIC_VAR_DECLARE(name, dsn::gauge_ptr<int64_t>)
-#define METRIC_VAR_DECLARE_counter(name)                                                           \
-    METRIC_VAR_DECLARE(name, dsn::counter_ptr<dsn::striped_long_adder, false>)
-#define METRIC_VAR_DECLARE_percentile_int64(name)                                                  \
-    METRIC_VAR_DECLARE(name, dsn::percentile_ptr<int64_t>)
+#define METRIC_VAR_DECLARE_gauge_int64(name, ...) METRIC_VAR_DECLARE(name, ##__VA_ARGS__, dsn::gauge_ptr<int64_t>)
+#define METRIC_VAR_DECLARE_counter(name, ...)                                                           \
+    METRIC_VAR_DECLARE(name, ##__VA_ARGS__, dsn::counter_ptr<dsn::striped_long_adder, false>)
+#define METRIC_VAR_DECLARE_percentile_int64(name, ...)                                                  \
+    METRIC_VAR_DECLARE(name, ##__VA_ARGS__, dsn::percentile_ptr<int64_t>)
+
+// Macro METRIC_VAR_DEFINE* are used for metrics as static members of classes.
+#define METRIC_VAR_DEFINE(name, clazz, ...) __VA_ARGS__ clazz::METRIC_VAR_NAME(name)
+#define METRIC_VAR_DEFINE_gauge_int64(name, clazz, ...) METRIC_VAR_DEFINE(name, clazz, ##__VA_ARGS__, dsn::gauge_ptr<int64_t>)
+#define METRIC_VAR_DEFINE_counter(name, clazz, ...)                                                           \
+    METRIC_VAR_DEFINE(name, clazz, ##__VA_ARGS__, dsn::counter_ptr<dsn::striped_long_adder, false>)
+#define METRIC_VAR_DEFINE_percentile_int64(name, clazz, ...)                                                  \
+    METRIC_VAR_DEFINE(name, clazz, ##__VA_ARGS__, dsn::percentile_ptr<int64_t>)
 
 // Initialize a metric variable in user class.
 #define METRIC_VAR_INIT(name, entity, ...)                                                         \

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -101,9 +101,9 @@ class error_code;
         {#entity_type, dsn::metric_type::kGauge, #name, unit, desc, ##__VA_ARGS__})
 
 // There are 2 kinds of counters:
-// - `counter` is the general type of counter that is implemented by striped_long_adder, which can
+// * `counter` is the general type of counter that is implemented by striped_long_adder, which can
 //   achieve high performance while consuming less memory if it's not updated very frequently.
-// - `concurrent_counter` uses concurrent_long_adder as the underlying implementation. It has
+// * `concurrent_counter` uses concurrent_long_adder as the underlying implementation. It has
 //   higher performance while consuming more memory if it's updated very frequently.
 // See also include/dsn/utility/long_adder.h for details.
 #define METRIC_DEFINE_counter(entity_type, name, unit, desc, ...)                                  \
@@ -144,7 +144,7 @@ class error_code;
 #define METRIC_DECLARE_percentile_double(name)                                                     \
     extern dsn::floating_percentile_prototype<double> METRIC_##name
 
-// Following METRIC_*VAR* macros are introduced so that:
+// Following METRIC_VAR* macros are introduced so that:
 // * only need to use prototype name to operate each metric variable;
 // * uniformly name each variable in user class;
 // * differentiate operations on metrics significantly from main logic, improving code readability.
@@ -155,7 +155,8 @@ class error_code;
 // instead of a single fixed argument to represent a type.
 #define METRIC_VAR_NAME(name) _metric_##name
 #define METRIC_VAR_DECLARE(name, ...) __VA_ARGS__ METRIC_VAR_NAME(name)
-// Following variadic arguments are used to input the possible qualifiers, such as `static`.
+
+// Variadic arguments are possible qualifiers for the variable, such as `static`.
 #define METRIC_VAR_DECLARE_gauge_int64(name, ...)                                                  \
     METRIC_VAR_DECLARE(name, __VA_ARGS__ dsn::gauge_ptr<int64_t>)
 #define METRIC_VAR_DECLARE_counter(name, ...)                                                      \
@@ -163,7 +164,9 @@ class error_code;
 #define METRIC_VAR_DECLARE_percentile_int64(name, ...)                                             \
     METRIC_VAR_DECLARE(name, __VA_ARGS__ dsn::percentile_ptr<int64_t>)
 
-// Macro METRIC_VAR_DEFINE* are used for metrics as static members of classes.
+// Macro METRIC_VAR_DEFINE* are used for the metric that is a static member of a class:
+// * `clazz` is the name of the class;
+// * variadic arguments are possible qualifiers for the variable.
 #define METRIC_VAR_DEFINE(name, clazz, ...) __VA_ARGS__ clazz::METRIC_VAR_NAME(name)
 #define METRIC_VAR_DEFINE_gauge_int64(name, clazz, ...)                                            \
     METRIC_VAR_DEFINE(name, clazz, __VA_ARGS__ dsn::gauge_ptr<int64_t>)
@@ -172,7 +175,11 @@ class error_code;
 #define METRIC_VAR_DEFINE_percentile_int64(name, clazz, ...)                                       \
     METRIC_VAR_DEFINE(name, clazz, __VA_ARGS__ dsn::percentile_ptr<int64_t>)
 
-// Initialize a metric variable in user class.
+// Initialize a metric variable in user class:
+// * macros METRIC_VAR_INIT* could be used to initialize metric variables in member initializer
+//   lists of the constructor of user class;
+// * macros METRIC_VAR_ASSIGN* could be used to initialize metric variables by assignment operator
+//   (=).
 #define METRIC_VAR_INSTANTIATE(name, entity, op, ...)                                              \
     METRIC_VAR_NAME(name) op(METRIC_##name.instantiate(entity##_metric_entity(), ##__VA_ARGS__))
 #define METRIC_VAR_ASSIGN(name, entity, ...) METRIC_VAR_INSTANTIATE(name, entity, =, ##__VA_ARGS__)

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -155,6 +155,7 @@ class error_code;
 // instead of a single fixed argument to represent a type.
 #define METRIC_VAR_NAME(name) _metric_##name
 #define METRIC_VAR_DECLARE(name, ...) __VA_ARGS__ METRIC_VAR_NAME(name)
+// Following variadic arguments are used to input the possible qualifiers, such as `static`.
 #define METRIC_VAR_DECLARE_gauge_int64(name, ...)                                                  \
     METRIC_VAR_DECLARE(name, __VA_ARGS__ dsn::gauge_ptr<int64_t>)
 #define METRIC_VAR_DECLARE_counter(name, ...)                                                      \
@@ -172,9 +173,12 @@ class error_code;
     METRIC_VAR_DEFINE(name, clazz, __VA_ARGS__ dsn::percentile_ptr<int64_t>)
 
 // Initialize a metric variable in user class.
-#define METRIC_VAR_INIT(name, entity, ...)                                                         \
-    METRIC_VAR_NAME(name)(METRIC_##name.instantiate(entity##_metric_entity(), ##__VA_ARGS__))
+#define METRIC_VAR_INSTANTIATE(name, entity, op, ...)                                              \
+    METRIC_VAR_NAME(name) op(METRIC_##name.instantiate(entity##_metric_entity(), ##__VA_ARGS__))
+#define METRIC_VAR_ASSIGN(name, entity, ...) METRIC_VAR_INSTANTIATE(name, entity, =, ##__VA_ARGS__)
+#define METRIC_VAR_INIT(name, entity, ...) METRIC_VAR_INSTANTIATE(name, entity, , ##__VA_ARGS__)
 #define METRIC_VAR_INIT_replica(name, ...) METRIC_VAR_INIT(name, replica, ##__VA_ARGS__)
+#define METRIC_VAR_ASSIGN_server(name, ...) METRIC_VAR_ASSIGN(name, server, ##__VA_ARGS__)
 #define METRIC_VAR_INIT_server(name, ...) METRIC_VAR_INIT(name, server, ##__VA_ARGS__)
 #define METRIC_VAR_INIT_disk(name, ...) METRIC_VAR_INIT(name, disk, ##__VA_ARGS__)
 #define METRIC_VAR_INIT_table(name, ...) METRIC_VAR_INIT(name, table, ##__VA_ARGS__)

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -155,18 +155,20 @@ class error_code;
 // instead of a single fixed argument to represent a type.
 #define METRIC_VAR_NAME(name) _metric_##name
 #define METRIC_VAR_DECLARE(name, ...) __VA_ARGS__ METRIC_VAR_NAME(name)
-#define METRIC_VAR_DECLARE_gauge_int64(name, ...) METRIC_VAR_DECLARE(name, ##__VA_ARGS__, dsn::gauge_ptr<int64_t>)
-#define METRIC_VAR_DECLARE_counter(name, ...)                                                           \
+#define METRIC_VAR_DECLARE_gauge_int64(name, ...)                                                  \
+    METRIC_VAR_DECLARE(name, ##__VA_ARGS__, dsn::gauge_ptr<int64_t>)
+#define METRIC_VAR_DECLARE_counter(name, ...)                                                      \
     METRIC_VAR_DECLARE(name, ##__VA_ARGS__, dsn::counter_ptr<dsn::striped_long_adder, false>)
-#define METRIC_VAR_DECLARE_percentile_int64(name, ...)                                                  \
+#define METRIC_VAR_DECLARE_percentile_int64(name, ...)                                             \
     METRIC_VAR_DECLARE(name, ##__VA_ARGS__, dsn::percentile_ptr<int64_t>)
 
 // Macro METRIC_VAR_DEFINE* are used for metrics as static members of classes.
 #define METRIC_VAR_DEFINE(name, clazz, ...) __VA_ARGS__ clazz::METRIC_VAR_NAME(name)
-#define METRIC_VAR_DEFINE_gauge_int64(name, clazz, ...) METRIC_VAR_DEFINE(name, clazz, ##__VA_ARGS__, dsn::gauge_ptr<int64_t>)
-#define METRIC_VAR_DEFINE_counter(name, clazz, ...)                                                           \
+#define METRIC_VAR_DEFINE_gauge_int64(name, clazz, ...)                                            \
+    METRIC_VAR_DEFINE(name, clazz, ##__VA_ARGS__, dsn::gauge_ptr<int64_t>)
+#define METRIC_VAR_DEFINE_counter(name, clazz, ...)                                                \
     METRIC_VAR_DEFINE(name, clazz, ##__VA_ARGS__, dsn::counter_ptr<dsn::striped_long_adder, false>)
-#define METRIC_VAR_DEFINE_percentile_int64(name, clazz, ...)                                                  \
+#define METRIC_VAR_DEFINE_percentile_int64(name, clazz, ...)                                       \
     METRIC_VAR_DEFINE(name, clazz, ##__VA_ARGS__, dsn::percentile_ptr<int64_t>)
 
 // Initialize a metric variable in user class.


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1505

All of the server-level metrics of rocksdb are migrated to the new framework,
including 2 metrics: the memory usage of block cache, and the through bytes
per second that go through the rate limiter which takes control of the write rate
of flush and compaction.

This migration are somewhat different from previous ones:

- firstly, both metrics are declared as static variables;
- then, both variables need to be defined globally;
- also, both metrics have to be initialized by assignment operator, rather than in
   the member initializer lists of the constructor of user class.

To support all of these new features, some new macros are introduced.