### PR TITLE
feat(Ranger): add a default database policy name for legacy table

### DIFF
--- a/src/runtime/ranger/ranger_resource_policy_manager.h
+++ b/src/runtime/ranger/ranger_resource_policy_manager.h
@@ -74,8 +74,9 @@ public:
     // When using Ranger for ACL, periodically pull policies from Ranger service.
     void start();
 
-    // Return true if the 'user_name' is allowed to access 'app_name' via 'rpc_code'.
-    bool allowed(const int rpc_code, const std::string &user_name, const std::string &app_name);
+    // Return true if the 'user_name' is allowed to access 'database_name' via 'rpc_code'.
+    bool
+    allowed(const int rpc_code, const std::string &user_name, const std::string &database_name);
 
 private:
     // Parse Ranger ACL policies from 'data' in JSON format into 'policies'.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/apache/incubator-pegasus/issues/1054

### What is changed and how does it work?

- This patch adds a new conf item `legacy_table_database_mapping_policy_name`, the old table will be matched to the database named `legacy_table_database_mapping_policy_name` for ACL.
- "*" can match any table, including legacy tables and tables named by new rules.