### PR TITLE
fix:dup conflict with balance

### DIFF
--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -53,6 +53,7 @@ void load_mutation::run()
 {
     decree last_decree = _duplicator->progress().last_decree;
     _start_decree = last_decree + 1;
+    _duplicator->set_is_loading(true);
     if (_replica->private_log()->max_commit_on_disk() < _start_decree) {
         // wait 100ms for next try if no mutation was added.
         repeat(100_ms);

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -246,7 +246,7 @@ void load_from_private_log::replay_log_block()
     // mutations()
     step_down_next_stage(_mutation_batch.last_decree(), _mutation_batch.move_all_mutations());
 
-    //step to ship meaning load has been finished
+    // step to ship meaning load has been finished
     _duplicator->set_is_loading(false);
 }
 

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -245,6 +245,9 @@ void load_from_private_log::replay_log_block()
     // case2: !err.is_ok(err.code() == ERR_HANDLE_EOF) and no next file, need commit the last
     // mutations()
     step_down_next_stage(_mutation_batch.last_decree(), _mutation_batch.move_all_mutations());
+
+    //step to ship meaning load has been finished
+    _duplicator->set_is_loading(false);
 }
 
 load_from_private_log::load_from_private_log(replica *r, replica_duplicator *dup)

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -53,6 +53,7 @@ replica_duplicator::replica_duplicator(const duplication_entry &ent, replica *r)
       _stub(r->get_replica_stub())
 {
     _status = ent.status;
+    _is_loading.store(false);
 
     auto it = ent.progress.find(get_gpid().get_partition_index());
     if (it->second == invalid_decree) {

--- a/src/replica/duplication/replica_duplicator.h
+++ b/src/replica/duplication/replica_duplicator.h
@@ -140,6 +140,14 @@ public:
 
     duplication_status::type status() const { return _status; };
 
+    void set_is_loading(bool loading){
+        _is_loading.store(loading);
+    }
+
+    bool get_is_loading(){
+        return _is_loading.load();
+    }
+
 private:
     friend class duplication_test_base;
     friend class replica_duplicator_test;
@@ -164,6 +172,9 @@ private:
     // protect the access of _progress.
     mutable zrwlock_nr _lock;
     duplication_progress _progress;
+
+    //avoid load conflict with replica close
+    std::atomic<bool> _is_loading;
 
     /// === pipeline === ///
     std::unique_ptr<load_mutation> _load;

--- a/src/replica/duplication/replica_duplicator.h
+++ b/src/replica/duplication/replica_duplicator.h
@@ -140,13 +140,9 @@ public:
 
     duplication_status::type status() const { return _status; };
 
-    void set_is_loading(bool loading){
-        _is_loading.store(loading);
-    }
+    void set_is_loading(bool loading) { _is_loading.store(loading); }
 
-    bool get_is_loading(){
-        return _is_loading.load();
-    }
+    bool get_is_loading() { return _is_loading.load(); }
 
 private:
     friend class duplication_test_base;
@@ -173,7 +169,7 @@ private:
     mutable zrwlock_nr _lock;
     duplication_progress _progress;
 
-    //avoid load conflict with replica close
+    // avoid load conflict with replica close
     std::atomic<bool> _is_loading;
 
     /// === pipeline === ///

--- a/src/replica/duplication/replica_duplicator_manager.h
+++ b/src/replica/duplication/replica_duplicator_manager.h
@@ -91,9 +91,10 @@ public:
     };
     std::vector<dup_state> get_dup_states() const;
 
-    bool check_still_have_dup_pipeline_loading(){
-        for(auto &kv : _duplications){
-            if (kv.second->get_is_loading()){
+    bool check_still_have_dup_pipeline_loading()
+    {
+        for (auto &kv : _duplications) {
+            if (kv.second->get_is_loading()) {
                 return true;
             }
         }

--- a/src/replica/duplication/replica_duplicator_manager.h
+++ b/src/replica/duplication/replica_duplicator_manager.h
@@ -91,6 +91,15 @@ public:
     };
     std::vector<dup_state> get_dup_states() const;
 
+    bool check_still_have_dup_pipeline_loading(){
+        for(auto &kv : _duplications){
+            if (kv.second->get_is_loading()){
+                return true;
+            }
+        }
+        return false;
+    }
+
 private:
     void sync_duplication(const duplication_entry &ent);
 

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -603,6 +603,14 @@ error_code replica::store_app_info(app_info &info, const std::string &path)
     return err;
 }
 
+bool replica::having_dup_loading()
+{
+    if(_duplication_mgr == nullptr){
+        return false;
+    }
+    return _duplication_mgr->check_still_have_dup_pipeline_loading();
+}
+
 bool replica::access_controller_allowed(message_ex *msg, const ranger::access_type &ac_type) const
 {
     return !_access_controller->is_enable_ranger_acl() || _access_controller->allowed(msg, ac_type);

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -605,7 +605,7 @@ error_code replica::store_app_info(app_info &info, const std::string &path)
 
 bool replica::having_dup_loading()
 {
-    if(_duplication_mgr == nullptr){
+    if (_duplication_mgr == nullptr) {
         return false;
     }
     return _duplication_mgr->check_still_have_dup_pipeline_loading();

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -254,6 +254,7 @@ public:
     replica_duplicator_manager *get_duplication_manager() const { return _duplication_mgr.get(); }
     bool is_duplication_master() const { return _is_duplication_master; }
     bool is_duplication_follower() const { return _is_duplication_follower; }
+    bool having_dup_loading();
 
     //
     // Backup
@@ -633,6 +634,7 @@ private:
     bool _is_manual_emergency_checkpointing{false};
     bool _is_duplication_master{false};
     bool _is_duplication_follower{false};
+    std::atomic<bool> _still_have_pipeline_loading{false};
 
     // backup
     std::unique_ptr<replica_backup_manager> _backup_mgr;

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1599,8 +1599,9 @@ void replica_stub::on_node_query_reply_scatter2(replica_stub_ptr this_, gpid id)
 
         // deal with double close when duplication and balance function running at the same time
         if (replica->status() == partition_status::PS_INACTIVE && replica->having_dup_loading()) {
-            LOG_INFO("{}: replica not exists on meta server,and still have dup on it. wait to close",
-                   replica->name());
+            LOG_INFO(
+                "{}: replica not exists on meta server,and still have dup on it. wait to close",
+                replica->name());
             return;
         }
 
@@ -2367,16 +2368,15 @@ task_ptr replica_stub::begin_close_replica(replica_ptr r)
         app_info a_info = *(r->get_app_info());
         replica_info r_info;
         get_replica_info(r_info, r);
-        task_ptr task = tasking::enqueue(
-            LPC_CLOSE_REPLICA,
-            &_tracker,
-            [=]() { close_replica(r); },
-            0,
-            std::chrono::milliseconds(delay_ms));
+        task_ptr task = tasking::enqueue(LPC_CLOSE_REPLICA,
+                                         &_tracker,
+                                         [=]() { close_replica(r); },
+                                         0,
+                                         std::chrono::milliseconds(delay_ms));
         _closing_replicas[id] = std::make_tuple(task, r, std::move(a_info), std::move(r_info));
         _counter_replicas_closing_count->increment();
         return task;
-    }else{
+    } else {
         return nullptr
     }
 }
@@ -2394,11 +2394,11 @@ void replica_stub::close_replica(replica_ptr r)
             "{} gpid {} has conflict between duplication load stage with close replica", name, id);
 
         task_ptr task = tasking::enqueue(LPC_CLOSE_REPLICA,
-            &_tracker,
-            [=]() { close_replica(r); },
-            0,
-            // todo: time may be configurable
-            std::chrono::milliseconds(60000)); // try 60s later
+                                         &_tracker,
+                                         [=]() { close_replica(r); },
+                                         0,
+                                         // todo: time may be configurable
+                                         std::chrono::milliseconds(60000)); // try 60s later
         return;
     }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#1589 

### What is changed and how does it work?
There are two conflict may occure when opening duplication and balance:
1.load(one stage of duplication) with replica close
  Add a atomic parameter and check replica still have doing log load when it's closed. 
  So how to end load and let replica close continue?There are two way could make it happen:
-duplication step to next stage(shipping)
-wait duplication do **update_duplication_map**,and it will `remove_all_duplications` when replica loss primary identity.

In remove_all_duplications,duplication will use a map named `_replica` to check the replica identity,so I protected it when replica close. 

2.gc useless replica with replica close (close one replica twice)
  After replica connected with meta, meta will request for config to replica every 500ms. And replica server update itself's config when meta reply.In this logic ,on_node_query_reply_scatter2 will gc useless replica(which status is PS_INACTIVE),to be precise will set status from PS_INACTIVE TO PS_ERROR.
  When replica doing `update_local_configuration`,it will exec close action when status changed and new status is PS_INACTIVE or PS_ERROR.
  So I judge replica is already closed or doing close when replica exec close replica to deal with above problem.


##### Tests <!-- At least one of them must be included. -->

- Cluster test(mentioned in issue#1589)


### In summary:
  The earliest zlock coredump was caused by the necessity of acquiring a lock during the 'dup' load stage, which requires a lock from a member variable of the 'replica' class. However, at this point, the 'replica' had already been closed, related members are destructedresulting in obtaining,resulting zlock get an error `_lock` value.

  The root cause of the replica being closed actually stems from the logic where the meta requests 'replica' for configuration, triggering a 'replica gc' process that sets the replica itself to 'PS_ERROR'. Based on the existing logic, both 'PS_INACTIVE' and 'PS_ERROR' trigger the 'begin_close' logic, with 'inactive' having a 10-minute delay and 'error' being executed immediately.

  A double safeguard was implemented for the modification. Firstly, when enqueuing the close operation, it is checked whether the replica has already been closed or is in the process of closing. Secondly, during the execution of the close operation, in case it encounters a 'dup load', it is configured to enter the task queue with a delay of one minute.



