### PR TITLE
fix(new_metrics): profiled tasks are measured by the wrong metrics

### DIFF
--- a/src/runtime/profiler_header.h
+++ b/src/runtime/profiler_header.h
@@ -40,6 +40,7 @@ struct task_spec_profiler
     bool is_profile;
     std::unique_ptr<std::atomic<int64_t>[]> call_counts;
 
+    task_spec_profiler() = default;
     task_spec_profiler(int code);
     const metric_entity_ptr &profiler_metric_entity() const;
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1527

Maintained in an array that includes all of the profilers, each profiler is
indexed and accessed by its task code. Therefore, `TASK_CODE_INVALID`,
albeit meaningless, should also be pushed into this array; otherwise, all
of the profiled tasks would be indexed by the wrong task code, then also
measured by the wrong metrics. 
