### PR TITLE
feat(new_metrics): migrate metrics for profiler

### DIFF
--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -29,11 +29,10 @@
 #include "common/replication_other_types.h"
 #include "metadata_types.h"
 #include "utils/autoref_ptr.h"
-#include "utils/error_code.h"
 #include "utils/flags.h"
-#include "utils/string_view.h"
 #include "utils/metrics.h"
 #include "utils/ports.h"
+#include "utils/string_view.h"
 #include "utils/zlocks.h"
 
 namespace dsn {

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -370,7 +370,7 @@ metric_entity_ptr instantiate_profiler_metric_entity(const std::string &task_nam
 task_spec_profiler::task_spec_profiler(int code)
     : collect_call_count(false),
       is_profile(false),
-      call_counts(new std::atomic<int64_t>[s_task_code_max + 1]),
+      call_counts(new std::atomic<int64_t>[ s_task_code_max + 1 ]),
       _task_name(dsn::task_code(code).to_string()),
       _profiler_metric_entity(instantiate_profiler_metric_entity(_task_name))
 {

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -353,6 +353,7 @@ const metric_entity_ptr &task_spec_profiler::profiler_metric_entity() const
 void profiler::install(service_spec &)
 {
     s_task_code_max = dsn::task_code::max();
+    s_spec_profilers.reserve(s_task_code_max + 1);
     task_ext_for_profiler::register_ext();
     message_ext_for_profiler::register_ext();
 

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -344,9 +344,9 @@ task_spec_profiler::task_spec_profiler(const std::string &task_name)
 const metric_entity_ptr &task_spec_profiler::profiler_metric_entity() const
 {
     CHECK_NOTNULL(_profiler_metric_entity,
-                  "queue metric entity (queue_name={}) should has been instantiated: "
+                  "profiler metric entity (task_name={}) should has been instantiated: "
                   "uninitialized entity cannot be used to instantiate metric",
-                  _name);
+                  _task_name);
     return _profiler_metric_entity;
 }
 

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -366,7 +366,7 @@ void profiler::install(service_spec &)
         task_spec *spec = task_spec::get(i);
         CHECK_NOTNULL(spec, "");
 
-        s_spec_profilers.emplace_back();
+        s_spec_profilers.emplace_back(name);
 
         s_spec_profilers[i].collect_call_count = dsn_config_get_value_bool(
             section_name.c_str(),

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -371,8 +371,8 @@ task_spec_profiler::task_spec_profiler(int code)
     : collect_call_count(false),
       is_profile(false),
       call_counts(s_task_code_max + 1),
-      _task_name(dsn::task_code(i).to_string()),
-      _profiler_metric_entity(instantiate_profiler_metric_entity(task_name))
+      _task_name(dsn::task_code(code).to_string()),
+      _profiler_metric_entity(instantiate_profiler_metric_entity(_task_name))
 {
     const auto &section_name = fmt::format("task.{}", _task_name);
     auto spec = task_spec::get(code);

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -101,9 +101,45 @@ METRIC_DEFINE_counter(profiler,
                           "The number of cancelled tasks");
 
 METRIC_DEFINE_percentile_int64(profiler,
-                          profiler_server_latency_ns,
+                          profiler_server_rpc_latency_ns,
                           dsn::metric_unit::kNanoSeconds,
-                          "The latency it takes for each task to be executed");
+                          "The latency from enqueue point to reply point on the server side "
+                          "for each RPC task");
+
+METRIC_DEFINE_percentile_int64(profiler,
+                          profiler_server_rpc_request_bytes,
+                          dsn::metric_unit::kBytes,
+                          "The body length of request received on the server side for each "
+                          "RPC task");
+
+METRIC_DEFINE_percentile_int64(profiler,
+                          profiler_server_rpc_response_bytes,
+                          dsn::metric_unit::kBytes,
+                          "The body length of response replied on the server side for each "
+                          "RPC task");
+
+METRIC_DEFINE_counter(profiler,
+                          profiler_dropped_timeout_rpcs,
+                          dsn::metric_unit::kTasks,
+                          "The accumulative number of dropped RPC tasks on the server side "
+                          "due to timeout");
+
+METRIC_DEFINE_percentile_int64(profiler,
+                          profiler_client_rpc_latency_ns,
+                          dsn::metric_unit::kNanoSeconds,
+                          "The non-timeout latency from call point to enqueue point on "
+                          "the client side for each RPC task");
+
+METRIC_DEFINE_counter(profiler,
+                          profiler_client_timeout_rpcs,
+                          dsn::metric_unit::kTasks,
+                          "The accumulative number of timeout RPC tasks on the client side");
+
+METRIC_DEFINE_percentile_int64(profiler,
+                          profiler_aio_latency_ns,
+                          dsn::metric_unit::kNanoSeconds,
+                          "The duration of the whole AIO operation (begin to exec aio -> "
+                          "executing -> finished -> callback is put into queue");
 
 namespace dsn {
 struct service_spec;

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -353,7 +353,6 @@ const metric_entity_ptr &task_spec_profiler::profiler_metric_entity() const
 void profiler::install(service_spec &)
 {
     s_task_code_max = dsn::task_code::max();
-    s_spec_profilers.reserve(s_task_code_max + 1);
     task_ext_for_profiler::register_ext();
     message_ext_for_profiler::register_ext();
 

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -508,7 +508,6 @@ const metric_entity_ptr &task_spec_profiler::profiler_metric_entity() const
 void profiler::install(service_spec &)
 {
     s_task_code_max = dsn::task_code::max();
-    s_spec_profilers.reserve(s_task_code_max + 1);
     task_ext_for_profiler::register_ext();
     message_ext_for_profiler::register_ext();
 

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -370,7 +370,7 @@ metric_entity_ptr instantiate_profiler_metric_entity(const std::string &task_nam
 task_spec_profiler::task_spec_profiler(int code)
     : collect_call_count(false),
       is_profile(false),
-      call_counts(s_task_code_max + 1),
+      call_counts(new std::atomic<int64_t>[s_task_code_max + 1]),
       _task_name(dsn::task_code(code).to_string()),
       _profiler_metric_entity(instantiate_profiler_metric_entity(_task_name))
 {
@@ -384,8 +384,8 @@ task_spec_profiler::task_spec_profiler(int code)
         FLAGS_collect_call_count,
         "whether to collect how many time this kind of tasks invoke each of other kinds tasks");
 
-    for (auto &count : call_counts) {
-        count.store(0);
+    for (int i = 0; i <= s_task_code_max; ++i) {
+        call_counts[i].store(0);
     }
 
     is_profile = dsn_config_get_value_bool(section_name.c_str(),

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -49,17 +49,16 @@ START<== queue(server) == ENQUEUE <===== net(reply) ======= REPLY <=============
 */
 #include "runtime/profiler.h"
 
-#include <stddef.h>
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
 #include "aio/aio_task.h"
-#include "perf_counter/perf_counter.h"
-#include "perf_counter/perf_counter_wrapper.h"
+#include "fmt/core.h"
 #include "profiler_header.h"
 #include "runtime/api_layer1.h"
 #include "runtime/rpc/rpc_message.h"
@@ -68,9 +67,11 @@ START<== queue(server) == ENQUEUE <===== net(reply) ======= REPLY <=============
 #include "runtime/task/task_spec.h"
 #include "utils/config_api.h"
 #include "utils/extensible_object.h"
-#include "utils/fmt_logging.h"
 #include "utils/flags.h"
+#include "utils/fmt_logging.h"
 #include "utils/join_point.h"
+#include "utils/metrics.h"
+#include "utils/string_view.h"
 
 METRIC_DEFINE_entity(profiler);
 

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -80,66 +80,66 @@ METRIC_DEFINE_gauge_int64(profiler,
                           "The number of tasks in all queues");
 
 METRIC_DEFINE_percentile_int64(profiler,
-                          profiler_queued_latency_ns,
-                          dsn::metric_unit::kNanoSeconds,
-                          "The latency it takes for each task to wait in each queue "
-                          "before beginning to be executed");
+                               profiler_queued_latency_ns,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The latency it takes for each task to wait in each queue "
+                               "before beginning to be executed");
 
 METRIC_DEFINE_percentile_int64(profiler,
-                          profiler_executed_latency_ns,
-                          dsn::metric_unit::kNanoSeconds,
-                          "The latency it takes for each task to be executed");
+                               profiler_executed_latency_ns,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The latency it takes for each task to be executed");
 
 METRIC_DEFINE_counter(profiler,
-                          profiler_executed_tasks,
-                          dsn::metric_unit::kTasks,
-                          "The number of tasks that have been executed");
+                      profiler_executed_tasks,
+                      dsn::metric_unit::kTasks,
+                      "The number of tasks that have been executed");
 
 METRIC_DEFINE_counter(profiler,
-                          profiler_cancelled_tasks,
-                          dsn::metric_unit::kTasks,
-                          "The number of cancelled tasks");
+                      profiler_cancelled_tasks,
+                      dsn::metric_unit::kTasks,
+                      "The number of cancelled tasks");
 
 METRIC_DEFINE_percentile_int64(profiler,
-                          profiler_server_rpc_latency_ns,
-                          dsn::metric_unit::kNanoSeconds,
-                          "The latency from enqueue point to reply point on the server side "
-                          "for each RPC task");
+                               profiler_server_rpc_latency_ns,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The latency from enqueue point to reply point on the server side "
+                               "for each RPC task");
 
 METRIC_DEFINE_percentile_int64(profiler,
-                          profiler_server_rpc_request_bytes,
-                          dsn::metric_unit::kBytes,
-                          "The body length of request received on the server side for each "
-                          "RPC task");
+                               profiler_server_rpc_request_bytes,
+                               dsn::metric_unit::kBytes,
+                               "The body length of request received on the server side for each "
+                               "RPC task");
 
 METRIC_DEFINE_percentile_int64(profiler,
-                          profiler_server_rpc_response_bytes,
-                          dsn::metric_unit::kBytes,
-                          "The body length of response replied on the server side for each "
-                          "RPC task");
+                               profiler_server_rpc_response_bytes,
+                               dsn::metric_unit::kBytes,
+                               "The body length of response replied on the server side for each "
+                               "RPC task");
 
 METRIC_DEFINE_counter(profiler,
-                          profiler_dropped_timeout_rpcs,
-                          dsn::metric_unit::kTasks,
-                          "The accumulative number of dropped RPC tasks on the server side "
-                          "due to timeout");
+                      profiler_dropped_timeout_rpcs,
+                      dsn::metric_unit::kTasks,
+                      "The accumulative number of dropped RPC tasks on the server side "
+                      "due to timeout");
 
 METRIC_DEFINE_percentile_int64(profiler,
-                          profiler_client_rpc_latency_ns,
-                          dsn::metric_unit::kNanoSeconds,
-                          "The non-timeout latency from call point to enqueue point on "
-                          "the client side for each RPC task");
+                               profiler_client_rpc_latency_ns,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The non-timeout latency from call point to enqueue point on "
+                               "the client side for each RPC task");
 
 METRIC_DEFINE_counter(profiler,
-                          profiler_client_timeout_rpcs,
-                          dsn::metric_unit::kTasks,
-                          "The accumulative number of timeout RPC tasks on the client side");
+                      profiler_client_timeout_rpcs,
+                      dsn::metric_unit::kTasks,
+                      "The accumulative number of timeout RPC tasks on the client side");
 
 METRIC_DEFINE_percentile_int64(profiler,
-                          profiler_aio_latency_ns,
-                          dsn::metric_unit::kNanoSeconds,
-                          "The duration of the whole AIO operation (begin to exec aio -> "
-                          "executing -> finished -> callback is put into queue");
+                               profiler_aio_latency_ns,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The duration of the whole AIO operation (begin to exec aio -> "
+                               "executing -> finished -> callback is put into queue");
 
 namespace dsn {
 struct service_spec;

--- a/src/runtime/profiler_header.h
+++ b/src/runtime/profiler_header.h
@@ -25,8 +25,12 @@
  */
 
 #pragma once
+
 #include <iomanip>
 #include "perf_counter/perf_counter_wrapper.h"
+
+#include "utils/autoref_ptr.h"
+#include "utils/metrics.h"
 
 namespace dsn {
 namespace tools {
@@ -57,13 +61,13 @@ struct task_spec_profiler
     bool is_profile;
     std::atomic<int64_t> *call_counts;
 
-    task_spec_profiler()
-    {
-        collect_call_count = false;
-        is_profile = false;
-        call_counts = nullptr;
-        memset((void *)ptr, 0, sizeof(ptr));
-    }
+    task_spec_profiler(const std::string &task_name);
+    const metric_entity_ptr &profiler_metric_entity() const;
+
+private:
+    std::string _task_name;
+    const metric_entity_ptr _profiler_metric_entity;
 };
+
 } // namespace tools
 } // namespace dsn

--- a/src/runtime/profiler_header.h
+++ b/src/runtime/profiler_header.h
@@ -62,6 +62,17 @@ private:
     const metric_entity_ptr _profiler_metric_entity;
 
     METRIC_VAR_DECLARE_gauge_int64(profiler_queued_tasks);
+    METRIC_VAR_DECLARE_percentile_int64(profiler_queue_latency_ns);
+    METRIC_VAR_DECLARE_percentile_int64(profiler_execute_latency_ns);
+    METRIC_VAR_DECLARE_counter(profiler_executed_tasks);
+    METRIC_VAR_DECLARE_counter(profiler_cancelled_tasks);
+    METRIC_VAR_DECLARE_percentile_int64(profiler_server_rpc_latency_ns);
+    METRIC_VAR_DECLARE_percentile_int64(profiler_server_rpc_request_bytes);
+    METRIC_VAR_DECLARE_percentile_int64(profiler_server_rpc_response_bytes);
+    METRIC_VAR_DECLARE_counter(profiler_dropped_timeout_rpcs);
+    METRIC_VAR_DECLARE_percentile_int64(profiler_client_rpc_latency_ns);
+    METRIC_VAR_DECLARE_counter(profiler_client_timeout_rpcs);
+    METRIC_VAR_DECLARE_percentile_int64(profiler_aio_latency_ns);
 };
 
 } // namespace tools

--- a/src/runtime/profiler_header.h
+++ b/src/runtime/profiler_header.h
@@ -38,7 +38,7 @@ struct task_spec_profiler
 {
     bool collect_call_count;
     bool is_profile;
-    std::vector<std::atomic<int64_t>> call_counts;
+    std::unique_ptr<std::atomic<int64_t>[]> call_counts;
 
     task_spec_profiler(int code);
     const metric_entity_ptr &profiler_metric_entity() const;

--- a/src/runtime/profiler_header.h
+++ b/src/runtime/profiler_header.h
@@ -45,17 +45,17 @@ struct task_spec_profiler
 
     METRIC_DEFINE_INCREMENT_NOTNULL(profiler_queued_tasks)
     METRIC_DEFINE_DECREMENT_NOTNULL(profiler_queued_tasks)
-    METRIC_DEFINE_SET_NOTNULL(profiler_queue_latency_ns)
-    METRIC_DEFINE_SET_NOTNULL(profiler_execute_latency_ns)
+    METRIC_DEFINE_SET_NOTNULL(profiler_queue_latency_ns, int64_t)
+    METRIC_DEFINE_SET_NOTNULL(profiler_execute_latency_ns, int64_t)
     METRIC_DEFINE_INCREMENT_NOTNULL(profiler_executed_tasks)
     METRIC_DEFINE_INCREMENT_NOTNULL(profiler_cancelled_tasks)
-    METRIC_DEFINE_SET_NOTNULL(profiler_server_rpc_latency_ns)
-    METRIC_DEFINE_SET_NOTNULL(profiler_server_rpc_request_bytes)
-    METRIC_DEFINE_SET_NOTNULL(profiler_server_rpc_response_bytes)
+    METRIC_DEFINE_SET_NOTNULL(profiler_server_rpc_latency_ns, int64_t)
+    METRIC_DEFINE_SET_NOTNULL(profiler_server_rpc_request_bytes, int64_t)
+    METRIC_DEFINE_SET_NOTNULL(profiler_server_rpc_response_bytes, int64_t)
     METRIC_DEFINE_INCREMENT_NOTNULL(profiler_dropped_timeout_rpcs)
-    METRIC_DEFINE_SET_NOTNULL(profiler_client_rpc_latency_ns)
+    METRIC_DEFINE_SET_NOTNULL(profiler_client_rpc_latency_ns, int64_t)
     METRIC_DEFINE_INCREMENT_NOTNULL(profiler_client_timeout_rpcs)
-    METRIC_DEFINE_SET_NOTNULL(profiler_aio_latency_ns)
+    METRIC_DEFINE_SET_NOTNULL(profiler_aio_latency_ns, int64_t)
 
 private:
     const std::string _task_name;

--- a/src/runtime/profiler_header.h
+++ b/src/runtime/profiler_header.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <iomanip>
-#include "perf_counter/perf_counter_wrapper.h"
 
 #include "utils/autoref_ptr.h"
 #include "utils/metrics.h"
@@ -56,7 +55,6 @@ enum perf_counter_ptr_type
 
 struct task_spec_profiler
 {
-    perf_counter_wrapper ptr[PERF_COUNTER_COUNT];
     bool collect_call_count;
     bool is_profile;
     std::atomic<int64_t> *call_counts;
@@ -64,9 +62,14 @@ struct task_spec_profiler
     task_spec_profiler(const std::string &task_name);
     const metric_entity_ptr &profiler_metric_entity() const;
 
+    METRIC_DEFINE_INCREMENT(profiler_queued_tasks)
+    METRIC_DEFINE_DECREMENT(profiler_queued_tasks)
+
 private:
-    std::string _task_name;
+    const std::string _task_name;
     const metric_entity_ptr _profiler_metric_entity;
+
+    METRIC_VAR_DECLARE_gauge_int64(profiler_queued_tasks);
 };
 
 } // namespace tools

--- a/src/runtime/profiler_header.h
+++ b/src/runtime/profiler_header.h
@@ -34,36 +34,28 @@
 namespace dsn {
 namespace tools {
 
-enum perf_counter_ptr_type
-{
-    TASK_QUEUEING_TIME_NS,
-    TASK_EXEC_TIME_NS,
-    TASK_THROUGHPUT,
-    TASK_CANCELLED,
-    AIO_LATENCY_NS,
-    RPC_SERVER_LATENCY_NS,
-    RPC_SERVER_SIZE_PER_REQUEST_IN_BYTES,
-    RPC_SERVER_SIZE_PER_RESPONSE_IN_BYTES,
-    RPC_CLIENT_NON_TIMEOUT_LATENCY_NS,
-    RPC_CLIENT_TIMEOUT_THROUGHPUT,
-    TASK_IN_QUEUE,
-    RPC_DROPPED_IF_TIMEOUT,
-
-    PERF_COUNTER_COUNT,
-    PERF_COUNTER_INVALID
-};
-
 struct task_spec_profiler
 {
     bool collect_call_count;
     bool is_profile;
-    std::atomic<int64_t> *call_counts;
+    std::vector<std::atomic<int64_t>> call_counts;
 
-    task_spec_profiler(const std::string &task_name);
+    task_spec_profiler(int code);
     const metric_entity_ptr &profiler_metric_entity() const;
 
-    METRIC_DEFINE_INCREMENT(profiler_queued_tasks)
-    METRIC_DEFINE_DECREMENT(profiler_queued_tasks)
+    METRIC_DEFINE_INCREMENT_NOTNULL(profiler_queued_tasks)
+    METRIC_DEFINE_DECREMENT_NOTNULL(profiler_queued_tasks)
+    METRIC_DEFINE_SET_NOTNULL(profiler_queue_latency_ns)
+    METRIC_DEFINE_SET_NOTNULL(profiler_execute_latency_ns)
+    METRIC_DEFINE_INCREMENT_NOTNULL(profiler_executed_tasks)
+    METRIC_DEFINE_INCREMENT_NOTNULL(profiler_cancelled_tasks)
+    METRIC_DEFINE_SET_NOTNULL(profiler_server_rpc_latency_ns)
+    METRIC_DEFINE_SET_NOTNULL(profiler_server_rpc_request_bytes)
+    METRIC_DEFINE_SET_NOTNULL(profiler_server_rpc_response_bytes)
+    METRIC_DEFINE_INCREMENT_NOTNULL(profiler_dropped_timeout_rpcs)
+    METRIC_DEFINE_SET_NOTNULL(profiler_client_rpc_latency_ns)
+    METRIC_DEFINE_INCREMENT_NOTNULL(profiler_client_timeout_rpcs)
+    METRIC_DEFINE_SET_NOTNULL(profiler_aio_latency_ns)
 
 private:
     const std::string _task_name;

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -192,6 +192,7 @@ class error_code;
 #define METRIC_VAR_INIT_partition(name, ...) METRIC_VAR_INIT(name, partition, ##__VA_ARGS__)
 #define METRIC_VAR_INIT_backup_policy(name, ...) METRIC_VAR_INIT(name, backup_policy, ##__VA_ARGS__)
 #define METRIC_VAR_INIT_queue(name, ...) METRIC_VAR_INIT(name, queue, ##__VA_ARGS__)
+#define METRIC_VAR_ASSIGN_profiler(name, ...) METRIC_VAR_ASSIGN(name, profiler, ##__VA_ARGS__)
 
 // Perform increment_by() operations on gauges and counters.
 #define METRIC_VAR_INCREMENT_BY(name, x)                                                           \

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -239,9 +239,12 @@ class error_code;
 #define METRIC_VAR_AUTO_COUNT(name, ...)                                                           \
     dsn::auto_count __##name##_auto_count(METRIC_VAR_NAME(name), ##__VA_ARGS__)
 
+// Implement a member function that runs `method` on the metric variable, without any argument.
 #define METRIC_DEFINE_NO_ARG(method, name)                                                         \
     void METRIC_FUNC_NAME_##method(name)() { METRIC_VAR_##method(name); }
 
+// Implement a member function that runs `method` on the metric variable if NOT NULL,
+// without any argument.
 #define METRIC_DEFINE_NO_ARG_NOTNULL(method, name)                                                 \
     void METRIC_FUNC_NAME_##method(name)()                                                         \
     {                                                                                              \
@@ -250,12 +253,17 @@ class error_code;
         }                                                                                          \
     }
 
+// Implement a member function that runs `method` on the metric variable and return `ret_type`,
+// without any argument.
 #define METRIC_DEFINE_RET_AND_NO_ARG(ret_type, method, name)                                       \
     ret_type METRIC_FUNC_NAME_##method(name)() { return METRIC_VAR_##method(name); }
 
+// Implement a member function that runs `method` on the metric variable, with an argument.
 #define METRIC_DEFINE_ONE_ARG(method, name, arg_type)                                              \
     void METRIC_FUNC_NAME_##method(name)(arg_type arg) { METRIC_VAR_##method(name, arg); }
 
+// Implement a member function that runs `method` on the metric variable if NOT NULL,
+// with an argument.
 #define METRIC_DEFINE_ONE_ARG_NOTNULL(method, name, arg_type)                                      \
     void METRIC_FUNC_NAME_##method(name)(arg_type arg)                                             \
     {                                                                                              \
@@ -264,45 +272,59 @@ class error_code;
         }                                                                                          \
     }
 
+// Call the member function of `obj` to run `method` on the metric variable.
 #define METRIC_CALL(obj, method, name, ...) (obj).METRIC_FUNC_NAME_##method(name)(__VA_ARGS__)
 
+// The name of the member function that increments the metric variable by some value.
 #define METRIC_FUNC_NAME_INCREMENT_BY(name) increment_##name##_by
 
+// Implement a member function that increments the metric variable by some value.
 #define METRIC_DEFINE_INCREMENT_BY(name) METRIC_DEFINE_ONE_ARG(INCREMENT_BY, name, int64_t)
 
 // To be adaptive to self-defined `increment_by` methods, arguments are declared as variadic.
 #define METRIC_INCREMENT_BY(obj, name, ...) METRIC_CALL(obj, INCREMENT_BY, name, ##__VA_ARGS__)
 
+// The name of the member function that increments the metric variable by one.
 #define METRIC_FUNC_NAME_INCREMENT(name) increment_##name
 
+// Implement a member function that increments the metric variable by one.
 #define METRIC_DEFINE_INCREMENT(name) METRIC_DEFINE_NO_ARG(INCREMENT, name)
 
+// Implement a member function that increments the metric variable by one if NOT NULL.
 #define METRIC_DEFINE_INCREMENT_NOTNULL(name) METRIC_DEFINE_NO_ARG_NOTNULL(INCREMENT, name)
 
 // To be adaptive to self-defined `increment` methods, arguments are declared as variadic.
 #define METRIC_INCREMENT(obj, name, ...) METRIC_CALL(obj, INCREMENT, name, ##__VA_ARGS__)
 
+// The name of the member function that decrements the metric variable by one.
 #define METRIC_FUNC_NAME_DECREMENT(name) decrement_##name
 
+// Implement a member function that decrements the metric variable by one.
 #define METRIC_DEFINE_DECREMENT(name) METRIC_DEFINE_NO_ARG(DECREMENT, name)
 
+// Implement a member function that decrements the metric variable by one if NOT NULL.
 #define METRIC_DEFINE_DECREMENT_NOTNULL(name) METRIC_DEFINE_NO_ARG_NOTNULL(DECREMENT, name)
 
 // To be adaptive to self-defined `decrement` methods, arguments are declared as variadic.
 #define METRIC_DECREMENT(obj, name, ...) METRIC_CALL(obj, DECREMENT, name, ##__VA_ARGS__)
 
+// The name of the member function that sets the metric variable with some value.
 #define METRIC_FUNC_NAME_SET(name) set_##name
 
+// Implement a member function that sets the metric variable with some value.
 #define METRIC_DEFINE_SET(name, value_type) METRIC_DEFINE_ONE_ARG(SET, name, value_type)
 
+// Implement a member function that sets the metric variable with some value if NOT NULL.
 #define METRIC_DEFINE_SET_NOTNULL(name, value_type)                                                \
     METRIC_DEFINE_ONE_ARG_NOTNULL(SET, name, value_type)
 
 // To be adaptive to self-defined `set` methods, arguments are declared as variadic.
 #define METRIC_SET(obj, name, ...) METRIC_CALL(obj, SET, name, ##__VA_ARGS__)
 
+// The name of the member function that gets the value of the metric variable.
 #define METRIC_FUNC_NAME_VALUE(name) get_##name
 
+// Implement a member function that gets the value of the metric variable.
 #define METRIC_DEFINE_VALUE(name, value_type) METRIC_DEFINE_RET_AND_NO_ARG(value_type, VALUE, name)
 
 // To be adaptive to self-defined `value` methods, arguments are declared as variadic.

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -238,59 +238,63 @@ class error_code;
 #define METRIC_VAR_AUTO_COUNT(name, ...)                                                           \
     dsn::auto_count __##name##_auto_count(METRIC_VAR_NAME(name), ##__VA_ARGS__)
 
-#define METRIC_DEFINE_NO_ARG(method, name)                                                           \
+#define METRIC_DEFINE_NO_ARG(method, name)                                                         \
     void METRIC_FUNC_NAME_##method(name)() { METRIC_VAR_##method(name); }
 
-#define METRIC_DEFINE_NO_ARG_NOTNULL(method, name)                                                           \
-    void METRIC_FUNC_NAME_##method(name)() { if (METRIC_VAR_NAME(name) != nullptr) {METRIC_VAR_##method(name);}  }
+#define METRIC_DEFINE_NO_ARG_NOTNULL(method, name)                                                 \
+    void METRIC_FUNC_NAME_##method(name)()                                                         \
+    {                                                                                              \
+        if (METRIC_VAR_NAME(name) != nullptr) {                                                    \
+            METRIC_VAR_##method(name);                                                             \
+        }                                                                                          \
+    }
 
-#define METRIC_DEFINE_RET_AND_NO_ARG(ret_type, method, name)                                                           \
+#define METRIC_DEFINE_RET_AND_NO_ARG(ret_type, method, name)                                       \
     ret_type METRIC_FUNC_NAME_##method(name)() { return METRIC_VAR_##method(name); }
 
-#define METRIC_DEFINE_ONE_ARG(method, name, arg_type)                                                           \
+#define METRIC_DEFINE_ONE_ARG(method, name, arg_type)                                              \
     void METRIC_FUNC_NAME_##method(name)(arg_type arg) { METRIC_VAR_##method(name, arg); }
 
-#define METRIC_DEFINE_ONE_ARG_NOTNULL(method, name, arg_type)                                                           \
-    void METRIC_FUNC_NAME_##method(name)(arg_type arg) { if (METRIC_VAR_NAME(name) != nullptr) {METRIC_VAR_##method(name, arg);} }
+#define METRIC_DEFINE_ONE_ARG_NOTNULL(method, name, arg_type)                                      \
+    void METRIC_FUNC_NAME_##method(name)(arg_type arg)                                             \
+    {                                                                                              \
+        if (METRIC_VAR_NAME(name) != nullptr) {                                                    \
+            METRIC_VAR_##method(name, arg);                                                        \
+        }                                                                                          \
+    }
 
 #define METRIC_CALL(obj, method, name, ...) (obj).METRIC_FUNC_NAME_##method(name)(__VA_ARGS__)
 
 #define METRIC_FUNC_NAME_INCREMENT_BY(name) increment_##name##_by
 
-#define METRIC_DEFINE_INCREMENT_BY(name)                                                           \
-    METRIC_DEFINE_ONE_ARG(INCREMENT_BY, name, int64_t)
+#define METRIC_DEFINE_INCREMENT_BY(name) METRIC_DEFINE_ONE_ARG(INCREMENT_BY, name, int64_t)
 
 // To be adaptive to self-defined `increment_by` methods, arguments are declared as variadic.
 #define METRIC_INCREMENT_BY(obj, name, ...) METRIC_CALL(obj, INCREMENT_BY, name, ##__VA_ARGS__)
 
 #define METRIC_FUNC_NAME_INCREMENT(name) increment_##name
 
-#define METRIC_DEFINE_INCREMENT(name)                                                              \
-    METRIC_DEFINE_NO_ARG(INCREMENT, name) 
+#define METRIC_DEFINE_INCREMENT(name) METRIC_DEFINE_NO_ARG(INCREMENT, name)
 
-#define METRIC_DEFINE_INCREMENT_NOTNULL(name)                                                              \
-    METRIC_DEFINE_NO_ARG_NOTNULL(INCREMENT, name)
+#define METRIC_DEFINE_INCREMENT_NOTNULL(name) METRIC_DEFINE_NO_ARG_NOTNULL(INCREMENT, name)
 
 // To be adaptive to self-defined `increment` methods, arguments are declared as variadic.
 #define METRIC_INCREMENT(obj, name, ...) METRIC_CALL(obj, INCREMENT, name, ##__VA_ARGS__)
 
 #define METRIC_FUNC_NAME_DECREMENT(name) decrement_##name
 
-#define METRIC_DEFINE_DECREMENT(name)                                                              \
-    METRIC_DEFINE_NO_ARG(DECREMENT, name)
+#define METRIC_DEFINE_DECREMENT(name) METRIC_DEFINE_NO_ARG(DECREMENT, name)
 
-#define METRIC_DEFINE_DECREMENT_NOTNULL(name)                                                              \
-    METRIC_DEFINE_NO_ARG_NOTNULL(DECREMENT, name)
+#define METRIC_DEFINE_DECREMENT_NOTNULL(name) METRIC_DEFINE_NO_ARG_NOTNULL(DECREMENT, name)
 
 // To be adaptive to self-defined `decrement` methods, arguments are declared as variadic.
 #define METRIC_DECREMENT(obj, name, ...) METRIC_CALL(obj, DECREMENT, name, ##__VA_ARGS__)
 
 #define METRIC_FUNC_NAME_SET(name) set_##name
 
-#define METRIC_DEFINE_SET(name, value_type)                                                        \
-    METRIC_DEFINE_ONE_ARG(SET, name, value_type)
+#define METRIC_DEFINE_SET(name, value_type) METRIC_DEFINE_ONE_ARG(SET, name, value_type)
 
-#define METRIC_DEFINE_SET_NOTNULL(name, value_type)                                                        \
+#define METRIC_DEFINE_SET_NOTNULL(name, value_type)                                                \
     METRIC_DEFINE_ONE_ARG_NOTNULL(SET, name, value_type)
 
 // To be adaptive to self-defined `set` methods, arguments are declared as variadic.
@@ -298,8 +302,7 @@ class error_code;
 
 #define METRIC_FUNC_NAME_VALUE(name) get_##name
 
-#define METRIC_DEFINE_VALUE(name, value_type)                                                      \
-    METRIC_DEFINE_RET_AND_NO_ARG(value_type, VALUE, name)
+#define METRIC_DEFINE_VALUE(name, value_type) METRIC_DEFINE_RET_AND_NO_ARG(value_type, VALUE, name)
 
 // To be adaptive to self-defined `value` methods, arguments are declared as variadic.
 #define METRIC_VALUE(obj, name, ...) METRIC_CALL(obj, VALUE, name, ##__VA_ARGS__)

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -238,37 +238,71 @@ class error_code;
 #define METRIC_VAR_AUTO_COUNT(name, ...)                                                           \
     dsn::auto_count __##name##_auto_count(METRIC_VAR_NAME(name), ##__VA_ARGS__)
 
+#define METRIC_DEFINE_NO_ARG(method, name)                                                           \
+    void METRIC_FUNC_NAME_##method(name)() { METRIC_VAR_##method(name); }
+
+#define METRIC_DEFINE_NO_ARG_NOTNULL(method, name)                                                           \
+    void METRIC_FUNC_NAME_##method(name)() { if (METRIC_VAR_NAME(name) != nullptr) {METRIC_VAR_##method(name);}  }
+
+#define METRIC_DEFINE_RET_AND_NO_ARG(ret_type, method, name)                                                           \
+    ret_type METRIC_FUNC_NAME_##method(name)() { return METRIC_VAR_##method(name); }
+
+#define METRIC_DEFINE_ONE_ARG(method, name, arg_type)                                                           \
+    void METRIC_FUNC_NAME_##method(name)(arg_type arg) { METRIC_VAR_##method(name, arg); }
+
+#define METRIC_DEFINE_ONE_ARG_NOTNULL(method, name, arg_type)                                                           \
+    void METRIC_FUNC_NAME_##method(name)(arg_type arg) { if (METRIC_VAR_NAME(name) != nullptr) {METRIC_VAR_##method(name, arg);} }
+
+#define METRIC_CALL(obj, method, name, ...) (obj).METRIC_FUNC_NAME_##method(name)(__VA_ARGS__)
+
 #define METRIC_FUNC_NAME_INCREMENT_BY(name) increment_##name##_by
 
 #define METRIC_DEFINE_INCREMENT_BY(name)                                                           \
-    void METRIC_FUNC_NAME_INCREMENT_BY(name)(int64_t x) { METRIC_VAR_INCREMENT_BY(name, x); }
+    METRIC_DEFINE_ONE_ARG(INCREMENT_BY, name, int64_t)
 
 // To be adaptive to self-defined `increment_by` methods, arguments are declared as variadic.
-#define METRIC_INCREMENT_BY(obj, name, ...) (obj).METRIC_FUNC_NAME_INCREMENT_BY(name)(__VA_ARGS__)
+#define METRIC_INCREMENT_BY(obj, name, ...) METRIC_CALL(obj, INCREMENT_BY, name, ##__VA_ARGS__)
 
 #define METRIC_FUNC_NAME_INCREMENT(name) increment_##name
 
 #define METRIC_DEFINE_INCREMENT(name)                                                              \
-    void METRIC_FUNC_NAME_INCREMENT(name)() { METRIC_VAR_INCREMENT(name); }
+    METRIC_DEFINE_NO_ARG(INCREMENT, name) 
+
+#define METRIC_DEFINE_INCREMENT_NOTNULL(name)                                                              \
+    METRIC_DEFINE_NO_ARG_NOTNULL(INCREMENT, name)
 
 // To be adaptive to self-defined `increment` methods, arguments are declared as variadic.
-#define METRIC_INCREMENT(obj, name, ...) (obj).METRIC_FUNC_NAME_INCREMENT(name)(__VA_ARGS__)
+#define METRIC_INCREMENT(obj, name, ...) METRIC_CALL(obj, INCREMENT, name, ##__VA_ARGS__)
+
+#define METRIC_FUNC_NAME_DECREMENT(name) decrement_##name
+
+#define METRIC_DEFINE_DECREMENT(name)                                                              \
+    METRIC_DEFINE_NO_ARG(DECREMENT, name)
+
+#define METRIC_DEFINE_DECREMENT_NOTNULL(name)                                                              \
+    METRIC_DEFINE_NO_ARG_NOTNULL(DECREMENT, name)
+
+// To be adaptive to self-defined `decrement` methods, arguments are declared as variadic.
+#define METRIC_DECREMENT(obj, name, ...) METRIC_CALL(obj, DECREMENT, name, ##__VA_ARGS__)
 
 #define METRIC_FUNC_NAME_SET(name) set_##name
 
 #define METRIC_DEFINE_SET(name, value_type)                                                        \
-    void METRIC_FUNC_NAME_SET(name)(value_type value) { METRIC_VAR_SET(name, value); }
+    METRIC_DEFINE_ONE_ARG(SET, name, value_type)
+
+#define METRIC_DEFINE_SET_NOTNULL(name, value_type)                                                        \
+    METRIC_DEFINE_ONE_ARG_NOTNULL(SET, name, value_type)
 
 // To be adaptive to self-defined `set` methods, arguments are declared as variadic.
-#define METRIC_SET(obj, name, ...) (obj).METRIC_FUNC_NAME_SET(name)(__VA_ARGS__)
+#define METRIC_SET(obj, name, ...) METRIC_CALL(obj, SET, name, ##__VA_ARGS__)
 
 #define METRIC_FUNC_NAME_VALUE(name) get_##name
 
 #define METRIC_DEFINE_VALUE(name, value_type)                                                      \
-    value_type METRIC_FUNC_NAME_VALUE(name)() { return METRIC_VAR_VALUE(name); }
+    METRIC_DEFINE_RET_AND_NO_ARG(value_type, VALUE, name)
 
 // To be adaptive to self-defined `value` methods, arguments are declared as variadic.
-#define METRIC_VALUE(obj, name, ...) (obj).METRIC_FUNC_NAME_VALUE(name)(__VA_ARGS__)
+#define METRIC_VALUE(obj, name, ...) METRIC_CALL(obj, VALUE, name, ##__VA_ARGS__)
 
 namespace dsn {
 class metric;                  // IWYU pragma: keep


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1523

Profiler-level metric entity is introduced and 12 profiler-related metrics are
migrate to the new framework, including the number of tasks in all queues,
the number of tasks that have been executed, the number of cancelled tasks,
the latency it takes for each task to wait in each queue before beginning to be
executed, the latency it takes for each task to be executed, the latency from
enqueue point to reply point on the server side for each RPC task, the non-timeout
latency from call point to enqueue point on the client side for each RPC task,
the body length of request received or response replied on the server side for
each RPC task, the accumulative number of dropped RPC tasks on the server
side, the accumulative number of timeout RPC tasks on the client side.

All these metrics are configurable thus might be NULL. `METRIC_DEFINE_*_NOTNULL`
macros are introduced to help defining the member functions that check if the
metric variables are NULL pointers. Some macros are refactored to make it more
convenient to define the member functions that increment/decrement/set/get the
value of the metric variables.