### PR TITLE
build: add a devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+    "image": "apache/pegasus:build-env-ubuntu2004"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,11 @@
 {
-    "image": "apache/pegasus:build-env-ubuntu2004"
+  "image": "apache/pegasus:build-env-ubuntu2004",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools-extension-pack",
+        "eamodio.gitlens"
+      ]
+    }
+  }
 }

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -30,6 +30,7 @@ header:
     - '.rat-excludes'
     - 'DISCLAIMER-WIP'
     - 'python-client/requirement.txt'
+    - '.devcontainer/devcontainer.json'
     # TODO(yingchun): shell/* files are import from thirdparties, we can move them to thirdparty later.
     - 'src/shell/argh.h'
     - 'src/shell/linenoise/linenoise.c'


### PR DESCRIPTION
Related issue: https://github.com/apache/incubator-pegasus/issues/1549

Support developing inside a container, ref: https://code.visualstudio.com/docs/devcontainers/containers
So that we can develop and compile Pegasus in a docker environment.
I can successfully compile the code in my WSL2 environment.
![image](https://github.com/apache/incubator-pegasus/assets/22953824/1a951614-8b1f-473f-8474-2b7392787151)
 