### PR TITLE
feat(new_metrics): remove all table-level perf-counters for each replica

### DIFF
--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -47,8 +47,6 @@
 #include "duplication/replica_follower.h"
 #include "mutation.h"
 #include "mutation_log.h"
-#include "perf_counter/perf_counter.h"
-#include "perf_counter/perf_counters.h"
 #include "replica/prepare_list.h"
 #include "replica/replica_context.h"
 #include "replica/replication_app_base.h"

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -29,11 +29,10 @@
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <inttypes.h>
-#include <algorithm>
+#include <rocksdb/status.h>
 #include <functional>
 #include <iosfwd>
-#include <rocksdb/status.h>
-#include <set>
+#include <vector>
 
 #include "backup/replica_backup_manager.h"
 #include "bulk_load/replica_bulk_loader.h"
@@ -55,8 +54,6 @@
 #include "replica_stub.h"
 #include "runtime/rpc/rpc_message.h"
 #include "runtime/security/access_controller.h"
-#include "runtime/task/task_code.h"
-#include "runtime/task/task_spec.h"
 #include "split/replica_split_manager.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -50,7 +50,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "common/replication_other_types.h"
 #include "dsn.layer2_types.h"

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -85,7 +85,6 @@ class rocksdb_wrapper_test;
 
 namespace dsn {
 class gpid;
-class perf_counter;
 class rpc_address;
 
 namespace dist {
@@ -489,8 +488,6 @@ private:
 
     manual_compaction_status::type get_manual_compact_status() const;
 
-    void init_table_level_latency_counters();
-
     void on_detect_hotkey(const detect_hotkey_request &req, /*out*/ detect_hotkey_response &resp);
 
     uint32_t query_data_version() const;
@@ -669,7 +666,6 @@ private:
     METRIC_VAR_DECLARE_counter(splitting_rejected_read_requests);
     METRIC_VAR_DECLARE_counter(bulk_load_ingestion_rejected_write_requests);
     METRIC_VAR_DECLARE_counter(dup_rejected_non_idempotent_write_requests);
-    std::vector<perf_counter *> _counters_table_level_latency;
 
     METRIC_VAR_DECLARE_counter(learn_count);
     METRIC_VAR_DECLARE_counter(learn_rounds);


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1327

Remove all table-level metrics that are measured by perf-counters. Later,
table-level metrics would be aggregated by Go Collector, if necessary.
