### PR TITLE
Fix write global seqno

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -147,9 +147,13 @@ jobs:
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release
           ccache -s
       - name: Pack Server
-        run: ./run.sh pack_server
+        run: |
+          ./run.sh pack_server
+          rm -rf pegasus-server-*
       - name: Pack Tools
-        run: ./run.sh pack_tools
+        run: |
+          ./run.sh pack_tools
+          rm -rf pegasus-tools-*
       - name: Tar files
         run: |
           mv thirdparty/hadoop-bin ./

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -330,6 +330,7 @@ stateful = true
   rocksdb_block_cache_capacity = 10737418240
   rocksdb_block_cache_num_shard_bits = -1
   rocksdb_disable_bloom_filter = false
+  rocksdb_write_global_seqno = false
   # Bloom filter type, should be either 'common' or 'prefix'
   rocksdb_filter_type = prefix
   # rocksdb_bloom_filter_bits_per_key |           false positive rate

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -47,6 +47,12 @@ DSN_DEFINE_int32(pegasus.server,
                  0,
                  "Which error code to inject in write path, 0 means no error. Only for test.");
 DSN_TAG_VARIABLE(inject_write_error_for_test, FT_MUTABLE);
+DSN_DEFINE_bool(pegasus.server,
+                rocksdb_write_global_seqno,
+                false,
+                "If write_global_seqno is true, rocksdb will modify "
+                "'rocksdb.external_sst_file.global_seqno' of ssttable file during ingest process. "
+                "If false, it will not be modified.");
 
 rocksdb_wrapper::rocksdb_wrapper(pegasus_server_impl *server)
     : replica_base(server),
@@ -212,6 +218,7 @@ int rocksdb_wrapper::ingest_files(int64_t decree,
     rocksdb::IngestExternalFileOptions ifo;
     ifo.move_files = true;
     ifo.ingest_behind = ingest_behind;
+    ifo.write_global_seqno = FLAGS_rocksdb_write_global_seqno;
     rocksdb::Status s = _db->IngestExternalFile(sst_file_list, ifo);
     if (dsn_unlikely(!s.ok())) {
         LOG_ERROR_ROCKSDB("IngestExternalFile",


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1562

Add this option to turn off rocksdb modifying `rocksdb.external_sst_file.global_seqno`
field of external sst file during ingest process. This is used to address a coredump
caused by incorrect field value in RocksDB. This pull request fixs the bug above.
Rocksdb 6.6.4 no longer recommends using this field.

```diff
[pegasus.server]
+ rocksdb_write_global_seqno = false
``` 