### PR TITLE
chore(github): free disk space for github workflows

### DIFF
--- a/.github/workflows/free_disk_space.sh
+++ b/.github/workflows/free_disk_space.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+echo "=============================================================================="
+echo "Freeing up disk space on Github workflows"
+echo "=============================================================================="
+
+echo "Before freeing, the space of each disk:"
+df -h
+
+echo "Listing 100 largest packages ..."
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+
+echo "Removing large packages ..."
+apt-get -s autoremove
+apt-get remove -y openjdk-11-jre-headless
+
+echo "After removing large packages, the space of each disk:"
+df -h
+
+echo "Listing directories ..."
+du -csh /__w/*/*
+du -csh /__t/*/*
+du -csh /opt/*
+du -csh /usr/local/*
+du -csh /usr/local/lib/*
+du -csh /usr/local/share/*
+du -csh /usr/share/*
+echo "AGENT_TOOLSDIRECTORY is $AGENT_TOOLSDIRECTORY"
+
+echo "Removing large directories ..."
+rm -rf /__t/CodeQL
+rm -rf /__t/node
+rm -rf /__t/PyPy
+rm -rf /opt/ghc
+rm -rf /usr/local/.ghcup
+rm -rf /usr/local/graalvm
+rm -rf /usr/local/lib/android
+rm -rf /usr/local/lib/node_modules
+rm -rf /usr/local/share/boost
+rm -rf /usr/local/share/chromium
+rm -rf /usr/local/share/powershell
+rm -rf /usr/share/dotnet
+
+echo "After freeing, the space of each disk:"
+df -h

--- a/.github/workflows/free_disk_space.sh
+++ b/.github/workflows/free_disk_space.sh
@@ -16,8 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-
 echo "=============================================================================="
 echo "Freeing up disk space on Github workflows"
 echo "=============================================================================="
@@ -36,9 +34,11 @@ echo "After removing large packages, the space of each disk:"
 df -h
 
 echo "Listing directories ..."
+mount
 du -csh /*
-du -csh /__w/*/*
+du -csh /__e/*/*
 du -csh /__t/*/*
+du -csh /__w/*/*
 du -csh /opt/*
 du -csh /usr/local/*
 du -csh /usr/local/lib/*

--- a/.github/workflows/free_disk_space.sh
+++ b/.github/workflows/free_disk_space.sh
@@ -42,9 +42,6 @@ du -csh /__t/*/*
 du -csh /__w/*/*
 ls -lrt /github
 du -csh /github/*
-ls -lrt /github/home
-du -csh /github/workflow/*
-ls -lrt /home
 du -csh /opt/*
 du -csh /usr/local/*
 du -csh /usr/local/lib/*

--- a/.github/workflows/free_disk_space.sh
+++ b/.github/workflows/free_disk_space.sh
@@ -39,6 +39,10 @@ du -csh /*
 du -csh /__e/*/*
 du -csh /__t/*/*
 du -csh /__w/*/*
+du -csh /github/*
+du -csh /github/home/*
+du -csh /github/workflow/*
+du -csh /home/*
 du -csh /opt/*
 du -csh /usr/local/*
 du -csh /usr/local/lib/*

--- a/.github/workflows/free_disk_space.sh
+++ b/.github/workflows/free_disk_space.sh
@@ -36,6 +36,7 @@ echo "After removing large packages, the space of each disk:"
 df -h
 
 echo "Listing directories ..."
+du -csh /*
 du -csh /__w/*/*
 du -csh /__t/*/*
 du -csh /opt/*
@@ -47,8 +48,11 @@ echo "AGENT_TOOLSDIRECTORY is $AGENT_TOOLSDIRECTORY"
 
 echo "Removing large directories ..."
 rm -rf /__t/CodeQL
-rm -rf /__t/node
 rm -rf /__t/PyPy
+rm -rf /__t/Python
+rm -rf /__t/Ruby
+rm -rf /__t/go
+rm -rf /__t/node
 rm -rf /opt/ghc
 rm -rf /usr/local/.ghcup
 rm -rf /usr/local/graalvm

--- a/.github/workflows/free_disk_space.sh
+++ b/.github/workflows/free_disk_space.sh
@@ -35,14 +35,16 @@ df -h
 
 echo "Listing directories ..."
 mount
+ls -lrt /
 du -csh /*
 du -csh /__e/*/*
 du -csh /__t/*/*
 du -csh /__w/*/*
+ls -lrt /github
 du -csh /github/*
-du -csh /github/home/*
+ls -lrt /github/home
 du -csh /github/workflow/*
-du -csh /home/*
+ls -lrt /home
 du -csh /opt/*
 du -csh /usr/local/*
 du -csh /usr/local/lib/*

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -70,6 +70,9 @@ jobs:
       image: apache/pegasus:thirdparties-bin-ubuntu2204-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
+      - name: Free Disk Space (Ubuntu)
+        run: |
+          .github/workflows/free_disk_space.sh
       - uses: dorny/paths-filter@v2
         id: changes
         with:
@@ -120,6 +123,9 @@ jobs:
           path: |
             /github/home/.ccache
           key: release_ccache
+      - name: Free Disk Space (Ubuntu)
+        run: |
+          .github/workflows/free_disk_space.sh
       - uses: dorny/paths-filter@v2
         id: changes
         with:
@@ -132,25 +138,36 @@ jobs:
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
         run: |
+          rm -f /root/thirdparties-src.zip
           unzip /root/thirdparties-bin.zip -d ./thirdparty
           rm -f /root/thirdparties-bin.zip
+          find ./thirdparty -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
+          rm -rf ./thirdparty/hadoop-bin/share/doc
+          rm -rf ./thirdparty/zookeeper-bin/docs
       - name: Rebuild third-parties
         if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
         # Build thirdparties and leave some necessary libraries and source
         run: |
+          rm -f /root/thirdparties-src.zip
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
           cmake --build build/ -j $(nproc)
           rm -rf build/Build build/Download/[a-y]* build/Source/[a-g]* build/Source/[i-q]* build/Source/[s-z]*
+          find ./ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
           ../scripts/download_hadoop.sh hadoop-bin
           ../scripts/download_zk.sh zookeeper-bin
+          rm -rf hadoop-bin/share/doc
+          rm -rf zookeeper-bin/docs
       - name: Compilation
         run: |
           ccache -p
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release
           ccache -s
+      - name: Clear Build Files
+        run: |
+          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server
         run: |
           ./run.sh pack_server
@@ -164,7 +181,6 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
           tar -zcvhf release__builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
@@ -252,6 +268,9 @@ jobs:
           path: |
             /github/home/.ccache
           key: asan_ccache
+      - name: Free Disk Space (Ubuntu)
+        run: |
+          .github/workflows/free_disk_space.sh
       - uses: dorny/paths-filter@v2
         id: changes
         with:
@@ -264,31 +283,41 @@ jobs:
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
         run: |
+          rm -f /root/thirdparties-src.zip
           unzip /root/thirdparties-bin.zip -d ./thirdparty
           rm -f /root/thirdparties-bin.zip
+          find ./thirdparty -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
+          rm -rf ./thirdparty/hadoop-bin/share/doc
+          rm -rf ./thirdparty/zookeeper-bin/docs
       - name: Rebuild third-parties
         if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
         # Build thirdparties and leave some necessary libraries and source
         run: |
+          rm -f /root/thirdparties-src.zip
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
           cmake --build build/ -j $(nproc)
           rm -rf build/Build build/Download/[a-y]* build/Source/[a-g]* build/Source/[i-q]* build/Source/[s-z]*
+          find ./ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
           ../scripts/download_hadoop.sh hadoop-bin
           ../scripts/download_zk.sh zookeeper-bin
+          rm -rf hadoop-bin/share/doc
+          rm -rf zookeeper-bin/docs
       - name: Compilation
         run: |
           ccache -p
           ccache -z
           ./run.sh build --test --sanitizer address --skip_thirdparty --disable_gperf -j $(nproc)
           ccache -s
+      - name: Clear Build Files
+        run: |
+          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Tar files
         run: |
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
           tar -zcvhf release_address_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
@@ -393,31 +422,41 @@ jobs:
 #      - name: Unpack prebuilt third-parties
 #        if: steps.changes.outputs.thirdparty == 'false'
 #        run: |
+#          rm -f /root/thirdparties-src.zip
 #          unzip /root/thirdparties-bin.zip -d ./thirdparty
 #          rm -f /root/thirdparties-bin.zip
+#          find ./thirdparty -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
+#          rm -rf ./thirdparty/hadoop-bin/share/doc
+#          rm -rf ./thirdparty/zookeeper-bin/docs
 #      - name: Rebuild third-parties
 #        if: steps.changes.outputs.thirdparty == 'true'
 #        working-directory: thirdparty
 #        # Build thirdparties and leave some necessary libraries and source
 #        run: |
+#          rm -f /root/thirdparties-src.zip
 #          mkdir build
 #          cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -B build/
 #          cmake --build build/ -j $(nproc)
 #          rm -rf build/Build build/Download/[a-y]* build/Source/[a-g]* build/Source/[i-q]* build/Source/[s-z]*
+#          find ./ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
 #          ../scripts/download_hadoop.sh hadoop-bin
 #          ../scripts/download_zk.sh zookeeper-bin
+#          rm -rf hadoop-bin/share/doc
+#          rm -rf zookeeper-bin/docs
 #      - name: Compilation
 #        run: |
 #          ccache -p
 #          ccache -z
 #          ./run.sh build --test --sanitizer undefined --skip_thirdparty --disable_gperf -j $(nproc)
 #          ccache -s
+#      - name: Clear Build Files
+#        run: |
+#          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
 #      - name: Tar files
 #        run: |
 #          mv thirdparty/hadoop-bin ./
 #          mv thirdparty/zookeeper-bin ./
 #          rm -rf thirdparty
-#          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
 #          tar -zcvhf release_undefined_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
 #      - name: Upload Artifact
 #        uses: actions/upload-artifact@v3
@@ -470,6 +509,9 @@ jobs:
 #      options: --cap-add=SYS_PTRACE
 #    steps:
 #      - uses: actions/checkout@v3
+#      - name: Free Disk Space (Ubuntu)
+#        run: |
+#          .github/workflows/free_disk_space.sh
 #      - name: Unpack prebuilt third-parties
 #        run: |
 #          unzip /root/thirdparties-bin.zip -d ./thirdparty
@@ -503,6 +545,9 @@ jobs:
           path: |
             /github/home/.ccache
           key: jemalloc_ccache
+      - name: Free Disk Space (Ubuntu)
+        run: |
+          .github/workflows/free_disk_space.sh
       - uses: dorny/paths-filter@v2
         id: changes
         with:
@@ -515,25 +560,36 @@ jobs:
       - name: Unpack prebuilt third-parties
         if: steps.changes.outputs.thirdparty == 'false'
         run: |
+          rm -f /root/thirdparties-src.zip
           unzip /root/thirdparties-bin.zip -d ./thirdparty
           rm -f /root/thirdparties-bin.zip
+          find ./thirdparty -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
+          rm -rf ./thirdparty/hadoop-bin/share/doc
+          rm -rf ./thirdparty/zookeeper-bin/docs
       - name: Rebuild third-parties
         if: steps.changes.outputs.thirdparty == 'true'
         working-directory: thirdparty
         # Build thirdparties and leave some necessary libraries and source
         run: |
+          rm -f /root/thirdparties-src.zip
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=ON -DUSE_JEMALLOC=ON -B build/
           cmake --build build/ -j $(nproc)
           rm -rf build/Build build/Download/[a-y]* build/Source/[a-g]* build/Source/[i-q]* build/Source/[s-z]*
+          find ./ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
           ../scripts/download_hadoop.sh hadoop-bin
           ../scripts/download_zk.sh zookeeper-bin
+          rm -rf hadoop-bin/share/doc
+          rm -rf zookeeper-bin/docs
       - name: Compilation
         run: |
           ccache -p
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release --use_jemalloc
           ccache -s
+      - name: Clear Build Files
+        run: |
+          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server
         run: ./run.sh pack_server -j
       - name: Pack Tools
@@ -543,7 +599,6 @@ jobs:
           mv thirdparty/hadoop-bin ./
           mv thirdparty/zookeeper-bin ./
           rm -rf thirdparty
-          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
           tar -zcvhf release_jemalloc_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -49,8 +49,8 @@ on:
 env:
   # Update the options to reduce the consumption of the disk space
   ONEBOX_OPTS: disk_min_available_space_ratio=5
-  TEST_OPTS: throttle_test_medium_value_kb=10,throttle_test_large_value_kb=25
-                                                                                                                
+  TEST_OPTS: disk_min_available_space_ratio=5,throttle_test_medium_value_kb=10,throttle_test_large_value_kb=25
+
 jobs:
   cpp_clang_format_linter:
     name: Lint

--- a/src/common/test/config-test.ini
+++ b/src/common/test/config-test.ini
@@ -92,6 +92,7 @@ rpc_message_header_format = dsn
 rpc_timeout_milliseconds = 5000
 
 [replication]
+disk_min_available_space_ratio = 10
 cluster_name = master-cluster
 
 [duplication-group]

--- a/src/common/test/run.sh
+++ b/src/common/test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # The MIT License (MIT)
 #
 # Copyright (c) 2015 Microsoft Corporation

--- a/src/common/test/run.sh
+++ b/src/common/test/run.sh
@@ -31,6 +31,25 @@ exit_if_fail() {
     fi
 }
 
+if [ -n ${TEST_OPTS} ]; then
+    if [ ! -f ./config-test.ini ]; then
+        echo "./config-test.ini does not exists !"
+        exit 1
+    fi
+
+    OPTS=`echo ${TEST_OPTS} | xargs`
+    config_kvs=(${OPTS//,/ })
+    for config_kv in ${config_kvs[@]}; do
+        config_kv=`echo $config_kv | xargs`
+        kv=(${config_kv//=/ })
+        if [ ! ${#kv[*]} -eq 2 ]; then
+            echo "Invalid config kv !"
+            exit 1
+        fi
+        sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./config-test.ini
+    done
+fi
+
 ./dsn_replication_common_test
 
 exit_if_fail $? "run unit test failed"

--- a/src/meta/test/config-test.ini
+++ b/src/meta/test/config-test.ini
@@ -106,6 +106,7 @@ only_move_primary = false
 cold_backup_disabled = false
 
 [replication]
+disk_min_available_space_ratio = 10
 cluster_name = master-cluster
 duplication_enabled = true
 

--- a/src/meta/test/run.sh
+++ b/src/meta/test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # The MIT License (MIT)
 #
 # Copyright (c) 2015 Microsoft Corporation

--- a/src/meta/test/run.sh
+++ b/src/meta/test/run.sh
@@ -29,8 +29,8 @@ if [ -z "${REPORT_DIR}" ]; then
 fi
 
 if [ -n ${TEST_OPTS} ]; then
-    if [ ! -f ./config-test.ini ]; then
-        echo "./config-test.ini does not exists !"
+    if [ ! -f "./config-test.ini" ]; then
+        echo "./config-test.ini does not exists"
         exit 1
     fi
 

--- a/src/meta/test/run.sh
+++ b/src/meta/test/run.sh
@@ -28,6 +28,25 @@ if [ -z "${REPORT_DIR}" ]; then
     REPORT_DIR="."
 fi
 
+if [ -n ${TEST_OPTS} ]; then
+    if [ ! -f ./config-test.ini ]; then
+        echo "./config-test.ini does not exists !"
+        exit 1
+    fi
+
+    OPTS=`echo ${TEST_OPTS} | xargs`
+    config_kvs=(${OPTS//,/ })
+    for config_kv in ${config_kvs[@]}; do
+        config_kv=`echo $config_kv | xargs`
+        kv=(${config_kv//=/ })
+        if [ ! ${#kv[*]} -eq 2 ]; then
+            echo "Invalid config kv !"
+            exit 1
+        fi
+        sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./config-test.ini
+    done
+fi
+
 ./clear.sh
 output_xml="${REPORT_DIR}/dsn.meta.test.1.xml"
 GTEST_OUTPUT="xml:${output_xml}" ./dsn.meta.test

--- a/src/replica/backup/test/config-test.ini
+++ b/src/replica/backup/test/config-test.ini
@@ -51,6 +51,7 @@ partitioned = true
 name = replica_long
 
 [replication]
+disk_min_available_space_ratio = 10
 cluster_name = master-cluster
 
 [duplication-group]

--- a/src/replica/backup/test/run.sh
+++ b/src/replica/backup/test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # The MIT License (MIT)
 #
 # Copyright (c) 2015 Microsoft Corporation
@@ -23,6 +23,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+if [ -n ${TEST_OPTS} ]; then
+    if [ ! -f "./config-test.ini" ]; then
+        echo "./config-test.ini does not exists"
+        exit 1
+    fi
+
+    OPTS=`echo ${TEST_OPTS} | xargs`
+    config_kvs=(${OPTS//,/ })
+    for config_kv in ${config_kvs[@]}; do
+        config_kv=`echo $config_kv | xargs`
+        kv=(${config_kv//=/ })
+        if [ ! ${#kv[*]} -eq 2 ]; then
+            echo "Invalid config kv !"
+            exit 1
+        fi
+        sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./config-test.ini
+    done
+fi
 
 ./dsn_replica_backup_test
 

--- a/src/replica/bulk_load/test/config-test.ini
+++ b/src/replica/bulk_load/test/config-test.ini
@@ -91,6 +91,9 @@ rpc_call_channel = RPC_CHANNEL_TCP
 rpc_message_header_format = dsn
 rpc_timeout_milliseconds = 5000
 
+[replication]
+disk_min_available_space_ratio = 10
+
 [block_service.local_service]
 type = local_service
 args =

--- a/src/replica/bulk_load/test/run.sh
+++ b/src/replica/bulk_load/test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # The MIT License (MIT)
 #
 # Copyright (c) 2015 Microsoft Corporation
@@ -23,6 +23,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+if [ -n ${TEST_OPTS} ]; then
+    if [ ! -f "./config-test.ini" ]; then
+        echo "./config-test.ini does not exists"
+        exit 1
+    fi
+
+    OPTS=`echo ${TEST_OPTS} | xargs`
+    config_kvs=(${OPTS//,/ })
+    for config_kv in ${config_kvs[@]}; do
+        config_kv=`echo $config_kv | xargs`
+        kv=(${config_kv//=/ })
+        if [ ! ${#kv[*]} -eq 2 ]; then
+            echo "Invalid config kv !"
+            exit 1
+        fi
+        sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./config-test.ini
+    done
+fi
 
 ./dsn_replica_bulk_load_test
 

--- a/src/replica/duplication/test/config-test.ini
+++ b/src/replica/duplication/test/config-test.ini
@@ -50,6 +50,9 @@ partitioned = true
 [threadpool.THREAD_POOL_REPLICATION_LONG]
 name = replica_long
 
+[replication]
+disk_min_available_space_ratio = 10
+
 [duplication-group]
 master-cluster = 1
 slave-cluster  = 2

--- a/src/replica/duplication/test/run.sh
+++ b/src/replica/duplication/test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # The MIT License (MIT)
 #
 # Copyright (c) 2015 Microsoft Corporation

--- a/src/replica/duplication/test/run.sh
+++ b/src/replica/duplication/test/run.sh
@@ -23,6 +23,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+if [ -n ${TEST_OPTS} ]; then
+    if [ ! -f ./config-test.ini ]; then
+        echo "./config-test.ini does not exists !"
+        exit 1
+    fi
+
+    OPTS=`echo ${TEST_OPTS} | xargs`
+    config_kvs=(${OPTS//,/ })
+    for config_kv in ${config_kvs[@]}; do
+        config_kv=`echo $config_kv | xargs`
+        kv=(${config_kv//=/ })
+        if [ ! ${#kv[*]} -eq 2 ]; then
+            echo "Invalid config kv !"
+            exit 1
+        fi
+        sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./config-test.ini
+    done
+fi
 
 ./dsn_replica_dup_test
 

--- a/src/replica/duplication/test/run.sh
+++ b/src/replica/duplication/test/run.sh
@@ -24,8 +24,8 @@
 # THE SOFTWARE.
 
 if [ -n ${TEST_OPTS} ]; then
-    if [ ! -f ./config-test.ini ]; then
-        echo "./config-test.ini does not exists !"
+    if [ ! -f "./config-test.ini" ]; then
+        echo "./config-test.ini does not exists"
         exit 1
     fi
 

--- a/src/replica/split/test/config-test.ini
+++ b/src/replica/split/test/config-test.ini
@@ -86,3 +86,6 @@ allow_inline = false
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_message_header_format = dsn
 rpc_timeout_milliseconds = 5000
+
+[replication]
+disk_min_available_space_ratio = 10

--- a/src/replica/split/test/run.sh
+++ b/src/replica/split/test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # The MIT License (MIT)
 #
 # Copyright (c) 2015 Microsoft Corporation

--- a/src/replica/split/test/run.sh
+++ b/src/replica/split/test/run.sh
@@ -23,6 +23,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+if [ -n ${TEST_OPTS} ]; then
+    if [ ! -f "./config-test.ini" ]; then
+        echo "./config-test.ini does not exists"
+        exit 1
+    fi
+
+    OPTS=`echo ${TEST_OPTS} | xargs`
+    config_kvs=(${OPTS//,/ })
+    for config_kv in ${config_kvs[@]}; do
+        config_kv=`echo $config_kv | xargs`
+        kv=(${config_kv//=/ })
+        if [ ! ${#kv[*]} -eq 2 ]; then
+            echo "Invalid config kv !"
+            exit 1
+        fi
+        sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./config-test.ini
+    done
+fi
 
 ./dsn_replica_split_test
 

--- a/src/replica/storage/simple_kv/config.ini
+++ b/src/replica/storage/simple_kv/config.ini
@@ -152,6 +152,7 @@ max_replica_count = 3
 stateful = true
 
 [replication]
+disk_min_available_space_ratio = 10
 prepare_timeout_ms_for_secondaries = 10000
 prepare_timeout_ms_for_potential_secondaries = 20000
 

--- a/src/replica/storage/simple_kv/run.sh
+++ b/src/replica/storage/simple_kv/run.sh
@@ -29,6 +29,25 @@ if [ ! -f dsn.replication.simple_kv ]; then
     exit 1
 fi
 
+if [ -n ${TEST_OPTS} ]; then
+    if [ ! -f "./config.ini" ]; then
+        echo "./config.ini does not exists"
+        exit 1
+    fi
+
+    OPTS=`echo ${TEST_OPTS} | xargs`
+    config_kvs=(${OPTS//,/ })
+    for config_kv in ${config_kvs[@]}; do
+        config_kv=`echo $config_kv | xargs`
+        kv=(${config_kv//=/ })
+        if [ ! ${#kv[*]} -eq 2 ]; then
+            echo "Invalid config kv !"
+            exit 1
+        fi
+        sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./config.ini
+    done
+fi
+
 ./clear.sh
 
 echo "running dsn.replication.simple_kv for 20 seconds ..."

--- a/src/replica/storage/simple_kv/test/case-000.ini
+++ b/src/replica/storage/simple_kv/test/case-000.ini
@@ -155,6 +155,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-001.ini
+++ b/src/replica/storage/simple_kv/test/case-001.ini
@@ -155,6 +155,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-002.ini
+++ b/src/replica/storage/simple_kv/test/case-002.ini
@@ -155,6 +155,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-003.ini
+++ b/src/replica/storage/simple_kv/test/case-003.ini
@@ -155,6 +155,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-004.ini
+++ b/src/replica/storage/simple_kv/test/case-004.ini
@@ -155,6 +155,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-005.ini
+++ b/src/replica/storage/simple_kv/test/case-005.ini
@@ -155,6 +155,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-006.ini
+++ b/src/replica/storage/simple_kv/test/case-006.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-100.ini
+++ b/src/replica/storage/simple_kv/test/case-100.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-101.ini
+++ b/src/replica/storage/simple_kv/test/case-101.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-102.ini
+++ b/src/replica/storage/simple_kv/test/case-102.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-103.ini
+++ b/src/replica/storage/simple_kv/test/case-103.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-104.ini
+++ b/src/replica/storage/simple_kv/test/case-104.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-105.ini
+++ b/src/replica/storage/simple_kv/test/case-105.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-106.ini
+++ b/src/replica/storage/simple_kv/test/case-106.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-107.ini
+++ b/src/replica/storage/simple_kv/test/case-107.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-108.ini
+++ b/src/replica/storage/simple_kv/test/case-108.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-109.ini
+++ b/src/replica/storage/simple_kv/test/case-109.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-200.ini
+++ b/src/replica/storage/simple_kv/test/case-200.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-201.ini
+++ b/src/replica/storage/simple_kv/test/case-201.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-202-0.ini
+++ b/src/replica/storage/simple_kv/test/case-202-0.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-202-1.ini
+++ b/src/replica/storage/simple_kv/test/case-202-1.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-203-0.ini
+++ b/src/replica/storage/simple_kv/test/case-203-0.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-204.ini
+++ b/src/replica/storage/simple_kv/test/case-204.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-205.ini
+++ b/src/replica/storage/simple_kv/test/case-205.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-206.ini
+++ b/src/replica/storage/simple_kv/test/case-206.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-207.ini
+++ b/src/replica/storage/simple_kv/test/case-207.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-208.ini
+++ b/src/replica/storage/simple_kv/test/case-208.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-209.ini
+++ b/src/replica/storage/simple_kv/test/case-209.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-210.ini
+++ b/src/replica/storage/simple_kv/test/case-210.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-211.ini
+++ b/src/replica/storage/simple_kv/test/case-211.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-212.ini
+++ b/src/replica/storage/simple_kv/test/case-212.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-213.ini
+++ b/src/replica/storage/simple_kv/test/case-213.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-214.ini
+++ b/src/replica/storage/simple_kv/test/case-214.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-215.ini
+++ b/src/replica/storage/simple_kv/test/case-215.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-216.ini
+++ b/src/replica/storage/simple_kv/test/case-216.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-300-0.ini
+++ b/src/replica/storage/simple_kv/test/case-300-0.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-300-1.ini
+++ b/src/replica/storage/simple_kv/test/case-300-1.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-300-2.ini
+++ b/src/replica/storage/simple_kv/test/case-300-2.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-301.ini
+++ b/src/replica/storage/simple_kv/test/case-301.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-302.ini
+++ b/src/replica/storage/simple_kv/test/case-302.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-303.ini
+++ b/src/replica/storage/simple_kv/test/case-303.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-304.ini
+++ b/src/replica/storage/simple_kv/test/case-304.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-305.ini
+++ b/src/replica/storage/simple_kv/test/case-305.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-306.ini
+++ b/src/replica/storage/simple_kv/test/case-306.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-307.ini
+++ b/src/replica/storage/simple_kv/test/case-307.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-400.ini
+++ b/src/replica/storage/simple_kv/test/case-400.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-401.ini
+++ b/src/replica/storage/simple_kv/test/case-401.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-402.ini
+++ b/src/replica/storage/simple_kv/test/case-402.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-600.ini
+++ b/src/replica/storage/simple_kv/test/case-600.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-601.ini
+++ b/src/replica/storage/simple_kv/test/case-601.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-602.ini
+++ b/src/replica/storage/simple_kv/test/case-602.ini
@@ -156,6 +156,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/case-603.ini
+++ b/src/replica/storage/simple_kv/test/case-603.ini
@@ -158,6 +158,7 @@ partition_count = 1
 max_replica_count = 3
 
 [replication]
+disk_min_available_space_ratio = 10
 empty_write_disabled = true
 prepare_timeout_ms_for_secondaries = 1000
 prepare_timeout_ms_for_potential_secondaries = 3000

--- a/src/replica/storage/simple_kv/test/config.ini
+++ b/src/replica/storage/simple_kv/test/config.ini
@@ -179,6 +179,7 @@ max_replica_count = 3
 stateful = true
 
 [replication]
+disk_min_available_space_ratio = 10
 
 prepare_timeout_ms_for_secondaries = 10000
 prepare_timeout_ms_for_potential_secondaries = 20000

--- a/src/replica/storage/simple_kv/test/run.sh
+++ b/src/replica/storage/simple_kv/test/run.sh
@@ -29,6 +29,26 @@ bin=./dsn.rep_tests.simple_kv
 function run_single()
 {
     prefix=$1
+
+    if [ -n ${TEST_OPTS} ]; then
+        if [ ! -f "./${prefix}.ini" ]; then
+            echo "./${prefix}.ini does not exists"
+            exit 1
+        fi
+
+        OPTS=`echo ${TEST_OPTS} | xargs`
+        config_kvs=(${OPTS//,/ })
+        for config_kv in ${config_kvs[@]}; do
+            config_kv=`echo $config_kv | xargs`
+            kv=(${config_kv//=/ })
+            if [ ! ${#kv[*]} -eq 2 ]; then
+                echo "Invalid config kv !"
+                exit 1
+            fi
+            sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./${prefix}.ini
+        done
+    fi
+
     echo "${bin} ${prefix}.ini ${prefix}.act"
     ${bin} ${prefix}.ini ${prefix}.act
     ret=$?

--- a/src/replica/test/config-test.ini
+++ b/src/replica/test/config-test.ini
@@ -87,6 +87,9 @@ rpc_call_channel = RPC_CHANNEL_TCP
 rpc_message_header_format = dsn
 rpc_timeout_milliseconds = 5000
 
+[replication]
+disk_min_available_space_ratio = 10
+
 [block_service.local_service]
 type = local_service
 args =

--- a/src/replica/test/run.sh
+++ b/src/replica/test/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # The MIT License (MIT)
 #
 # Copyright (c) 2015 Microsoft Corporation
@@ -26,6 +26,25 @@
 
 if [ -z "${REPORT_DIR}" ]; then
     REPORT_DIR="."
+fi
+
+if [ -n ${TEST_OPTS} ]; then
+    if [ ! -f "./config-test.ini" ]; then
+        echo "./config-test.ini does not exists"
+        exit 1
+    fi
+
+    OPTS=`echo ${TEST_OPTS} | xargs`
+    config_kvs=(${OPTS//,/ })
+    for config_kv in ${config_kvs[@]}; do
+        config_kv=`echo $config_kv | xargs`
+        kv=(${config_kv//=/ })
+        if [ ! ${#kv[*]} -eq 2 ]; then
+            echo "Invalid config kv !"
+            exit 1
+        fi
+        sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./config-test.ini
+    done
 fi
 
 ./clear.sh

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -144,6 +144,7 @@ max_replica_count = 3
 stateful = true
 
 [replication]
+disk_min_available_space_ratio = 10
 data_dirs_black_list_file = /home/mi/.pegasus_data_dirs_black_list
 cluster_name = onebox
 

--- a/src/server/test/run.sh
+++ b/src/server/test/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -22,6 +22,25 @@ exit_if_fail() {
         exit 1
     fi
 }
+
+if [ -n ${TEST_OPTS} ]; then
+    if [ ! -f ./config.ini ]; then
+        echo "./config.ini does not exists !"
+        exit 1
+    fi
+
+    OPTS=`echo ${TEST_OPTS} | xargs`
+    config_kvs=(${OPTS//,/ })
+    for config_kv in ${config_kvs[@]}; do
+        config_kv=`echo $config_kv | xargs`
+        kv=(${config_kv//=/ })
+        if [ ! ${#kv[*]} -eq 2 ]; then
+            echo "Invalid config kv !"
+            exit 1
+        fi
+        sed -i '/^\s*'"${kv[0]}"'/c '"${kv[0]}"' = '"${kv[1]}" ./config.ini
+    done
+fi
 
 ./pegasus_unit_test
 

--- a/src/test/function_test/run.sh
+++ b/src/test/function_test/run.sh
@@ -26,7 +26,7 @@ fi
 
 if [ -n ${TEST_OPTS} ]; then
     if [ ! -f ./config.ini ]; then
-        echo "./config.ini does not exists !"
+        echo "./config.ini does not exists"
         exit 1
     fi
 

--- a/src/utils/filesystem.cpp
+++ b/src/utils/filesystem.cpp
@@ -694,7 +694,7 @@ bool get_disk_space_info(const std::string &path, disk_space_info &info)
     FAIL_POINT_INJECT_F("filesystem_get_disk_space_info", [&info](string_view str) {
         info.capacity = 100 * 1024 * 1024;
         if (str.find("insufficient") != string_view::npos) {
-            info.available = 5 * 1024 * 1024;
+            info.available = 512 * 1024;
         } else {
             info.available = 50 * 1024 * 1024;
         }

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -41,6 +41,7 @@
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
+#include "utils/ports.h"
 #include "utils/process_utils.h"
 #include "utils/strings.h"
 #include "utils/time_utils.h"


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1576

Free more disk space for github workflows in the following ways:

- remove unnecessary packages and directories with reduced disk space up
   to 11GB;
- support updating options such as `disk_min_available_space_ratio` by env
   `TEST_OPTS` for some tests;
- reduce `disk_min_available_space_ratio` from 10 to 5 to some failed tests
   due to `SPACE_INSUFFICIENT`.