### PR TITLE
chore(github): free disk space for daily building on github

### DIFF
--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -75,14 +75,27 @@ jobs:
         working-directory: /root
         run: |
           git clone -b ${{ github.ref_name }} --depth=1 https://github.com/apache/incubator-pegasus.git
+      - name: Free Disk Space (Ubuntu)
+        run: |
+          .github/workflows/free_disk_space.sh
       - name: Unpack prebuilt third-parties
         run: |
+          rm -f /root/thirdparties-src.zip
           unzip /root/thirdparties-bin.zip -d ./thirdparty
           rm -f /root/thirdparties-bin.zip
+          find ./thirdparty -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
+          rm -rf ./thirdparty/hadoop-bin/share/doc
+          rm -rf ./thirdparty/zookeeper-bin/docs
       - name: Compilation Pegasus
-        run: ./run.sh build --test --compiler ${{ matrix.compiler }} --skip_thirdparty -j $(nproc)
+        run: |
+          ./run.sh build --test --compiler ${{ matrix.compiler }} --skip_thirdparty -j $(nproc)
+      - name: Clear Build Files
+        run: |
+          find ./build/latest/src/ -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
       - name: Packaging Server
-        run: ./run.sh pack_server
+        run: |
+          ./run.sh pack_server
+          rm -rf pegasus-server-*
 
   build_and_lint_go:
     name: Build and Lint Golang


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1585

Free more disk space for daily building cpp by referring to https://github.com/apache/incubator-pegasus/pull/1577.

Test has been run manually on [Lint and build regularly](https://github.com/apache/incubator-pegasus/actions/workflows/regular-build.yml) for the branch [free-regular-disk-space](https://github.com/apache/incubator-pegasus/tree/free-regular-disk-space).