### PR TITLE
feat(slog): flush and remove all shared logs for garbage collection

### DIFF
--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <iterator>
+#include <map>
 #include <utility>
 
 #include "common/duplication_common.h"

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -57,11 +57,11 @@ bool load_from_private_log::will_fail_fast() const
 // we try to list all files and select a new one to start (find_log_file_to_start).
 bool load_from_private_log::switch_to_next_log_file()
 {
-    auto file_map = _private_log->get_log_file_map();
-    auto next_file_it = file_map.find(_current->index() + 1);
+    const auto &file_map = _private_log->get_log_file_map();
+    const auto &next_file_it = file_map.find(_current->index() + 1);
     if (next_file_it != file_map.end()) {
         log_file_ptr file;
-        error_s es = log_utils::open_read(next_file_it->second->path(), file);
+        const auto &es = log_utils::open_read(next_file_it->second->path(), file);
         if (!es.is_ok()) {
             LOG_ERROR_PREFIX("{}", es);
             _current = nullptr;
@@ -123,11 +123,11 @@ void load_from_private_log::run()
 void load_from_private_log::find_log_file_to_start()
 {
     // `file_map` has already excluded the useless log files during replica init.
-    auto file_map = _private_log->get_log_file_map();
+    const auto &file_map = _private_log->get_log_file_map();
 
     // Reopen the files. Because the internal file handle of `file_map`
     // is cleared once WAL replay finished. They are unable to read.
-    std::map<int, log_file_ptr> new_file_map;
+    mutation_log::log_file_map_by_index new_file_map;
     for (const auto &pr : file_map) {
         log_file_ptr file;
         error_s es = log_utils::open_read(pr.second->path(), file);
@@ -141,7 +141,8 @@ void load_from_private_log::find_log_file_to_start()
     find_log_file_to_start(std::move(new_file_map));
 }
 
-void load_from_private_log::find_log_file_to_start(std::map<int, log_file_ptr> log_file_map)
+void load_from_private_log::find_log_file_to_start(
+    const mutation_log::log_file_map_by_index &log_file_map)
 {
     _current = nullptr;
     if (dsn_unlikely(log_file_map.empty())) {

--- a/src/replica/duplication/load_from_private_log.h
+++ b/src/replica/duplication/load_from_private_log.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <chrono>
-#include <map>
 
 #include "common/replication_other_types.h"
 #include "mutation_batch.h"

--- a/src/replica/duplication/load_from_private_log.h
+++ b/src/replica/duplication/load_from_private_log.h
@@ -61,7 +61,7 @@ public:
 
     /// Find the log file that contains `_start_decree`.
     void find_log_file_to_start();
-    void find_log_file_to_start(std::map<int, log_file_ptr> log_files);
+    void find_log_file_to_start(const mutation_log::log_file_map_by_index &log_files);
 
     void replay_log_block();
 

--- a/src/replica/duplication/test/duplication_test_base.h
+++ b/src/replica/duplication/test/duplication_test_base.h
@@ -68,9 +68,9 @@ public:
         return duplicator;
     }
 
-    std::map<int, log_file_ptr> open_log_file_map(const std::string &log_dir)
+    mutation_log::log_file_map_by_index open_log_file_map(const std::string &log_dir)
     {
-        std::map<int, log_file_ptr> log_file_map;
+        mutation_log::log_file_map_by_index log_file_map;
         error_s err = log_utils::open_log_file_map(log_dir, log_file_map);
         EXPECT_EQ(err, error_s::ok());
         return log_file_map;

--- a/src/replica/log_file.cpp
+++ b/src/replica/log_file.cpp
@@ -166,15 +166,15 @@ log_file::~log_file() { close(); }
 
 log_file::log_file(
     const char *path, disk_file *handle, int index, int64_t start_offset, bool is_read)
-    : _is_read(is_read)
+    :  _crc32(0),
+    _start_offset(start_offset),
+    _end_offset(start_offset),
+    _handle(handle),
+        _is_read(is_read),
+    _path(path),
+    _index(index),
+    _last_write_time(0)
 {
-    _start_offset = start_offset;
-    _end_offset = start_offset;
-    _handle = handle;
-    _path = path;
-    _index = index;
-    _crc32 = 0;
-    _last_write_time = 0;
     memset(&_header, 0, sizeof(_header));
 
     if (is_read) {

--- a/src/replica/log_file.cpp
+++ b/src/replica/log_file.cpp
@@ -166,14 +166,14 @@ log_file::~log_file() { close(); }
 
 log_file::log_file(
     const char *path, disk_file *handle, int index, int64_t start_offset, bool is_read)
-    :  _crc32(0),
-    _start_offset(start_offset),
-    _end_offset(start_offset),
-    _handle(handle),
-        _is_read(is_read),
-    _path(path),
-    _index(index),
-    _last_write_time(0)
+    : _crc32(0),
+      _start_offset(start_offset),
+      _end_offset(start_offset),
+      _handle(handle),
+      _is_read(is_read),
+      _path(path),
+      _index(index),
+      _last_write_time(0)
 {
     memset(&_header, 0, sizeof(_header));
 

--- a/src/replica/log_file.cpp
+++ b/src/replica/log_file.cpp
@@ -357,7 +357,7 @@ void log_file::reset_stream(size_t offset /*default = 0*/)
     }
 }
 
-decree log_file::previous_log_max_decree(const dsn::gpid &pid)
+decree log_file::previous_log_max_decree(const dsn::gpid &pid) const
 {
     auto it = _previous_log_max_decrees.find(pid);
     return it == _previous_log_max_decrees.end() ? 0 : it->second.max_decree;

--- a/src/replica/log_file.h
+++ b/src/replica/log_file.h
@@ -216,7 +216,7 @@ private:
     friend class mock_log_file;
 
     uint32_t _crc32;
-    bool int64_t _start_offset; // start offset in the global space
+    const int64_t _start_offset; // start offset in the global space
     std::atomic<int64_t>
         _end_offset; // end offset in the global space: end_offset = start_offset + file_size
     class file_streamer;

--- a/src/replica/log_file.h
+++ b/src/replica/log_file.h
@@ -65,9 +65,9 @@ struct log_file_header
 // a structure to record replica's log info
 struct replica_log_info
 {
-    int64_t max_decree;
+    decree max_decree;
     int64_t valid_start_offset; // valid start offset in global space
-    replica_log_info(int64_t d, int64_t o)
+    replica_log_info(decree d, int64_t o)
     {
         max_decree = d;
         valid_start_offset = o;
@@ -184,11 +184,11 @@ public:
     // file path
     const std::string &path() const { return _path; }
     // previous decrees
-    const replica_log_info_map &previous_log_max_decrees() { return _previous_log_max_decrees; }
+    const replica_log_info_map &previous_log_max_decrees() const { return _previous_log_max_decrees; }
     // previous decree for speicified gpid
-    decree previous_log_max_decree(const gpid &pid);
+    decree previous_log_max_decree(const gpid &pid) const;
     // file header
-    log_file_header &header() { return _header; }
+    const log_file_header &header() const { return _header; }
 
     // read file header from reader, return byte count consumed
     int read_file_header(binary_reader &reader);

--- a/src/replica/log_file.h
+++ b/src/replica/log_file.h
@@ -213,7 +213,7 @@ private:
     friend class mock_log_file;
 
     uint32_t _crc32;
-    int64_t _start_offset; // start offset in the global space
+    bool int64_t _start_offset; // start offset in the global space
     std::atomic<int64_t>
         _end_offset; // end offset in the global space: end_offset = start_offset + file_size
     class file_streamer;
@@ -221,8 +221,8 @@ private:
     std::unique_ptr<file_streamer> _stream;
     disk_file *_handle;        // file handle
     const bool _is_read;       // if opened for read or write
-    std::string _path;         // file path
-    int _index;                // file index
+    const std::string _path;   // file path
+    const int _index;          // file index
     log_file_header _header;   // file header
     uint64_t _last_write_time; // seconds from epoch time
 

--- a/src/replica/log_file.h
+++ b/src/replica/log_file.h
@@ -184,7 +184,10 @@ public:
     // file path
     const std::string &path() const { return _path; }
     // previous decrees
-    const replica_log_info_map &previous_log_max_decrees() const { return _previous_log_max_decrees; }
+    const replica_log_info_map &previous_log_max_decrees() const
+    {
+        return _previous_log_max_decrees;
+    }
     // previous decree for speicified gpid
     decree previous_log_max_decree(const gpid &pid) const;
     // file header

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -528,7 +528,7 @@ error_code mutation_log::open(replay_callback read_callback,
                               io_failure_callback write_error_callback,
                               const std::map<gpid, decree> &replay_condition)
 {
-    CHECK(!_is_opened, "cannot open a opened mutation_log");
+    CHECK(!_is_opened, "cannot open an opened mutation_log");
     CHECK_NULL(_current_log_file, "");
 
     // create dir if necessary

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -27,7 +27,6 @@
 #include "mutation_log.h"
 
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <algorithm>
 #include <cstdint>
 #include <ctime>

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -1418,7 +1418,7 @@ struct stop_gc_info
                            log_index,
                            decree_gap,
                            garbage_max_decree,
-                           log_max_decree)
+                           log_max_decree);
     }
 
     friend std::ostream &operator<<(std::ostream &os, const stop_gc_info &stop_gc)
@@ -1495,8 +1495,8 @@ bool can_gc_replica_slog(const dsn::replication::replica_log_info_map &max_decre
 
 } // anonymous namespace
 
-int mutation_log::garbage_collection(const replica_log_info_map &gc_condition,
-                                     std::set<gpid> &prevent_gc_replicas)
+size_t mutation_log::garbage_collection(const replica_log_info_map &gc_condition,
+                                        std::set<gpid> &prevent_gc_replicas)
 {
     CHECK(!_is_private, "this method is only valid for shared log");
 

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -1495,7 +1495,7 @@ bool can_gc_replica_slog(const dsn::replication::replica_log_info_map &max_decre
 } // anonymous namespace
 
 void mutation_log::garbage_collection(const replica_log_info_map &gc_condition,
-                                        std::set<gpid> &prevent_gc_replicas)
+                                      std::set<gpid> &prevent_gc_replicas)
 {
     CHECK(!_is_private, "this method is only valid for shared log");
 

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -1410,13 +1410,15 @@ struct stop_gc_info
     dsn::replication::decree garbage_max_decree = 0;
     dsn::replication::decree log_max_decree = 0;
 
-    std::string to_string() const {
-        return fmt::format("stop_gc_replica = {}, stop_gc_log_index = {}, stop_gc_decree_gap = {}, stop_gc_garbage_max_decree = {}, stop_gc_log_max_decree = {}",
-                     replica,
-                     log_index,
-                     decree_gap,
-                     garbage_max_decree,
-                     log_max_decree)
+    std::string to_string() const
+    {
+        return fmt::format("stop_gc_replica = {}, stop_gc_log_index = {}, stop_gc_decree_gap = {}, "
+                           "stop_gc_garbage_max_decree = {}, stop_gc_log_max_decree = {}",
+                           replica,
+                           log_index,
+                           decree_gap,
+                           garbage_max_decree,
+                           log_max_decree)
     }
 
     friend std::ostream &operator<<(std::ostream &os, const stop_gc_info &stop_gc)
@@ -1425,7 +1427,11 @@ struct stop_gc_info
     }
 };
 
-bool can_gc_replica_slog(const dsn::replication::replica_log_info_map &max_decrees, const dsn::replication::log_file_ptr &log, const dsn::gpid &pid, const dsn::replication::replica_log_info &rep_info, stop_gc_info &stop_gc)
+bool can_gc_replica_slog(const dsn::replication::replica_log_info_map &max_decrees,
+                         const dsn::replication::log_file_ptr &log,
+                         const dsn::gpid &pid,
+                         const dsn::replication::replica_log_info &rep_info,
+                         stop_gc_info &stop_gc)
 {
     const auto &garbage_max_decree = rep_info.max_decree;
     const auto &valid_start_offset = rep_info.valid_start_offset;
@@ -1438,23 +1444,21 @@ bool can_gc_replica_slog(const dsn::replication::replica_log_info_map &max_decre
         CHECK(valid_start_offset == 0 || valid_start_offset >= log->end_offset(),
               "valid start offset must be 0 or greater than the end of this log file");
 
-        LOG_DEBUG(
-            "gc @ {}: max_decree for {} is missing vs {} as garbage max decree, it's "
-            "safe to delete this and all older logs for this replica",
-            pid,
-            log->path(),
-            garbage_max_decree);
+        LOG_DEBUG("gc @ {}: max_decree for {} is missing vs {} as garbage max decree, it's "
+                  "safe to delete this and all older logs for this replica",
+                  pid,
+                  log->path(),
+                  garbage_max_decree);
         return true;
     } else if (log->end_offset() <= valid_start_offset) {
         // log is invalid for this replica, ok to delete
-        LOG_DEBUG(
-            "gc @ {}: log is invalid for {}, as valid start offset vs log end offset = "
-            "{} vs {}, it is therefore safe to delete this and all older logs for this "
-            "replica",
-            pid,
-            log->path(),
-            valid_start_offset,
-            log->end_offset());
+        LOG_DEBUG("gc @ {}: log is invalid for {}, as valid start offset vs log end offset = "
+                  "{} vs {}, it is therefore safe to delete this and all older logs for this "
+                  "replica",
+                  pid,
+                  log->path(),
+                  valid_start_offset,
+                  log->end_offset());
         return true;
     } else if (it->second.max_decree <= garbage_max_decree) {
         // all decrees are no more than garbage max decree, ok to delete
@@ -1503,7 +1507,8 @@ int mutation_log::garbage_collection(const replica_log_info_map &gc_condition,
         zauto_lock l(_lock);
         files = _log_files;
         max_decrees = _shared_log_info_map;
-        CHECK_NULL(_current_log_file, "shared logs have been deprecated, thus could not be created");
+        CHECK_NULL(_current_log_file,
+                   "shared logs have been deprecated, thus could not be created");
         total_log_size = total_size_no_lock();
         CHECK_EQ(total_log_size, 0);
     }
@@ -1513,7 +1518,8 @@ int mutation_log::garbage_collection(const replica_log_info_map &gc_condition,
         return 0;
     }
 
-    reserved_log_info reserved_log = {files.size(),total_log_size,files.begin()->first,files.rbegin()->first};
+    reserved_log_info reserved_log = {
+        files.size(), total_log_size, files.begin()->first, files.rbegin()->first};
 
     // find the largest file which can be deleted.
     // after iterate, the 'mark_it' will point to the largest file which can be deleted.
@@ -1576,7 +1582,10 @@ int mutation_log::garbage_collection(const replica_log_info_map &gc_condition,
     return reserved_log.log_count;
 }
 
-void mutation_log::remove_obsolete_log_files(const int largest_log_to_delete, log_file_map &files, reserved_log_info &reserved_log, log_deletion_info &log_deletion)
+void mutation_log::remove_obsolete_log_files(const int largest_log_to_delete,
+                                             log_file_map &files,
+                                             reserved_log_info &reserved_log,
+                                             log_deletion_info &log_deletion)
 {
     for (auto it = files.begin(); it != files.end() && it->second->index() <= largest_log_to_delete;
          ++it) {
@@ -1621,7 +1630,6 @@ void mutation_log::remove_obsolete_log_files(const int largest_log_to_delete, lo
             }
         }
     }
-
 }
 
 std::map<int, log_file_ptr> mutation_log::get_log_file_map() const

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -231,11 +231,11 @@ public:
     // remove log files if satisfy:
     //  - for each replica "r":
     //         r is not in file.max_decree
-    //      || file.max_decree[r] <= gc_condition[r].max_decree
-    //      || file.end_offset[r] <= gc_condition[r].valid_start_offset
+    //      || file.max_decree[r] <= replica_durable_decrees[r].max_decree
+    //      || file.end_offset[r] <= replica_durable_decrees[r].valid_start_offset
     //  - the current log file should not be removed
     // thread safe
-    void garbage_collection(const replica_log_info_map &gc_condition,
+    void garbage_collection(const replica_log_info_map &replica_durable_decrees,
                             std::set<gpid> &prevent_gc_replicas);
 
     //

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -26,11 +26,13 @@
 
 #pragma once
 
+#include <fmt/core.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <algorithm>
 #include <atomic>
 #include <functional>
+#include <iosfwd>
 #include <map>
 #include <memory>
 #include <set>

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -470,21 +470,21 @@ public:
     {
     }
 
-    virtual ~mutation_log_shared() override
+    ~mutation_log_shared() override
     {
         close();
         _tracker.cancel_outstanding_tasks();
     }
 
-    virtual ::dsn::task_ptr append(mutation_ptr &mu,
-                                   dsn::task_code callback_code,
-                                   dsn::task_tracker *tracker,
-                                   aio_handler &&callback,
-                                   int hash = 0,
-                                   int64_t *pending_size = nullptr) override;
+    ::dsn::task_ptr append(mutation_ptr &mu,
+                           dsn::task_code callback_code,
+                           dsn::task_tracker *tracker,
+                           aio_handler &&callback,
+                           int hash = 0,
+                           int64_t *pending_size = nullptr) override;
 
-    virtual void flush() override;
-    virtual void flush_once() override;
+    void flush() override;
+    void flush_once() override;
 
 private:
     // async write pending mutations into log file
@@ -527,24 +527,22 @@ public:
         _tracker.cancel_outstanding_tasks();
     }
 
-    virtual ::dsn::task_ptr append(mutation_ptr &mu,
-                                   dsn::task_code callback_code,
-                                   dsn::task_tracker *tracker,
-                                   aio_handler &&callback,
-                                   int hash = 0,
-                                   int64_t *pending_size = nullptr) override;
+    ::dsn::task_ptr append(mutation_ptr &mu,
+                           dsn::task_code callback_code,
+                           dsn::task_tracker *tracker,
+                           aio_handler &&callback,
+                           int hash = 0,
+                           int64_t *pending_size = nullptr) override;
 
-    virtual bool get_learn_state_in_memory(decree start_decree,
-                                           binary_writer &writer) const override;
+    bool get_learn_state_in_memory(decree start_decree, binary_writer &writer) const override;
 
     // get in-memory mutations, including pending and writing mutations
-    virtual void
-    get_in_memory_mutations(decree start_decree,
-                            ballot start_ballot,
-                            /*out*/ std::vector<mutation_ptr> &mutation_list) const override;
+    void get_in_memory_mutations(decree start_decree,
+                                 ballot start_ballot,
+                                 /*out*/ std::vector<mutation_ptr> &mutation_list) const override;
 
-    virtual void flush() override;
-    virtual void flush_once() override;
+    void flush() override;
+    void flush_once() override;
 
 private:
     // async write pending mutations into log file
@@ -559,7 +557,7 @@ private:
                                   std::shared_ptr<log_appender> &pending,
                                   decree max_commit);
 
-    virtual void init_states() override;
+    void init_states() override;
 
     // flush at most count times
     // if count <= 0, means flush until all data is on disk

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -234,7 +234,7 @@ public:
     //  - the current log file should not be removed
     // thread safe
     void garbage_collection(const replica_log_info_map &gc_condition,
-                              std::set<gpid> &prevent_gc_replicas);
+                            std::set<gpid> &prevent_gc_replicas);
 
     //
     // when this is a private log, log files are learned by remote replicas

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -233,7 +233,7 @@ public:
     //      || file.end_offset[r] <= gc_condition[r].valid_start_offset
     //  - the current log file should not be removed
     // thread safe
-    size_t garbage_collection(const replica_log_info_map &gc_condition,
+    void garbage_collection(const replica_log_info_map &gc_condition,
                               std::set<gpid> &prevent_gc_replicas);
 
     //

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -346,55 +346,61 @@ private:
     // get total size ithout lock.
     int64_t total_size_no_lock() const;
 
-struct reserved_log_info
-{
-    int log_count;
-    int64_t log_size;
-    int smallest_log;
-    int largest_log;
-
-    std::string to_string() const {
-        return fmt::format("reserved_log_count = {}, reserved_log_size = {}, reserved_smallest_log = {}, reserved_largest_log = {}",
-                     log_count,
-                     log_size,
-                     smallest_log,
-                     largest_log
-        );
-    }
-
-    friend std::ostream &operator<<(std::ostream &os, const reserved_log_info &reserved_log)
+    struct reserved_log_info
     {
-        return os << reserved_log.to_string();
-    }
-};
+        int log_count;
+        int64_t log_size;
+        int smallest_log;
+        int largest_log;
 
-struct log_deletion_info
-{
-    int to_delete_log_count = 0;
-    int64_t to_delete_log_size = 0;
-    int deleted_log_count = 0;
-    int64_t deleted_log_size = 0;
-    int deleted_smallest_log = 0;
-    int deleted_largest_log = 0;
+        std::string to_string() const
+        {
+            return fmt::format("reserved_log_count = {}, reserved_log_size = {}, "
+                               "reserved_smallest_log = {}, reserved_largest_log = {}",
+                               log_count,
+                               log_size,
+                               smallest_log,
+                               largest_log);
+        }
 
-    std::string to_string() const {
-        return fmt::format("to_delete_log_count = {}, to_delete_log_size = {}, deleted_log_count = {}, deleted_log_size = {}, deleted_smallest_log = {}, deleted_largest_log = {}", 
-                 to_delete_log_count,
-                 to_delete_log_size,
-                 deleted_log_count,
-                 deleted_log_size,
-                 deleted_smallest_log,
-                 deleted_largest_log
-                );
-    }
+        friend std::ostream &operator<<(std::ostream &os, const reserved_log_info &reserved_log)
+        {
+            return os << reserved_log.to_string();
+        }
+    };
 
-    friend std::ostream &operator<<(std::ostream &os, const log_deletion_info &log_deletion)
+    struct log_deletion_info
     {
-        return os << log_deletion.to_string();
-    }
-};
+        int to_delete_log_count = 0;
+        int64_t to_delete_log_size = 0;
+        int deleted_log_count = 0;
+        int64_t deleted_log_size = 0;
+        int deleted_smallest_log = 0;
+        int deleted_largest_log = 0;
 
-void remove_obsolete_log_files(const int largest_log_to_delete, log_file_map &files, reserved_log_info &reserved_log, log_deletion_info &log_deletion);
+        std::string to_string() const
+        {
+            return fmt::format("to_delete_log_count = {}, to_delete_log_size = {}, "
+                               "deleted_log_count = {}, deleted_log_size = {}, "
+                               "deleted_smallest_log = {}, deleted_largest_log = {}",
+                               to_delete_log_count,
+                               to_delete_log_size,
+                               deleted_log_count,
+                               deleted_log_size,
+                               deleted_smallest_log,
+                               deleted_largest_log);
+        }
+
+        friend std::ostream &operator<<(std::ostream &os, const log_deletion_info &log_deletion)
+        {
+            return os << log_deletion.to_string();
+        }
+    };
+
+    void remove_obsolete_log_files(const int largest_log_to_delete,
+                                   log_file_map &files,
+                                   reserved_log_info &reserved_log,
+                                   log_deletion_info &log_deletion);
 
 protected:
     std::string _dir;
@@ -424,13 +430,13 @@ private:
     bool _switch_file_demand;
 
     // logs
-    int _last_file_index;                   // new log file index = _last_file_index + 1
-    using log_file_map = std::map<int, log_file_ptr>; 
-    log_file_map _log_files;                // index -> log_file_ptr
-    log_file_ptr _current_log_file;         // current log file
-    int64_t _global_start_offset;           // global start offset of all files.
-                                            // invalid if _log_files.size() == 0.
-    int64_t _global_end_offset;             // global end offset currently
+    int _last_file_index; // new log file index = _last_file_index + 1
+    using log_file_map = std::map<int, log_file_ptr>;
+    log_file_map _log_files;        // index -> log_file_ptr
+    log_file_ptr _current_log_file; // current log file
+    int64_t _global_start_offset;   // global start offset of all files.
+                                    // invalid if _log_files.size() == 0.
+    int64_t _global_end_offset;     // global end offset currently
 
     // replica log info
     // - log_info.max_decree: the max decree of mutations up to now

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -233,8 +233,8 @@ public:
     //      || file.end_offset[r] <= gc_condition[r].valid_start_offset
     //  - the current log file should not be removed
     // thread safe
-    int garbage_collection(const replica_log_info_map &gc_condition,
-                           std::set<gpid> &prevent_gc_replicas);
+    size_t garbage_collection(const replica_log_info_map &gc_condition,
+                              std::set<gpid> &prevent_gc_replicas);
 
     //
     // when this is a private log, log files are learned by remote replicas
@@ -348,7 +348,7 @@ private:
 
     struct reserved_log_info
     {
-        int log_count;
+        size_t log_count;
         int64_t log_size;
         int smallest_log;
         int largest_log;
@@ -397,6 +397,7 @@ private:
         }
     };
 
+    using log_file_map = std::map<int, log_file_ptr>;
     void remove_obsolete_log_files(const int largest_log_to_delete,
                                    log_file_map &files,
                                    reserved_log_info &reserved_log,
@@ -430,8 +431,7 @@ private:
     bool _switch_file_demand;
 
     // logs
-    int _last_file_index; // new log file index = _last_file_index + 1
-    using log_file_map = std::map<int, log_file_ptr>;
+    int _last_file_index;           // new log file index = _last_file_index + 1
     log_file_map _log_files;        // index -> log_file_ptr
     log_file_ptr _current_log_file; // current log file
     int64_t _global_start_offset;   // global start offset of all files.

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -52,6 +52,7 @@
 #include "utils/autoref_ptr.h"
 #include "utils/error_code.h"
 #include "utils/errors.h"
+#include "utils/fmt_utils.h"
 #include "utils/zlocks.h"
 
 namespace dsn {

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -348,62 +348,63 @@ private:
     // get total size ithout lock.
     int64_t total_size_no_lock() const;
 
-    struct reserved_log_info
+    struct reserved_slog_info
     {
-        size_t log_count;
+        size_t file_count;
         int64_t log_size;
-        int smallest_log;
-        int largest_log;
+        int smallest_file_index;
+        int largest_file_index;
 
         std::string to_string() const
         {
-            return fmt::format("reserved_log_count = {}, reserved_log_size = {}, "
-                               "reserved_smallest_log = {}, reserved_largest_log = {}",
-                               log_count,
+            return fmt::format("reserved_slog_info = [file_count = {}, log_size = {}, "
+                               "smallest_file_index = {}, largest_file_index = {}]",
+                               file_count,
                                log_size,
-                               smallest_log,
-                               largest_log);
+                               smallest_file_index,
+                               largest_file_index);
         }
 
-        friend std::ostream &operator<<(std::ostream &os, const reserved_log_info &reserved_log)
+        friend std::ostream &operator<<(std::ostream &os, const reserved_slog_info &reserved_log)
         {
             return os << reserved_log.to_string();
         }
     };
 
-    struct log_deletion_info
+    struct slog_deletion_info
     {
-        int to_delete_log_count = 0;
+        int to_delete_file_count = 0;
         int64_t to_delete_log_size = 0;
-        int deleted_log_count = 0;
+        int deleted_file_count = 0;
         int64_t deleted_log_size = 0;
-        int deleted_smallest_log = 0;
-        int deleted_largest_log = 0;
+        int deleted_smallest_file_index = 0;
+        int deleted_largest_file_index = 0;
 
         std::string to_string() const
         {
-            return fmt::format("to_delete_log_count = {}, to_delete_log_size = {}, "
-                               "deleted_log_count = {}, deleted_log_size = {}, "
-                               "deleted_smallest_log = {}, deleted_largest_log = {}",
-                               to_delete_log_count,
+            return fmt::format("slog_deletion_info = [to_delete_file_count = {}, "
+                               "to_delete_log_size = {}, deleted_file_count = {}, "
+                               "deleted_log_size = {}, deleted_smallest_file_index = {}, "
+                               "deleted_largest_file_index = {}]",
+                               to_delete_file_count,
                                to_delete_log_size,
-                               deleted_log_count,
+                               deleted_file_count,
                                deleted_log_size,
-                               deleted_smallest_log,
-                               deleted_largest_log);
+                               deleted_smallest_file_index,
+                               deleted_largest_file_index);
         }
 
-        friend std::ostream &operator<<(std::ostream &os, const log_deletion_info &log_deletion)
+        friend std::ostream &operator<<(std::ostream &os, const slog_deletion_info &log_deletion)
         {
             return os << log_deletion.to_string();
         }
     };
 
     using log_file_map = std::map<int, log_file_ptr>;
-    void remove_obsolete_log_files(const int largest_log_to_delete,
-                                   log_file_map &files,
-                                   reserved_log_info &reserved_log,
-                                   log_deletion_info &log_deletion);
+    void remove_obsolete_slog_files(const int largest_log_to_delete,
+                                    log_file_map &files,
+                                    reserved_slog_info &reserved_log,
+                                    slog_deletion_info &log_deletion);
 
 protected:
     std::string _dir;

--- a/src/replica/mutation_log_replay.cpp
+++ b/src/replica/mutation_log_replay.cpp
@@ -133,7 +133,7 @@ namespace replication {
                                            replay_callback callback,
                                            /*out*/ int64_t &end_offset)
 {
-    std::map<int, log_file_ptr> logs;
+    log_file_map_by_index logs;
     for (auto &fpath : log_files) {
         error_code err;
         log_file_ptr log = log_file::open_read(fpath.c_str(), err);
@@ -154,7 +154,7 @@ namespace replication {
     return replay(logs, callback, end_offset);
 }
 
-/*static*/ error_code mutation_log::replay(std::map<int, log_file_ptr> &logs,
+/*static*/ error_code mutation_log::replay(log_file_map_by_index &logs,
                                            replay_callback callback,
                                            /*out*/ int64_t &end_offset)
 {

--- a/src/replica/mutation_log_utils.cpp
+++ b/src/replica/mutation_log_utils.cpp
@@ -64,7 +64,7 @@ namespace log_utils {
 }
 
 /*extern*/
-error_s check_log_files_continuity(const std::map<int, log_file_ptr> &logs)
+error_s check_log_files_continuity(const mutation_log::log_file_map_by_index &logs)
 {
     if (logs.empty()) {
         return error_s::ok();

--- a/src/replica/mutation_log_utils.h
+++ b/src/replica/mutation_log_utils.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "replica/log_file.h"
+#include "replica/mutation_log.h"
 #include "utils/autoref_ptr.h"
 #include "utils/errors.h"
 #include "utils/string_view.h"
@@ -44,7 +45,7 @@ extern error_s open_read(string_view path, /*out*/ log_file_ptr &file);
 extern error_s list_all_files(const std::string &dir, /*out*/ std::vector<std::string> &files);
 
 inline error_s open_log_file_map(const std::vector<std::string> &log_files,
-                                 /*out*/ std::map<int, log_file_ptr> &log_file_map)
+                                 /*out*/ mutation_log::log_file_map_by_index &log_file_map)
 {
     for (const std::string &fname : log_files) {
         log_file_ptr lf;
@@ -58,7 +59,7 @@ inline error_s open_log_file_map(const std::vector<std::string> &log_files,
 }
 
 inline error_s open_log_file_map(const std::string &dir,
-                                 /*out*/ std::map<int, log_file_ptr> &log_file_map)
+                                 /*out*/ mutation_log::log_file_map_by_index &log_file_map)
 {
     std::vector<std::string> log_files;
     error_s es = list_all_files(dir, log_files);
@@ -68,11 +69,11 @@ inline error_s open_log_file_map(const std::string &dir,
     return open_log_file_map(log_files, log_file_map) << "open_log_file_map(dir)";
 }
 
-extern error_s check_log_files_continuity(const std::map<int, log_file_ptr> &logs);
+extern error_s check_log_files_continuity(const mutation_log::log_file_map_by_index &logs);
 
 inline error_s check_log_files_continuity(const std::string &dir)
 {
-    std::map<int, log_file_ptr> log_file_map;
+    mutation_log::log_file_map_by_index log_file_map;
     error_s es = open_log_file_map(dir, log_file_map);
     if (!es.is_ok()) {
         return es << "check_log_files_continuity(dir)";

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1805,7 +1805,7 @@ void replica_stub::gc_slog(const replica_gc_map &rs)
     //   replicas which block garbage collection of the oldest log file.
     //
 
-    replica_log_info_map gc_condition;
+    replica_log_info_map replica_durable_decrees;
     for (auto &kv : rs) {
         replica_log_info ri;
         auto &rep = kv.second.rep;
@@ -1834,11 +1834,11 @@ void replica_stub::gc_slog(const replica_gc_map &rs)
                      kv.second.last_durable_decree);
         }
         ri.valid_start_offset = kv.second.init_offset_in_shared_log;
-        gc_condition[kv.first] = ri;
+        replica_durable_decrees[kv.first] = ri;
     }
 
     std::set<gpid> prevent_gc_replicas;
-    _log->garbage_collection(gc_condition, prevent_gc_replicas);
+    _log->garbage_collection(replica_durable_decrees, prevent_gc_replicas);
     flush_replicas_for_slog_gc(rs, prevent_gc_replicas);
 
     auto total_size = _log->total_size();

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -167,7 +167,7 @@ DSN_DEFINE_int32(replication,
                  32,
                  "shared log maximum segment file size (MB)");
 
-DSN_DEFINE_int32(replication, log_shared_file_count_limit, 100, "shared log maximum file count");
+// DSN_DEFINE_int32(replication, log_shared_file_count_limit, 100, "shared log maximum file count");
 DSN_DEFINE_int32(
     replication,
     mem_release_check_interval_ms,

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -36,6 +36,7 @@
 #include <boost/algorithm/string/replace.hpp>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1880,7 +1880,8 @@ void replica_stub::limit_flush_replicas_for_slog_gc(size_t prevent_gc_replica_co
     size_t flushed_replicas = _last_prevent_gc_replica_count - prevent_gc_replica_count;
     if (flushed_replicas == 0) {
         // It's too busy to process more flush tasks.
-        _real_log_shared_gc_flush_replicas_limit = 2;
+        _real_log_shared_gc_flush_replicas_limit =
+            std::min(2UL, log_shared_gc_flush_replicas_limit);
         return;
     }
 

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -588,13 +588,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     LOG_INFO("primary_address = {}", _primary_address_str);
 
     set_options(opts);
-    std::ostringstream oss;
-    for (int i = 0; i < _options.meta_servers.size(); ++i) {
-        if (i != 0)
-            oss << ",";
-        oss << _options.meta_servers[i].to_string();
-    }
-    LOG_INFO("meta_servers = {}", oss.str());
+    LOG_INFO("meta_servers = {}", fmt::join(_options.meta_servers, ", "));
 
     _deny_client = FLAGS_deny_client_on_start;
     _verbose_client_log = FLAGS_verbose_client_log_on_start;
@@ -1910,23 +1904,14 @@ void replica_stub::flush_replicas_for_slog_gc(const replica_gc_info_map &replica
     limit_flush_replicas_for_slog_gc(prevent_gc_replicas.size());
     _last_prevent_gc_replica_count = prevent_gc_replicas.size();
 
-    std::ostringstream oss;
-    size_t i = 0;
-    for (const auto &pid : prevent_gc_replicas) {
-        if (i != 0) {
-            oss << ", ";
-        }
-        oss << pid.to_string();
-        ++i;
-    }
     LOG_INFO("gc_shared: trigger emergency checkpoints to flush replicas for gc shared logs: "
-             "log_shared_gc_flush_replicas_limit = {}/{}, replicas({}) = {}",
+             "log_shared_gc_flush_replicas_limit = {}/{}, prevent_gc_replicas({}) = {}",
              _real_log_shared_gc_flush_replicas_limit,
              FLAGS_log_shared_gc_flush_replicas_limit,
              prevent_gc_replicas.size(),
-             oss.str());
+             fmt::join(prevent_gc_replicas, ", "));
 
-    i = 0;
+    size_t i = 0;
     for (const auto &pid : prevent_gc_replicas) {
         const auto &replica_gc = replica_gc_map.find(pid);
         if (replica_gc == replica_gc_map.end()) {

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -32,11 +32,14 @@
 //   replica_stub(singleton) --> replica --> replication_app_base
 //
 
+#include <gtest/gtest_prod.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <atomic>
 #include <functional>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <tuple>
 #include <unordered_map>

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -361,6 +361,18 @@ private:
     replica_life_cycle get_replica_life_cycle(gpid id);
     void on_gc_replica(replica_stub_ptr this_, gpid id);
 
+    struct gc_info
+    {
+        replica_ptr rep;
+        partition_status::type status;
+        mutation_log_ptr plog;
+        decree last_durable_decree;
+        int64_t init_offset_in_shared_log;
+    };
+    using replica_gc_map = std::unordered_map<gpid, gc_info>;
+    void gc_slog(const replica_gc_map &rs);
+void flush_replicas_for_gc_slog(const replica_gc_map &rs, const std::set<gpid> &prevent_gc_replicas);
+
     void response_client(gpid id,
                          bool is_read,
                          dsn::message_ex *request,
@@ -435,8 +447,8 @@ private:
     opening_replicas _opening_replicas;
     closing_replicas _closing_replicas;
     closed_replicas _closed_replicas;
-    std::atomic<size_t> _last_gc_slog_flushed_replicas;
-    std::atomic<size_t> _last_prevent_gc_replica_count;
+    size_t _last_prevent_gc_replica_count;
+    size_t _log_shared_gc_flush_replicas;
 
     mutation_log_ptr _log;
     ::dsn::rpc_address _primary_address;

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -46,8 +46,6 @@
 #include <utility>
 #include <vector>
 
-#include <gtest/gtest_prod.h>
-
 #include "block_service/block_service_manager.h"
 #include "bulk_load_types.h"
 #include "common/bulk_load_common.h"
@@ -464,7 +462,7 @@ private:
     closing_replicas _closing_replicas;
     closed_replicas _closed_replicas;
 
-    // The number of replicas that prevent slog files from being removed for gc at last round.
+    // The number of replicas that prevent slog files from being removed for gc at the last round.
     size_t _last_prevent_gc_replica_count;
 
     // The real limit of flushed replicas for the garbage collection of shared log.

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -371,8 +371,9 @@ private:
     };
     using replica_gc_map = std::unordered_map<gpid, gc_info>;
     void gc_slog(const replica_gc_map &rs);
-void limit_flush_replicas_for_slog_gc();
-void flush_replicas_for_slog_gc(const replica_gc_map &rs, const std::set<gpid> &prevent_gc_replicas);
+    void limit_flush_replicas_for_slog_gc(size_t prevent_gc_replica_count);
+    void flush_replicas_for_slog_gc(const replica_gc_map &rs,
+                                    const std::set<gpid> &prevent_gc_replicas);
 
     void response_client(gpid id,
                          bool is_read,

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -435,6 +435,8 @@ private:
     opening_replicas _opening_replicas;
     closing_replicas _closing_replicas;
     closed_replicas _closed_replicas;
+    std::atomic<size_t> _last_gc_slog_flushed_replicas;
+    std::atomic<size_t> _last_prevent_gc_replica_count;
 
     mutation_log_ptr _log;
     ::dsn::rpc_address _primary_address;

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -373,8 +373,18 @@ private:
         int64_t init_offset_in_shared_log;
     };
     using replica_gc_info_map = std::unordered_map<gpid, replica_gc_info>;
+
+    // Try to remove obsolete files of shared log for garbage collection according to the provided
+    // states of all replicas. The purpose is to remove all of the files of shared log, since it
+    // has been deprecated, and would not be appended any more.
     void gc_slog(const replica_gc_info_map &replica_gc_map);
+
+    // The number of flushed replicas for the garbage collection of shared log at a time should be
+    // limited.
     void limit_flush_replicas_for_slog_gc(size_t prevent_gc_replica_count);
+
+    // Flush rocksdb data to sst files for replicas to facilitate garbage collection of more files
+    // of shared log.
     void flush_replicas_for_slog_gc(const replica_gc_info_map &replica_gc_map,
                                     const std::set<gpid> &prevent_gc_replicas);
 
@@ -453,8 +463,14 @@ private:
     opening_replicas _opening_replicas;
     closing_replicas _closing_replicas;
     closed_replicas _closed_replicas;
+
+    // The number of replicas that prevent slog files from being removed for gc at last round.
     size_t _last_prevent_gc_replica_count;
+
+    // The real limit of flushed replicas for the garbage collection of shared log.
     size_t _real_log_shared_gc_flush_replicas_limit;
+
+    // The number of flushed replicas, mocked only for test.
     size_t _mock_flush_replicas_for_test;
 
     mutation_log_ptr _log;

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -371,7 +371,8 @@ private:
     };
     using replica_gc_map = std::unordered_map<gpid, gc_info>;
     void gc_slog(const replica_gc_map &rs);
-void flush_replicas_for_gc_slog(const replica_gc_map &rs, const std::set<gpid> &prevent_gc_replicas);
+void limit_flush_replicas_for_slog_gc();
+void flush_replicas_for_slog_gc(const replica_gc_map &rs, const std::set<gpid> &prevent_gc_replicas);
 
     void response_client(gpid id,
                          bool is_read,
@@ -448,7 +449,7 @@ private:
     closing_replicas _closing_replicas;
     closed_replicas _closed_replicas;
     size_t _last_prevent_gc_replica_count;
-    size_t _log_shared_gc_flush_replicas;
+    size_t _real_log_shared_gc_flush_replicas_limit;
 
     mutation_log_ptr _log;
     ::dsn::rpc_address _primary_address;

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -440,6 +440,7 @@ private:
     FRIEND_TEST(open_replica_test, open_replica_add_decree_and_ballot_check);
     FRIEND_TEST(replica_error_test, test_auto_trash_of_corruption);
     FRIEND_TEST(replica_test, test_clear_on_failure);
+    FRIEND_TEST(GcSlogFlushFeplicasTest, FlushReplicas);
 
     typedef std::unordered_map<gpid, ::dsn::task_ptr> opening_replicas;
     typedef std::unordered_map<gpid, std::tuple<task_ptr, replica_ptr, app_info, replica_info>>
@@ -454,6 +455,7 @@ private:
     closed_replicas _closed_replicas;
     size_t _last_prevent_gc_replica_count;
     size_t _real_log_shared_gc_flush_replicas_limit;
+    size_t _mock_flush_replicas_for_test;
 
     mutation_log_ptr _log;
     ::dsn::rpc_address _primary_address;

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -364,7 +364,7 @@ private:
     replica_life_cycle get_replica_life_cycle(gpid id);
     void on_gc_replica(replica_stub_ptr this_, gpid id);
 
-    struct gc_info
+    struct replica_gc_info
     {
         replica_ptr rep;
         partition_status::type status;
@@ -372,10 +372,10 @@ private:
         decree last_durable_decree;
         int64_t init_offset_in_shared_log;
     };
-    using replica_gc_map = std::unordered_map<gpid, gc_info>;
-    void gc_slog(const replica_gc_map &rs);
+    using replica_gc_info_map = std::unordered_map<gpid, replica_gc_info>;
+    void gc_slog(const replica_gc_info_map &replica_gc_map);
     void limit_flush_replicas_for_slog_gc(size_t prevent_gc_replica_count);
-    void flush_replicas_for_slog_gc(const replica_gc_map &rs,
+    void flush_replicas_for_slog_gc(const replica_gc_info_map &replica_gc_map,
                                     const std::set<gpid> &prevent_gc_replicas);
 
     void response_client(gpid id,

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -51,7 +51,6 @@
 #include "runtime/task/task_code.h"
 #include "runtime/task/task_spec.h"
 #include "runtime/task/task_tracker.h"
-#include "utils/autoref_ptr.h"
 #include "utils/binary_reader.h"
 #include "utils/binary_writer.h"
 #include "utils/blob.h"

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -445,7 +445,7 @@ public:
                            dsn::task_tracker *tracker,
                            aio_handler &&callback,
                            int hash = 0,
-                           int64_t *pending_size = nullptr)
+                           int64_t *pending_size = nullptr) override
     {
         _mu_list.push_back(mu);
         return nullptr;

--- a/src/replica/test/mutation_log_test.cpp
+++ b/src/replica/test/mutation_log_test.cpp
@@ -491,21 +491,25 @@ public:
 
             for (size_t j = 0; j < replica_mutations[i].second; ++j) {
                 if (i == 0) {
+                    // Record the start offset of each slog file.
                     slog_file_start_offset.first = pid;
                     slog_file_start_offset.second = mlog->get_global_offset();
                 }
 
                 const auto &it = valid_start_offsets.find(pid);
                 if (it == valid_start_offsets.end()) {
+                    // Add new partition with its start offset in slog.
                     valid_start_offsets.emplace(pid, mlog->get_global_offset());
                     mlog->set_valid_start_offset_on_open(pid, mlog->get_global_offset());
                 }
 
+                // Append a mutation.
                 auto mu = generate_slog_mutation(pid, d++, "test data");
                 mlog->append(mu, LPC_AIO_IMMEDIATE_CALLBACK, mlog->tracker(), nullptr, 0);
             }
         }
 
+        // Wait until all mutations are written into this file.
         mlog->tracker()->wait_outstanding_tasks();
     }
 

--- a/src/replica/test/mutation_log_test.cpp
+++ b/src/replica/test/mutation_log_test.cpp
@@ -809,9 +809,9 @@ TEST_P(GcSlogFlushFeplicasTest, FlushReplicas)
              last_limit,
              expected_flush_replicas) = GetParam();
 
-    replica_stub::replica_gc_map rs;
+    replica_stub::replica_gc_info_map replica_gc_map;
     for (const auto &r : prevent_gc_replicas) {
-        rs.emplace(r, replica_stub::gc_info());
+        replica_gc_map.emplace(r, replica_stub::replica_gc_info());
     }
 
     const auto reserved_log_shared_gc_flush_replicas_limit =
@@ -825,7 +825,7 @@ TEST_P(GcSlogFlushFeplicasTest, FlushReplicas)
     stub._last_prevent_gc_replica_count = last_prevent_gc_replica_count;
     stub._real_log_shared_gc_flush_replicas_limit = last_limit;
 
-    stub.flush_replicas_for_slog_gc(rs, prevent_gc_replicas);
+    stub.flush_replicas_for_slog_gc(replica_gc_map, prevent_gc_replicas);
     EXPECT_EQ(expected_flush_replicas, stub._mock_flush_replicas_for_test);
 
     dsn::fail::teardown();

--- a/src/replica/test/mutation_log_test.cpp
+++ b/src/replica/test/mutation_log_test.cpp
@@ -121,7 +121,7 @@ TEST(replication, log_file)
             lf->write_file_header(temp_writer, mdecrees);
             writer->add(temp_writer.get_buffer());
             ASSERT_EQ(mdecrees, lf->previous_log_max_decrees());
-            log_file_header &h = lf->header();
+            const auto &h = lf->header();
             ASSERT_EQ(100, h.start_global_offset);
         }
 

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -278,7 +278,7 @@ stateful = true
   plog_force_flush = false
 
   log_shared_file_size_mb = 128
-  log_shared_file_count_limit = 100
+  log_shared_gc_flush_replicas_limit = 64
   log_shared_batch_buffer_kb = 0
   log_shared_force_flush = false
   log_shared_pending_size_throttling_threshold_kb = 0

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2040,7 +2040,7 @@ private:
     }
 
     int64_t checkpoint_decree = 0;
-    ::dsn::error_code err = copy_checkpoint_to_dir_unsafe(tmp_dir.c_str(), &checkpoint_decree);
+    ::dsn::error_code err = copy_checkpoint_to_dir_unsafe(tmp_dir.c_str(), &checkpoint_decree, flush_memtable);
     if (err != ::dsn::ERR_OK) {
         LOG_ERROR_PREFIX("copy_checkpoint_to_dir_unsafe failed with err = {}", err.to_string());
         return ::dsn::ERR_LOCAL_APP_FAILURE;

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2040,7 +2040,8 @@ private:
     }
 
     int64_t checkpoint_decree = 0;
-    ::dsn::error_code err = copy_checkpoint_to_dir_unsafe(tmp_dir.c_str(), &checkpoint_decree, flush_memtable);
+    ::dsn::error_code err =
+        copy_checkpoint_to_dir_unsafe(tmp_dir.c_str(), &checkpoint_decree, flush_memtable);
     if (err != ::dsn::ERR_OK) {
         LOG_ERROR_PREFIX("copy_checkpoint_to_dir_unsafe failed with err = {}", err.to_string());
         return ::dsn::ERR_LOCAL_APP_FAILURE;

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -187,7 +187,7 @@ log_private_reserve_max_size_mb = 0
 log_private_reserve_max_time_seconds = 0
 
 log_shared_file_size_mb = 32
-log_shared_file_count_limit = 32
+log_shared_gc_flush_replicas_limit = 64
 log_shared_batch_buffer_kb = 0
 log_shared_force_flush = false
 

--- a/src/utils/autoref_ptr.h
+++ b/src/utils/autoref_ptr.h
@@ -159,6 +159,8 @@ public:
 
     void swap(ref_ptr<T> &r) noexcept { std::swap(_obj, r._obj); }
 
+    void reset(T *obj = nullptr) { *this = obj; }
+
     T *get() const { return _obj; }
 
     operator T *() const { return _obj; }

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -64,7 +64,8 @@
     } while (false)
 
 #define CHECK(x, ...) CHECK_EXPRESSION(x, x, __VA_ARGS__)
-#define CHECK_NOTNULL(p, ...) CHECK(p != nullptr, __VA_ARGS__)
+#define CHECK_NOTNULL(p, ...) CHECK((p) != nullptr, __VA_ARGS__)
+#define CHECK_NULL(p, ...) CHECK((p) == nullptr, __VA_ARGS__)
 
 // Macros for writing log message prefixed by log_prefix().
 #define LOG_DEBUG_PREFIX(...) LOG_DEBUG("[{}] {}", log_prefix(), fmt::format(__VA_ARGS__))


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1593

In https://github.com/XiaoMi/rdsn/pull/1019 we've written private logs as
WAL instead of shared logs, which also means shared log files would never
be appended with new mutations.

However, obsolete shared logs that had been applied to rocksdb were not
removed since then. There is at least 1 shared log file which is never removed.
We should change this policy of garbage collection, to delete all obsolete
shared log files.

To facilitate the garbage collection of shared log files, we also trigger checkpoints
which would flush rocksdb data to disk for each replica that has prevented shared
log files from being removed for garbage collection. It is necessary to limit the
number of submitted replicas that would be flushed at a time to avoid too much
consumption of I/O resources which might affect the processing of read/write
requests from clients.