### PR TITLE
fix: support core dump for fatal logging in simple_logger::dsn_logv and call fatal logging exactly once for the assertion

### DIFF
--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -45,7 +45,6 @@
 #include "common/replication.codes.h"
 #include "common/replication_common.h"
 #include "common/replication_enums.h"
-#include "fmt/core.h"
 #include "fmt/ostream.h"
 #include "meta/meta_rpc_types.h"
 #include "runtime/api_layer1.h"

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -29,6 +29,7 @@
 #include <set>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/src/server/result_writer.cpp
+++ b/src/server/result_writer.cpp
@@ -21,6 +21,7 @@
 
 #include <pegasus/error.h>
 #include <chrono>
+#include <type_traits>
 #include <utility>
 
 #include "pegasus/client.h"

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -57,7 +57,7 @@
 #define CHECK_EXPRESSION(expression, evaluation, ...)                                              \
     do {                                                                                           \
         if (dsn_unlikely(!(evaluation))) {                                                         \
-            std::string assertion_info("assertion expression: " #expression " !!! ");              \
+            std::string assertion_info("assertion expression: [" #expression "] ");                \
             assertion_info += fmt::format(__VA_ARGS__);                                            \
             LOG_FATAL(assertion_info);                                                             \
         }                                                                                          \

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -57,9 +57,7 @@
 #define CHECK_EXPRESSION(expression, evaluation, ...)                                              \
     do {                                                                                           \
         if (dsn_unlikely(!(evaluation))) {                                                         \
-            dlog_f(LOG_LEVEL_FATAL, "assertion expression: " #expression);                         \
-            dlog_f(LOG_LEVEL_FATAL, __VA_ARGS__);                                                  \
-            dsn_coredump();                                                                        \
+            LOG_FATAL("assertion expression: " #expression " !! " __VA_ARGS__);                    \
         }                                                                                          \
     } while (false)
 

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -57,7 +57,9 @@
 #define CHECK_EXPRESSION(expression, evaluation, ...)                                              \
     do {                                                                                           \
         if (dsn_unlikely(!(evaluation))) {                                                         \
-            LOG_FATAL("assertion expression: " #expression " !! " __VA_ARGS__);                    \
+            std::string assertion_info("assertion expression: " #expression " !!! ");              \
+            assertion_info += fmt::format(__VA_ARGS__);                                            \
+            LOG_FATAL(assertion_info);                                                             \
         }                                                                                          \
     } while (false)
 

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -300,11 +300,10 @@ void simple_logger::dsn_log(const char *file,
     if (dsn_unlikely(log_level >= LOG_LEVEL_FATAL)) {
         bool coredump = true;
         FAIL_POINT_INJECT_NOT_RETURN_F(
-            "coredump_for_fatal_log",
-            [&coredump, this](dsn::string_view str) {
-            CHECK(buf2bool(str, coredump),
-                              "invalid coredump toggle for fatal log, should be true or false: {}",
-                              str);
+            "coredump_for_fatal_log", [&coredump, this](dsn::string_view str) {
+                CHECK(buf2bool(str, coredump),
+                      "invalid coredump toggle for fatal log, should be true or false: {}",
+                      str);
             });
 
         if (coredump) {

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -42,8 +42,10 @@
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
+#include "utils/ports.h"
 #include "utils/process_utils.h"
 #include "utils/string_conv.h"
+#include "utils/string_view.h"
 #include "utils/strings.h"
 #include "utils/time_utils.h"
 

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -46,18 +46,18 @@ public:
     explicit screen_logger(bool short_header);
     ~screen_logger() override;
 
-    virtual void dsn_logv(const char *file,
+    void dsn_logv(const char *file,
                           const char *function,
                           const int line,
                           dsn_log_level_t log_level,
                           const char *fmt,
-                          va_list args);
+                          va_list args) override;
 
-    virtual void dsn_log(const char *file,
+    void dsn_log(const char *file,
                          const char *function,
                          const int line,
                          dsn_log_level_t log_level,
-                         const char *str){};
+                         const char *str) override {}
 
     virtual void flush();
 

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -47,17 +47,19 @@ public:
     ~screen_logger() override;
 
     void dsn_logv(const char *file,
-                          const char *function,
-                          const int line,
-                          dsn_log_level_t log_level,
-                          const char *fmt,
-                          va_list args) override;
+                  const char *function,
+                  const int line,
+                  dsn_log_level_t log_level,
+                  const char *fmt,
+                  va_list args) override;
 
     void dsn_log(const char *file,
-                         const char *function,
-                         const int line,
-                         dsn_log_level_t log_level,
-                         const char *str) override {}
+                 const char *function,
+                 const int line,
+                 dsn_log_level_t log_level,
+                 const char *str) override
+    {
+    }
 
     virtual void flush();
 

--- a/src/utils/test/logging.cpp
+++ b/src/utils/test/logging.cpp
@@ -38,6 +38,7 @@
 #include <string>
 
 #include "utils/api_utilities.h"
+#include "utils/fail_point.h"
 #include "utils/fmt_logging.h"
 
 TEST(core, logging)
@@ -76,8 +77,8 @@ TEST(core, dlog_f)
                  {dsn_log_level_t::LOG_LEVEL_ERROR, "\\x00%d\\x00\\x01%n/nm"},
                  {dsn_log_level_t::LOG_LEVEL_FATAL, "\\x00%d\\x00\\x01%n/nm"}};
 
-    fail::setup();
-    fail::cfg("coredump_for_fatal_log", "void(false)");
+    dsn::fail::setup();
+    dsn::fail::cfg("coredump_for_fatal_log", "void(false)");
 
     for (auto test : tests) {
         // Test logging_provider::dsn_log
@@ -87,5 +88,5 @@ TEST(core, dlog_f)
         dlog(test.level, "dlog: sortkey = %s", test.str.c_str());
     }
 
-    fail::teardown();
+    dsn::fail::teardown();
 }

--- a/src/utils/test/logging.cpp
+++ b/src/utils/test/logging.cpp
@@ -76,7 +76,16 @@ TEST(core, dlog_f)
                  {dsn_log_level_t::LOG_LEVEL_ERROR, "\\x00%d\\x00\\x01%n/nm"},
                  {dsn_log_level_t::LOG_LEVEL_FATAL, "\\x00%d\\x00\\x01%n/nm"}};
 
+    fail::setup();
+    fail::cfg("coredump_for_fatal_log", "void(false)");
+
     for (auto test : tests) {
-        dlog_f(test.level, "sortkey = {}", test.str);
+        // Test logging_provider::dsn_log
+        dlog_f(test.level, "dlog_f: sortkey = {}", test.str);
+
+        // Test logging_provider::dsn_logv
+        dlog(test.level, "dlog: sortkey = %s", test.str.c_str());
     }
+
+    fail::teardown();
 }

--- a/src/utils/test/logging.cpp
+++ b/src/utils/test/logging.cpp
@@ -64,7 +64,7 @@ TEST(core, logging_big_log)
              big_str.c_str());
 }
 
-TEST(core, dlog_f)
+TEST(core, dlog)
 {
     struct test_case
     {


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1579

Following fixes are included in this PR to solve the problems:
- support core dump for fatal logging in `simple_logger::dsn_logv`;
- call fatal logging exactly once for the assertion macros `CHECK*`;
- add fail point to keep the logging test running without termination.