### PR TITLE
fix: Add a flag "rocksdb_write_global_seqno" and set it to false by default.

### DIFF
--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -330,6 +330,7 @@ stateful = true
   rocksdb_block_cache_capacity = 10737418240
   rocksdb_block_cache_num_shard_bits = -1
   rocksdb_disable_bloom_filter = false
+  rocksdb_write_global_seqno = false
   # Bloom filter type, should be either 'common' or 'prefix'
   rocksdb_filter_type = prefix
   # rocksdb_bloom_filter_bits_per_key |           false positive rate

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -47,6 +47,10 @@ DSN_DEFINE_int32(pegasus.server,
                  0,
                  "Which error code to inject in write path, 0 means no error. Only for test.");
 DSN_TAG_VARIABLE(inject_write_error_for_test, FT_MUTABLE);
+DSN_DEFINE_bool(pegasus.server,
+                 rocksdb_write_global_seqno,
+                 false,
+                 "If write_global_seqno is true, rocksdb will modify 'rocksdb.external_sst_file.global_seqno' of ssttable file during ingest process. If false, it will not be modified.");
 
 rocksdb_wrapper::rocksdb_wrapper(pegasus_server_impl *server)
     : replica_base(server),
@@ -212,6 +216,7 @@ int rocksdb_wrapper::ingest_files(int64_t decree,
     rocksdb::IngestExternalFileOptions ifo;
     ifo.move_files = true;
     ifo.ingest_behind = ingest_behind;
+    ifo.write_global_seqno = FLAGS_rocksdb_write_global_seqno;
     rocksdb::Status s = _db->IngestExternalFile(sst_file_list, ifo);
     if (dsn_unlikely(!s.ok())) {
         LOG_ERROR_ROCKSDB("IngestExternalFile",


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1562

Add rocksdb_write_global_seqno, and set its default value to false.