### PR TITLE
feat(new_metrics): migrate metrics for latency tracer

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -255,26 +255,46 @@ jobs:
           key: asan_ccache
       - name: Free Disk Space (Ubuntu)
         run: |
+          echo "Listing 100 largest packages"
+          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+          df -h
+          echo "Removing large packages"
           # apt-get remove -y '^dotnet-.*'
-          apt-get remove -y '^llvm-.*'
-          apt-get remove -y 'php.*'
-          apt-get remove -y '^mongodb-.*'
+          # apt-get remove -y '^llvm-.*'
+          # apt-get remove -y 'php.*'
+          # apt-get remove -y '^mongodb-.*'
           # apt-get remove -y '^mysql-.*'
           # apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
           apt-get remove -y libgl1-mesa-dri
-          apt-get autoremove -y
+          # apt-get autoremove -y
+          apt-get -s autoremove
           apt-get clean
+          df -h
+          echo "Removing large directories"
+          du -csh /mnt/swapfile
           rm -f /mnt/swapfile
+          du -csh /opt/ghc
           rm -rf /opt/ghc
+          du -csh /usr/local/.ghcup
           rm -rf /usr/local/.ghcup
+          du -csh /usr/local/graalvm
           rm -rf /usr/local/graalvm
+          du -csh /usr/local/lib/android
           rm -rf /usr/local/lib/android
+          du -csh /usr/local/lib/node_modules
           rm -rf /usr/local/lib/node_modules
+          du -csh /usr/local/share/boost
           rm -rf /usr/local/share/boost
+          du -csh /usr/local/share/chromium
           rm -rf /usr/local/share/chromium
+          du -csh /usr/local/share/powershell
           rm -rf /usr/local/share/powershell
+          du -csh /usr/share/dotnet
           rm -rf /usr/share/dotnet
+          echo "AGENT_TOOLSDIRECTORY is $AGENT_TOOLSDIRECTORY"
+          du -csh "$AGENT_TOOLSDIRECTORY"
           rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
       - uses: dorny/paths-filter@v2
         id: changes
         with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -247,6 +247,20 @@ jobs:
       image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # This might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # All of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
       - name: Setup cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -255,11 +255,11 @@ jobs:
           key: asan_ccache
       - name: Free Disk Space (Ubuntu)
         run: |
+          df -h
           du -csh /__w/*/*
           du -csh /__t/*/*
           echo "Listing 100 largest packages"
           dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
-          df -h
           echo "Removing large packages"
           # apt-get remove -y '^dotnet-.*'
           # apt-get remove -y '^llvm-.*'
@@ -270,9 +270,13 @@ jobs:
           # apt-get remove -y libgl1-mesa-dri
           # apt-get autoremove -y
           apt-get -s autoremove
+          apt-get remove -y openjdk-11-jre-headless
           # apt-get clean
           df -h
           echo "Removing large directories"
+          rm -rf /__t/CodeQL
+          rm -rf /__t/node
+          rm -rf /__t/PyPy
           # du -csh /mnt/swapfile
           # rm -f /mnt/swapfile
           # du -csh /opt/ghc

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -276,7 +276,6 @@ jobs:
           du -csh /__w/*/*
           du -csh /__t/*/*
           du -csh /opt/*
-          du -csh /mnt/*
           du -csh /usr/local/*
           du -csh /usr/local/lib/*
           du -csh /usr/local/share/*
@@ -286,7 +285,6 @@ jobs:
           rm -rf /__t/CodeQL
           rm -rf /__t/node
           rm -rf /__t/PyPy
-          rm -f /mnt/swapfile
           rm -rf /opt/ghc
           rm -rf /usr/local/.ghcup
           rm -rf /usr/local/graalvm

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -127,6 +127,7 @@ jobs:
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
         run: |
+          df -h
           unzip /root/thirdparties-bin.zip -d ./thirdparty
           rm -f /root/thirdparties-bin.zip
       - name: Rebuild third-parties
@@ -134,6 +135,7 @@ jobs:
         working-directory: thirdparty
         # Build thirdparties and leave some necessary libraries and source
         run: |
+          df -h
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
           cmake --build build/ -j $(nproc)
@@ -142,25 +144,33 @@ jobs:
           ../scripts/download_zk.sh zookeeper-bin
       - name: Compilation
         run: |
+          df -h
           ccache -p
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release
           ccache -s
+      - name: Clear Build Files
+        run: |
+          df -h
           find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server
         run: |
+          df -h
           ./run.sh pack_server
           rm -rf pegasus-server-*
       - name: Pack Tools
         run: |
+          df -h
           ./run.sh pack_tools
           rm -rf pegasus-tools-*
       - name: Tar files
         run: |
+          df -h
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
           tar -zcvhf release__builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
+          df -h
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -256,50 +266,36 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         run: |
           df -h
-          du -csh /__w/*/*
-          du -csh /__t/*/*
           echo "Listing 100 largest packages"
           dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
           echo "Removing large packages"
-          # apt-get remove -y '^dotnet-.*'
-          # apt-get remove -y '^llvm-.*'
-          # apt-get remove -y 'php.*'
-          # apt-get remove -y '^mongodb-.*'
-          # apt-get remove -y '^mysql-.*'
-          # apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
-          # apt-get remove -y libgl1-mesa-dri
-          # apt-get autoremove -y
           apt-get -s autoremove
           apt-get remove -y openjdk-11-jre-headless
-          # apt-get clean
           df -h
+          echo "Listing directories"
+          du -csh /__w/*/*
+          du -csh /__t/*/*
+          du -csh /opt/*
+          du -csh /mnt/*
+          du -csh /usr/local/*
+          du -csh /usr/local/lib/*
+          du -csh /usr/local/share/*
+          du -csh /usr/share/*
+          echo "AGENT_TOOLSDIRECTORY is $AGENT_TOOLSDIRECTORY"
           echo "Removing large directories"
           rm -rf /__t/CodeQL
           rm -rf /__t/node
           rm -rf /__t/PyPy
-          # du -csh /mnt/swapfile
-          # rm -f /mnt/swapfile
-          # du -csh /opt/ghc
-          # rm -rf /opt/ghc
-          # du -csh /usr/local/.ghcup
+          rm -f /mnt/swapfile
+          rm -rf /opt/ghc
           rm -rf /usr/local/.ghcup
-          # du -csh /usr/local/graalvm
-          # rm -rf /usr/local/graalvm
-          #du -csh /usr/local/lib/android
+          rm -rf /usr/local/graalvm
           rm -rf /usr/local/lib/android
-          #du -csh /usr/local/lib/node_modules
           rm -rf /usr/local/lib/node_modules
-          #du -csh /usr/local/share/boost
           rm -rf /usr/local/share/boost
-          #du -csh /usr/local/share/chromium
           rm -rf /usr/local/share/chromium
-          #du -csh /usr/local/share/powershell
           rm -rf /usr/local/share/powershell
-          #du -csh /usr/share/dotnet
           rm -rf /usr/share/dotnet
-          echo "AGENT_TOOLSDIRECTORY is $AGENT_TOOLSDIRECTORY"
-          # du -csh "$AGENT_TOOLSDIRECTORY"
-          # rm -rf "$AGENT_TOOLSDIRECTORY"
           df -h
       - uses: dorny/paths-filter@v2
         id: changes
@@ -314,6 +310,7 @@ jobs:
         if: steps.changes.outputs.thirdparty == 'false'
         run: |
           # TODO(wangdan): clear unneeded files here temporarily. Later, unneeded files could be cleared in images.
+          df -h
           rm -f /root/thirdparties-src.zip
           unzip /root/thirdparties-bin.zip -d ./thirdparty
           rm -f /root/thirdparties-bin.zip
@@ -327,6 +324,7 @@ jobs:
         # Build thirdparties and leave some necessary libraries and source
         run: |
           # TODO(wangdan): clear unneeded files here temporarily. Later, unneeded files could be cleared in images.
+          df -h
           rm -f /root/thirdparties-src.zip
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
@@ -341,17 +339,23 @@ jobs:
           rm -rf zookeeper-bin/docs
       - name: Compilation
         run: |
+          df -h
           ccache -p
           ccache -z
           ./run.sh build --test --sanitizer address --skip_thirdparty --disable_gperf -j $(nproc)
           ccache -s
+      - name: Clear Build Files
+        run: |
+          df -h
           find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Tar files
         run: |
+          df -h
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
           tar -zcvhf release_address_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
+          df -h
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -480,6 +484,9 @@ jobs:
 #          ccache -z
 #          ./run.sh build --test --sanitizer undefined --skip_thirdparty --disable_gperf -j $(nproc)
 #          ccache -s
+#      - name: Clear Build Files
+#        run: |
+#          df -h
 #          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
 #      - name: Tar files
 #        run: |
@@ -589,6 +596,7 @@ jobs:
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
         run: |
+          df -h
           unzip /root/thirdparties-bin.zip -d ./thirdparty
           rm -f /root/thirdparties-bin.zip
       - name: Rebuild third-parties
@@ -596,6 +604,7 @@ jobs:
         working-directory: thirdparty
         # Build thirdparties and leave some necessary libraries and source
         run: |
+          df -h
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -DUSE_JEMALLOC=ON -B build/
           cmake --build build/ -j $(nproc)
@@ -604,25 +613,33 @@ jobs:
           ../scripts/download_zk.sh zookeeper-bin
       - name: Compilation
         run: |
+          df -h
           ccache -p
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release --use_jemalloc
           ccache -s
+      - name: Clear Build Files
+        run: |
+          df -h
           find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server
         run: |
+          df -h
           ./run.sh pack_server -j
           rm -rf pegasus-server-*
       - name: Pack Tools
         run:
+          df -h
           ./run.sh pack_tools -j
           rm -rf pegasus-tools-*
       - name: Tar files
         run: |
+          df -h
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
           tar -zcvhf release_jemalloc_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
+          df -h
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -255,7 +255,8 @@ jobs:
           key: asan_ccache
       - name: Free Disk Space (Ubuntu)
         run: |
-          du -csh /__t/*
+          du -csh /__w/*/*
+          du -csh /__t/*/*
           echo "Listing 100 largest packages"
           dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
           df -h
@@ -266,9 +267,9 @@ jobs:
           # apt-get remove -y '^mongodb-.*'
           # apt-get remove -y '^mysql-.*'
           # apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
-          apt-get remove -y libgl1-mesa-dri
+          # apt-get remove -y libgl1-mesa-dri
           # apt-get autoremove -y
-          # apt-get -s autoremove
+          apt-get -s autoremove
           # apt-get clean
           df -h
           echo "Removing large directories"

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -255,6 +255,7 @@ jobs:
           key: asan_ccache
       - name: Free Disk Space (Ubuntu)
         run: |
+          du -csh /*
           echo "Listing 100 largest packages"
           dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
           df -h
@@ -268,7 +269,7 @@ jobs:
           apt-get remove -y libgl1-mesa-dri
           # apt-get autoremove -y
           # apt-get -s autoremove
-          apt-get clean
+          # apt-get clean
           df -h
           echo "Removing large directories"
           # du -csh /mnt/swapfile

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -255,12 +255,12 @@ jobs:
           key: asan_ccache
       - name: Free Disk Space (Ubuntu)
         run: |
-          apt-get remove -m -y '^dotnet-.*'
-          apt-get remove -m -y '^llvm-.*'
-          apt-get remove -m -y 'php.*'
-          apt-get remove -m -y '^mongodb-.*'
-          apt-get remove -m -y '^mysql-.*'
-          apt-get remove -m -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          # apt-get remove -y '^dotnet-.*'
+          apt-get remove -y '^llvm-.*'
+          apt-get remove -y 'php.*'
+          apt-get remove -y '^mongodb-.*'
+          apt-get remove -y '^mysql-.*'
+          apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
           apt-get autoremove -y
           apt-get clean
           rm -f /mnt/swapfile

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -247,20 +247,6 @@ jobs:
       image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # This might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # All of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
       - name: Setup cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -247,20 +247,6 @@ jobs:
       image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # This might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # All of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
       - name: Setup cache
         uses: actions/cache@v3
         with:
@@ -276,6 +262,20 @@ jobs:
               - 'docker/thirdparties-src/**'
               - 'docker/thirdparties-bin/**'
               - 'thirdparty/**'
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # This might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # All of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
         run: |

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -271,8 +271,8 @@ jobs:
           apt-get clean
           df -h
           echo "Removing large directories"
-          du -csh /mnt/swapfile
-          rm -f /mnt/swapfile
+          # du -csh /mnt/swapfile
+          # rm -f /mnt/swapfile
           du -csh /opt/ghc
           rm -rf /opt/ghc
           du -csh /usr/local/.ghcup

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -273,9 +273,9 @@ jobs:
           echo "Removing large directories"
           # du -csh /mnt/swapfile
           # rm -f /mnt/swapfile
-          du -csh /opt/ghc
-          rm -rf /opt/ghc
-          du -csh /usr/local/.ghcup
+          # du -csh /opt/ghc
+          # rm -rf /opt/ghc
+          [[ -d /usr/local/.ghcup ]] && du -csh /usr/local/.ghcup
           rm -rf /usr/local/.ghcup
           du -csh /usr/local/graalvm
           rm -rf /usr/local/graalvm

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -254,19 +254,26 @@ jobs:
             /github/home/.ccache
           key: asan_ccache
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # This might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # All of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
+        run: |
+          apt-get remove -y '^dotnet-.*'
+          apt-get remove -y '^llvm-.*'
+          apt-get remove -y 'php.*'
+          apt-get remove -y '^mongodb-.*'
+          apt-get remove -y '^mysql-.*'
+          apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          apt-get autoremove -y
+          apt-get clean
+          rm -f /mnt/swapfile
+          rm -rf /opt/ghc
+          rm -rf /usr/local/.ghcup
+          rm -rf /usr/local/graalvm
+          rm -rf /usr/local/lib/android
+          rm -rf /usr/local/lib/node_modules
+          rm -rf /usr/local/share/boost
+          rm -rf /usr/local/share/chromium
+          rm -rf /usr/local/share/powershell
+          rm -rf /usr/share/dotnet
+          rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: dorny/paths-filter@v2
         id: changes
         with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -284,10 +284,10 @@ jobs:
         run: |
           # TODO(wangdan): clear unneeded files here temporarily. Clearing unneeded files should be
           # done in images of pegasus-build-env.
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          rm -rf /usr/share/dotnet
+          rm -rf /opt/ghc
+          rm -rf "/usr/local/share/boost"
+          rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Compilation
         run: |
           ccache -p

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -246,7 +246,15 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
-      - uses: jlumbroso/free-disk-space@main
+      - uses: actions/checkout@v3
+      - name: Setup cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            /github/home/.ccache
+          key: asan_ccache
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
         with:
           # This might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
@@ -259,13 +267,6 @@ jobs:
           haskell: true
           large-packages: true
           swap-storage: true
-      - uses: actions/checkout@v3
-      - name: Setup cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            /github/home/.ccache
-          key: asan_ccache
       - uses: dorny/paths-filter@v2
         id: changes
         with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -260,7 +260,8 @@ jobs:
           apt-get remove -y 'php.*'
           apt-get remove -y '^mongodb-.*'
           # apt-get remove -y '^mysql-.*'
-          apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          # apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          apt-get remove -y libgl1-mesa-dri
           apt-get autoremove -y
           apt-get clean
           rm -f /mnt/swapfile

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -255,7 +255,7 @@ jobs:
           key: asan_ccache
       - name: Free Disk Space (Ubuntu)
         run: |
-          du -csh /*
+          du -csh /__t/*
           echo "Listing 100 largest packages"
           dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
           df -h

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -246,7 +246,7 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
-      - name: Free Disk Space (Ubuntu)
+      - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
         with:
           # This might remove tools that are actually needed,

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -246,6 +246,20 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # This might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # All of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
       - uses: actions/checkout@v3
       - name: Setup cache
         uses: actions/cache@v3
@@ -262,20 +276,6 @@ jobs:
               - 'docker/thirdparties-src/**'
               - 'docker/thirdparties-bin/**'
               - 'thirdparty/**'
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # This might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # All of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
         run: |

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -246,8 +246,7 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+      - uses: jlumbroso/free-disk-space@main
         with:
           # This might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -146,8 +146,6 @@ jobs:
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release
           ccache -s
-      - name: Clear Build Files
-        run: |
           find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server
         run: |
@@ -267,35 +265,40 @@ jobs:
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
         run: |
+          # TODO(wangdan): clear unneeded files here temporarily. Later, unneeded files could be cleared in images.
+          rm -f /root/thirdparties-src.zip
           unzip /root/thirdparties-bin.zip -d ./thirdparty
           rm -f /root/thirdparties-bin.zip
+          # TODO(wangdan): clear unneeded files here temporarily. Later, unneeded files could be cleared in images.
+          find ./thirdparty -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
+          rm -rf ./thirdparty/hadoop-bin/share/doc
+          rm -rf ./thirdparty/zookeeper-bin/docs
       - name: Rebuild third-parties
         if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
         # Build thirdparties and leave some necessary libraries and source
         run: |
+          # TODO(wangdan): clear unneeded files here temporarily. Later, unneeded files could be cleared in images.
+          rm -f /root/thirdparties-src.zip
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
           cmake --build build/ -j $(nproc)
           rm -rf build/Build build/Download/[a-y]* build/Source/[a-g]* build/Source/[i-q]* build/Source/[s-z]*
+          # TODO(wangdan): clear unneeded files here temporarily. Later, unneeded files could be cleared in images.
+          find ./ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
           ../scripts/download_hadoop.sh hadoop-bin
           ../scripts/download_zk.sh zookeeper-bin
+          # TODO(wangdan): clear unneeded files here temporarily. Later, unneeded files could be cleared in images.
+          rm -rf hadoop-bin/share/doc
+          rm -rf zookeeper-bin/docs
       - name: Clear Unneeded Files
         run: |
-          # TODO(wangdan): clear unneeded files here temporarily. Clearing unneeded files should be
-          # done in images of pegasus-build-env.
-          rm -rf /usr/share/dotnet
-          rm -rf /opt/ghc
-          rm -rf "/usr/local/share/boost"
-          rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Compilation
         run: |
           ccache -p
           ccache -z
           ./run.sh build --test --sanitizer address --skip_thirdparty --disable_gperf -j $(nproc)
           ccache -s
-      - name: Clear Build Files
-        run: |
           find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Tar files
         run: |
@@ -431,8 +434,6 @@ jobs:
 #          ccache -z
 #          ./run.sh build --test --sanitizer undefined --skip_thirdparty --disable_gperf -j $(nproc)
 #          ccache -s
-#      - name: Clear Build Files
-#        run: |
 #          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
 #      - name: Tar files
 #        run: |
@@ -561,8 +562,6 @@ jobs:
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release --use_jemalloc
           ccache -s
-      - name: Clear Build Files
-        run: |
           find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server
         run: |

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -267,7 +267,7 @@ jobs:
           # apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
           apt-get remove -y libgl1-mesa-dri
           # apt-get autoremove -y
-          apt-get -s autoremove
+          # apt-get -s autoremove
           apt-get clean
           df -h
           echo "Removing large directories"
@@ -275,21 +275,21 @@ jobs:
           # rm -f /mnt/swapfile
           # du -csh /opt/ghc
           # rm -rf /opt/ghc
-          [[ -d /usr/local/.ghcup ]] && du -csh /usr/local/.ghcup
+          du -csh /usr/local/.ghcup
           rm -rf /usr/local/.ghcup
-          du -csh /usr/local/graalvm
-          rm -rf /usr/local/graalvm
-          du -csh /usr/local/lib/android
+          # du -csh /usr/local/graalvm
+          # rm -rf /usr/local/graalvm
+          #du -csh /usr/local/lib/android
           rm -rf /usr/local/lib/android
-          du -csh /usr/local/lib/node_modules
+          #du -csh /usr/local/lib/node_modules
           rm -rf /usr/local/lib/node_modules
-          du -csh /usr/local/share/boost
+          #du -csh /usr/local/share/boost
           rm -rf /usr/local/share/boost
-          du -csh /usr/local/share/chromium
+          #du -csh /usr/local/share/chromium
           rm -rf /usr/local/share/chromium
-          du -csh /usr/local/share/powershell
+          #du -csh /usr/local/share/powershell
           rm -rf /usr/local/share/powershell
-          du -csh /usr/share/dotnet
+          #du -csh /usr/share/dotnet
           rm -rf /usr/share/dotnet
           echo "AGENT_TOOLSDIRECTORY is $AGENT_TOOLSDIRECTORY"
           du -csh "$AGENT_TOOLSDIRECTORY"

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -146,6 +146,9 @@ jobs:
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release
           ccache -s
+      - name: Clear Files
+        run: |
+          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server
         run: |
           ./run.sh pack_server
@@ -159,7 +162,6 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
           tar -zcvhf release__builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
@@ -284,12 +286,14 @@ jobs:
           ccache -z
           ./run.sh build --test --sanitizer address --skip_thirdparty --disable_gperf -j $(nproc)
           ccache -s
+      - name: Clear Files
+        run: |
+          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Tar files
         run: |
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
           tar -zcvhf release_address_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
@@ -419,12 +423,14 @@ jobs:
 #          ccache -z
 #          ./run.sh build --test --sanitizer undefined --skip_thirdparty --disable_gperf -j $(nproc)
 #          ccache -s
+#      - name: Clear Files
+#        run: |
+#          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
 #      - name: Tar files
 #        run: |
 #          mv thirdparty/hadoop-bin ./
 #          mv thirdparty/zookeeper-bin ./
 #          rm -rf thirdparty
-#          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
 #          tar -zcvhf release_undefined_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
 #      - name: Upload Artifact
 #        uses: actions/upload-artifact@v3
@@ -547,6 +553,9 @@ jobs:
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release --use_jemalloc
           ccache -s
+      - name: Clear Files
+        run: |
+          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server
         run: |
           ./run.sh pack_server -j
@@ -560,7 +569,6 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
           tar -zcvhf release_jemalloc_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -292,8 +292,8 @@ jobs:
           #du -csh /usr/share/dotnet
           rm -rf /usr/share/dotnet
           echo "AGENT_TOOLSDIRECTORY is $AGENT_TOOLSDIRECTORY"
-          du -csh "$AGENT_TOOLSDIRECTORY"
-          rm -rf "$AGENT_TOOLSDIRECTORY"
+          # du -csh "$AGENT_TOOLSDIRECTORY"
+          # rm -rf "$AGENT_TOOLSDIRECTORY"
           df -h
       - uses: dorny/paths-filter@v2
         id: changes

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -275,7 +275,7 @@ jobs:
           # rm -f /mnt/swapfile
           # du -csh /opt/ghc
           # rm -rf /opt/ghc
-          du -csh /usr/local/.ghcup
+          # du -csh /usr/local/.ghcup
           rm -rf /usr/local/.ghcup
           # du -csh /usr/local/graalvm
           # rm -rf /usr/local/graalvm

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -626,7 +626,7 @@ jobs:
           ./run.sh pack_server -j
           rm -rf pegasus-server-*
       - name: Pack Tools
-        run:
+        run: |
           df -h
           ./run.sh pack_tools -j
           rm -rf pegasus-tools-*

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -247,6 +247,20 @@ jobs:
       image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # This might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # All of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
       - name: Setup cache
         uses: actions/cache@v3
         with:
@@ -291,8 +305,6 @@ jobs:
           # TODO(wangdan): clear unneeded files here temporarily. Later, unneeded files could be cleared in images.
           rm -rf hadoop-bin/share/doc
           rm -rf zookeeper-bin/docs
-      - name: Clear Unneeded Files
-        run: |
       - name: Compilation
         run: |
           ccache -p

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -255,12 +255,12 @@ jobs:
           key: asan_ccache
       - name: Free Disk Space (Ubuntu)
         run: |
-          apt-get remove -y '^dotnet-.*'
-          apt-get remove -y '^llvm-.*'
-          apt-get remove -y 'php.*'
-          apt-get remove -y '^mongodb-.*'
-          apt-get remove -y '^mysql-.*'
-          apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          apt-get remove -m -y '^dotnet-.*'
+          apt-get remove -m -y '^llvm-.*'
+          apt-get remove -m -y 'php.*'
+          apt-get remove -m -y '^mongodb-.*'
+          apt-get remove -m -y '^mysql-.*'
+          apt-get remove -m -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
           apt-get autoremove -y
           apt-get clean
           rm -f /mnt/swapfile

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -146,7 +146,7 @@ jobs:
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release
           ccache -s
-      - name: Clear Files
+      - name: Clear Build Files
         run: |
           find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server
@@ -280,13 +280,21 @@ jobs:
           rm -rf build/Build build/Download/[a-y]* build/Source/[a-g]* build/Source/[i-q]* build/Source/[s-z]*
           ../scripts/download_hadoop.sh hadoop-bin
           ../scripts/download_zk.sh zookeeper-bin
+      - name: Clear Unneeded Files
+        run: |
+          # TODO(wangdan): clear unneeded files here temporarily. Clearing unneeded files should be
+          # done in images of pegasus-build-env.
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Compilation
         run: |
           ccache -p
           ccache -z
           ./run.sh build --test --sanitizer address --skip_thirdparty --disable_gperf -j $(nproc)
           ccache -s
-      - name: Clear Files
+      - name: Clear Build Files
         run: |
           find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Tar files
@@ -423,7 +431,7 @@ jobs:
 #          ccache -z
 #          ./run.sh build --test --sanitizer undefined --skip_thirdparty --disable_gperf -j $(nproc)
 #          ccache -s
-#      - name: Clear Files
+#      - name: Clear Build Files
 #        run: |
 #          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
 #      - name: Tar files
@@ -553,7 +561,7 @@ jobs:
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release --use_jemalloc
           ccache -s
-      - name: Clear Files
+      - name: Clear Build Files
         run: |
           find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -259,7 +259,7 @@ jobs:
           apt-get remove -y '^llvm-.*'
           apt-get remove -y 'php.*'
           apt-get remove -y '^mongodb-.*'
-          apt-get remove -y '^mysql-.*'
+          # apt-get remove -y '^mysql-.*'
           apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
           apt-get autoremove -y
           apt-get clean

--- a/run.sh
+++ b/run.sh
@@ -310,8 +310,6 @@ function run_build()
     if [ ! -z "${IWYU}" ]; then
         make $MAKE_OPTIONS 2> iwyu.out
     else
-        make $MAKE_OPTIONS
-        find ${BUILD_LATEST_DIR}/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
         make install $MAKE_OPTIONS
     fi
     exit_if_fail $?

--- a/run.sh
+++ b/run.sh
@@ -310,6 +310,8 @@ function run_build()
     if [ ! -z "${IWYU}" ]; then
         make $MAKE_OPTIONS 2> iwyu.out
     else
+        make $MAKE_OPTIONS
+        find ${BUILD_LATEST_DIR}/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
         make install $MAKE_OPTIONS
     fi
     exit_if_fail $?

--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -85,7 +85,7 @@ namespace {
 metric_entity_ptr instantiate_disk_metric_entity(const std::string &tag,
                                                  const std::string &data_dir)
 {
-    auto entity_id = fmt::format("disk_{}", tag);
+    auto entity_id = fmt::format("disk@{}", tag);
 
     return METRIC_ENTITY_disk.instantiate(entity_id, {{"tag", tag}, {"data_dir", data_dir}});
 }

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -69,7 +69,7 @@ namespace {
 
 metric_entity_ptr instantiate_backup_policy_metric_entity(const std::string &policy_name)
 {
-    auto entity_id = fmt::format("backup_policy_{}", policy_name);
+    auto entity_id = fmt::format("backup_policy@{}", policy_name);
 
     return METRIC_ENTITY_backup_policy.instantiate(entity_id, {{"policy_name", policy_name}});
 }

--- a/src/meta/table_metrics.cpp
+++ b/src/meta/table_metrics.cpp
@@ -112,7 +112,7 @@ namespace {
 
 metric_entity_ptr instantiate_partition_metric_entity(int32_t table_id, int32_t partition_id)
 {
-    auto entity_id = fmt::format("partition_{}", gpid(table_id, partition_id));
+    auto entity_id = fmt::format("partition@{}", gpid(table_id, partition_id));
 
     return METRIC_ENTITY_partition.instantiate(
         entity_id,
@@ -121,7 +121,7 @@ metric_entity_ptr instantiate_partition_metric_entity(int32_t table_id, int32_t 
 
 metric_entity_ptr instantiate_table_metric_entity(int32_t table_id)
 {
-    auto entity_id = fmt::format("table_{}", table_id);
+    auto entity_id = fmt::format("table@{}", table_id);
 
     return METRIC_ENTITY_table.instantiate(entity_id, {{"table_id", std::to_string(table_id)}});
 }

--- a/src/replica/replica_base.cpp
+++ b/src/replica/replica_base.cpp
@@ -30,7 +30,7 @@ namespace {
 
 metric_entity_ptr instantiate_replica_metric_entity(const gpid &id)
 {
-    auto entity_id = fmt::format("replica_{}", id);
+    auto entity_id = fmt::format("replica@{}", id);
 
     // Do NOT add `replica_base._app_name` as the table name to the attributes of entity, since
     // it is read-only and will never be updated even if the table is renamed.

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -361,7 +361,7 @@ namespace {
 
 metric_entity_ptr instantiate_profiler_metric_entity(const std::string &task_name)
 {
-    auto entity_id = fmt::format("task_{}", task_name);
+    auto entity_id = fmt::format("task@{}", task_name);
 
     return METRIC_ENTITY_profiler.instantiate(entity_id, {{"task_name", task_name}});
 }

--- a/src/runtime/task/task_queue.cpp
+++ b/src/runtime/task/task_queue.cpp
@@ -63,7 +63,7 @@ namespace {
 
 metric_entity_ptr instantiate_queue_metric_entity(const std::string &queue_name)
 {
-    auto entity_id = fmt::format("queue_{}", queue_name);
+    auto entity_id = fmt::format("queue@{}", queue_name);
 
     return METRIC_ENTITY_queue.instantiate(entity_id, {{"queue_name", queue_name}});
 }

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -22,8 +22,6 @@
 #include <iterator>
 #include <utility>
 
-#include "perf_counter/perf_counter.h"
-#include "perf_counter/perf_counters.h"
 #include "runtime/api_layer1.h"
 #include "utils/autoref_ptr.h"
 #include "utils/config_api.h"
@@ -50,7 +48,7 @@ DSN_TAG_VARIABLE(enable_latency_tracer, FT_MUTABLE);
 DSN_DEFINE_bool(replication,
                 enable_latency_tracer_report,
                 false,
-                "whether open the latency tracer report perf counter");
+                "whether open the latency tracer report for metrics");
 DSN_TAG_VARIABLE(enable_latency_tracer_report, FT_MUTABLE);
 
 namespace {
@@ -70,6 +68,7 @@ metric_entity_ptr instantiate_latency_tracer_metric_entity(const std::string &de
                                                      {"end_point", end_point}});
 }
 
+// Maintain each latency-tracer-level metric entity, and all metrics attached to it.
 class latency_tracer_metrics
 {
 public:
@@ -117,6 +116,7 @@ const dsn::metric_entity_ptr &latency_tracer_metrics::latency_tracer_metric_enti
     return _latency_tracer_metric_entity;
 }
 
+// Manage the lifetime of all latency-tracer-level metric entities.
 class latency_tracer_metric_entities
 {
 public:

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -127,6 +127,8 @@ public:
     latency_tracer_metric_entities() = default;
     ~latency_tracer_metric_entities() = default;
 
+// Acquire read lock firstly, since once the metric entity were created, there would be no need to
+// acquire write lock again.
 #define __METRIC_DEFINE_SET(name, value_type)                                                      \
     void METRIC_FUNC_NAME_SET(name)(const std::string &description,                                \
                                     const std::string &starting_point,                             \

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -123,6 +123,7 @@ class latency_tracer_metric_entities
 {
 public:
     using entity_map = std::unordered_map<std::string, std::unique_ptr<latency_tracer_metrics>>;
+
     latency_tracer_metric_entities() = default;
     ~latency_tracer_metric_entities() = default;
 
@@ -144,7 +145,7 @@ public:
                                                                                                    \
         dsn::utils::auto_write_lock l(_lock);                                                      \
         auto iter = _entities.find(entity_id);                                                     \
-        if (iter != _entities.end()) {                                                             \
+        if (dsn_unlikely(iter != _entities.end())) {                                               \
             METRIC_SET(*(iter->second), name, value);                                              \
             return;                                                                                \
         }                                                                                          \

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -54,7 +54,7 @@ DSN_TAG_VARIABLE(enable_latency_tracer_report, FT_MUTABLE);
 namespace {
 
 #define LATENCY_TRACER_METRIC_ENTITY_ID(description, starting_point, end_point)                    \
-    fmt::format("latency_tracer@{};{};{}", description, starting_point, end_point)
+    fmt::format("latency_tracer@{}|{}|{}", description, starting_point, end_point)
 
 metric_entity_ptr instantiate_latency_tracer_metric_entity(const std::string &description,
                                                            const std::string &starting_point,

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -20,6 +20,7 @@
 #include <fmt/core.h>
 #include <cstdint>
 #include <iterator>
+#include <set>
 #include <utility>
 
 #include "runtime/api_layer1.h"
@@ -28,6 +29,7 @@
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/metrics.h"
+#include "utils/string_view.h"
 
 METRIC_DEFINE_entity(latency_tracer);
 

--- a/src/utils/latency_tracer.h
+++ b/src/utils/latency_tracer.h
@@ -165,9 +165,6 @@ public:
     bool enabled() const { return _enable_trace; }
 
 private:
-    // report the trace point duration to monitor system
-    static void report_trace_point(const std::string &name, uint64_t span);
-
     // dump and print the trace point into log file
     void dump_trace_points(/*out*/ std::string &traces);
 

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -193,7 +193,7 @@ class error_code;
 #define METRIC_VAR_INIT_backup_policy(name, ...) METRIC_VAR_INIT(name, backup_policy, ##__VA_ARGS__)
 #define METRIC_VAR_INIT_queue(name, ...) METRIC_VAR_INIT(name, queue, ##__VA_ARGS__)
 #define METRIC_VAR_ASSIGN_profiler(name, ...) METRIC_VAR_ASSIGN(name, profiler, ##__VA_ARGS__)
-#define METRIC_VAR_ASSIGN_latency_tracer(name, ...) METRIC_VAR_ASSIGN(name, latency_tracer, ##__VA_ARGS__)
+#define METRIC_VAR_INIT_latency_tracer(name, ...) METRIC_VAR_INIT(name, latency_tracer, ##__VA_ARGS__)
 
 // Perform increment_by() operations on gauges and counters.
 #define METRIC_VAR_INCREMENT_BY(name, x)                                                           \

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -193,6 +193,7 @@ class error_code;
 #define METRIC_VAR_INIT_backup_policy(name, ...) METRIC_VAR_INIT(name, backup_policy, ##__VA_ARGS__)
 #define METRIC_VAR_INIT_queue(name, ...) METRIC_VAR_INIT(name, queue, ##__VA_ARGS__)
 #define METRIC_VAR_ASSIGN_profiler(name, ...) METRIC_VAR_ASSIGN(name, profiler, ##__VA_ARGS__)
+#define METRIC_VAR_ASSIGN_latency_tracer(name, ...) METRIC_VAR_ASSIGN(name, latency_tracer, ##__VA_ARGS__)
 
 // Perform increment_by() operations on gauges and counters.
 #define METRIC_VAR_INCREMENT_BY(name, x)                                                           \

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -193,7 +193,8 @@ class error_code;
 #define METRIC_VAR_INIT_backup_policy(name, ...) METRIC_VAR_INIT(name, backup_policy, ##__VA_ARGS__)
 #define METRIC_VAR_INIT_queue(name, ...) METRIC_VAR_INIT(name, queue, ##__VA_ARGS__)
 #define METRIC_VAR_ASSIGN_profiler(name, ...) METRIC_VAR_ASSIGN(name, profiler, ##__VA_ARGS__)
-#define METRIC_VAR_INIT_latency_tracer(name, ...) METRIC_VAR_INIT(name, latency_tracer, ##__VA_ARGS__)
+#define METRIC_VAR_INIT_latency_tracer(name, ...)                                                  \
+    METRIC_VAR_INIT(name, latency_tracer, ##__VA_ARGS__)
 
 // Perform increment_by() operations on gauges and counters.
 #define METRIC_VAR_INCREMENT_BY(name, x)                                                           \


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1536

The only metric of latency tracer, namely the duration between two points
(stages), is migrated to the new framework:

- latency tracer entity is introduced as the new metric entity to which the
metric is attached;
- create new class that bind each entity and manage the metric;
- create new class that manage all entity instances, with a read-write lock
that helps improving the performance of search for the target entity;
- solve the problem of "No space left on device" for Build ASAN temporarily.                                                                   