### PR TITLE
fix: fix errors in format string for logging and macro

### DIFF
--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1036,10 +1036,7 @@ void policy_context::sync_remove_backup_info(const backup_info &info, dsn::task_
                 0,
                 _backup_service->backup_option().meta_retry_delay_ms);
         } else {
-            CHECK(false,
-                  "{}: we can't handle this right now, error({})",
-                  _policy.policy_name,
-                  err);
+            CHECK(false, "{}: we can't handle this right now, error({})", _policy.policy_name, err);
         }
     };
 
@@ -1373,9 +1370,7 @@ void backup_service::do_add_policy(dsn::message_ex *req,
                                  _opt.meta_retry_delay_ms);
                 return;
             } else {
-                CHECK(false,
-                      "we can't handle this when create backup policy, err({})",
-                      err);
+                CHECK(false, "we can't handle this when create backup policy, err({})", err);
             }
         },
         value);
@@ -1411,9 +1406,7 @@ void backup_service::do_update_policy_to_remote_storage(
                                  0,
                                  _opt.meta_retry_delay_ms);
             } else {
-                CHECK(false,
-                      "we can't handle this when create backup policy, err({})",
-                      err);
+                CHECK(false, "we can't handle this when create backup policy, err({})", err);
             }
         });
 }

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1039,7 +1039,7 @@ void policy_context::sync_remove_backup_info(const backup_info &info, dsn::task_
             CHECK(false,
                   "{}: we can't handle this right now, error({})",
                   _policy.policy_name,
-                  err.to_string());
+                  err);
         }
     };
 
@@ -1375,7 +1375,7 @@ void backup_service::do_add_policy(dsn::message_ex *req,
             } else {
                 CHECK(false,
                       "we can't handle this when create backup policy, err({})",
-                      err.to_string());
+                      err);
             }
         },
         value);
@@ -1413,7 +1413,7 @@ void backup_service::do_update_policy_to_remote_storage(
             } else {
                 CHECK(false,
                       "we can't handle this when create backup policy, err({})",
-                      err.to_string());
+                      err);
             }
         });
 }

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -159,9 +159,7 @@ bool construct_replica(meta_view view, const gpid &pid, int max_replica_count)
     // we put max_replica_count-1 recent replicas to last_drops, in case of the DDD-state when the
     // only primary dead
     // when add node to pc.last_drops, we don't remove it from our cc.drop_list
-    CHECK(pc.last_drops.empty(),
-          "last_drops of partition({}) must be empty",
-          pid);
+    CHECK(pc.last_drops.empty(), "last_drops of partition({}) must be empty", pid);
     for (auto iter = drop_list.rbegin(); iter != drop_list.rend(); ++iter) {
         if (pc.last_drops.size() + 1 >= max_replica_count)
             break;

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -160,9 +160,8 @@ bool construct_replica(meta_view view, const gpid &pid, int max_replica_count)
     // only primary dead
     // when add node to pc.last_drops, we don't remove it from our cc.drop_list
     CHECK(pc.last_drops.empty(),
-          "last_drops of partition({}.{}) must be empty",
-          pid.get_app_id(),
-          pid.get_partition_index());
+          "last_drops of partition({}) must be empty",
+          pid);
     for (auto iter = drop_list.rbegin(); iter != drop_list.rend(); ++iter) {
         if (pc.last_drops.size() + 1 >= max_replica_count)
             break;
@@ -402,10 +401,9 @@ int config_context::collect_drop_replica(const rpc_address &node, const replica_
     iter = find_from_dropped(node);
     if (iter == dropped.end()) {
         CHECK(!in_dropped,
-              "adjust position of existing node({}) failed, this is a bug, partition({}.{})",
-              node.to_string(),
-              config_owner->pid.get_app_id(),
-              config_owner->pid.get_partition_index());
+              "adjust position of existing node({}) failed, this is a bug, partition({})",
+              node,
+              config_owner->pid);
         return -1;
     }
     return in_dropped ? 1 : 0;

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -102,9 +102,7 @@ void partition_guardian::reconfig(meta_view view, const configuration_update_req
     if (!cc->lb_actions.empty()) {
         const configuration_proposal_action *current = cc->lb_actions.front();
         CHECK(current != nullptr && current->type != config_type::CT_INVALID,
-              "invalid proposal for gpid({}.{})",
-              gpid.get_app_id(),
-              gpid.get_partition_index());
+              "invalid proposal for gpid({})", gpid);
         // if the valid proposal is from cure
         if (!cc->lb_actions.is_from_balancer()) {
             finish_cure_proposal(view, gpid, *current);
@@ -132,7 +130,7 @@ void partition_guardian::reconfig(meta_view view, const configuration_update_req
 
                 CHECK(cc->record_drop_history(request.node),
                       "node({}) has been in the dropped",
-                      request.node.to_string());
+                      request.node);
             }
         });
     }
@@ -242,7 +240,7 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
         for (int i = 0; i < pc.secondaries.size(); ++i) {
             node_state *ns = get_node_state(*(view.nodes), pc.secondaries[i], false);
             CHECK_NOTNULL(
-                ns, "invalid secondary address, address = {}", pc.secondaries[i].to_string());
+                ns, "invalid secondary address, address = {}", pc.secondaries[i]);
             if (!ns->alive())
                 continue;
 
@@ -609,7 +607,7 @@ pc_status partition_guardian::on_missing_secondary(meta_view &view, const dsn::g
         if (is_node_alive(*view.nodes, server.node)) {
             CHECK(!server.node.is_invalid(),
                   "invalid server address, address = {}",
-                  server.node.to_string());
+                  server.node);
             action.node = server.node;
         }
 

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -102,7 +102,8 @@ void partition_guardian::reconfig(meta_view view, const configuration_update_req
     if (!cc->lb_actions.empty()) {
         const configuration_proposal_action *current = cc->lb_actions.front();
         CHECK(current != nullptr && current->type != config_type::CT_INVALID,
-              "invalid proposal for gpid({})", gpid);
+              "invalid proposal for gpid({})",
+              gpid);
         // if the valid proposal is from cure
         if (!cc->lb_actions.is_from_balancer()) {
             finish_cure_proposal(view, gpid, *current);
@@ -239,8 +240,7 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
 
         for (int i = 0; i < pc.secondaries.size(); ++i) {
             node_state *ns = get_node_state(*(view.nodes), pc.secondaries[i], false);
-            CHECK_NOTNULL(
-                ns, "invalid secondary address, address = {}", pc.secondaries[i]);
+            CHECK_NOTNULL(ns, "invalid secondary address, address = {}", pc.secondaries[i]);
             if (!ns->alive())
                 continue;
 
@@ -605,9 +605,7 @@ pc_status partition_guardian::on_missing_secondary(meta_view &view, const dsn::g
         // if not emergency, only try to recover last dropped server
         const dropped_replica &server = cc.dropped.back();
         if (is_node_alive(*view.nodes, server.node)) {
-            CHECK(!server.node.is_invalid(),
-                  "invalid server address, address = {}",
-                  server.node);
+            CHECK(!server.node.is_invalid(), "invalid server address, address = {}", server.node);
             action.node = server.node;
         }
 

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -29,7 +29,6 @@
 #include <set>
 #include <string>
 #include <thread>
-#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -285,8 +285,7 @@ void replica::on_client_read(dsn::message_ex *request, bool ignore_throttling)
 
         // a small window where the state is not the latest yet
         if (last_committed_decree() < _primary_states.last_prepare_decree_on_new_primary) {
-            LOG_ERROR_PREFIX("last_committed_decree(%" PRId64
-                             ") < last_prepare_decree_on_new_primary(%" PRId64 ")",
+            LOG_ERROR_PREFIX("last_committed_decree({}) < last_prepare_decree_on_new_primary({})",
                              last_committed_decree(),
                              _primary_states.last_prepare_decree_on_new_primary);
             response_client_read(request, ERR_INVALID_STATE);

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -28,11 +28,10 @@
 
 #include <fmt/core.h>
 #include <fmt/ostream.h>
-#include <inttypes.h>
+#include <rocksdb/status.h>
 #include <algorithm>
 #include <functional>
 #include <iosfwd>
-#include <rocksdb/status.h>
 #include <set>
 
 #include "backup/replica_backup_manager.h"

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -259,8 +259,8 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
     }
 
     mu->_tracer->set_name(fmt::format("mutation[{}]", mu->name()));
-    dlog(level,
-         "%s: mutation %s init_prepare, mutation_tid=%" PRIu64,
+    dlog_f(level,
+         "{}: mutation {} init_prepare, mutation_tid={}",
          name(),
          mu->name(),
          mu->tid());

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -259,11 +259,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
     }
 
     mu->_tracer->set_name(fmt::format("mutation[{}]", mu->name()));
-    dlog_f(level,
-         "{}: mutation {} init_prepare, mutation_tid={}",
-         name(),
-         mu->name(),
-         mu->tid());
+    dlog_f(level, "{}: mutation {} init_prepare, mutation_tid={}", name(), mu->name(), mu->tid());
 
     // child should prepare mutation synchronously
     mu->set_is_sync_to_child(_primary_states.sync_send_write_request);

--- a/src/runtime/task/task.cpp
+++ b/src/runtime/task/task.cpp
@@ -120,8 +120,8 @@ task::task(dsn::task_code code, int hash, service_node *node)
     } else {
         auto p = get_current_node();
         CHECK_NOTNULL(p,
-                      "tasks without explicit service node "
-                      "can only be created inside threads which is attached to specific node");
+                      "tasks without explicit service node can only be created "
+                      "inside threads which is attached to specific node");
         _node = p;
     }
 

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2308,7 +2308,7 @@ bool pegasus_server_impl::validate_filter(::dsn::apps::filter_type::type filter_
         }
     }
     default:
-        CHECK(false, "unsupported filter type: %d", filter_type);
+        CHECK(false, "unsupported filter type: {}", filter_type);
     }
     return false;
 }


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1587

Fix some wrong format string in logging and macro that are:

- still using c-style format string, which would not print the correct messages;
- calling `to_string()` method for the classes which have implemented `operator<<`.