### PR TITLE
Revert "build(thirdparty): add thirdparty for centos6 build env  (#1017)"

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -259,7 +259,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup cache

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -259,7 +259,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup cache

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         osversion:
-          - ubuntu2204
+          - ubuntu1804
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -58,7 +58,7 @@ jobs:
           file: ./docker/thirdparties-src/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-src-${{ github.ref_name }}
+            apache/pegasus:thirdparties-src-master
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
       - name: Image digest
@@ -93,7 +93,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-${{ matrix.osversion }}-${{ github.ref_name }}
+            apache/pegasus:thirdparties-bin-${{ matrix.osversion }}-master
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
@@ -129,7 +129,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-jemallc-${{ matrix.osversion }}-${{ github.ref_name }}
+            apache/pegasus:thirdparties-bin-jemallc-${{ matrix.osversion }}-master
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
@@ -163,7 +163,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-test-${{ matrix.osversion }}-${{ github.ref_name }}
+            apache/pegasus:thirdparties-bin-test-${{ matrix.osversion }}-master
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
@@ -199,7 +199,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-test-jemallc-${{ matrix.osversion }}-${{ github.ref_name }}
+            apache/pegasus:thirdparties-bin-test-jemallc-${{ matrix.osversion }}-master
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -58,7 +58,7 @@ jobs:
           file: ./docker/thirdparties-src/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-src-master
+            apache/pegasus:thirdparties-src-${{ github.ref_name }}
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
       - name: Image digest
@@ -93,7 +93,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-${{ matrix.osversion }}-master
+            apache/pegasus:thirdparties-bin-${{ matrix.osversion }}-${{ github.ref_name }}
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
@@ -129,7 +129,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-jemallc-${{ matrix.osversion }}-master
+            apache/pegasus:thirdparties-bin-jemallc-${{ matrix.osversion }}-${{ github.ref_name }}
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
@@ -163,7 +163,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-test-${{ matrix.osversion }}-master
+            apache/pegasus:thirdparties-bin-test-${{ matrix.osversion }}-${{ github.ref_name }}
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
@@ -199,7 +199,7 @@ jobs:
           file: ./docker/thirdparties-bin/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-bin-test-jemallc-${{ matrix.osversion }}-master
+            apache/pegasus:thirdparties-bin-test-jemallc-${{ matrix.osversion }}-${{ github.ref_name }}
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -50,6 +50,8 @@ RUN yum -y install centos-release-scl \
                    lz4-devel \
                    bison \
                    flex \
+                   krb5-devel \
+                   cyrus-sasl-devel \
                    patch; \
                    yum clean all; \
                    rm -rf /var/cache/yum;

--- a/docker/pegasus-build-env/ubuntu1804/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu1804/Dockerfile
@@ -50,6 +50,8 @@ RUN apt-get update -y; \
                        libtool \
                        libssl-dev \
                        bison \
+                       libkrb5-dev \
+                       libsasl2-dev \
                        maven \
                        flex \
                        python3-setuptools; \

--- a/docker/pegasus-build-env/ubuntu2004/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2004/Dockerfile
@@ -50,6 +50,8 @@ RUN apt-get update -y; \
                        libtool \
                        libssl-dev \
                        bison \
+                       libkrb5-dev \
+                       libsasl2-dev \
                        maven \
                        flex; \
     rm -rf /var/lib/apt/lists/*

--- a/docker/pegasus-build-env/ubuntu2204/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2204/Dockerfile
@@ -51,6 +51,8 @@ RUN apt-get update -y; \
                        libtool \
                        libssl-dev \
                        bison \
+                       libkrb5-dev \
+                       libsasl2-dev \
                        maven \
                        flex; \
     rm -rf /var/lib/apt/lists/*

--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -125,8 +125,6 @@ fi
 
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/bin
 copy_file ./thirdparty/output/lib/libhdfs* ${pack}/bin
-copy_file ./thirdparty/output/lib/libsasl*.so.* ${pack}/bin
-copy_file ./thirdparty/output/lib/libcom_err*.so.* ${pack}/bin
 copy_file ./scripts/sendmail.sh ${pack}/bin
 copy_file ./src/server/config.ini ${pack}/bin
 copy_file ./src/server/config.min.ini ${pack}/bin

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -159,35 +159,6 @@ ExternalProject_Add(thrift
         DEPENDS boost
         )
 
-if (NOT APPLE)
-    # kerberos
-    ExternalProject_Add(krb5
-            URL ${OSS_URL_PREFIX}/krb5-1.16.1.tar.gz
-            http://web.mit.edu/kerberos/dist/krb5/1.16/krb5-1.16.1.tar.gz
-            URL_MD5 848e9b80d6aaaa798e3f3df24b83c407
-            CONFIGURE_COMMAND cd src && ./configure --prefix=${TP_OUTPUT}
-            BUILD_COMMAND cd src && make
-            INSTALL_COMMAND cd src && make install
-            BUILD_IN_SOURCE 1
-            )
-
-    # cyrus-sasl
-    ExternalProject_Add(cyrus-sasl
-            URL ${OSS_URL_PREFIX}/cyrus-sasl-2.1.27.tar.gz
-            http://www.cyrusimap.org/releases/cyrus-sasl-2.1.27.tar.gz
-            URL_MD5 a33820c66e0622222c5aefafa1581083
-            CONFIGURE_COMMAND ./configure --prefix=${TP_OUTPUT}
-            --enable-gssapi=${TP_OUTPUT}
-            --enable-scram=no
-            --enable-digest=no
-            --enable-cram=no
-            --enable-otp=no
-            BUILD_COMMAND make
-            INSTALL_COMMAND make install
-            BUILD_IN_SOURCE 1
-            )
-endif()
-
 check_cxx_compiler_flag(-Wformat-overflow COMPILER_SUPPORTS_FORMAT_OVERFLOW)
 if (COMPILER_SUPPORTS_FORMAT_OVERFLOW)
     set(ZOOKEEPER_CFLAGS -Wno-error=format-overflow)
@@ -212,9 +183,6 @@ ExternalProject_Add(zookeeper
         INSTALL_COMMAND ""
         BUILD_IN_SOURCE 1
         )
-if (NOT APPLE)
-    add_dependencies(zookeeper cyrus-sasl krb5)
-endif ()
 
 ExternalProject_Add(libevent
         URL ${OSS_URL_PREFIX}/libevent-release-2.1.8-stable.tar.gz


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1348

Now that we drop supporting CentOS, this path reverts commit 862c824231bcc8309444e62d7b2d40523c8ea742.