### PR TITLE
fix(github): throttle_test failed frequently due to insufficient disk space

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -47,6 +47,7 @@ on:
   workflow_dispatch:
 
 env:
+  # Update the options to reduce the consumption of the disk space
   ONEBOX_OPTS: disk_min_available_space_ratio=5
   TEST_OPTS: throttle_test_medium_value_kb=10,throttle_test_large_value_kb=25
                                                                                                                 

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -46,6 +46,10 @@ on:
   # for manually triggering workflow
   workflow_dispatch:
 
+env:
+  ONEBOX_OPTS: disk_min_available_space_ratio=5
+  TEST_OPTS: throttle_test_medium_value_kb=10,throttle_test_large_value_kb=25
+                                                                                                                
 jobs:
   cpp_clang_format_linter:
     name: Lint
@@ -231,7 +235,7 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
           . ./scripts/config_hdfs.sh
-          ./run.sh test --onebox_opts "disk_min_available_space_ratio=5" -m ${{ matrix.test_module }}
+          ./run.sh test --onebox_opts "$ONEBOX_OPTS" --test_opts "$TEST_OPTS" -m ${{ matrix.test_module }}
 
   build_ASAN:
     name: Build ASAN
@@ -357,7 +361,7 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
           . ./scripts/config_hdfs.sh
-          ./run.sh test --onebox_opts "disk_min_available_space_ratio=5" -m ${{ matrix.test_module }}
+          ./run.sh test --onebox_opts "$ONEBOX_OPTS" --test_opts "$TEST_OPTS" -m ${{ matrix.test_module }}
 
 # TODO(yingchun): Build and test UBSAN version would cost a very long time, we will run these tests
 #                 when we are going to release a stable version. So we disable them in regular CI
@@ -482,7 +486,7 @@ jobs:
 #          export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
 #          ulimit -s unlimited
 #          . ./scripts/config_hdfs.sh
-#          ./run.sh test --onebox_opts "disk_min_available_space_ratio=5" -m ${{ matrix.test_module }}
+#          ./run.sh test --onebox_opts "$ONEBOX_OPTS" --test_opts "$TEST_OPTS" -m ${{ matrix.test_module }}
 
   build_with_jemalloc:
     name: Build with jemalloc
@@ -577,7 +581,7 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
           . ./scripts/config_hdfs.sh
-          ./run.sh test --onebox_opts "disk_min_available_space_ratio=5" -m ${{ matrix.test_module }}
+          ./run.sh test --onebox_opts "$ONEBOX_OPTS" --test_opts "$TEST_OPTS" -m ${{ matrix.test_module }}
 
   build_pegasus_on_macos:
     name: macOS

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -231,7 +231,7 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
           . ./scripts/config_hdfs.sh
-          ./run.sh test -m ${{ matrix.test_module }}
+          ./run.sh test --onebox_opts "disk_min_available_space_ratio=5" -m ${{ matrix.test_module }}
 
   build_ASAN:
     name: Build ASAN
@@ -357,7 +357,7 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
           . ./scripts/config_hdfs.sh
-          ./run.sh test -m ${{ matrix.test_module }}
+          ./run.sh test --onebox_opts "disk_min_available_space_ratio=5" -m ${{ matrix.test_module }}
 
 # TODO(yingchun): Build and test UBSAN version would cost a very long time, we will run these tests
 #                 when we are going to release a stable version. So we disable them in regular CI
@@ -482,7 +482,7 @@ jobs:
 #          export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
 #          ulimit -s unlimited
 #          . ./scripts/config_hdfs.sh
-#          ./run.sh test -m ${{ matrix.test_module }}
+#          ./run.sh test --onebox_opts "disk_min_available_space_ratio=5" -m ${{ matrix.test_module }}
 
   build_with_jemalloc:
     name: Build with jemalloc
@@ -577,7 +577,7 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
           ulimit -s unlimited
           . ./scripts/config_hdfs.sh
-          ./run.sh test -m ${{ matrix.test_module }}
+          ./run.sh test --onebox_opts "disk_min_available_space_ratio=5" -m ${{ matrix.test_module }}
 
   build_pegasus_on_macos:
     name: macOS

--- a/run.sh
+++ b/run.sh
@@ -343,6 +343,7 @@ function usage_test()
     echo "                     e.g., \"pegasus_unit_test,dsn_runtime_tests,dsn_meta_state_tests\","
     echo "                     if not set, then run all tests"
     echo "   -k|--keep_onebox  whether keep the onebox after the test[default false]"
+    echo "   -o|--onebox_opts  options for starting onebox, e.g. k1=v1,k2=v2"
 }
 function run_test()
 {
@@ -383,6 +384,7 @@ function run_test()
       restore_test
       throttle_test
     )
+    local onebox_opts=""
     while [[ $# > 0 ]]; do
         key="$1"
         case $key in
@@ -399,6 +401,10 @@ function run_test()
                 ;;
             --enable_gcov)
                 enable_gcov="yes"
+                ;;
+            -o|--onebox_opts)
+                onebox_opts=$2
+                shift
                 ;;
             *)
                 echo "Error: unknown option \"$key\""
@@ -459,6 +465,7 @@ function run_test()
             if [ "${module}" == "restore_test" ]; then
                 opts="cold_backup_disabled=false,cold_backup_checkpoint_reserve_minutes=0,cold_backup_root=mycluster"
             fi
+            [ -z ${onebox_opts} ] || opts="${opts},${onebox_opts}"
             if ! run_start_onebox -m ${m_count} -w -c --opts ${opts}; then
                 echo "ERROR: unable to continue on testing because starting onebox failed"
                 exit 1

--- a/run.sh
+++ b/run.sh
@@ -343,7 +343,8 @@ function usage_test()
     echo "                     e.g., \"pegasus_unit_test,dsn_runtime_tests,dsn_meta_state_tests\","
     echo "                     if not set, then run all tests"
     echo "   -k|--keep_onebox  whether keep the onebox after the test[default false]"
-    echo "   -o|--onebox_opts  options for starting onebox, e.g. k1=v1,k2=v2"
+    echo "   --onebox_opts     update configs for onebox, e.g. key1=value1,key2=value2"
+    echo "   --test_opts       update configs for tests, e.g. key1=value1,key2=value2"
 }
 function run_test()
 {
@@ -385,6 +386,7 @@ function run_test()
       throttle_test
     )
     local onebox_opts=""
+    local test_opts=""
     while [[ $# > 0 ]]; do
         key="$1"
         case $key in
@@ -402,8 +404,12 @@ function run_test()
             --enable_gcov)
                 enable_gcov="yes"
                 ;;
-            -o|--onebox_opts)
+            --onebox_opts)
                 onebox_opts=$2
+                shift
+                ;;
+            --test_opts)
+                test_opts=$2
                 shift
                 ;;
             *)
@@ -477,7 +483,7 @@ function run_test()
             run_start_zk
         fi
         pushd ${BUILD_LATEST_DIR}/bin/$module
-        REPORT_DIR=$REPORT_DIR TEST_BIN=$module ./run.sh
+        REPORT_DIR=${REPORT_DIR} TEST_BIN=${module} TEST_OPTS=${test_opts} ./run.sh
         if [ $? != 0 ]; then
             echo "run test \"$module\" in `pwd` failed"
             exit 1

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -135,6 +135,7 @@
 
 [replication]
   mutation_2pc_min_replica_count = 1
+  disk_min_available_space_ratio = 10
   cold_backup_root = onebox
   cluster_name = onebox
 

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -79,3 +79,7 @@ lb_interval_ms = 3000
 mycluster = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
 onebox = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
 single_master_cluster = 127.0.0.1:34601
+
+[function_test.throttle_test]
+  throttle_test_medium_value_kb = 20
+  throttle_test_large_value_kb = 50

--- a/src/test/function_test/run.sh
+++ b/src/test/function_test/run.sh
@@ -24,6 +24,25 @@ if [ -z ${TEST_BIN} ]; then
     exit 1
 fi
 
+if [ -n ${TEST_OPTS} ]; then
+    if [ ! -f ./config.ini ]; then
+        echo "./config.ini does not exists !"
+        exit 1
+    fi
+
+    OPTS=`echo ${TEST_OPTS} | xargs`
+    config_kvs=(${OPTS//,/ })
+    for config_kv in ${config_kvs[@]}; do
+        config_kv=`echo $config_kv | xargs`
+        kv=(${config_kv//=/ })
+        if [ ! ${#kv[*]} -eq 2 ]; then
+            echo "Invalid config kv !"
+            exit 1
+        fi
+        sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./config.ini
+    done
+fi
+
 loop_count=0
 last_ret=0
 while [ $loop_count -le 5 ]

--- a/src/test/function_test/throttle_test/test_throttle.cpp
+++ b/src/test/function_test/throttle_test/test_throttle.cpp
@@ -43,6 +43,7 @@
 #include "test_util/test_util.h"
 #include "utils/error_code.h"
 #include "utils/errors.h"
+#include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/rand.h"
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1529

Options used by onebox and function tests are made configurable. The default
values for these options are unchanged. Once custom options are provided as
the arguments of `run.sh`, these custom options would be used to substitute
for the current configurations. Github workflow for cpp has used custom options
to reduce the consumption of disk space.

On the other hand, to solve the problem that `throttle_test` failed frequently
fundamentally, `throttle_test` should be refactored: at the end of each test
case, onebox for each replica server should be stopped and the data should
be cleared to release the disk space. This is tracked by another issue:
        https://github.com/apache/incubator-pegasus/issues/1534