### PR TITLE
refactor(new_metrics): remove perf-counters that are still used in shared log

### DIFF
--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -39,8 +39,6 @@
 #include "common/replication.codes.h"
 #include "consensus_types.h"
 #include "mutation_log_utils.h"
-#include "perf_counter/perf_counter.h"
-#include "perf_counter/perf_counter_wrapper.h"
 #include "replica.h"
 #include "replica/log_block.h"
 #include "replica/log_file.h"
@@ -183,10 +181,6 @@ void mutation_log_shared::commit_pending_mutations(log_file_ptr &lf,
                     //
                     // FIXME : the file could have been closed
                     lf->flush();
-                }
-
-                if (_write_size_counter) {
-                    (*_write_size_counter)->add(sz);
                 }
             } else {
                 LOG_ERROR("write shared log failed, err = {}", err);

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -398,9 +398,7 @@ typedef dsn::ref_ptr<mutation_log> mutation_log_ptr;
 class mutation_log_shared : public mutation_log
 {
 public:
-    mutation_log_shared(const std::string &dir,
-                        int32_t max_log_file_mb,
-                        bool force_flush)
+    mutation_log_shared(const std::string &dir, int32_t max_log_file_mb, bool force_flush)
         : mutation_log(dir, max_log_file_mb, dsn::gpid(), nullptr),
           _is_writing(false),
           _force_flush(force_flush)

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -54,7 +54,6 @@
 
 namespace dsn {
 class binary_writer;
-class perf_counter_wrapper;
 
 namespace replication {
 
@@ -241,9 +240,9 @@ public:
     //
     bool get_learn_state(gpid gpid, decree start, /*out*/ learn_state &state) const;
 
-    // only valid for private log
-    // get parent mutations in memory and private log files during partition split
-    // total_file_size is used for split perf-counter
+    // only valid for private log.
+    // get parent mutations in memory and private log files during partition split.
+    // `total_file_size` is used for the metrics of partition split.
     void get_parent_mutations_and_logs(gpid pid,
                                        decree start_decree,
                                        ballot start_ballot,
@@ -401,12 +400,10 @@ class mutation_log_shared : public mutation_log
 public:
     mutation_log_shared(const std::string &dir,
                         int32_t max_log_file_mb,
-                        bool force_flush,
-                        perf_counter_wrapper *write_size_counter = nullptr)
+                        bool force_flush)
         : mutation_log(dir, max_log_file_mb, dsn::gpid(), nullptr),
           _is_writing(false),
-          _force_flush(force_flush),
-          _write_size_counter(write_size_counter)
+          _force_flush(force_flush)
     {
     }
 
@@ -448,7 +445,6 @@ private:
     std::shared_ptr<log_appender> _pending_write;
 
     bool _force_flush;
-    perf_counter_wrapper *_write_size_counter;
 };
 
 class mutation_log_private : public mutation_log, private replica_base


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1532

In https://github.com/apache/incubator-pegasus/pull/1462, all metrics of
shared log have been removed. However, there are still some perf-counters
that are used in shared log. All of them should be removed.