### PR TITLE
chore(github): free disk space after packaging with jemalloc in github workflows

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -410,6 +410,9 @@ jobs:
 #          path: |
 #            /github/home/.ccache
 #          key: ubsan_ccache
+#      - name: Free Disk Space (Ubuntu)
+#        run: |
+#          .github/workflows/free_disk_space.sh
 #      - uses: dorny/paths-filter@v2
 #        id: changes
 #        with:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -591,9 +591,13 @@ jobs:
         run: |
           find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Pack Server
-        run: ./run.sh pack_server -j
+        run: |
+          ./run.sh pack_server -j
+          rm -rf pegasus-server-*
       - name: Pack Tools
-        run: ./run.sh pack_tools -j
+        run: |
+          ./run.sh pack_tools -j
+          rm -rf pegasus-tools-*
       - name: Tar files
         run: |
           mv thirdparty/hadoop-bin ./


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1576

In the workflow that builds pegasus with jemalloc, more space could be
freed after packaging is tested.