### PR TITLE
refactor: improve the single-responsibility of class fs_manager (2/n)

### DIFF
--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -38,8 +38,11 @@ namespace dsn {
 class gpid;
 
 namespace replication {
+class disk_info;
 
 DSN_DECLARE_int32(disk_min_available_space_ratio);
+
+error_code disk_status_to_error_code(disk_status::type ds);
 
 struct dir_node
 {
@@ -116,16 +119,20 @@ public:
                                        gpid child_pid,
                                        const std::string &parent_dir);
     void remove_replica(const dsn::gpid &pid);
-    bool for_each_dir_node(const std::function<bool(const dir_node &)> &func) const;
     void update_disk_stat();
 
     void add_new_dir_node(const std::string &data_dir, const std::string &tag);
+    bool is_dir_node_exist(const std::string &data_dir, const std::string &tag) const;
     const std::vector<std::shared_ptr<dir_node>> &get_dir_nodes() const
     {
         zauto_read_lock l(_lock);
         return _dir_nodes;
     }
-    bool is_dir_node_available(const std::string &data_dir, const std::string &tag) const;
+    error_code validate_migrate_op(gpid pid,
+                                   const std::string &origin_disk,
+                                   const std::string &target_disk,
+                                   std::string &err_msg) const;
+    std::vector<disk_info> get_disk_infos(int app_id) const;
 
 private:
     void reset_disk_stat()

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -117,21 +117,6 @@ DSN_DEFINE_uint64(
 DSN_DECLARE_int32(max_mutation_count_in_prepare_list);
 DSN_DECLARE_int32(staleness_for_commit);
 
-namespace {
-error_code disk_status_to_error_code(disk_status::type ds)
-{
-    switch (ds) {
-    case disk_status::SPACE_INSUFFICIENT:
-        return dsn::ERR_DISK_INSUFFICIENT;
-    case disk_status::IO_ERROR:
-        return dsn::ERR_DISK_IO_ERROR;
-    default:
-        CHECK_EQ(disk_status::NORMAL, ds);
-        return dsn::ERR_OK;
-    }
-}
-} // anonymous namespace
-
 void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
 {
     _checker.only_one_thread_access();

--- a/src/utils/filesystem.cpp
+++ b/src/utils/filesystem.cpp
@@ -94,6 +94,7 @@ static inline int get_stat_internal(const std::string &npath, struct stat_ &st)
     return err;
 }
 
+// TODO(yingchun): remove the return value because it's always 0.
 int get_normalized_path(const std::string &path, std::string &npath)
 {
     char sep;


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1383

This patch moves some functions to fs_manager which are more reasonable to be
responsibilities of class fs_manager rather than those of other classes.