### PR TITLE
fix(docker): fix pegasus-build-env of ubuntu:18.04 Dockerfile

### DIFF
--- a/docker/pegasus-build-env/ubuntu1804/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu1804/Dockerfile
@@ -51,7 +51,8 @@ RUN apt-get update -y; \
                        libssl-dev \
                        bison \
                        maven \
-                       flex; \
+                       flex \
+                       python3-setuptools; \
     rm -rf /var/lib/apt/lists/*
 
 RUN add-apt-repository ppa:git-core/ppa -y; \
@@ -60,7 +61,7 @@ RUN add-apt-repository ppa:git-core/ppa -y; \
     apt-get install pkg-config -y --no-install-recommends; \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir cmake
+RUN pip3 install --upgrade pip && pip3 install --no-cache-dir cmake
 
 RUN wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/0.11.0.tar.gz -P /opt/thrift && \
     cd /opt/thrift && tar xzf 0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1559

Fix the error of `pip3 install --no-cache-dir cmake`