### PR TITLE
fix(logs): fix logs in FATAL level not take effect

### DIFF
--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -112,6 +112,10 @@ void screen_logger::dsn_logv(const char *file,
     }
     vprintf(fmt, args);
     printf("\n");
+
+    if (log_level >= LOG_LEVEL_FATAL) {
+        dsn_coredump();
+    }
 }
 
 void screen_logger::flush() { ::fflush(stdout); }
@@ -285,6 +289,10 @@ void simple_logger::dsn_log(const char *file,
             printf("%s:%d:%s(): ", file, line, function);
         }
         printf("%s\n", str);
+    }
+
+    if (log_level >= LOG_LEVEL_FATAL) {
+        dsn_coredump();
     }
 
     if (++_lines >= 200000) {

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -113,7 +113,7 @@ void screen_logger::dsn_logv(const char *file,
     vprintf(fmt, args);
     printf("\n");
 
-    if (log_level >= LOG_LEVEL_FATAL) {
+    if (dsn_unlikely(log_level >= LOG_LEVEL_FATAL)) {
         dsn_coredump();
     }
 }
@@ -291,7 +291,7 @@ void simple_logger::dsn_log(const char *file,
         printf("%s\n", str);
     }
 
-    if (log_level >= LOG_LEVEL_FATAL) {
+    if (dsn_unlikely(log_level >= LOG_LEVEL_FATAL)) {
         dsn_coredump();
     }
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1572

If the logs are called in FATAL level, the process should exit.