### PR TITLE
feat(encryption): support data encrypt at rest

### DIFF
--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -81,8 +81,7 @@ public:
     const std::string kTestFileName = "aio_test.txt";
 };
 
-// TODO(yingchun): ENCRYPTION: add enable encryption test.
-INSTANTIATE_TEST_CASE_P(, aio_test, ::testing::Values(false));
+INSTANTIATE_TEST_CASE_P(, aio_test, ::testing::Values(false, true));
 
 TEST_P(aio_test, basic)
 {

--- a/src/block_service/fds/fds_service.cpp
+++ b/src/block_service/fds/fds_service.cpp
@@ -39,6 +39,7 @@
 #include "utils/TokenBucket.h"
 #include "utils/autoref_ptr.h"
 #include "utils/blob.h"
+#include "utils/env.h"
 #include "utils/error_code.h"
 #include "utils/filesystem.h"
 #include "utils/flags.h"
@@ -606,7 +607,8 @@ dsn::task_ptr fds_file_object::upload(const upload_request &req,
         const std::string &local_file = req.input_local_name;
         // get file size
         int64_t file_sz = 0;
-        dsn::utils::filesystem::file_size(local_file, file_sz);
+        dsn::utils::filesystem::file_size(
+            local_file, dsn::utils::FileDataType::kSensitive, file_sz);
 
         upload_response resp;
         // TODO: we can cache the whole file in buffer, then upload the buffer rather than the
@@ -671,6 +673,7 @@ dsn::task_ptr fds_file_object::download(const download_request &req,
     t->set_tracker(tracker);
     download_response resp;
 
+    // TODO(yingchun): use rocksdb API to implement this.
     std::shared_ptr<std::ofstream> handle(new std::ofstream(
         req.output_local_name, std::ios::binary | std::ios::out | std::ios::trunc));
     if (!handle->is_open()) {

--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -385,8 +385,8 @@ dsn::task_ptr hdfs_file_object::upload(const upload_request &req,
             rocksdb::EnvOptions env_options;
             env_options.use_direct_reads = FLAGS_enable_direct_io;
             std::unique_ptr<rocksdb::SequentialFile> rfile;
-            auto s = rocksdb::Env::Default()->NewSequentialFile(
-                req.input_local_name, &rfile, env_options);
+            auto s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)
+                         ->NewSequentialFile(req.input_local_name, &rfile, env_options);
             if (!s.ok()) {
                 LOG_ERROR(
                     "open local file '{}' failed, err = {}", req.input_local_name, s.ToString());
@@ -552,7 +552,8 @@ dsn::task_ptr hdfs_file_object::download(const download_request &req,
             rocksdb::EnvOptions env_options;
             env_options.use_direct_writes = FLAGS_enable_direct_io;
             std::unique_ptr<rocksdb::WritableFile> wfile;
-            auto s = rocksdb::Env::Default()->NewWritableFile(target_file, &wfile, env_options);
+            auto s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)
+                         ->NewWritableFile(target_file, &wfile, env_options);
             if (!s.ok()) {
                 LOG_ERROR("create local file '{}' failed, err = {}", target_file, s.ToString());
                 break;

--- a/src/block_service/local/local_service.cpp
+++ b/src/block_service/local/local_service.cpp
@@ -269,7 +269,8 @@ error_code local_file_object::load_metadata()
 
     std::string metadata_path = local_service::get_metafile(file_name());
     std::string data;
-    auto s = rocksdb::ReadFileToString(rocksdb::Env::Default(), metadata_path, &data);
+    auto s = rocksdb::ReadFileToString(
+        dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive), metadata_path, &data);
     if (!s.ok()) {
         LOG_WARNING("read file '{}' failed, err = {}", metadata_path, s.ToString());
         return ERR_FS_INTERNAL;
@@ -294,10 +295,11 @@ error_code local_file_object::store_metadata()
     meta.size = _size;
     std::string data = nlohmann::json(meta).dump();
     std::string metadata_path = local_service::get_metafile(file_name());
-    auto s = rocksdb::WriteStringToFile(rocksdb::Env::Default(),
-                                        rocksdb::Slice(data),
-                                        metadata_path,
-                                        /* should_sync */ true);
+    auto s =
+        rocksdb::WriteStringToFile(dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive),
+                                   rocksdb::Slice(data),
+                                   metadata_path,
+                                   /* should_sync */ true);
     if (!s.ok()) {
         LOG_WARNING("store to metadata file {} failed, err={}", metadata_path, s.ToString());
         return ERR_FS_INTERNAL;
@@ -341,7 +343,7 @@ dsn::task_ptr local_file_object::write(const write_request &req,
 
             do {
                 auto s = rocksdb::WriteStringToFile(
-                    rocksdb::Env::Default(),
+                    dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive),
                     rocksdb::Slice(req.buffer.data(), req.buffer.length()),
                     file_name(),
                     /* should_sync */ true);
@@ -418,7 +420,8 @@ dsn::task_ptr local_file_object::read(const read_request &req,
             rocksdb::EnvOptions env_options;
             env_options.use_direct_reads = FLAGS_enable_direct_io;
             std::unique_ptr<rocksdb::SequentialFile> sfile;
-            auto s = rocksdb::Env::Default()->NewSequentialFile(file_name(), &sfile, env_options);
+            auto s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)
+                         ->NewSequentialFile(file_name(), &sfile, env_options);
             if (!s.ok()) {
                 LOG_WARNING("open file '{}' failed, err = {}", file_name(), s.ToString());
                 resp.err = ERR_FS_INTERNAL;

--- a/src/block_service/test/CMakeLists.txt
+++ b/src/block_service/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set(MY_PROJ_LIBS
     dsn.block_service.fds
     dsn.block_service.hdfs
     dsn_runtime
+    dsn_utils
     galaxy-fds-sdk-cpp
     PocoNet
     PocoFoundation

--- a/src/block_service/test/block_service_manager_test.cpp
+++ b/src/block_service/test/block_service_manager_test.cpp
@@ -72,8 +72,7 @@ public:
     std::string FILE_NAME = "test_file";
 };
 
-// TODO(yingchun): ENCRYPTION: add enable encryption test.
-INSTANTIATE_TEST_CASE_P(, block_service_manager_test, ::testing::Values(false));
+INSTANTIATE_TEST_CASE_P(, block_service_manager_test, ::testing::Values(false, true));
 
 TEST_P(block_service_manager_test, remote_file_not_exist)
 {

--- a/src/block_service/test/fds_service_test.cpp
+++ b/src/block_service/test/fds_service_test.cpp
@@ -147,6 +147,7 @@ void FDSClientTest::TearDown() {}
 
 DEFINE_TASK_CODE(lpc_btest, TASK_PRIORITY_HIGH, dsn::THREAD_POOL_DEFAULT)
 
+// TODO(yingchun): add encryption test when FDSClient supports encryption.
 TEST_F(FDSClientTest, test_basic_operation)
 {
     const char *files[] = {"/fdstest/fdstest1/test1/test1",

--- a/src/block_service/test/hdfs_service_test.cpp
+++ b/src/block_service/test/hdfs_service_test.cpp
@@ -90,7 +90,8 @@ void HDFSClientTest::generate_test_file(const std::string &filename)
 {
     int lines = FLAGS_num_test_file_lines;
     std::unique_ptr<rocksdb::WritableFile> wfile;
-    auto s = rocksdb::Env::Default()->NewWritableFile(filename, &wfile, rocksdb::EnvOptions());
+    auto s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)
+                 ->NewWritableFile(filename, &wfile, rocksdb::EnvOptions());
     ASSERT_TRUE(s.ok()) << s.ToString();
     for (int i = 0; i < lines; ++i) {
         rocksdb::Slice data(fmt::format("{:04}d_this_is_a_simple_test_file\n", i));
@@ -128,8 +129,7 @@ void HDFSClientTest::write_test_files_async(const std::string &local_test_path,
     }
 }
 
-// TODO(yingchun): ENCRYPTION: add enable encryption test.
-INSTANTIATE_TEST_CASE_P(, HDFSClientTest, ::testing::Values(false));
+INSTANTIATE_TEST_CASE_P(, HDFSClientTest, ::testing::Values(false, true));
 
 TEST_P(HDFSClientTest, test_hdfs_read_write)
 {

--- a/src/common/fs_manager.h
+++ b/src/common/fs_manager.h
@@ -172,10 +172,10 @@ private:
     friend class replica_disk_migrator;
     friend class replica_disk_test_base;
     friend class open_replica_test;
-    FRIEND_TEST(fs_manager, find_best_dir_for_new_replica);
-    FRIEND_TEST(fs_manager, get_dir_node);
+    FRIEND_TEST(fs_manager_test, find_best_dir_for_new_replica);
+    FRIEND_TEST(fs_manager_test, get_dir_node);
     FRIEND_TEST(open_replica_test, open_replica_add_decree_and_ballot_check);
-    FRIEND_TEST(replica_error_test, test_auto_trash_of_corruption);
+    FRIEND_TEST(replica_test, test_auto_trash_of_corruption);
 };
 } // replication
 } // dsn

--- a/src/common/test/fs_manager_test.cpp
+++ b/src/common/test/fs_manager_test.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
@@ -33,6 +34,7 @@
 #include "common/gpid.h"
 #include "common/replication_other_types.h"
 #include "metadata_types.h"
+#include "test_util/test_util.h"
 #include "utils/fail_point.h"
 #include "utils/filesystem.h"
 
@@ -47,7 +49,13 @@ TEST(dir_node, replica_dir)
     ASSERT_EQ("path/1.0.test", dn.replica_dir("test", gpid(1, 0)));
 }
 
-TEST(fs_manager, initialize)
+class fs_manager_test : public pegasus::encrypt_data_test_base
+{
+};
+
+INSTANTIATE_TEST_CASE_P(, fs_manager_test, ::testing::Values(false, true));
+
+TEST_P(fs_manager_test, initialize)
 {
     fail::setup();
     struct broken_disk_test
@@ -69,7 +77,7 @@ TEST(fs_manager, initialize)
     fail::teardown();
 }
 
-TEST(fs_manager, dir_update_disk_status)
+TEST_P(fs_manager_test, dir_update_disk_status)
 {
     struct update_disk_status
     {
@@ -94,7 +102,7 @@ TEST(fs_manager, dir_update_disk_status)
     }
 }
 
-TEST(fs_manager, get_dir_node)
+TEST_P(fs_manager_test, get_dir_node)
 {
     fs_manager fm;
     fm.initialize({"./data1"}, {"data1"});
@@ -115,7 +123,7 @@ TEST(fs_manager, get_dir_node)
     ASSERT_EQ(nullptr, fm.get_dir_node(base_dir + "/data2/replica1"));
 }
 
-TEST(fs_manager, find_replica_dir)
+TEST_P(fs_manager_test, find_replica_dir)
 {
     fs_manager fm;
     fm.initialize({"./data1", "./data2", "./data3"}, {"data1", "data2", "data3"});
@@ -137,7 +145,7 @@ TEST(fs_manager, find_replica_dir)
     ASSERT_EQ(dn, dn1);
 }
 
-TEST(fs_manager, create_replica_dir_if_necessary)
+TEST_P(fs_manager_test, create_replica_dir_if_necessary)
 {
     fs_manager fm;
 
@@ -154,7 +162,7 @@ TEST(fs_manager, create_replica_dir_if_necessary)
     ASSERT_EQ("data1", dn->tag);
 }
 
-TEST(fs_manager, create_child_replica_dir)
+TEST_P(fs_manager_test, create_child_replica_dir)
 {
     fs_manager fm;
     fm.initialize({"./data1", "./data2", "./data3"}, {"data1", "data2", "data3"});
@@ -174,7 +182,7 @@ TEST(fs_manager, create_child_replica_dir)
     ASSERT_EQ(dir, child_dir);
 }
 
-TEST(fs_manager, find_best_dir_for_new_replica)
+TEST_P(fs_manager_test, find_best_dir_for_new_replica)
 {
     // dn1 | 1.0,  1.1 +1.6
     // dn2 | 1.2,  1.3 +1.7   2.0

--- a/src/geo/bench/bench.cpp
+++ b/src/geo/bench/bench.cpp
@@ -34,6 +34,7 @@
 
 #include "geo/lib/geo_client.h"
 #include "geo/lib/latlng_codec.h"
+#include "utils/env.h"
 #include "utils/errors.h"
 #include "utils/fmt_logging.h"
 #include "utils/string_conv.h"
@@ -110,7 +111,7 @@ int main(int argc, char **argv)
         RESULT_COUNT
     };
     auto statistics = rocksdb::CreateDBStatistics();
-    rocksdb::Env *env = rocksdb::Env::Default();
+    rocksdb::Env *env = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive);
     uint64_t start = env->NowNanos();
     std::atomic<uint64_t> count(test_count);
     dsn::utils::notify_event get_completed;

--- a/src/geo/test/geo_test.cpp
+++ b/src/geo/test/geo_test.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <base/pegasus_key_schema.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -55,6 +56,10 @@ namespace geo {
 
 DSN_DECLARE_int32(min_level);
 
+// TODO(yingchun): it doesn't make sense to derive from pegasus::encrypt_data_test_base to test
+//  encryption or non-encryption senarios, because the Pegasus cluster has been started with a
+//  fixed value of FLAGS_encrypt_data_at_rest.
+//  We can test the senarios after clearing and restarting the cluster.
 class geo_client_test : public ::testing::Test
 {
 public:

--- a/src/meta/meta_state_service_simple.cpp
+++ b/src/meta/meta_state_service_simple.cpp
@@ -41,6 +41,7 @@
 #include "runtime/task/task.h"
 #include "utils/autoref_ptr.h"
 #include "utils/binary_reader.h"
+#include "utils/env.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
 #include "utils/strings.h"
@@ -243,8 +244,8 @@ error_code meta_state_service_simple::initialize(const std::vector<std::string> 
     std::string log_path = dsn::utils::filesystem::path_combine(work_dir, "meta_state_service.log");
     if (utils::filesystem::file_exists(log_path)) {
         std::unique_ptr<rocksdb::SequentialFile> log_file;
-        auto s =
-            rocksdb::Env::Default()->NewSequentialFile(log_path, &log_file, rocksdb::EnvOptions());
+        auto s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)
+                     ->NewSequentialFile(log_path, &log_file, rocksdb::EnvOptions());
         CHECK(s.ok(), "open log file '{}' failed, err = {}", log_path, s.ToString());
 
         while (true) {

--- a/src/meta/test/meta_backup_test.cpp
+++ b/src/meta/test/meta_backup_test.cpp
@@ -38,6 +38,7 @@
 #include "meta_test_base.h"
 #include "runtime/api_layer1.h"
 #include "runtime/rpc/rpc_address.h"
+#include "utils/env.h"
 #include "utils/error_code.h"
 #include "utils/fail_point.h"
 #include "utils/filesystem.h"
@@ -108,7 +109,8 @@ public:
             cold_backup::get_app_metadata_file(backup_root, app->app_name, app_id, backup_id);
 
         int64_t metadata_file_size = 0;
-        if (!dsn::utils::filesystem::file_size(metadata_file, metadata_file_size)) {
+        if (!dsn::utils::filesystem::file_size(
+                metadata_file, dsn::utils::FileDataType::kSensitive, metadata_file_size)) {
             return false;
         }
         return metadata_file_size > 0;

--- a/src/meta/test/meta_state/meta_state_service.cpp
+++ b/src/meta/test/meta_state/meta_state_service.cpp
@@ -293,8 +293,7 @@ class meta_state_service_test : public pegasus::encrypt_data_test_base
 {
 };
 
-// TODO(yingchun): ENCRYPTION: add enable encryption test.
-INSTANTIATE_TEST_CASE_P(, meta_state_service_test, ::testing::Values(false));
+INSTANTIATE_TEST_CASE_P(, meta_state_service_test, ::testing::Values(false, true));
 
 TEST_P(meta_state_service_test, simple)
 {

--- a/src/nfs/test/CMakeLists.txt
+++ b/src/nfs/test/CMakeLists.txt
@@ -33,7 +33,7 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_LIBS dsn_nfs dsn_runtime gtest dsn_aio rocksdb)
+set(MY_PROJ_LIBS dsn_nfs dsn_runtime gtest dsn_aio rocksdb test_utils)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
 

--- a/src/replica/backup/replica_backup_server.cpp
+++ b/src/replica/backup/replica_backup_server.cpp
@@ -51,6 +51,12 @@ replica_backup_server::replica_backup_server(const replica_stub *rs) : _stub(rs)
     });
 }
 
+replica_backup_server::~replica_backup_server()
+{
+    dsn_rpc_unregiser_handler(RPC_COLD_BACKUP);
+    dsn_rpc_unregiser_handler(RPC_CLEAR_COLD_BACKUP);
+}
+
 void replica_backup_server::on_cold_backup(backup_rpc rpc)
 {
     const backup_request &request = rpc.request();

--- a/src/replica/backup/replica_backup_server.h
+++ b/src/replica/backup/replica_backup_server.h
@@ -30,6 +30,7 @@ class replica_backup_server
 {
 public:
     explicit replica_backup_server(const replica_stub *rs);
+    ~replica_backup_server();
 
 private:
     void on_cold_backup(backup_rpc rpc);

--- a/src/replica/backup/test/replica_backup_manager_test.cpp
+++ b/src/replica/backup/test/replica_backup_manager_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -39,7 +40,9 @@ public:
     }
 };
 
-TEST_F(replica_backup_manager_test, clear_cold_backup)
+INSTANTIATE_TEST_CASE_P(, replica_backup_manager_test, ::testing::Values(false, true));
+
+TEST_P(replica_backup_manager_test, clear_cold_backup)
 {
     std::string policy_name = "test_policy";
 

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -565,7 +565,8 @@ void replica_bulk_loader::download_sst_file(const std::string &remote_dir,
 error_code replica_bulk_loader::parse_bulk_load_metadata(const std::string &fname)
 {
     std::string buf;
-    auto s = rocksdb::ReadFileToString(rocksdb::Env::Default(), fname, &buf);
+    auto s = rocksdb::ReadFileToString(
+        dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive), fname, &buf);
     if (dsn_unlikely(!s.ok())) {
         LOG_ERROR_PREFIX("read file {} failed, error = {}", fname, s.ToString());
         return ERR_FILE_OPERATION_FAILED;

--- a/src/replica/bulk_load/test/CMakeLists.txt
+++ b/src/replica/bulk_load/test/CMakeLists.txt
@@ -30,7 +30,7 @@ set(MY_PROJ_LIBS dsn_meta_server
         test_utils
         rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex rocksdb test_utils)
 
 set(MY_BINPLACES
         config-test.ini

--- a/src/replica/duplication/test/CMakeLists.txt
+++ b/src/replica/duplication/test/CMakeLists.txt
@@ -30,6 +30,7 @@ set(MY_PROJ_LIBS dsn_meta_server
         zookeeper
         hashtable
         gtest
+        test_utils
         rocksdb)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/replica/duplication/test/dup_replica_http_service_test.cpp
+++ b/src/replica/duplication/test/dup_replica_http_service_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -39,7 +40,9 @@ class dup_replica_http_service_test : public duplication_test_base
 {
 };
 
-TEST_F(dup_replica_http_service_test, query_duplication_handler)
+INSTANTIATE_TEST_CASE_P(, dup_replica_http_service_test, ::testing::Values(false, true));
+
+TEST_P(dup_replica_http_service_test, query_duplication_handler)
 {
     auto pri = stub->add_primary_replica(1, 1);
 

--- a/src/replica/duplication/test/duplication_sync_timer_test.cpp
+++ b/src/replica/duplication/test/duplication_sync_timer_test.cpp
@@ -17,6 +17,7 @@
 
 #include "replica/duplication/duplication_sync_timer.h"
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -376,19 +377,21 @@ protected:
     std::unique_ptr<duplication_sync_timer> dup_sync;
 };
 
-TEST_F(duplication_sync_timer_test, duplication_sync) { test_duplication_sync(); }
+INSTANTIATE_TEST_CASE_P(, duplication_sync_timer_test, ::testing::Values(false, true));
 
-TEST_F(duplication_sync_timer_test, update_duplication_map) { test_update_duplication_map(); }
+TEST_P(duplication_sync_timer_test, duplication_sync) { test_duplication_sync(); }
 
-TEST_F(duplication_sync_timer_test, update_on_non_primary) { test_update_on_non_primary(); }
+TEST_P(duplication_sync_timer_test, update_duplication_map) { test_update_duplication_map(); }
 
-TEST_F(duplication_sync_timer_test, update_confirmed_points) { test_update_confirmed_points(); }
+TEST_P(duplication_sync_timer_test, update_on_non_primary) { test_update_on_non_primary(); }
 
-TEST_F(duplication_sync_timer_test, on_duplication_sync_reply) { test_on_duplication_sync_reply(); }
+TEST_P(duplication_sync_timer_test, update_confirmed_points) { test_update_confirmed_points(); }
 
-TEST_F(duplication_sync_timer_test, replica_status_transition) { test_replica_status_transition(); }
+TEST_P(duplication_sync_timer_test, on_duplication_sync_reply) { test_on_duplication_sync_reply(); }
 
-TEST_F(duplication_sync_timer_test, receive_illegal_duplication_status)
+TEST_P(duplication_sync_timer_test, replica_status_transition) { test_replica_status_transition(); }
+
+TEST_P(duplication_sync_timer_test, receive_illegal_duplication_status)
 {
     test_receive_illegal_duplication_status();
 }

--- a/src/replica/duplication/test/mutation_batch_test.cpp
+++ b/src/replica/duplication/test/mutation_batch_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -55,7 +56,9 @@ public:
     }
 };
 
-TEST_F(mutation_batch_test, add_mutation_if_valid)
+INSTANTIATE_TEST_CASE_P(, mutation_batch_test, ::testing::Values(false, true));
+
+TEST_P(mutation_batch_test, add_mutation_if_valid)
 {
     auto duplicator = create_test_duplicator(0);
     mutation_batch batcher(duplicator.get());
@@ -85,7 +88,7 @@ TEST_F(mutation_batch_test, add_mutation_if_valid)
     ASSERT_EQ(result.size(), 2);
 }
 
-TEST_F(mutation_batch_test, ignore_non_idempotent_write)
+TEST_P(mutation_batch_test, ignore_non_idempotent_write)
 {
     auto duplicator = create_test_duplicator(0);
     mutation_batch batcher(duplicator.get());
@@ -98,7 +101,7 @@ TEST_F(mutation_batch_test, ignore_non_idempotent_write)
     ASSERT_EQ(result.size(), 0);
 }
 
-TEST_F(mutation_batch_test, mutation_buffer_commit)
+TEST_P(mutation_batch_test, mutation_buffer_commit)
 {
     auto duplicator = create_test_duplicator(0);
     mutation_batch batcher(duplicator.get());

--- a/src/replica/duplication/test/replica_duplicator_manager_test.cpp
+++ b/src/replica/duplication/test/replica_duplicator_manager_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -184,24 +185,26 @@ public:
     }
 };
 
-TEST_F(replica_duplicator_manager_test, get_duplication_confirms)
+INSTANTIATE_TEST_CASE_P(, replica_duplicator_manager_test, ::testing::Values(false, true));
+
+TEST_P(replica_duplicator_manager_test, get_duplication_confirms)
 {
     test_get_duplication_confirms();
 }
 
-TEST_F(replica_duplicator_manager_test, set_confirmed_decree_non_primary)
+TEST_P(replica_duplicator_manager_test, set_confirmed_decree_non_primary)
 {
     test_set_confirmed_decree_non_primary();
 }
 
-TEST_F(replica_duplicator_manager_test, remove_non_existed_duplications)
+TEST_P(replica_duplicator_manager_test, remove_non_existed_duplications)
 {
     test_remove_non_existed_duplications();
 }
 
-TEST_F(replica_duplicator_manager_test, min_confirmed_decree) { test_min_confirmed_decree(); }
+TEST_P(replica_duplicator_manager_test, min_confirmed_decree) { test_min_confirmed_decree(); }
 
-TEST_F(replica_duplicator_manager_test, update_checkpoint_prepared)
+TEST_P(replica_duplicator_manager_test, update_checkpoint_prepared)
 {
     auto r = stub->add_primary_replica(2, 1);
     duplication_entry ent;

--- a/src/replica/duplication/test/replica_duplicator_test.cpp
+++ b/src/replica/duplication/test/replica_duplicator_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -138,11 +139,13 @@ public:
     }
 };
 
-TEST_F(replica_duplicator_test, new_duplicator) { test_new_duplicator(); }
+INSTANTIATE_TEST_CASE_P(, replica_duplicator_test, ::testing::Values(false, true));
 
-TEST_F(replica_duplicator_test, pause_start_duplication) { test_pause_start_duplication(); }
+TEST_P(replica_duplicator_test, new_duplicator) { test_new_duplicator(); }
 
-TEST_F(replica_duplicator_test, duplication_progress)
+TEST_P(replica_duplicator_test, pause_start_duplication) { test_pause_start_duplication(); }
+
+TEST_P(replica_duplicator_test, duplication_progress)
 {
     auto duplicator = create_test_duplicator();
     ASSERT_EQ(duplicator->progress().last_decree, 0); // start duplication from empty plog
@@ -171,7 +174,7 @@ TEST_F(replica_duplicator_test, duplication_progress)
     ASSERT_TRUE(duplicator_for_checkpoint->progress().checkpoint_has_prepared);
 }
 
-TEST_F(replica_duplicator_test, prapre_dup)
+TEST_P(replica_duplicator_test, prapre_dup)
 {
     auto duplicator = create_test_duplicator(invalid_decree, 100);
     replica()->update_expect_last_durable_decree(100);

--- a/src/replica/duplication/test/replica_follower_test.cpp
+++ b/src/replica/duplication/test/replica_follower_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -116,7 +117,9 @@ public:
     mock_replica_ptr _mock_replica;
 };
 
-TEST_F(replica_follower_test, test_init_master_info)
+INSTANTIATE_TEST_CASE_P(, replica_follower_test, ::testing::Values(false, true));
+
+TEST_P(replica_follower_test, test_init_master_info)
 {
     _app_info.envs.emplace(duplication_constants::kDuplicationEnvMasterClusterKey, "master");
     _app_info.envs.emplace(duplication_constants::kDuplicationEnvMasterMetasKey,
@@ -140,7 +143,7 @@ TEST_F(replica_follower_test, test_init_master_info)
     ASSERT_FALSE(_mock_replica->is_duplication_follower());
 }
 
-TEST_F(replica_follower_test, test_duplicate_checkpoint)
+TEST_P(replica_follower_test, test_duplicate_checkpoint)
 {
     _app_info.envs.emplace(duplication_constants::kDuplicationEnvMasterClusterKey, "master");
     _app_info.envs.emplace(duplication_constants::kDuplicationEnvMasterMetasKey,
@@ -160,7 +163,7 @@ TEST_F(replica_follower_test, test_duplicate_checkpoint)
     ASSERT_EQ(follower->duplicate_checkpoint(), ERR_BUSY);
 }
 
-TEST_F(replica_follower_test, test_async_duplicate_checkpoint_from_master_replica)
+TEST_P(replica_follower_test, test_async_duplicate_checkpoint_from_master_replica)
 {
     _app_info.envs.emplace(duplication_constants::kDuplicationEnvMasterClusterKey, "master");
     _app_info.envs.emplace(duplication_constants::kDuplicationEnvMasterMetasKey,
@@ -182,7 +185,7 @@ TEST_F(replica_follower_test, test_async_duplicate_checkpoint_from_master_replic
     fail::teardown();
 }
 
-TEST_F(replica_follower_test, test_update_master_replica_config)
+TEST_P(replica_follower_test, test_update_master_replica_config)
 {
     _app_info.envs.emplace(duplication_constants::kDuplicationEnvMasterClusterKey, "master");
     _app_info.envs.emplace(duplication_constants::kDuplicationEnvMasterMetasKey,
@@ -229,7 +232,7 @@ TEST_F(replica_follower_test, test_update_master_replica_config)
     ASSERT_EQ(master_replica_config(follower).pid, p.pid);
 }
 
-TEST_F(replica_follower_test, test_nfs_copy_checkpoint)
+TEST_P(replica_follower_test, test_nfs_copy_checkpoint)
 {
     _app_info.envs.emplace(duplication_constants::kDuplicationEnvMasterClusterKey, "master");
     _app_info.envs.emplace(duplication_constants::kDuplicationEnvMasterMetasKey,

--- a/src/replica/duplication/test/ship_mutation_test.cpp
+++ b/src/replica/duplication/test/ship_mutation_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -105,14 +106,16 @@ public:
     std::unique_ptr<replica_duplicator> duplicator;
 };
 
-TEST_F(ship_mutation_test, ship_mutation_tuple_set) { test_ship_mutation_tuple_set(); }
+INSTANTIATE_TEST_CASE_P(, ship_mutation_test, ::testing::Values(false, true));
+
+TEST_P(ship_mutation_test, ship_mutation_tuple_set) { test_ship_mutation_tuple_set(); }
 
 void retry(pipeline::base *base)
 {
     base->schedule([base]() { retry(base); }, 10_s);
 }
 
-TEST_F(ship_mutation_test, pause)
+TEST_P(ship_mutation_test, pause)
 {
     auto shipper = mock_ship_mutation();
 

--- a/src/replica/log_file.cpp
+++ b/src/replica/log_file.cpp
@@ -41,6 +41,7 @@
 #include "utils/binary_writer.h"
 #include "utils/blob.h"
 #include "utils/crc.h"
+#include "utils/env.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
 #include "utils/latency_tracer.h"
@@ -178,7 +179,9 @@ log_file::log_file(
 
     if (is_read) {
         int64_t sz;
-        CHECK(dsn::utils::filesystem::file_size(_path, sz), "fail to get file size of {}.", _path);
+        CHECK(dsn::utils::filesystem::file_size(_path, dsn::utils::FileDataType::kSensitive, sz),
+              "fail to get file size of {}.",
+              _path);
         _end_offset += sz;
     }
 }

--- a/src/replica/log_file_stream.h
+++ b/src/replica/log_file_stream.h
@@ -34,7 +34,6 @@
 namespace dsn {
 namespace replication {
 
-// log_file::file_streamer
 class log_file::file_streamer
 {
 public:

--- a/src/replica/mutation_cache.cpp
+++ b/src/replica/mutation_cache.cpp
@@ -26,9 +26,6 @@
 
 #include "mutation_cache.h"
 
-// HACK: iwyu suggests <ext/alloc_traits.h> each time vector[] is used.
-// https://github.com/include-what-you-use/include-what-you-use/issues/166
-// TODO(yingchun): remove this pragma by using mapping.imp
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include "consensus_types.h"
 #include "mutation.h"

--- a/src/replica/mutation_log_replay.cpp
+++ b/src/replica/mutation_log_replay.cpp
@@ -140,7 +140,7 @@ namespace replication {
         if (log == nullptr) {
             if (err == ERR_HANDLE_EOF || err == ERR_INCOMPLETE_DATA ||
                 err == ERR_INVALID_PARAMETERS) {
-                LOG_DEBUG("skip file {} during log replay", fpath);
+                LOG_INFO("skip file {} during log replay", fpath);
                 continue;
             } else {
                 return err;

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -450,7 +450,7 @@ private:
 
     /////////////////////////////////////////////////////////////////
     // replica restore from backup
-    bool read_cold_backup_metadata(const std::string &file, cold_backup_metadata &backup_metadata);
+    bool read_cold_backup_metadata(const std::string &fname, cold_backup_metadata &backup_metadata);
     // checkpoint on cold backup media maybe contain useless file,
     // we should abandon these file base cold_backup_metadata
     bool remove_useless_file_under_chkpt(const std::string &chkpt_dir,
@@ -555,7 +555,7 @@ private:
     friend class ::pegasus::server::pegasus_server_test_base;
     friend class ::pegasus::server::rocksdb_wrapper_test;
     FRIEND_TEST(replica_disk_test, disk_io_error_test);
-    FRIEND_TEST(replica_error_test, test_auto_trash_of_corruption);
+    FRIEND_TEST(replica_test, test_auto_trash_of_corruption);
 
     // replica configuration, updated by update_local_configuration ONLY
     replica_configuration _config;

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -51,6 +51,7 @@
 #include "runtime/api_layer1.h"
 #include "runtime/task/async_calls.h"
 #include "utils/autoref_ptr.h"
+#include "utils/env.h"
 #include "utils/error_code.h"
 #include "utils/filesystem.h"
 #include "utils/flags.h"
@@ -386,10 +387,12 @@ statistic_file_infos_under_dir(const std::string &dir,
     total_size = 0;
     file_infos.clear();
 
+    // TODO(yingchun): check if there are any files that are not sensitive (not encrypted).
     for (std::string &file : sub_files) {
         std::pair<std::string, int64_t> file_info;
 
-        if (!utils::filesystem::file_size(file, file_info.second)) {
+        if (!utils::filesystem::file_size(
+                file, dsn::utils::FileDataType::kSensitive, file_info.second)) {
             LOG_ERROR("get file size of {} failed", file);
             return false;
         }

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -105,7 +105,8 @@ bool replica::read_cold_backup_metadata(const std::string &fname,
     }
 
     std::string data;
-    auto s = rocksdb::ReadFileToString(rocksdb::Env::Default(), fname, &data);
+    auto s = rocksdb::ReadFileToString(
+        dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive), fname, &data);
     if (!s.ok()) {
         LOG_ERROR_PREFIX("read file '{}' failed, err = {}", fname, s.ToString());
         return false;

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -446,7 +446,7 @@ private:
     friend class replica_follower_test;
     friend class replica_http_service_test;
     FRIEND_TEST(open_replica_test, open_replica_add_decree_and_ballot_check);
-    FRIEND_TEST(replica_error_test, test_auto_trash_of_corruption);
+    FRIEND_TEST(replica_test, test_auto_trash_of_corruption);
     FRIEND_TEST(replica_test, test_clear_on_failure);
     FRIEND_TEST(GcSlogFlushFeplicasTest, FlushReplicas);
 

--- a/src/replica/split/test/replica_split_test.cpp
+++ b/src/replica/split/test/replica_split_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -558,8 +559,10 @@ public:
     learn_state _mock_learn_state;
 };
 
+INSTANTIATE_TEST_CASE_P(, replica_split_test, ::testing::Values(false, true));
+
 // parent_start_split tests
-TEST_F(replica_split_test, parent_start_split_tests)
+TEST_P(replica_split_test, parent_start_split_tests)
 {
     fail::cfg("replica_stub_create_child_replica_if_not_found", "return()");
     fail::cfg("replica_child_init_replica", "return()");
@@ -595,7 +598,7 @@ TEST_F(replica_split_test, parent_start_split_tests)
 }
 
 // child_init_replica test
-TEST_F(replica_split_test, child_init_replica_test)
+TEST_P(replica_split_test, child_init_replica_test)
 {
     fail::cfg("replica_stub_split_replica_exec", "return()");
     test_child_init_replica();
@@ -605,7 +608,7 @@ TEST_F(replica_split_test, child_init_replica_test)
 }
 
 // parent_check_states tests
-TEST_F(replica_split_test, parent_check_states_tests)
+TEST_P(replica_split_test, parent_check_states_tests)
 {
     fail::cfg("replica_stub_split_replica_exec", "return()");
 
@@ -625,7 +628,7 @@ TEST_F(replica_split_test, parent_check_states_tests)
 }
 
 // child_copy_prepare_list test
-TEST_F(replica_split_test, copy_prepare_list_succeed)
+TEST_P(replica_split_test, copy_prepare_list_succeed)
 {
     fail::cfg("replica_stub_split_replica_exec", "return()");
     fail::cfg("replica_child_learn_states", "return()");
@@ -642,7 +645,7 @@ TEST_F(replica_split_test, copy_prepare_list_succeed)
 }
 
 // child_learn_states tests
-TEST_F(replica_split_test, child_learn_states_tests)
+TEST_P(replica_split_test, child_learn_states_tests)
 {
     generate_child();
 
@@ -674,7 +677,7 @@ TEST_F(replica_split_test, child_learn_states_tests)
 }
 
 // child_apply_private_logs test
-TEST_F(replica_split_test, child_apply_private_logs_succeed)
+TEST_P(replica_split_test, child_apply_private_logs_succeed)
 {
     fail::cfg("mutation_log_replay_succeed", "return()");
     fail::cfg("replication_app_base_apply_mutation", "return()");
@@ -688,7 +691,7 @@ TEST_F(replica_split_test, child_apply_private_logs_succeed)
 }
 
 // child_catch_up_states tests
-TEST_F(replica_split_test, child_catch_up_states_tests)
+TEST_P(replica_split_test, child_catch_up_states_tests)
 {
     fail::cfg("replica_child_notify_catch_up", "return()");
     fail::cfg("replication_app_base_apply_mutation", "return()");
@@ -713,7 +716,7 @@ TEST_F(replica_split_test, child_catch_up_states_tests)
 }
 
 // parent_handle_child_catch_up tests
-TEST_F(replica_split_test, parent_handle_catch_up_test)
+TEST_P(replica_split_test, parent_handle_catch_up_test)
 {
     fail::cfg("replica_parent_check_sync_point_commit", "return()");
     ballot WRONG_BALLOT = 1;
@@ -739,7 +742,7 @@ TEST_F(replica_split_test, parent_handle_catch_up_test)
 }
 
 // update_child_group_partition_count tests
-TEST_F(replica_split_test, update_child_group_partition_count_test)
+TEST_P(replica_split_test, update_child_group_partition_count_test)
 {
     fail::cfg("replica_parent_update_partition_count_request", "return()");
     generate_child();
@@ -775,7 +778,7 @@ TEST_F(replica_split_test, update_child_group_partition_count_test)
 }
 
 // on_update_child_group_partition_count tests
-TEST_F(replica_split_test, child_update_partition_count_test)
+TEST_P(replica_split_test, child_update_partition_count_test)
 {
     ballot WRONG_BALLOT = INIT_BALLOT + 1;
     generate_child();
@@ -802,7 +805,7 @@ TEST_F(replica_split_test, child_update_partition_count_test)
 }
 
 // on_update_child_group_partition_count_reply tests
-TEST_F(replica_split_test, parent_on_update_partition_reply_test)
+TEST_P(replica_split_test, parent_on_update_partition_reply_test)
 {
     fail::cfg("replica_register_child_on_meta", "return()");
     generate_child();
@@ -836,7 +839,7 @@ TEST_F(replica_split_test, parent_on_update_partition_reply_test)
 }
 
 // register_child test
-TEST_F(replica_split_test, register_child_test)
+TEST_P(replica_split_test, register_child_test)
 {
     fail::cfg("replica_parent_send_register_request", "return()");
     test_register_child_on_meta();
@@ -845,7 +848,7 @@ TEST_F(replica_split_test, register_child_test)
 }
 
 // register_child_reply tests
-TEST_F(replica_split_test, register_child_reply_test)
+TEST_P(replica_split_test, register_child_reply_test)
 {
     fail::cfg("replica_init_group_check", "return()");
     fail::cfg("replica_broadcast_group_check", "return()");
@@ -878,7 +881,7 @@ TEST_F(replica_split_test, register_child_reply_test)
 }
 
 // trigger_primary_parent_split unit test
-TEST_F(replica_split_test, trigger_primary_parent_split_test)
+TEST_P(replica_split_test, trigger_primary_parent_split_test)
 {
     fail::cfg("replica_broadcast_group_check", "return()");
     generate_child();
@@ -923,7 +926,7 @@ TEST_F(replica_split_test, trigger_primary_parent_split_test)
 }
 
 // trigger_secondary_parent_split unit test
-TEST_F(replica_split_test, secondary_handle_split_test)
+TEST_P(replica_split_test, secondary_handle_split_test)
 {
     generate_child();
 
@@ -970,7 +973,7 @@ TEST_F(replica_split_test, secondary_handle_split_test)
     }
 }
 
-TEST_F(replica_split_test, primary_parent_handle_stop_test)
+TEST_P(replica_split_test, primary_parent_handle_stop_test)
 {
     fail::cfg("replica_parent_send_notify_stop_request", "return()");
     // Test cases:
@@ -1002,7 +1005,7 @@ TEST_F(replica_split_test, primary_parent_handle_stop_test)
     }
 }
 
-TEST_F(replica_split_test, query_child_state_reply_test)
+TEST_P(replica_split_test, query_child_state_reply_test)
 {
     fail::cfg("replica_init_group_check", "return()");
     fail::cfg("replica_broadcast_group_check", "return()");
@@ -1014,7 +1017,7 @@ TEST_F(replica_split_test, query_child_state_reply_test)
     ASSERT_TRUE(primary_parent_not_in_split());
 }
 
-TEST_F(replica_split_test, check_partition_hash_test)
+TEST_P(replica_split_test, check_partition_hash_test)
 {
     uint64_t send_to_parent_after_split = 1;
     uint64_t send_to_child_after_split = 9;

--- a/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
@@ -58,6 +58,7 @@
 #include "utils/autoref_ptr.h"
 #include "utils/binary_reader.h"
 #include "utils/blob.h"
+#include "utils/env.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
 #include "utils/utils.h"
@@ -186,7 +187,8 @@ void simple_kv_service_impl::recover(const std::string &name, int64_t version)
     zauto_lock l(_lock);
 
     std::unique_ptr<rocksdb::SequentialFile> rfile;
-    auto s = rocksdb::Env::Default()->NewSequentialFile(name, &rfile, rocksdb::EnvOptions());
+    auto s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)
+                 ->NewSequentialFile(name, &rfile, rocksdb::EnvOptions());
     CHECK(s.ok(), "open log file '{}' failed, err = {}", name, s.ToString());
 
     _store.clear();

--- a/src/replica/storage/simple_kv/test/run.sh
+++ b/src/replica/storage/simple_kv/test/run.sh
@@ -118,8 +118,7 @@ if [ ! -z "${cases}" ]; then
         run_case ${id}
         echo
     done
-    # TODO(yingchun): ENCRYPTION: add enable encryption test.
-    # TEST_OPTS=${OLD_TEST_OPTS},encrypt_data_at_rest=true
+    TEST_OPTS=${OLD_TEST_OPTS},encrypt_data_at_rest=true
     for id in ${cases}; do
         run_case ${id}
         echo

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
@@ -46,6 +46,7 @@
 #include "utils/autoref_ptr.h"
 #include "utils/binary_reader.h"
 #include "utils/blob.h"
+#include "utils/env.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
 #include "utils/threadpool_code.h"
@@ -189,7 +190,8 @@ void simple_kv_service_impl::recover(const std::string &name, int64_t version)
     dsn::zauto_lock l(_lock);
 
     std::unique_ptr<rocksdb::SequentialFile> rfile;
-    auto s = rocksdb::Env::Default()->NewSequentialFile(name, &rfile, rocksdb::EnvOptions());
+    auto s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)
+                 ->NewSequentialFile(name, &rfile, rocksdb::EnvOptions());
     CHECK(s.ok(), "open log file '{}' failed, err = {}", name, s.ToString());
 
     _store.clear();

--- a/src/replica/test/log_block_test.cpp
+++ b/src/replica/test/log_block_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -39,7 +40,9 @@ class log_block_test : public replica_test_base
 {
 };
 
-TEST_F(log_block_test, constructor)
+INSTANTIATE_TEST_CASE_P(, log_block_test, ::testing::Values(false, true));
+
+TEST_P(log_block_test, constructor)
 {
     log_block block(1);
     ASSERT_EQ(block.data().size(), 1);
@@ -47,7 +50,7 @@ TEST_F(log_block_test, constructor)
     ASSERT_EQ(block.start_offset(), 1);
 }
 
-TEST_F(log_block_test, log_block_header)
+TEST_P(log_block_test, log_block_header)
 {
     log_block block(10);
     auto hdr = (log_block_header *)block.front().data();
@@ -60,7 +63,9 @@ class log_appender_test : public replica_test_base
 {
 };
 
-TEST_F(log_appender_test, constructor)
+INSTANTIATE_TEST_CASE_P(, log_appender_test, ::testing::Values(false, true));
+
+TEST_P(log_appender_test, constructor)
 {
     log_block block;
     binary_writer temp_writer;
@@ -75,7 +80,7 @@ TEST_F(log_appender_test, constructor)
     ASSERT_EQ(appender.callbacks().size(), 0);
 }
 
-TEST_F(log_appender_test, append_mutation)
+TEST_P(log_appender_test, append_mutation)
 {
     log_appender appender(10);
     for (int i = 0; i < 5; i++) {
@@ -88,7 +93,7 @@ TEST_F(log_appender_test, append_mutation)
     ASSERT_EQ(appender.blob_count(), 1 + 5 * 2);
 }
 
-TEST_F(log_appender_test, log_block_not_full)
+TEST_P(log_appender_test, log_block_not_full)
 {
     log_appender appender(10);
     for (int i = 0; i < 5; i++) {
@@ -106,7 +111,7 @@ TEST_F(log_appender_test, log_block_not_full)
     ASSERT_EQ(block.data().size(), 1 + 5 * 2);
 }
 
-TEST_F(log_appender_test, log_block_full)
+TEST_P(log_appender_test, log_block_full)
 {
     log_appender appender(10);
     for (int i = 0; i < 1024; i++) { // more than DEFAULT_MAX_BLOCK_BYTES
@@ -130,7 +135,7 @@ TEST_F(log_appender_test, log_block_full)
     ASSERT_EQ(sz, appender.size());
 }
 
-TEST_F(log_appender_test, read_log_block)
+TEST_P(log_appender_test, read_log_block)
 {
     log_appender appender(10);
     for (int i = 0; i < 1024; i++) { // more than DEFAULT_MAX_BLOCK_BYTES

--- a/src/replica/test/log_file_test.cpp
+++ b/src/replica/test/log_file_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -56,7 +57,9 @@ protected:
     size_t _start_offset{10};
 };
 
-TEST_F(log_file_test, commit_log_blocks)
+INSTANTIATE_TEST_CASE_P(, log_file_test, ::testing::Values(false, true));
+
+TEST_P(log_file_test, commit_log_blocks)
 {
     // write one block
     auto appender = std::make_shared<log_appender>(_start_offset);

--- a/src/replica/test/main.cpp
+++ b/src/replica/test/main.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 #include <chrono>
 #include <string>
@@ -24,27 +25,35 @@
 #include "replication_service_test_app.h"
 #include "runtime/app_model.h"
 #include "runtime/service_app.h"
+#include "test_util/test_util.h"
 #include "utils/error_code.h"
 
 int gtest_flags = 0;
 int gtest_ret = 0;
 replication_service_test_app *app;
 
-TEST(cold_backup_context, check_backup_on_remote) { app->check_backup_on_remote_test(); }
+class cold_backup_context_test : public pegasus::encrypt_data_test_base
+{
+};
 
-TEST(cold_backup_context, read_current_chkpt_file) { app->read_current_chkpt_file_test(); }
+TEST_P(cold_backup_context_test, check_backup_on_remote) { app->check_backup_on_remote_test(); }
 
-TEST(cold_backup_context, remote_chkpt_dir_exist) { app->remote_chkpt_dir_exist_test(); }
+TEST_P(cold_backup_context_test, read_current_chkpt_file) { app->read_current_chkpt_file_test(); }
 
-TEST(cold_backup_context, upload_checkpoint_to_remote) { app->upload_checkpoint_to_remote_test(); }
+TEST_P(cold_backup_context_test, remote_chkpt_dir_exist) { app->remote_chkpt_dir_exist_test(); }
 
-TEST(cold_backup_context, read_backup_metadata) { app->read_backup_metadata_test(); }
+TEST_P(cold_backup_context_test, upload_checkpoint_to_remote)
+{
+    app->upload_checkpoint_to_remote_test();
+}
 
-TEST(cold_backup_context, on_upload_chkpt_dir) { app->on_upload_chkpt_dir_test(); }
+TEST_P(cold_backup_context_test, read_backup_metadata) { app->read_backup_metadata_test(); }
 
-TEST(cold_backup_context, write_metadata_file) { app->write_backup_metadata_test(); }
+TEST_P(cold_backup_context_test, on_upload_chkpt_dir) { app->on_upload_chkpt_dir_test(); }
 
-TEST(cold_backup_context, write_current_chkpt_file) { app->write_current_chkpt_file_test(); }
+TEST_P(cold_backup_context_test, write_metadata_file) { app->write_backup_metadata_test(); }
+
+TEST_P(cold_backup_context_test, write_current_chkpt_file) { app->write_current_chkpt_file_test(); }
 
 error_code replication_service_test_app::start(const std::vector<std::string> &args)
 {

--- a/src/replica/test/mutation_log_learn_test.cpp
+++ b/src/replica/test/mutation_log_learn_test.cpp
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -56,11 +57,13 @@ class message_ex;
 
 namespace replication {
 
-class mutation_log_test : public replica_test_base
+class mutation_log_learn_test : public replica_test_base
 {
 };
 
-TEST_F(mutation_log_test, learn)
+INSTANTIATE_TEST_CASE_P(, mutation_log_learn_test, ::testing::Values(false, true));
+
+TEST_P(mutation_log_learn_test, learn)
 {
     std::chrono::steady_clock clock;
     gpid gpid(1, 1);

--- a/src/replica/test/mutation_log_test.cpp
+++ b/src/replica/test/mutation_log_test.cpp
@@ -49,6 +49,7 @@
 #include "replica/test/mock_utils.h"
 #include "replica_test_base.h"
 #include "rrdb/rrdb.code.definition.h"
+#include "test_util/test_util.h"
 #include "utils/binary_reader.h"
 #include "utils/binary_writer.h"
 #include "utils/blob.h"
@@ -86,7 +87,13 @@ static void overwrite_file(const char *file, int offset, const void *buf, int si
     ASSERT_EQ(ERR_OK, file::close(wfile));
 }
 
-TEST(replication_test, log_file)
+class replication_test : public pegasus::encrypt_data_test_base
+{
+};
+
+INSTANTIATE_TEST_CASE_P(, replication_test, ::testing::Values(false, true));
+
+TEST_P(replication_test, log_file)
 {
     replica_log_info_map mdecrees;
     gpid gpid(1, 0);
@@ -522,20 +529,22 @@ public:
     }
 };
 
-TEST_F(mutation_log_test, replay_single_file_1000) { test_replay_single_file(1000); }
+INSTANTIATE_TEST_CASE_P(, mutation_log_test, ::testing::Values(false, true));
 
-TEST_F(mutation_log_test, replay_single_file_2000) { test_replay_single_file(2000); }
+TEST_P(mutation_log_test, replay_single_file_1000) { test_replay_single_file(1000); }
 
-TEST_F(mutation_log_test, replay_single_file_5000) { test_replay_single_file(5000); }
+TEST_P(mutation_log_test, replay_single_file_2000) { test_replay_single_file(2000); }
 
-TEST_F(mutation_log_test, replay_single_file_10000) { test_replay_single_file(10000); }
+TEST_P(mutation_log_test, replay_single_file_5000) { test_replay_single_file(5000); }
 
-TEST_F(mutation_log_test, replay_single_file_1) { test_replay_single_file(1); }
+TEST_P(mutation_log_test, replay_single_file_10000) { test_replay_single_file(10000); }
 
-TEST_F(mutation_log_test, replay_single_file_10) { test_replay_single_file(10); }
+TEST_P(mutation_log_test, replay_single_file_1) { test_replay_single_file(1); }
+
+TEST_P(mutation_log_test, replay_single_file_10) { test_replay_single_file(10); }
 
 // mutation_log::open
-TEST_F(mutation_log_test, open)
+TEST_P(mutation_log_test, open)
 {
     std::vector<mutation_ptr> mutations;
 
@@ -568,13 +577,13 @@ TEST_F(mutation_log_test, open)
     }
 }
 
-TEST_F(mutation_log_test, replay_multiple_files_10000_1mb) { test_replay_multiple_files(10000, 1); }
+TEST_P(mutation_log_test, replay_multiple_files_10000_1mb) { test_replay_multiple_files(10000, 1); }
 
-TEST_F(mutation_log_test, replay_multiple_files_20000_1mb) { test_replay_multiple_files(20000, 1); }
+TEST_P(mutation_log_test, replay_multiple_files_20000_1mb) { test_replay_multiple_files(20000, 1); }
 
-TEST_F(mutation_log_test, replay_multiple_files_50000_1mb) { test_replay_multiple_files(50000, 1); }
+TEST_P(mutation_log_test, replay_multiple_files_50000_1mb) { test_replay_multiple_files(50000, 1); }
 
-TEST_F(mutation_log_test, replay_start_decree)
+TEST_P(mutation_log_test, replay_start_decree)
 {
     // decree ranges from [1, 30)
     generate_multiple_log_files(3);
@@ -587,7 +596,7 @@ TEST_F(mutation_log_test, replay_start_decree)
     ASSERT_EQ(mlog->get_log_file_map().size(), 3);
 }
 
-TEST_F(mutation_log_test, reset_from)
+TEST_P(mutation_log_test, reset_from)
 {
     std::vector<mutation_ptr> expected;
     { // writing logs
@@ -635,7 +644,7 @@ TEST_F(mutation_log_test, reset_from)
 
 // multi-threaded testing. ensure reset_from will wait until
 // all previous writes complete.
-TEST_F(mutation_log_test, reset_from_while_writing)
+TEST_P(mutation_log_test, reset_from_while_writing)
 {
     std::vector<mutation_ptr> expected;
     { // writing logs
@@ -677,7 +686,7 @@ TEST_F(mutation_log_test, reset_from_while_writing)
     ASSERT_EQ(actual.size(), expected.size());
 }
 
-TEST_F(mutation_log_test, gc_slog)
+TEST_P(mutation_log_test, gc_slog)
 {
     // Remove the slog dir and create a new one.
     const std::string slog_dir("./slog_test");

--- a/src/replica/test/open_replica_test.cpp
+++ b/src/replica/test/open_replica_test.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <gtest/gtest-death-test.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -46,7 +47,9 @@ public:
     ~open_replica_test() { dsn::utils::filesystem::remove_path("./tmp_dir"); }
 };
 
-TEST_F(open_replica_test, open_replica_add_decree_and_ballot_check)
+INSTANTIATE_TEST_CASE_P(, open_replica_test, ::testing::Values(false, true));
+
+TEST_P(open_replica_test, open_replica_add_decree_and_ballot_check)
 {
     app_info ai;
     ai.app_type = "replica";

--- a/src/replica/test/replica_disk_migrate_test.cpp
+++ b/src/replica/test/replica_disk_migrate_test.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <fmt/core.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -149,7 +150,9 @@ private:
     }
 };
 
-TEST_F(replica_disk_migrate_test, on_migrate_replica)
+INSTANTIATE_TEST_CASE_P(, replica_disk_migrate_test, ::testing::Values(false, true));
+
+TEST_P(replica_disk_migrate_test, on_migrate_replica)
 {
     auto &request = *fake_migrate_rpc.mutable_request();
     auto &response = fake_migrate_rpc.response();
@@ -169,7 +172,7 @@ TEST_F(replica_disk_migrate_test, on_migrate_replica)
     ASSERT_EQ(response.err, ERR_OK);
 }
 
-TEST_F(replica_disk_migrate_test, migrate_disk_replica_check)
+TEST_P(replica_disk_migrate_test, migrate_disk_replica_check)
 {
     auto &request = *fake_migrate_rpc.mutable_request();
     auto &response = fake_migrate_rpc.response();
@@ -228,7 +231,7 @@ TEST_F(replica_disk_migrate_test, migrate_disk_replica_check)
     ASSERT_EQ(response.err, ERR_OK);
 }
 
-TEST_F(replica_disk_migrate_test, disk_migrate_replica_run)
+TEST_P(replica_disk_migrate_test, disk_migrate_replica_run)
 {
     auto &request = *fake_migrate_rpc.mutable_request();
 
@@ -293,7 +296,7 @@ TEST_F(replica_disk_migrate_test, disk_migrate_replica_run)
     ASSERT_EQ(replica_ptr->disk_migrator()->status(), disk_migration_status::IDLE);
 }
 
-TEST_F(replica_disk_migrate_test, disk_migrate_replica_close)
+TEST_P(replica_disk_migrate_test, disk_migrate_replica_close)
 {
     auto &request = *fake_migrate_rpc.mutable_request();
     request.pid = dsn::gpid(app_info_1.app_id, 2);
@@ -308,7 +311,7 @@ TEST_F(replica_disk_migrate_test, disk_migrate_replica_close)
     ASSERT_TRUE(close_current_replica(fake_migrate_rpc));
 }
 
-TEST_F(replica_disk_migrate_test, disk_migrate_replica_update)
+TEST_P(replica_disk_migrate_test, disk_migrate_replica_update)
 {
     auto &request = *fake_migrate_rpc.mutable_request();
     request.pid = dsn::gpid(app_info_1.app_id, 3);
@@ -364,7 +367,7 @@ TEST_F(replica_disk_migrate_test, disk_migrate_replica_update)
 
 // Test load from new replica dir failed, then fall back to load from origin dir succeed,
 // and then mark the "new" replica dir as ".gar".
-TEST_F(replica_disk_migrate_test, disk_migrate_replica_open)
+TEST_P(replica_disk_migrate_test, disk_migrate_replica_open)
 {
     gpid test_pid(app_info_1.app_id, 4);
 

--- a/src/replica/test/replica_disk_test.cpp
+++ b/src/replica/test/replica_disk_test.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -86,7 +87,9 @@ public:
     }
 };
 
-TEST_F(replica_disk_test, on_query_disk_info_all_app)
+INSTANTIATE_TEST_CASE_P(, replica_disk_test, ::testing::Values(false, true));
+
+TEST_P(replica_disk_test, on_query_disk_info_all_app)
 {
     generate_fake_rpc();
     stub->on_query_disk_info(fake_query_disk_rpc);
@@ -160,7 +163,7 @@ TEST_F(replica_disk_test, on_query_disk_info_all_app)
     }
 }
 
-TEST_F(replica_disk_test, on_query_disk_info_app_not_existed)
+TEST_P(replica_disk_test, on_query_disk_info_app_not_existed)
 {
     generate_fake_rpc();
     query_disk_info_request &request = *fake_query_disk_rpc.mutable_request();
@@ -169,7 +172,7 @@ TEST_F(replica_disk_test, on_query_disk_info_app_not_existed)
     ASSERT_EQ(fake_query_disk_rpc.response().err, ERR_OBJECT_NOT_FOUND);
 }
 
-TEST_F(replica_disk_test, on_query_disk_info_one_app)
+TEST_P(replica_disk_test, on_query_disk_info_one_app)
 {
     generate_fake_rpc();
     query_disk_info_request &request = *fake_query_disk_rpc.mutable_request();
@@ -195,7 +198,7 @@ TEST_F(replica_disk_test, on_query_disk_info_one_app)
     }
 }
 
-TEST_F(replica_disk_test, gc_disk_useless_dir)
+TEST_P(replica_disk_test, gc_disk_useless_dir)
 {
     FLAGS_gc_disk_error_replica_interval_seconds = 1;
     FLAGS_gc_disk_garbage_replica_interval_seconds = 1;
@@ -237,7 +240,7 @@ TEST_F(replica_disk_test, gc_disk_useless_dir)
     ASSERT_EQ(report.error_replica_count, 2);
 }
 
-TEST_F(replica_disk_test, disk_status_test)
+TEST_P(replica_disk_test, disk_status_test)
 {
     struct disk_status_test
     {
@@ -261,7 +264,7 @@ TEST_F(replica_disk_test, disk_status_test)
     dn->status = disk_status::NORMAL;
 }
 
-TEST_F(replica_disk_test, add_new_disk_test)
+TEST_P(replica_disk_test, add_new_disk_test)
 {
     // Test case:
     // - invalid params
@@ -291,7 +294,7 @@ TEST_F(replica_disk_test, add_new_disk_test)
     }
 }
 
-TEST_F(replica_disk_test, disk_io_error_test)
+TEST_P(replica_disk_test, disk_io_error_test)
 {
     // Disable failure detector to avoid connecting with meta server which is not started.
     FLAGS_fd_disabled = true;

--- a/src/replica/test/replica_http_service_test.cpp
+++ b/src/replica/test/replica_http_service_test.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <fmt/core.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -32,6 +33,7 @@
 #include "replica/test/mock_utils.h"
 #include "replica/test/replica_test_base.h"
 #include "utils/flags.h"
+#include "utils/test_macros.h"
 
 using std::map;
 using std::string;
@@ -54,6 +56,15 @@ public:
 
         http_call_registry::instance().clear_paths();
         _http_svc = std::make_unique<replica_http_service>(stub.get());
+    }
+
+    void SetUp() override
+    {
+        // Reset config_sync_interval_ms to 30000.
+        NO_FATALS(test_update_config({{"config_sync_interval_ms", "30000"}},
+                                     R"({"update_status":"ERR_OK"})"
+                                     "\n"));
+        NO_FATALS(test_check_config("config_sync_interval_ms", "30000"));
     }
 
     void test_update_config(const map<string, string> &configs, const string &expect_resp)
@@ -86,40 +97,42 @@ private:
     std::unique_ptr<replica_http_service> _http_svc;
 };
 
-TEST_F(replica_http_service_test, update_config_handler)
+INSTANTIATE_TEST_CASE_P(, replica_http_service_test, ::testing::Values(false, true));
+
+TEST_P(replica_http_service_test, update_config_handler)
 {
     // Test the default value.
-    test_check_config("config_sync_interval_ms", "30000");
+    NO_FATALS(test_check_config("config_sync_interval_ms", "30000"));
     ASSERT_EQ(30000, FLAGS_config_sync_interval_ms);
 
     // Update config failed and value not changed.
-    test_update_config(
+    NO_FATALS(test_update_config(
         {},
         R"({"update_status":"ERR_INVALID_PARAMETERS: there should be exactly one config to be updated once"})"
-        "\n");
-    test_check_config("config_sync_interval_ms", "30000");
+        "\n"));
+    NO_FATALS(test_check_config("config_sync_interval_ms", "30000"));
     ASSERT_EQ(30000, FLAGS_config_sync_interval_ms);
 
     // Update config failed and value not changed.
-    test_update_config(
+    NO_FATALS(test_update_config(
         {{"config_sync_interval_ms", "10"}, {"fds_write_limit_rate", "50"}},
         R"({"update_status":"ERR_INVALID_PARAMETERS: there should be exactly one config to be updated once"})"
-        "\n");
-    test_check_config("config_sync_interval_ms", "30000");
+        "\n"));
+    NO_FATALS(test_check_config("config_sync_interval_ms", "30000"));
     ASSERT_EQ(30000, FLAGS_config_sync_interval_ms);
 
     // Update config failed and value not changed.
-    test_update_config({{"config_sync_interval_ms", "-1"}},
-                       R"({"update_status":"ERR_INVALID_PARAMETERS: -1 is invalid"})"
-                       "\n");
-    test_check_config("config_sync_interval_ms", "30000");
+    NO_FATALS(test_update_config({{"config_sync_interval_ms", "-1"}},
+                                 R"({"update_status":"ERR_INVALID_PARAMETERS: -1 is invalid"})"
+                                 "\n"));
+    NO_FATALS(test_check_config("config_sync_interval_ms", "30000"));
     ASSERT_EQ(30000, FLAGS_config_sync_interval_ms);
 
     // Update config success and value changed.
-    test_update_config({{"config_sync_interval_ms", "10"}},
-                       R"({"update_status":"ERR_OK"})"
-                       "\n");
-    test_check_config("config_sync_interval_ms", "10");
+    NO_FATALS(test_update_config({{"config_sync_interval_ms", "10"}},
+                                 R"({"update_status":"ERR_OK"})"
+                                 "\n"));
+    NO_FATALS(test_check_config("config_sync_interval_ms", "10"));
     ASSERT_EQ(10, FLAGS_config_sync_interval_ms);
 }
 

--- a/src/replica/test/replica_learn_test.cpp
+++ b/src/replica/test/replica_learn_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -180,9 +181,11 @@ public:
     }
 };
 
-TEST_F(replica_learn_test, get_learn_start_decree) { test_get_learn_start_decree(); }
+INSTANTIATE_TEST_CASE_P(, replica_learn_test, ::testing::Values(false, true));
 
-TEST_F(replica_learn_test, get_max_gced_decree_for_learn) { test_get_max_gced_decree_for_learn(); }
+TEST_P(replica_learn_test, get_learn_start_decree) { test_get_learn_start_decree(); }
+
+TEST_P(replica_learn_test, get_max_gced_decree_for_learn) { test_get_max_gced_decree_for_learn(); }
 
 } // namespace replication
 } // namespace dsn

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -16,7 +16,7 @@
 // under the License.
 
 #include <gmock/gmock-matchers.h>
-#include <gtest/gtest-param-test.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -61,6 +61,7 @@
 #include "runtime/task/task_tracker.h"
 #include "utils/autoref_ptr.h"
 #include "utils/defer.h"
+#include "utils/env.h"
 #include "utils/error_code.h"
 #include "utils/filesystem.h"
 #include "utils/flags.h"
@@ -185,7 +186,8 @@ public:
             cold_backup::get_current_chkpt_file(backup_root, req.app_name, req.pid, req.backup_id);
         ASSERT_TRUE(dsn::utils::filesystem::file_exists(current_chkpt_file));
         int64_t size = 0;
-        dsn::utils::filesystem::file_size(current_chkpt_file, size);
+        dsn::utils::filesystem::file_size(
+            current_chkpt_file, dsn::utils::FileDataType::kSensitive, size);
         ASSERT_LT(0, size);
     }
 
@@ -241,7 +243,7 @@ public:
 
         // load new max_replica_count from file
         auto err = replica_info.load(path);
-        ASSERT_EQ(err, ERR_OK);
+        ASSERT_EQ(ERR_OK, err);
         ASSERT_EQ(info, _mock_replica->_app_info);
         std::cout << "the loaded new app_info is " << info << std::endl;
 
@@ -256,6 +258,8 @@ public:
         std::cout << "the loaded original app_info is " << info << std::endl;
     }
 
+    void test_auto_trash(error_code ec);
+
 public:
     dsn::app_info _app_info;
     dsn::gpid _pid;
@@ -267,7 +271,9 @@ private:
     const std::string _policy_name;
 };
 
-TEST_F(replica_test, write_size_limited)
+INSTANTIATE_TEST_CASE_P(, replica_test, ::testing::Values(false, true));
+
+TEST_P(replica_test, write_size_limited)
 {
     int count = 100;
     struct dsn::message_header header;
@@ -287,7 +293,7 @@ TEST_F(replica_test, write_size_limited)
     ASSERT_EQ(get_write_size_exceed_threshold_count(), count);
 }
 
-TEST_F(replica_test, backup_request_qps)
+TEST_P(replica_test, backup_request_qps)
 {
     // create backup request
     struct dsn::message_header header;
@@ -306,7 +312,7 @@ TEST_F(replica_test, backup_request_qps)
     ASSERT_GT(get_table_level_backup_request_qps(), 0);
 }
 
-TEST_F(replica_test, query_data_version_test)
+TEST_P(replica_test, query_data_version_test)
 {
     replica_http_service http_svc(stub.get());
     struct query_data_version_test
@@ -333,7 +339,7 @@ TEST_F(replica_test, query_data_version_test)
     }
 }
 
-TEST_F(replica_test, query_compaction_test)
+TEST_P(replica_test, query_compaction_test)
 {
     replica_http_service http_svc(stub.get());
     struct query_compaction_test
@@ -361,7 +367,7 @@ TEST_F(replica_test, query_compaction_test)
     }
 }
 
-TEST_F(replica_test, update_validate_partition_hash_test)
+TEST_P(replica_test, update_validate_partition_hash_test)
 {
     struct update_validate_partition_hash_test
     {
@@ -384,7 +390,7 @@ TEST_F(replica_test, update_validate_partition_hash_test)
     }
 }
 
-TEST_F(replica_test, update_allow_ingest_behind_test)
+TEST_P(replica_test, update_allow_ingest_behind_test)
 {
     struct update_allow_ingest_behind_test
     {
@@ -407,24 +413,26 @@ TEST_F(replica_test, update_allow_ingest_behind_test)
     }
 }
 
-TEST_F(replica_test, test_replica_backup_and_restore)
+TEST_P(replica_test, test_replica_backup_and_restore)
 {
     // TODO(yingchun): this test last too long time, optimize it!
+    return;
     test_on_cold_backup();
     auto err = test_find_valid_checkpoint();
     ASSERT_EQ(ERR_OK, err);
 }
 
-TEST_F(replica_test, test_replica_backup_and_restore_with_specific_path)
+TEST_P(replica_test, test_replica_backup_and_restore_with_specific_path)
 {
     // TODO(yingchun): this test last too long time, optimize it!
+    return;
     std::string user_specified_path = "test/backup";
     test_on_cold_backup(user_specified_path);
     auto err = test_find_valid_checkpoint(user_specified_path);
     ASSERT_EQ(ERR_OK, err);
 }
 
-TEST_F(replica_test, test_trigger_manual_emergency_checkpoint)
+TEST_P(replica_test, test_trigger_manual_emergency_checkpoint)
 {
     ASSERT_EQ(_mock_replica->trigger_manual_emergency_checkpoint(100), ERR_OK);
     ASSERT_TRUE(is_checkpointing());
@@ -451,7 +459,7 @@ TEST_F(replica_test, test_trigger_manual_emergency_checkpoint)
     _mock_replica->tracker()->wait_outstanding_tasks();
 }
 
-TEST_F(replica_test, test_query_last_checkpoint_info)
+TEST_P(replica_test, test_query_last_checkpoint_info)
 {
     // test no exist gpid
     auto req = std::make_unique<learn_request>();
@@ -474,7 +482,7 @@ TEST_F(replica_test, test_query_last_checkpoint_info)
     ASSERT_STR_CONTAINS(resp.base_local_dir, "/data/checkpoint.100");
 }
 
-TEST_F(replica_test, test_clear_on_failure)
+TEST_P(replica_test, test_clear_on_failure)
 {
     // Clear up the remaining state.
     auto *dn = stub->get_fs_manager()->find_replica_dir(_app_info.app_type, _pid);
@@ -497,26 +505,18 @@ TEST_F(replica_test, test_clear_on_failure)
     ASSERT_FALSE(has_gpid(_pid));
 }
 
-class replica_error_test : public replica_test, public testing::WithParamInterface<error_code>
+void replica_test::test_auto_trash(error_code ec)
 {
-};
-
-INSTANTIATE_TEST_CASE_P(,
-                        replica_error_test,
-                        ::testing::Values(ERR_RDB_CORRUPTION, ERR_DISK_IO_ERROR));
-
-TEST_P(replica_error_test, test_auto_trash_of_corruption)
-{
-    const auto ec = GetParam();
-    // The replica path will only be moved to error path when encounter ERR_RDB_CORRUPTION error.
+    // The replica path will only be moved to error path when encounter ERR_RDB_CORRUPTION
+    // error.
     bool moved_to_err_path = (ec == ERR_RDB_CORRUPTION);
 
     // Clear up the remaining state.
     auto *dn = stub->get_fs_manager()->find_replica_dir(_app_info.app_type, _pid);
     if (dn != nullptr) {
         dsn::utils::filesystem::remove_path(dn->replica_dir(_app_info.app_type, _pid));
+        dn->holding_replicas.clear();
     }
-    dn->holding_replicas.clear();
 
     // Disable failure detector to avoid connecting with meta server which is not started.
     FLAGS_fd_disabled = true;
@@ -564,7 +564,14 @@ TEST_P(replica_error_test, test_auto_trash_of_corruption)
     }
 }
 
-TEST_F(replica_test, update_deny_client_test)
+TEST_P(replica_test, test_auto_trash_of_corruption)
+{
+    NO_FATALS(test_auto_trash(ERR_RDB_CORRUPTION));
+}
+
+TEST_P(replica_test, test_auto_trash_of_io_error) { NO_FATALS(test_auto_trash(ERR_DISK_IO_ERROR)); }
+
+TEST_P(replica_test, update_deny_client_test)
 {
     struct update_deny_client_test
     {
@@ -583,7 +590,7 @@ TEST_F(replica_test, update_deny_client_test)
     }
 }
 
-TEST_F(replica_test, test_update_app_max_replica_count) { test_update_app_max_replica_count(); }
+TEST_P(replica_test, test_update_app_max_replica_count) { test_update_app_max_replica_count(); }
 
 } // namespace replication
 } // namespace dsn

--- a/src/replica/test/replica_test_base.h
+++ b/src/replica/test/replica_test_base.h
@@ -26,20 +26,20 @@
 
 #pragma once
 
-#include "utils/smart_pointers.h"
-#include "replica/replication_app_base.h"
-#include "utils/filesystem.h"
-#include "utils/errors.h"
 #include <gtest/gtest.h>
 
-#include "replica/replica_stub.h"
-
 #include "mock_utils.h"
+#include "replica/replication_app_base.h"
+#include "replica/replica_stub.h"
+#include "test_util/test_util.h"
+#include "utils/errors.h"
+#include "utils/filesystem.h"
+#include "utils/smart_pointers.h"
 
 namespace dsn {
 namespace replication {
 
-class replica_stub_test_base : public ::testing::Test
+class replica_stub_test_base : public pegasus::encrypt_data_test_base
 {
 public:
     replica_stub_test_base() { stub = std::make_unique<mock_replica_stub>(); }

--- a/src/runtime/test/task_test.cpp
+++ b/src/runtime/test/task_test.cpp
@@ -25,7 +25,10 @@
 #include "aio/file_io.h"
 #include "runtime/task/task_code.h"
 #include "runtime/task/task_spec.h"
+#include "utils/flags.h"
 #include "utils/threadpool_code.h"
+
+DSN_DECLARE_bool(encrypt_data_at_rest);
 
 namespace dsn {
 class disk_file;
@@ -65,6 +68,9 @@ public:
 
     static void test_signal_finished_task()
     {
+        // config-test.ini is not encrypted, so set FLAGS_encrypt_data_at_rest = false on force.
+        FLAGS_encrypt_data_at_rest = false;
+
         disk_file *fp = file::open("config-test.ini", file::FileOpenType::kReadOnly);
 
         // this aio task is enqueued into read-queue of disk_engine

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -400,6 +400,7 @@ stateful = true
 
   # The HTTP port exposed to Prometheus for pulling metrics from pegasus server.
   prometheus_port = 9091
+  encrypt_data_at_rest = false
 
 [pegasus.collector]
   available_detect_app = stat

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -158,6 +158,7 @@
   perf_counter_sink =
   # The HTTP port exposed to Prometheus for pulling metrics from pegasus server.
   prometheus_port = @PROMETHEUS_PORT@
+  encrypt_data_at_rest = false
 
 [pegasus.collector]
   available_detect_app = stat

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -25,7 +25,6 @@
 #include <rocksdb/advanced_cache.h>
 #include <rocksdb/convenience.h>
 #include <rocksdb/db.h>
-#include <rocksdb/env.h>
 #include <rocksdb/iterator.h>
 #include <rocksdb/rate_limiter.h>
 #include <rocksdb/statistics.h>
@@ -77,6 +76,7 @@
 #include "utils/blob.h"
 #include "utils/chrono_literals.h"
 #include "utils/defer.h"
+#include "utils/env.h"
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
@@ -1638,7 +1638,7 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
         rocksdb::ConfigOptions config_options;
         // Set `ignore_unknown_options` true for forward compatibility.
         config_options.ignore_unknown_options = true;
-        config_options.env = rocksdb::Env::Default();
+        config_options.env = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive);
         auto status =
             rocksdb::LoadLatestOptions(config_options, rdb_path, &loaded_db_opt, &loaded_cf_descs);
         if (!status.ok()) {
@@ -1683,7 +1683,7 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
     config_options.ignore_unsupported_options = true;
     config_options.sanity_level =
         rocksdb::ConfigOptions::SanityLevel::kSanityLevelLooselyCompatible;
-    config_options.env = rocksdb::Env::Default();
+    config_options.env = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive);
     auto s =
         rocksdb::CheckOptionsCompatibility(config_options, rdb_path, _db_opts, column_families);
     if (!s.ok() && !s.IsNotFound() && !has_incompatible_db_options) {

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -19,7 +19,6 @@
 
 #include <fmt/core.h>
 #include <rocksdb/cache.h>
-#include <rocksdb/env.h>
 #include <rocksdb/filter_policy.h>
 #include <rocksdb/options.h>
 #include <rocksdb/rate_limiter.h>
@@ -52,6 +51,7 @@
 #include "server/pegasus_read_service.h"
 #include "server/pegasus_server_write.h" // IWYU pragma: keep
 #include "server/range_read_limiter.h"
+#include "utils/env.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/strings.h"
@@ -423,7 +423,7 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     _rng_rd_opts.rocksdb_iteration_threshold_time_ms = FLAGS_rocksdb_iteration_threshold_time_ms;
 
     // init rocksdb::DBOptions
-    _db_opts.env = rocksdb::Env::Default();
+    _db_opts.env = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive);
     _db_opts.create_if_missing = true;
     // atomic flush data CF and meta CF, aim to keep consistency of 'last flushed decree' in meta CF
     // and data in data CF.

--- a/src/server/test/capacity_unit_calculator_test.cpp
+++ b/src/server/test/capacity_unit_calculator_test.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <fmt/core.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -157,9 +158,11 @@ public:
     }
 };
 
-TEST_F(capacity_unit_calculator_test, init) { test_init(); }
+INSTANTIATE_TEST_CASE_P(, capacity_unit_calculator_test, ::testing::Values(false, true));
 
-TEST_F(capacity_unit_calculator_test, get)
+TEST_P(capacity_unit_calculator_test, init) { test_init(); }
+
+TEST_P(capacity_unit_calculator_test, get)
 {
     dsn::message_ptr msg = dsn::message_ex::create_request(RPC_TEST, static_cast<int>(1000), 1, 1);
     msg->header->context.u.is_backup_request = false;
@@ -199,7 +202,7 @@ TEST_F(capacity_unit_calculator_test, get)
     _cal->reset();
 }
 
-TEST_F(capacity_unit_calculator_test, multi_get)
+TEST_P(capacity_unit_calculator_test, multi_get)
 {
     dsn::message_ptr msg = dsn::message_ex::create_request(RPC_TEST, static_cast<int>(1000), 1, 1);
     msg->header->context.u.is_backup_request = false;
@@ -231,7 +234,7 @@ TEST_F(capacity_unit_calculator_test, multi_get)
     _cal->reset();
 }
 
-TEST_F(capacity_unit_calculator_test, scan)
+TEST_P(capacity_unit_calculator_test, scan)
 {
     dsn::message_ptr msg = dsn::message_ex::create_request(RPC_TEST, static_cast<int>(1000), 1, 1);
     msg->header->context.u.is_backup_request = false;
@@ -266,7 +269,7 @@ TEST_F(capacity_unit_calculator_test, scan)
     _cal->reset();
 }
 
-TEST_F(capacity_unit_calculator_test, sortkey_count)
+TEST_P(capacity_unit_calculator_test, sortkey_count)
 {
     dsn::message_ptr msg = dsn::message_ex::create_request(RPC_TEST, static_cast<int>(1000), 1, 1);
     msg->header->context.u.is_backup_request = false;
@@ -282,7 +285,7 @@ TEST_F(capacity_unit_calculator_test, sortkey_count)
     }
 }
 
-TEST_F(capacity_unit_calculator_test, ttl)
+TEST_P(capacity_unit_calculator_test, ttl)
 {
     dsn::message_ptr msg = dsn::message_ex::create_request(RPC_TEST, static_cast<int>(1000), 1, 1);
     msg->header->context.u.is_backup_request = false;
@@ -298,7 +301,7 @@ TEST_F(capacity_unit_calculator_test, ttl)
     }
 }
 
-TEST_F(capacity_unit_calculator_test, put)
+TEST_P(capacity_unit_calculator_test, put)
 {
     for (int i = 0; i < MAX_ROCKSDB_STATUS_CODE; i++) {
         _cal->add_put_cu(i, key, dsn::blob::create_from_bytes(std::string(4097, ' ')));
@@ -312,7 +315,7 @@ TEST_F(capacity_unit_calculator_test, put)
     }
 }
 
-TEST_F(capacity_unit_calculator_test, remove)
+TEST_P(capacity_unit_calculator_test, remove)
 {
     for (int i = 0; i < MAX_ROCKSDB_STATUS_CODE; i++) {
         _cal->add_remove_cu(i, key);
@@ -326,7 +329,7 @@ TEST_F(capacity_unit_calculator_test, remove)
     }
 }
 
-TEST_F(capacity_unit_calculator_test, multi_put)
+TEST_P(capacity_unit_calculator_test, multi_put)
 {
     std::vector<::dsn::apps::key_value> kvs;
 
@@ -348,7 +351,7 @@ TEST_F(capacity_unit_calculator_test, multi_put)
     }
 }
 
-TEST_F(capacity_unit_calculator_test, multi_remove)
+TEST_P(capacity_unit_calculator_test, multi_remove)
 {
     std::vector<::dsn::blob> keys;
 
@@ -370,7 +373,7 @@ TEST_F(capacity_unit_calculator_test, multi_remove)
     }
 }
 
-TEST_F(capacity_unit_calculator_test, incr)
+TEST_P(capacity_unit_calculator_test, incr)
 {
     for (int i = 0; i < MAX_ROCKSDB_STATUS_CODE; i++) {
         _cal->add_incr_cu(i, key);
@@ -388,7 +391,7 @@ TEST_F(capacity_unit_calculator_test, incr)
     }
 }
 
-TEST_F(capacity_unit_calculator_test, check_and_set)
+TEST_P(capacity_unit_calculator_test, check_and_set)
 {
     dsn::blob cas_hash_key = dsn::blob::create_from_bytes("hash_key");
     dsn::blob check_sort_key = dsn::blob::create_from_bytes("check_sort_key");
@@ -420,7 +423,7 @@ TEST_F(capacity_unit_calculator_test, check_and_set)
     _cal->reset();
 }
 
-TEST_F(capacity_unit_calculator_test, check_and_mutate)
+TEST_P(capacity_unit_calculator_test, check_and_mutate)
 {
     dsn::blob cam_hash_key = dsn::blob::create_from_bytes("hash_key");
     dsn::blob check_sort_key = dsn::blob::create_from_bytes("check_sort_key");
@@ -457,7 +460,7 @@ TEST_F(capacity_unit_calculator_test, check_and_mutate)
     _cal->reset();
 }
 
-TEST_F(capacity_unit_calculator_test, backup_request_bytes)
+TEST_P(capacity_unit_calculator_test, backup_request_bytes)
 {
     dsn::message_ptr msg = dsn::message_ex::create_request(RPC_TEST, static_cast<int>(1000), 1, 1);
 

--- a/src/server/test/hotkey_collector_test.cpp
+++ b/src/server/test/hotkey_collector_test.cpp
@@ -18,6 +18,7 @@
 #include "server/hotkey_collector.h"
 
 #include <fmt/core.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -123,7 +124,9 @@ public:
     dsn::task_tracker _tracker;
 };
 
-TEST_F(coarse_collector_test, coarse_collector)
+INSTANTIATE_TEST_CASE_P(, coarse_collector_test, ::testing::Values(false, true));
+
+TEST_P(coarse_collector_test, coarse_collector)
 {
     detect_hotkey_result result;
 
@@ -178,7 +181,9 @@ public:
     dsn::task_tracker _tracker;
 };
 
-TEST_F(fine_collector_test, fine_collector)
+INSTANTIATE_TEST_CASE_P(, fine_collector_test, ::testing::Values(false, true));
+
+TEST_P(fine_collector_test, fine_collector)
 {
     detect_hotkey_result result;
 
@@ -286,13 +291,15 @@ public:
     dsn::task_tracker _tracker;
 };
 
-TEST_F(hotkey_collector_test, hotkey_type)
+INSTANTIATE_TEST_CASE_P(, hotkey_collector_test, ::testing::Values(false, true));
+
+TEST_P(hotkey_collector_test, hotkey_type)
 {
     ASSERT_EQ(get_collector_type(get_read_collector()), dsn::replication::hotkey_type::READ);
     ASSERT_EQ(get_collector_type(get_write_collector()), dsn::replication::hotkey_type::WRITE);
 }
 
-TEST_F(hotkey_collector_test, state_transform)
+TEST_P(hotkey_collector_test, state_transform)
 {
     auto collector = get_read_collector();
     ASSERT_EQ(get_collector_stat(collector), hotkey_collector_state::STOPPED);
@@ -360,7 +367,7 @@ TEST_F(hotkey_collector_test, state_transform)
     _tracker.wait_outstanding_tasks();
 }
 
-TEST_F(hotkey_collector_test, data_completeness)
+TEST_P(hotkey_collector_test, data_completeness)
 {
     dsn::replication::detect_hotkey_response resp;
     on_detect_hotkey(generate_control_rpc(dsn::replication::hotkey_type::READ,

--- a/src/server/test/hotspot_partition_test.cpp
+++ b/src/server/test/hotspot_partition_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
@@ -122,7 +123,9 @@ public:
     void clear_calculator_histories() { calculator._partitions_stat_histories.clear(); }
 };
 
-TEST_F(hotspot_partition_test, hotspot_partition_policy)
+INSTANTIATE_TEST_CASE_P(, hotspot_partition_test, ::testing::Values(false, true));
+
+TEST_P(hotspot_partition_test, hotspot_partition_policy)
 {
     // Insert normal scenario data to test
     std::vector<row_data> test_rows = generate_row_data();
@@ -175,7 +178,7 @@ TEST_F(hotspot_partition_test, hotspot_partition_policy)
     clear_calculator_histories();
 }
 
-TEST_F(hotspot_partition_test, send_detect_hotkey_request)
+TEST_P(hotspot_partition_test, send_detect_hotkey_request)
 {
     const int READ_HOT_PARTITION = 7;
     const int WRITE_HOT_PARTITION = 0;

--- a/src/server/test/manual_compact_service_test.cpp
+++ b/src/server/test/manual_compact_service_test.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -110,7 +111,9 @@ public:
     }
 };
 
-TEST_F(manual_compact_service_test, check_compact_disabled)
+INSTANTIATE_TEST_CASE_P(, manual_compact_service_test, ::testing::Values(false, true));
+
+TEST_P(manual_compact_service_test, check_compact_disabled)
 {
     std::map<std::string, std::string> envs;
     check_compact_disabled(envs, false);
@@ -134,7 +137,7 @@ TEST_F(manual_compact_service_test, check_compact_disabled)
     check_compact_disabled(envs, false);
 }
 
-TEST_F(manual_compact_service_test, check_once_compact)
+TEST_P(manual_compact_service_test, check_once_compact)
 {
     // suppose compacted at 1500000000
     set_compact_time(compacted_ts);
@@ -167,7 +170,7 @@ TEST_F(manual_compact_service_test, check_once_compact)
     check_once_compact(envs, true);
 }
 
-TEST_F(manual_compact_service_test, check_periodic_compact)
+TEST_P(manual_compact_service_test, check_periodic_compact)
 {
     std::map<std::string, std::string> envs;
 
@@ -245,7 +248,7 @@ TEST_F(manual_compact_service_test, check_periodic_compact)
     check_periodic_compact(envs, false);
 }
 
-TEST_F(manual_compact_service_test, extract_manual_compact_opts)
+TEST_P(manual_compact_service_test, extract_manual_compact_opts)
 {
     // init _db max level
     set_num_level(7);
@@ -283,7 +286,7 @@ TEST_F(manual_compact_service_test, extract_manual_compact_opts)
     ASSERT_EQ(out.target_level, -1);
 }
 
-TEST_F(manual_compact_service_test, check_manual_compact_state_0_interval)
+TEST_P(manual_compact_service_test, check_manual_compact_state_0_interval)
 {
     FLAGS_manual_compact_min_interval_seconds = 0;
 
@@ -299,7 +302,7 @@ TEST_F(manual_compact_service_test, check_manual_compact_state_0_interval)
     check_manual_compact_state(false, "2nd start not ok");
 }
 
-TEST_F(manual_compact_service_test, check_manual_compact_state_1h_interval)
+TEST_P(manual_compact_service_test, check_manual_compact_state_1h_interval)
 {
     FLAGS_manual_compact_min_interval_seconds = 3600;
 

--- a/src/server/test/pegasus_compression_options_test.cpp
+++ b/src/server/test/pegasus_compression_options_test.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -101,7 +102,9 @@ public:
     }
 };
 
-TEST_F(pegasus_compression_options_test, compression_type_convert_ok)
+INSTANTIATE_TEST_CASE_P(, pegasus_compression_options_test, ::testing::Values(false, true));
+
+TEST_P(pegasus_compression_options_test, compression_type_convert_ok)
 {
     compression_type_convert("none", none);
     compression_type_convert("snappy", snappy);
@@ -109,7 +112,7 @@ TEST_F(pegasus_compression_options_test, compression_type_convert_ok)
     compression_type_convert("zstd", zstd);
 }
 
-TEST_F(pegasus_compression_options_test, compression_type_convert_not_support)
+TEST_P(pegasus_compression_options_test, compression_type_convert_not_support)
 {
     rocksdb::CompressionType tmp_type;
     ASSERT_FALSE(compression_str_to_type("not_support_zip", tmp_type));
@@ -122,7 +125,7 @@ TEST_F(pegasus_compression_options_test, compression_type_convert_not_support)
     ASSERT_EQ("<unsupported>", compression_type_to_str(rocksdb::kDisableCompressionOption));
 }
 
-TEST_F(pegasus_compression_options_test, compression_types_convert_ok)
+TEST_P(pegasus_compression_options_test, compression_types_convert_ok)
 {
     // Old style.
     compression_types_convert_ok("none", {none, none, none, none, none, none, none});
@@ -143,7 +146,7 @@ TEST_F(pegasus_compression_options_test, compression_types_convert_ok)
                                  {none, lz4, snappy, zstd, lz4, snappy, zstd});
 }
 
-TEST_F(pegasus_compression_options_test, compression_types_convert_fail)
+TEST_P(pegasus_compression_options_test, compression_types_convert_fail)
 {
     // Old style.
     compression_types_convert_fail("none1");
@@ -157,7 +160,7 @@ TEST_F(pegasus_compression_options_test, compression_types_convert_fail)
     compression_types_convert_fail("per_levelsnappy");
 }
 
-TEST_F(pegasus_compression_options_test, check_rocksdb_compression_types_default)
+TEST_P(pegasus_compression_options_test, check_rocksdb_compression_types_default)
 {
     start();
     check_db_compression_types({none, none, lz4, lz4, lz4, lz4}, "start with default");

--- a/src/server/test/pegasus_mutation_duplicator_test.cpp
+++ b/src/server/test/pegasus_mutation_duplicator_test.cpp
@@ -20,6 +20,7 @@
 #include "server/pegasus_mutation_duplicator.h"
 
 #include <fmt/core.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -288,7 +289,9 @@ private:
     }
 };
 
-TEST_F(pegasus_mutation_duplicator_test, get_hash_from_request)
+INSTANTIATE_TEST_CASE_P(, pegasus_mutation_duplicator_test, ::testing::Values(false, true));
+
+TEST_P(pegasus_mutation_duplicator_test, get_hash_from_request)
 {
     std::string hash_key("hash");
     std::string sort_key("sort");
@@ -336,7 +339,7 @@ TEST_F(pegasus_mutation_duplicator_test, get_hash_from_request)
 // Verifies that calls on `get_hash_key_from_request` won't make
 // message unable to read. (if `get_hash_key_from_request` doesn't
 // copy the message internally, it will.)
-TEST_F(pegasus_mutation_duplicator_test, read_after_get_hash_key)
+TEST_P(pegasus_mutation_duplicator_test, read_after_get_hash_key)
 {
     std::string hash_key("hash");
     std::string sort_key("sort");
@@ -358,18 +361,18 @@ TEST_F(pegasus_mutation_duplicator_test, read_after_get_hash_key)
     ASSERT_EQ(rpc.request().key.to_string(), raw_key.to_string());
 }
 
-TEST_F(pegasus_mutation_duplicator_test, duplicate) { test_duplicate(); }
+TEST_P(pegasus_mutation_duplicator_test, duplicate) { test_duplicate(); }
 
-TEST_F(pegasus_mutation_duplicator_test, duplicate_failed) { test_duplicate_failed(); }
+TEST_P(pegasus_mutation_duplicator_test, duplicate_failed) { test_duplicate_failed(); }
 
-TEST_F(pegasus_mutation_duplicator_test, duplicate_isolated_hashkeys)
+TEST_P(pegasus_mutation_duplicator_test, duplicate_isolated_hashkeys)
 {
     test_duplicate_isolated_hashkeys();
 }
 
-TEST_F(pegasus_mutation_duplicator_test, create_duplicator) { test_create_duplicator(); }
+TEST_P(pegasus_mutation_duplicator_test, create_duplicator) { test_create_duplicator(); }
 
-TEST_F(pegasus_mutation_duplicator_test, duplicate_duplicate)
+TEST_P(pegasus_mutation_duplicator_test, duplicate_duplicate)
 {
     replica_base replica(dsn::gpid(1, 1), "fake_replica", "temp");
     auto duplicator = new_mutation_duplicator(&replica, "onebox2", "temp");

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -144,19 +144,21 @@ public:
     }
 };
 
-TEST_F(pegasus_server_impl_test, test_table_level_slow_query)
+INSTANTIATE_TEST_CASE_P(, pegasus_server_impl_test, ::testing::Values(false, true));
+
+TEST_P(pegasus_server_impl_test, test_table_level_slow_query)
 {
     ASSERT_EQ(dsn::ERR_OK, start());
     test_table_level_slow_query();
 }
 
-TEST_F(pegasus_server_impl_test, default_data_version)
+TEST_P(pegasus_server_impl_test, default_data_version)
 {
     ASSERT_EQ(dsn::ERR_OK, start());
     ASSERT_EQ(_server->_pegasus_data_version, 1);
 }
 
-TEST_F(pegasus_server_impl_test, test_open_db_with_latest_options)
+TEST_P(pegasus_server_impl_test, test_open_db_with_latest_options)
 {
     // open a new db with no app env.
     ASSERT_EQ(dsn::ERR_OK, start());
@@ -176,7 +178,7 @@ TEST_F(pegasus_server_impl_test, test_open_db_with_latest_options)
     ASSERT_EQ(opts.disable_auto_compactions, _server->_db->GetOptions().disable_auto_compactions);
 }
 
-TEST_F(pegasus_server_impl_test, test_open_db_with_app_envs)
+TEST_P(pegasus_server_impl_test, test_open_db_with_app_envs)
 {
     std::map<std::string, std::string> envs;
     envs[ROCKSDB_ENV_USAGE_SCENARIO_KEY] = ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD;
@@ -184,19 +186,19 @@ TEST_F(pegasus_server_impl_test, test_open_db_with_app_envs)
     ASSERT_EQ(ROCKSDB_ENV_USAGE_SCENARIO_BULK_LOAD, _server->_usage_scenario);
 }
 
-TEST_F(pegasus_server_impl_test, test_open_db_with_rocksdb_envs)
+TEST_P(pegasus_server_impl_test, test_open_db_with_rocksdb_envs)
 {
     // Hint: Verify the set_rocksdb_options_before_creating function by boolean is_restart=false.
     test_open_db_with_rocksdb_envs(false);
 }
 
-TEST_F(pegasus_server_impl_test, test_restart_db_with_rocksdb_envs)
+TEST_P(pegasus_server_impl_test, test_restart_db_with_rocksdb_envs)
 {
     // Hint: Verify the reset_rocksdb_options function by boolean is_restart=true.
     test_open_db_with_rocksdb_envs(true);
 }
 
-TEST_F(pegasus_server_impl_test, test_stop_db_twice)
+TEST_P(pegasus_server_impl_test, test_stop_db_twice)
 {
     ASSERT_EQ(dsn::ERR_OK, start());
     ASSERT_TRUE(_server->_is_open);
@@ -212,7 +214,7 @@ TEST_F(pegasus_server_impl_test, test_stop_db_twice)
     ASSERT_TRUE(_server->_db == nullptr);
 }
 
-TEST_F(pegasus_server_impl_test, test_update_user_specified_compaction)
+TEST_P(pegasus_server_impl_test, test_update_user_specified_compaction)
 {
     _server->_user_specified_compaction = "";
     std::map<std::string, std::string> envs;
@@ -226,7 +228,7 @@ TEST_F(pegasus_server_impl_test, test_update_user_specified_compaction)
     ASSERT_EQ(user_specified_compaction, _server->_user_specified_compaction);
 }
 
-TEST_F(pegasus_server_impl_test, test_load_from_duplication_data)
+TEST_P(pegasus_server_impl_test, test_load_from_duplication_data)
 {
     auto origin_file = fmt::format("{}/{}", _server->duplication_dir(), "checkpoint");
     dsn::utils::filesystem::create_directory(_server->duplication_dir());

--- a/src/server/test/pegasus_server_write_test.cpp
+++ b/src/server/test/pegasus_server_write_test.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <fmt/core.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -140,7 +141,9 @@ public:
     }
 };
 
-TEST_F(pegasus_server_write_test, batch_writes) { test_batch_writes(); }
+INSTANTIATE_TEST_CASE_P(, pegasus_server_write_test, ::testing::Values(false, true));
+
+TEST_P(pegasus_server_write_test, batch_writes) { test_batch_writes(); }
 
 } // namespace server
 } // namespace pegasus

--- a/src/server/test/pegasus_write_service_impl_test.cpp
+++ b/src/server/test/pegasus_write_service_impl_test.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <fmt/core.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -87,7 +88,9 @@ public:
     dsn::apps::incr_response resp;
 };
 
-TEST_F(incr_test, incr_on_absent_record)
+INSTANTIATE_TEST_CASE_P(, incr_test, ::testing::Values(false, true));
+
+TEST_P(incr_test, incr_on_absent_record)
 {
     // ensure key is absent
     db_get_context get_ctx;
@@ -102,7 +105,7 @@ TEST_F(incr_test, incr_on_absent_record)
     ASSERT_TRUE(get_ctx.found);
 }
 
-TEST_F(incr_test, negative_incr_and_zero_incr)
+TEST_P(incr_test, negative_incr_and_zero_incr)
 {
     req.increment = -100;
     ASSERT_EQ(0, _write_impl->incr(0, req, resp));
@@ -117,7 +120,7 @@ TEST_F(incr_test, negative_incr_and_zero_incr)
     ASSERT_EQ(resp.new_value, -101);
 }
 
-TEST_F(incr_test, invalid_incr)
+TEST_P(incr_test, invalid_incr)
 {
     single_set(req.key, dsn::blob::create_from_bytes("abc"));
 
@@ -134,7 +137,7 @@ TEST_F(incr_test, invalid_incr)
     ASSERT_EQ(resp.new_value, 100);
 }
 
-TEST_F(incr_test, fail_on_get)
+TEST_P(incr_test, fail_on_get)
 {
     dsn::fail::setup();
     dsn::fail::cfg("db_get", "100%1*return()");
@@ -147,7 +150,7 @@ TEST_F(incr_test, fail_on_get)
     dsn::fail::teardown();
 }
 
-TEST_F(incr_test, fail_on_put)
+TEST_P(incr_test, fail_on_put)
 {
     dsn::fail::setup();
     dsn::fail::cfg("db_write_batch_put", "100%1*return()");
@@ -160,7 +163,7 @@ TEST_F(incr_test, fail_on_put)
     dsn::fail::teardown();
 }
 
-TEST_F(incr_test, incr_on_expire_record)
+TEST_P(incr_test, incr_on_expire_record)
 {
     // make the key expired
     req.expire_ts_seconds = 1;

--- a/src/server/test/pegasus_write_service_test.cpp
+++ b/src/server/test/pegasus_write_service_test.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <fmt/core.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -224,13 +225,15 @@ public:
     }
 };
 
-TEST_F(pegasus_write_service_test, multi_put) { test_multi_put(); }
+INSTANTIATE_TEST_CASE_P(, pegasus_write_service_test, ::testing::Values(false, true));
 
-TEST_F(pegasus_write_service_test, multi_remove) { test_multi_remove(); }
+TEST_P(pegasus_write_service_test, multi_put) { test_multi_put(); }
 
-TEST_F(pegasus_write_service_test, batched_writes) { test_batched_writes(); }
+TEST_P(pegasus_write_service_test, multi_remove) { test_multi_remove(); }
 
-TEST_F(pegasus_write_service_test, duplicate_not_batched)
+TEST_P(pegasus_write_service_test, batched_writes) { test_batched_writes(); }
+
+TEST_P(pegasus_write_service_test, duplicate_not_batched)
 {
     std::string hash_key = "hash_key";
     constexpr int kv_num = 100;
@@ -280,7 +283,7 @@ TEST_F(pegasus_write_service_test, duplicate_not_batched)
     }
 }
 
-TEST_F(pegasus_write_service_test, duplicate_batched)
+TEST_P(pegasus_write_service_test, duplicate_batched)
 {
     std::string hash_key = "hash_key";
     constexpr int kv_num = 100;
@@ -314,7 +317,7 @@ TEST_F(pegasus_write_service_test, duplicate_batched)
     }
 }
 
-TEST_F(pegasus_write_service_test, illegal_duplicate_request)
+TEST_P(pegasus_write_service_test, illegal_duplicate_request)
 {
     std::string hash_key = "hash_key";
     std::string sort_key = "sort_key";

--- a/src/server/test/rocksdb_wrapper_test.cpp
+++ b/src/server/test/rocksdb_wrapper_test.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <fmt/core.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -103,7 +104,9 @@ public:
     }
 };
 
-TEST_F(rocksdb_wrapper_test, get)
+INSTANTIATE_TEST_CASE_P(, rocksdb_wrapper_test, ::testing::Values(false, true));
+
+TEST_P(rocksdb_wrapper_test, get)
 {
     // not found
     db_get_context get_ctx1;
@@ -135,7 +138,7 @@ TEST_F(rocksdb_wrapper_test, get)
     ASSERT_EQ(user_value, value);
 }
 
-TEST_F(rocksdb_wrapper_test, put_verify_timetag)
+TEST_P(rocksdb_wrapper_test, put_verify_timetag)
 {
     set_app_duplicating();
 
@@ -212,7 +215,7 @@ TEST_F(rocksdb_wrapper_test, put_verify_timetag)
 }
 
 // verify timetag on data version v0
-TEST_F(rocksdb_wrapper_test, verify_timetag_compatible_with_version_0)
+TEST_P(rocksdb_wrapper_test, verify_timetag_compatible_with_version_0)
 {
     const_cast<uint32_t &>(_rocksdb_wrapper->_pegasus_data_version) = 0; // old version
 

--- a/src/test/bench_test/config.cpp
+++ b/src/test/bench_test/config.cpp
@@ -19,11 +19,11 @@
 
 #include "config.h"
 
-#include <rocksdb/env.h>
+#include "utils/env.h"
 
 namespace pegasus {
 namespace test {
 
-config::config() { env = rocksdb::Env::Default(); }
+config::config() { env = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive); }
 } // namespace test
 } // namespace pegasus

--- a/src/test/function_test/base_api/test_range_read.cpp
+++ b/src/test/function_test/base_api/test_range_read.cpp
@@ -109,7 +109,6 @@ public:
     std::map<std::string, std::string> expect_kvs_;
 };
 
-// TODO(yingchun): use TEST_P to refact
 TEST_F(range_read_test, multiget_test)
 {
     pegasus::pegasus_client::multi_get_options options;

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -80,6 +80,9 @@ mycluster = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
 onebox = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
 single_master_cluster = 127.0.0.1:34601
 
+[pegasus.server]
+encrypt_data_at_rest = false
+
 [function_test.throttle_test]
-  throttle_test_medium_value_kb = 20
-  throttle_test_large_value_kb = 50
+throttle_test_medium_value_kb = 20
+throttle_test_large_value_kb = 50

--- a/src/test_util/test_util.cpp
+++ b/src/test_util/test_util.cpp
@@ -41,10 +41,11 @@ namespace pegasus {
 void create_local_test_file(const std::string &full_name, dsn::replication::file_meta *fm)
 {
     ASSERT_NE(fm, nullptr);
-    auto s = rocksdb::WriteStringToFile(rocksdb::Env::Default(),
-                                        rocksdb::Slice("write some data."),
-                                        full_name,
-                                        /* should_sync */ true);
+    auto s =
+        rocksdb::WriteStringToFile(dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive),
+                                   rocksdb::Slice("write some data."),
+                                   full_name,
+                                   /* should_sync */ true);
     ASSERT_TRUE(s.ok()) << s.ToString();
     fm->name = full_name;
     ASSERT_EQ(dsn::ERR_OK, dsn::utils::filesystem::md5sum(full_name, fm->md5));

--- a/src/test_util/test_util.h
+++ b/src/test_util/test_util.h
@@ -22,12 +22,13 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <fmt/core.h>
 #include <functional>
 #include <gtest/gtest.h>
 #include <string>
 
-#include "fmt/core.h"
 #include "runtime/api_layer1.h"
+#include "utils/env.h"
 #include "utils/flags.h"
 #include "utils/test_macros.h"
 
@@ -45,7 +46,20 @@ namespace pegasus {
 class encrypt_data_test_base : public testing::TestWithParam<bool>
 {
 public:
-    encrypt_data_test_base() { FLAGS_encrypt_data_at_rest = GetParam(); }
+    encrypt_data_test_base()
+    {
+        FLAGS_encrypt_data_at_rest = GetParam();
+        // The size of an actual encrypted file should plus kEncryptionHeaderkSize bytes if consider
+        // it as kNonSensitive.
+        if (FLAGS_encrypt_data_at_rest) {
+            _extra_encrypted_file_size = dsn::utils::kEncryptionHeaderkSize;
+        }
+    }
+
+    uint64_t extra_encrypted_file_size() const { return _extra_encrypted_file_size; }
+
+private:
+    uint64_t _extra_encrypted_file_size = 0;
 };
 
 class stop_watch

--- a/src/utils/alloc.h
+++ b/src/utils/alloc.h
@@ -17,19 +17,17 @@
 
 #pragma once
 
-#include <algorithm>
+#include <algorithm> // IWYU pragma: keep
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <new>
 
 #include "utils/ports.h"
 
 // The check for the definition of CACHELINE_SIZE has to be put after including "utils/ports.h",
 // where CACHELINE_SIZE is defined.
 #ifdef CACHELINE_SIZE
-
-#include <stddef.h>
-#include <algorithm> // IWYU pragma: keep
-#include <functional>
-#include <memory>
-#include <new>
 
 #ifndef NDEBUG
 #include "utils/fmt_logging.h"

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -179,7 +179,7 @@ command_manager::~command_manager()
 {
     _cmds.clear();
     CHECK(_handlers.empty(),
-          "All commands must be deregistered before command_manager is destroyed, however {} is "
+          "All commands must be deregistered before command_manager is destroyed, however '{}' is "
           "still registered",
           _handlers.begin()->first);
 }

--- a/src/utils/flags.h
+++ b/src/utils/flags.h
@@ -51,7 +51,7 @@ struct hash<flag_tag>
 // Example:
 //    DSN_DEFINE_string(core, filename, "my_file.txt", "The file to read");
 //    DSN_DEFINE_validator(filename, [](const char *fname){ return is_file(fname); });
-//    auto fptr = file::open(FLAGS_filename, O_RDONLY | O_BINARY, 0);
+//    auto fptr = file::open(FLAGS_filename, file::FileOpenType::kReadOnly);
 
 #define DSN_DECLARE_VARIABLE(type, name) extern type FLAGS_##name
 

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -182,6 +182,10 @@ simple_logger::simple_logger(const char *log_dir)
 
     create_log_file();
 
+    // TODO(yingchun): simple_logger is destroyed after command_manager, so will cause crash like
+    //  "assertion expression: [_handlers.empty()] All commands must be deregistered before
+    //  command_manager is destroyed, however 'flush-log' is still registered".
+    //  We need to fix it.
     _cmds.emplace_back(::dsn::command_manager::instance().register_command(
         {"flush-log"},
         "flush-log - flush log to stderr or log file",

--- a/src/utils/strings.h
+++ b/src/utils/strings.h
@@ -114,6 +114,7 @@ std::string get_last_component(const std::string &input, const char splitters[])
 
 char *trim_string(char *s);
 
+// TODO(yingchun): unify the following functions with the ones in utils::filesystem
 // calculate the md5 checksum of buffer
 std::string string_md5(const char *buffer, unsigned int length);
 

--- a/src/utils/test/TokenBucketTest.cpp
+++ b/src/utils/test/TokenBucketTest.cpp
@@ -18,7 +18,7 @@
 
 #include <boost/optional/optional.hpp>
 // IWYU pragma: no_include <gtest/gtest-message.h>
-#include <gtest/gtest-param-test.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 #include <stddef.h>

--- a/src/utils/test/env.cpp
+++ b/src/utils/test/env.cpp
@@ -41,8 +41,8 @@
 #include <rocksdb/env.h>
 #include <rocksdb/slice.h>
 #include <rocksdb/status.h>
-#include <stdint.h>
 #include <algorithm>
+#include <cstdint>
 #include <limits>
 #include <string>
 
@@ -87,16 +87,6 @@ TEST(env_test, get_env)
 
 class env_file_test : public pegasus::encrypt_data_test_base
 {
-public:
-    env_file_test() : pegasus::encrypt_data_test_base()
-    {
-        // The size of an actual encrypted file should plus kEncryptionHeaderkSize bytes if consider
-        // it as kNonSensitive.
-        if (FLAGS_encrypt_data_at_rest) {
-            _extra_size = dsn::utils::kEncryptionHeaderkSize;
-        }
-    }
-    uint64_t _extra_size = 0;
 };
 
 INSTANTIATE_TEST_CASE_P(, env_file_test, ::testing::Values(false, true));
@@ -134,7 +124,7 @@ TEST_P(env_file_test, encrypt_file_2_files)
         ASSERT_EQ(kFileContentSize, wfile_size);
         ASSERT_TRUE(dsn::utils::filesystem::file_size(
             kEncryptedFileName, dsn::utils::FileDataType::kNonSensitive, wfile_size));
-        ASSERT_EQ(kFileContentSize + _extra_size, wfile_size);
+        ASSERT_EQ(kFileContentSize + extra_encrypted_file_size(), wfile_size);
         // Check file content.
         std::string data;
         s = rocksdb::ReadFileToString(dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive),
@@ -174,7 +164,7 @@ TEST_P(env_file_test, encrypt_file_1_file)
     ASSERT_EQ(kFileContentSize, wfile_size);
     ASSERT_TRUE(dsn::utils::filesystem::file_size(
         kFileName, dsn::utils::FileDataType::kNonSensitive, wfile_size));
-    ASSERT_EQ(kFileContentSize + _extra_size, wfile_size);
+    ASSERT_EQ(kFileContentSize + extra_encrypted_file_size(), wfile_size);
     // Check file content.
     std::string data;
     s = rocksdb::ReadFileToString(
@@ -204,7 +194,7 @@ TEST_P(env_file_test, copy_file)
     ASSERT_EQ(kFileContentSize, wfile_size);
     ASSERT_TRUE(dsn::utils::filesystem::file_size(
         kFileName, dsn::utils::FileDataType::kNonSensitive, wfile_size));
-    ASSERT_EQ(kFileContentSize + _extra_size, wfile_size);
+    ASSERT_EQ(kFileContentSize + extra_encrypted_file_size(), wfile_size);
 
     // Check copy_file(src_fname, dst_fname, total_size).
     // Loop twice to check overwrite.
@@ -218,7 +208,7 @@ TEST_P(env_file_test, copy_file)
         ASSERT_EQ(kFileContentSize, wfile_size);
         ASSERT_TRUE(dsn::utils::filesystem::file_size(
             kCopyFileName, dsn::utils::FileDataType::kNonSensitive, wfile_size));
-        ASSERT_EQ(kFileContentSize + _extra_size, wfile_size);
+        ASSERT_EQ(kFileContentSize + extra_encrypted_file_size(), wfile_size);
         // Check file content.
         std::string data;
         s = rocksdb::ReadFileToString(
@@ -249,7 +239,7 @@ TEST_P(env_file_test, copy_file_by_size)
     ASSERT_EQ(kFileContentSize, wfile_size);
     ASSERT_TRUE(dsn::utils::filesystem::file_size(
         kFileName, dsn::utils::FileDataType::kNonSensitive, wfile_size));
-    ASSERT_EQ(kFileContentSize + _extra_size, wfile_size);
+    ASSERT_EQ(kFileContentSize + extra_encrypted_file_size(), wfile_size);
 
     // Check copy_file_by_size(src_fname, dst_fname, limit_size).
     struct test_case
@@ -271,7 +261,7 @@ TEST_P(env_file_test, copy_file_by_size)
         ASSERT_EQ(test.expect_size, actual_size);
         ASSERT_TRUE(dsn::utils::filesystem::file_size(
             kCopyFileName, dsn::utils::FileDataType::kNonSensitive, wfile_size));
-        ASSERT_EQ(test.expect_size + _extra_size, wfile_size);
+        ASSERT_EQ(test.expect_size + extra_encrypted_file_size(), wfile_size);
         // Check file content.
         std::string data;
         s = rocksdb::ReadFileToString(

--- a/src/utils/test/file_utils.cpp
+++ b/src/utils/test/file_utils.cpp
@@ -343,7 +343,7 @@ public:
     void file_utils_test_cleanup() {}
 };
 
-INSTANTIATE_TEST_CASE_P(, file_utils, ::testing::Values(false));
+INSTANTIATE_TEST_CASE_P(, file_utils, ::testing::Values(false, true));
 
 TEST_P(file_utils, basic)
 {

--- a/src/utils/test/utils.cpp
+++ b/src/utils/test/utils.cpp
@@ -34,7 +34,7 @@
  */
 
 // IWYU pragma: no_include <gtest/gtest-message.h>
-#include <gtest/gtest-param-test.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 #include <stddef.h>


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1575

- Mark all files as sensitive, thus all files will be encrypted when `encrypt_data_at_rest` is enabled
- Eanble both true and false for config `encrypt_data_at_rest` is related tests
- The FDS module has not implemented encryption feature yet, do not enable `encrypt_data_at_rest` if you are using FDS
- Some small refacors