### PR TITLE
feat(build): make C++17 as required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ project(pegasus)
 cmake_minimum_required(VERSION 3.11.0)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    # require at least gcc 5.4.0
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.4.0)
-        message(FATAL_ERROR "GCC version must be at least 5.4.0!")
+    # require at least gcc 7.0.0
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.0)
+        message(FATAL_ERROR "GCC version must be at least 7.0.0!")
     endif ()
 endif ()
 

--- a/cmake_modules/BaseFunctions.cmake
+++ b/cmake_modules/BaseFunctions.cmake
@@ -204,7 +204,7 @@ function(dsn_setup_compiler_flags)
   # We want access to the PRI* print format macros.
   add_definitions(-D__STDC_FORMAT_MACROS)
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -gdwarf-4" CACHE STRING "" FORCE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -gdwarf-4" CACHE STRING "" FORCE)
 
   #  -Wall: Enable all warnings.
   add_compile_options(-Wall)
@@ -221,9 +221,6 @@ function(dsn_setup_compiler_flags)
   #   use frame pointers to allow simple stack frame walking for backtraces.
   #   This has a small perf hit but worth it for the ability to profile in production
   add_compile_options( -fno-omit-frame-pointer)
-  # -Wno-deprecated-register
-  #   kbr5.h uses the legacy 'register' keyword.
-  add_compile_options(-Wno-deprecated-register)
   # -Wno-implicit-float-conversion
   #   Poco/Dynamic/VarHolder.h uses 'unsigned long' to 'float' conversion
   add_compile_options(-Wno-implicit-float-conversion)
@@ -388,7 +385,7 @@ function(dsn_common_setup)
 
   set(BUILD_SHARED_LIBS OFF)
 
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/cmake_modules/BaseFunctions.cmake
+++ b/cmake_modules/BaseFunctions.cmake
@@ -147,6 +147,7 @@ function(dsn_add_project)
   endif()
   ms_add_project("${MY_PROJ_TYPE}" "${MY_PROJ_NAME}" "${MY_PROJ_SRC}" "${MY_PROJ_LIBS}" "${MY_BINPLACES}")
   define_file_basename_for_sources(${MY_PROJ_NAME})
+  target_compile_features(${MY_PROJ_NAME} PRIVATE cxx_std_17)
 endfunction(dsn_add_project)
 
 function(dsn_add_static_library)

--- a/src/aio/disk_engine.cpp
+++ b/src/aio/disk_engine.cpp
@@ -26,7 +26,6 @@
 
 #include "disk_engine.h"
 
-#include <algorithm>
 #include <list>
 // IWYU pragma: no_include <string>
 #include <utility>

--- a/src/base/test/utils_test.cpp
+++ b/src/base/test/utils_test.cpp
@@ -20,7 +20,6 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
-#include <algorithm>
 #include <list>
 #include <string>
 

--- a/src/common/test/common_test.cpp
+++ b/src/common/test/common_test.cpp
@@ -22,6 +22,7 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <memory>
 
 namespace dsn {
 TEST(duplication_common, get_current_cluster_name)

--- a/src/geo/lib/geo_client.cpp
+++ b/src/geo/lib/geo_client.cpp
@@ -32,7 +32,6 @@
 #include <s2/s2region_coverer.h>
 #include <s2/util/units/length-units.h>
 #include <stddef.h>
-#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <limits>

--- a/src/geo/lib/latlng_codec.cpp
+++ b/src/geo/lib/latlng_codec.cpp
@@ -22,6 +22,7 @@
 #include <s2/s1angle.h>
 #include <s2/s2latlng.h>
 #include <stddef.h>
+#include <algorithm>
 
 #include "utils/error_code.h"
 #include "utils/errors.h"

--- a/src/meta/meta_backup_service.h
+++ b/src/meta/meta_backup_service.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <gtest/gtest_prod.h>
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -25,8 +25,8 @@
  */
 
 // IWYU pragma: no_include <boost/detail/basic_pointerbuf.hpp>
+// IWYU pragma: no_include <ext/alloc_traits.h>
 #include <boost/lexical_cast.hpp>
-#include <ext/alloc_traits.h>
 #include <algorithm> // for std::remove_if
 #include <chrono>
 #include <functional>

--- a/src/meta/test/meta_service_test.cpp
+++ b/src/meta/test/meta_service_test.cpp
@@ -27,7 +27,6 @@
 #include "meta/meta_service.h"
 #include "meta_admin_types.h"
 #include "meta_test_base.h"
-#include "runtime/rpc/network.h"
 #include "runtime/rpc/network.sim.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_holder.h"

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -32,6 +32,7 @@
 #include <chrono>
 #include <cstdint>
 #include <mutex>
+#include <type_traits>
 #include <vector>
 
 #include "nfs/nfs_code_definition.h"

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -32,7 +32,6 @@
 #include <chrono>
 #include <cstdint>
 #include <mutex>
-#include <type_traits>
 #include <vector>
 
 #include "nfs/nfs_code_definition.h"

--- a/src/perf_counter/test/perf_counter_test.cpp
+++ b/src/perf_counter/test/perf_counter_test.cpp
@@ -38,6 +38,7 @@
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 #include <stdlib.h>
+#include <algorithm>
 #include <chrono>
 #include <functional>
 #include <memory>

--- a/src/redis_protocol/proxy_ut/redis_proxy_test.cpp
+++ b/src/redis_protocol/proxy_ut/redis_proxy_test.cpp
@@ -37,7 +37,6 @@
 #include <gtest/gtest_prod.h>
 #include <s2/third_party/absl/base/port.h>
 #include <string.h>
-#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <set>

--- a/src/replica/backup/cold_backup_context.cpp
+++ b/src/replica/backup/cold_backup_context.cpp
@@ -17,7 +17,6 @@
 
 #include "cold_backup_context.h"
 
-#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -20,7 +20,6 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
-#include <algorithm>
 #include <fstream> // IWYU pragma: keep
 #include <memory>
 #include <vector>

--- a/src/replica/duplication/replica_follower.cpp
+++ b/src/replica/duplication/replica_follower.cpp
@@ -20,7 +20,6 @@
 #include "replica_follower.h"
 
 #include <stddef.h>
-#include <algorithm>
 #include <cstdint>
 #include <map>
 #include <memory>

--- a/src/replica/mutation_cache.cpp
+++ b/src/replica/mutation_cache.cpp
@@ -30,8 +30,6 @@
 // https://github.com/include-what-you-use/include-what-you-use/issues/166
 // TODO(yingchun): remove this pragma by using mapping.imp
 // IWYU pragma: no_include <ext/alloc_traits.h>
-#include <algorithm>
-
 #include "consensus_types.h"
 #include "mutation.h"
 #include "utils/autoref_ptr.h"

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -28,7 +28,6 @@
 
 #include <fmt/core.h>
 #include <rocksdb/status.h>
-#include <algorithm>
 #include <functional>
 #include <set>
 

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -46,6 +46,7 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/std.h> // IWYU pragma: keep
 
 #include "common/fs_manager.h"
 #include "common/gpid.h"

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -46,9 +46,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/std.h> // IWYU pragma: keep
 
-#include "aio/aio_task.h"
 #include "common/fs_manager.h"
 #include "common/gpid.h"
 #include "common/replication.codes.h"

--- a/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
@@ -39,7 +39,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <algorithm>
 #include <atomic>
 #include <fstream>
 #include <utility>

--- a/src/replica/storage/simple_kv/test/client.cpp
+++ b/src/replica/storage/simple_kv/test/client.cpp
@@ -36,7 +36,6 @@
 #include "client.h"
 
 #include <stdint.h>
-#include <algorithm>
 #include <chrono>
 #include <functional>
 #include <utility>

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
@@ -29,7 +29,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <algorithm>
 #include <fstream>
 #include <utility>
 #include <vector>

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -54,7 +54,6 @@
 #include "replica/test/mock_utils.h"
 #include "replica_test_base.h"
 #include "runtime/api_layer1.h"
-#include "runtime/rpc/network.h"
 #include "runtime/rpc/network.sim.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_message.h"

--- a/src/runtime/providers.common.cpp
+++ b/src/runtime/providers.common.cpp
@@ -33,7 +33,6 @@
  *     xxxx-xx-xx, author, fix bug about xxx
  */
 
-#include <algorithm>
 #include <string>
 
 #include "runtime/env_provider.h"

--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -31,7 +31,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <algorithm>
 #include <cstddef>
 #include <limits>
 #include <memory>

--- a/src/runtime/rpc/asio_rpc_session.cpp
+++ b/src/runtime/rpc/asio_rpc_session.cpp
@@ -27,6 +27,7 @@
 #include "asio_rpc_session.h"
 
 #include <boost/asio.hpp> // IWYU pragma: keep
+// IWYU pragma: no_include <ext/alloc_traits.h>
 #include <cstddef>
 #include <iterator>
 #include <new>

--- a/src/runtime/rpc/asio_rpc_session.cpp
+++ b/src/runtime/rpc/asio_rpc_session.cpp
@@ -27,8 +27,6 @@
 #include "asio_rpc_session.h"
 
 #include <boost/asio.hpp> // IWYU pragma: keep
-// IWYU pragma: no_include <ext/alloc_traits.h>
-#include <algorithm>
 #include <cstddef>
 #include <iterator>
 #include <new>

--- a/src/runtime/rpc/rpc_address.h
+++ b/src/runtime/rpc/rpc_address.h
@@ -33,6 +33,7 @@
 #include <functional>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include "utils/fmt_utils.h"
 

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -25,6 +25,7 @@
 #include <functional>
 #include <iosfwd>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "runtime/rpc/rpc_address.h"

--- a/src/runtime/rpc/thrift_message_parser.cpp
+++ b/src/runtime/rpc/thrift_message_parser.cpp
@@ -27,7 +27,6 @@
 #include "thrift_message_parser.h"
 
 #include <string.h>
-#include <algorithm>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -36,6 +36,7 @@
 #include <stddef.h>
 #include <algorithm>
 #include <chrono>
+#include <random>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -276,10 +277,9 @@ void scheduler::schedule()
                 _time_ns = ts;
             }
 
-            // randomize the events, and see
-            std::random_shuffle(
-                events->begin(), events->end(), [](int n) { return rand::next_u32(0, n - 1); });
-
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::shuffle(events->begin(), events->end(), g);
             for (auto e : *events) {
                 if (e.app_task != nullptr) {
                     task *t = e.app_task;

--- a/src/runtime/service_engine.cpp
+++ b/src/runtime/service_engine.cpp
@@ -27,7 +27,6 @@
 #include "service_engine.h"
 
 #include <stdlib.h>
-#include <algorithm>
 #include <functional>
 #include <list>
 #include <unordered_map>

--- a/src/runtime/task/task_engine.cpp
+++ b/src/runtime/task/task_engine.cpp
@@ -28,7 +28,6 @@
 
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <limits.h>
-#include <algorithm>
 #include <mutex>
 #include <ostream>
 

--- a/src/runtime/test/client_negotiation_test.cpp
+++ b/src/runtime/test/client_negotiation_test.cpp
@@ -22,7 +22,6 @@
 #include <string>
 #include <utility>
 
-#include "runtime/rpc/network.h"
 #include "runtime/rpc/network.sim.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_holder.h"

--- a/src/runtime/test/pipeline_test.cpp
+++ b/src/runtime/test/pipeline_test.cpp
@@ -27,6 +27,7 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <memory>
 #include <utility>
 
 #include "common/replication.codes.h"

--- a/src/runtime/test/server_negotiation_test.cpp
+++ b/src/runtime/test/server_negotiation_test.cpp
@@ -23,7 +23,6 @@
 #include <memory>
 #include <utility>
 
-#include "runtime/rpc/network.h"
 #include "runtime/rpc/network.sim.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_holder.h"

--- a/src/utils/alloc.h
+++ b/src/utils/alloc.h
@@ -24,7 +24,7 @@
 #ifdef CACHELINE_SIZE
 
 #include <stddef.h>
-#include <algorithm>
+#include <algorithm> // IWYU pragma: keep
 #include <functional>
 #include <memory>
 #include <new>

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -27,7 +27,6 @@
 #include "utils/command_manager.h"
 
 #include <stdlib.h>
-#include <algorithm>
 #include <chrono>
 #include <limits>
 #include <sstream> // IWYU pragma: keep

--- a/src/utils/config_api.cpp
+++ b/src/utils/config_api.cpp
@@ -25,6 +25,9 @@
  */
 
 #include "utils/config_api.h"
+
+#include <algorithm>
+
 #include "utils/configuration.h"
 
 dsn::configuration g_config;

--- a/src/utils/filesystem.cpp
+++ b/src/utils/filesystem.cpp
@@ -33,8 +33,6 @@
  *     xxxx-xx-xx, author, fix bug about xxx
  */
 
-// IWYU pragma: no_include <bits/struct_stat.h>
-#include <sys/stat.h> // IWYU pragma: keep
 #include <boost/filesystem/operations.hpp>
 #include <boost/system/error_code.hpp>
 #include <errno.h>
@@ -46,8 +44,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+// IWYU pragma: no_include <bits/struct_stat.h>
+#include <sys/stat.h> // IWYU pragma: keep
 #include <unistd.h>
-#include <algorithm>
 #include <fstream>
 
 #include "utils/defer.h"

--- a/src/utils/flags.h
+++ b/src/utils/flags.h
@@ -22,6 +22,7 @@
 // IWYU pragma: no_include <experimental/string_view>
 #include <functional>
 #include <string>
+#include <string_view>
 
 #include "enum_helper.h"
 #include "errors.h"

--- a/src/utils/output_utils.h
+++ b/src/utils/output_utils.h
@@ -20,6 +20,7 @@
 // IWYU pragma: no_include <bits/std_abs.h>
 #include <rapidjson/ostreamwrapper.h>
 #include <stdlib.h>
+#include <algorithm>
 #include <cmath> // IWYU pragma: keep
 #include <iomanip>
 // IWYU pragma: no_include <new>

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -29,7 +29,6 @@
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <fmt/core.h>
 #include <stdint.h>
-#include <algorithm>
 #include <functional>
 #include <memory>
 #include <sstream>

--- a/src/utils/test/autoref_ptr_test.cpp
+++ b/src/utils/test/autoref_ptr_test.cpp
@@ -8,6 +8,7 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <memory>
 #include <ostream>
 #include <utility>
 

--- a/src/utils/test/env.cpp
+++ b/src/utils/test/env.cpp
@@ -38,6 +38,7 @@
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <limits>
+#include <memory>
 
 #include "utils/rand.h"
 

--- a/src/utils/test/fail_point_test.cpp
+++ b/src/utils/test/fail_point_test.cpp
@@ -31,6 +31,7 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <memory>
 
 #include "utils/fail_point.h"
 #include "utils/fail_point_impl.h"

--- a/src/utils/test/fmt_logging_test.cpp
+++ b/src/utils/test/fmt_logging_test.cpp
@@ -28,6 +28,8 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <iosfwd>
+#include <memory>
 
 #include "common/gpid.h"
 #include "common/replication.codes.h"

--- a/src/utils/test/fmt_logging_test.cpp
+++ b/src/utils/test/fmt_logging_test.cpp
@@ -28,7 +28,6 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
-#include <iosfwd>
 #include <memory>
 
 #include "common/gpid.h"

--- a/src/utils/test/join_point_test.cpp
+++ b/src/utils/test/join_point_test.cpp
@@ -29,7 +29,6 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
-#include <algorithm>
 #include <vector>
 
 namespace dsn {

--- a/src/utils/test/lock.std.cpp
+++ b/src/utils/test/lock.std.cpp
@@ -27,6 +27,7 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <memory>
 #include <thread>
 
 #include "runtime/rpc/rpc_address.h"

--- a/src/utils/test/main.cpp
+++ b/src/utils/test/main.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <gtest/gtest.h>
+#include <memory>
 
 #include "utils/flags.h"
 #include "utils/logging_provider.h"

--- a/src/utils/test/memutil_test.cpp
+++ b/src/utils/test/memutil_test.cpp
@@ -19,6 +19,7 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <memory>
 
 TEST(MemUtilTest, memmatch)
 {

--- a/src/utils/test/nth_element_utils.h
+++ b/src/utils/test/nth_element_utils.h
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <random>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -93,7 +94,10 @@ public:
             auto delta = _rand(_range_size);
             value += delta;
         }
-        std::random_shuffle(array.begin(), array.end());
+
+        std::random_device rd;
+        std::mt19937 g(rd());
+        std::shuffle(array.begin(), array.end(), g);
     }
 
 private:

--- a/src/utils/test/sema.cpp
+++ b/src/utils/test/sema.cpp
@@ -39,6 +39,7 @@
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 #include <chrono>
+#include <memory>
 #include <thread>
 
 TEST(core, Semaphore)

--- a/src/utils/test/smart_pointers_test.cpp
+++ b/src/utils/test/smart_pointers_test.cpp
@@ -17,6 +17,7 @@
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -28,7 +28,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <algorithm>
+#include <algorithm> // IWYU pragma: keep
 #include <iterator>
 #include <map>
 #include <memory>

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -21,9 +21,9 @@ project(pegasus_thirdparties)
 cmake_minimum_required(VERSION 3.11.0)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    # require at least gcc 5.4.0
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.4.0)
-        message(FATAL_ERROR "GCC version must be at least 5.4.0!")
+    # require at least gcc 7.0.0
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.0)
+        message(FATAL_ERROR "GCC version must be at least 7.0.0!")
     endif ()
 endif ()
 
@@ -244,7 +244,6 @@ ExternalProject_Add(fds
         BUILD_IN_SOURCE 1
         )
 
-# fmtlib >=6.x requires c++14 support, do not update this library for now
 ExternalProject_Add(fmt
         URL https://github.com/fmtlib/fmt/archive/refs/tags/10.1.1.tar.gz
         URL_MD5 0d41a16f1b3878d44e6fd7ff1f6cc45a


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1602

This patch adjust the build to start supporting and requiring C++17
(therefore GCC 7+).

`std::random_shuffle` has to be replaced by `std::shuffle`, because
the former has been removed since C++17.