### PR TITLE
fix(docker): fix build failure of rocksdb when PORTABLE=0

### DIFF
--- a/docker/thirdparties-bin/Dockerfile
+++ b/docker/thirdparties-bin/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=builder /root/thirdparties-src.zip /root/thirdparties-src.zip
 
 ARG GITHUB_BRANCH=master
 ARG GITHUB_REPOSITORY_URL=https://github.com/apache/incubator-pegasus.git
-ARG ROCKSDB_PORTABLE=0
+ARG ROCKSDB_PORTABLE=native
 ARG USE_JEMALLOC=OFF
 ARG HADOOP_BIN_PATH
 ARG ZOOKEEPER_BIN_PATH

--- a/docker/thirdparties-src/Dockerfile
+++ b/docker/thirdparties-src/Dockerfile
@@ -23,9 +23,10 @@ ARG GITHUB_BRANCH=master
 ARG GITHUB_REPOSITORY_URL=https://github.com/apache/incubator-pegasus.git
 RUN git clone --depth=1 --branch=${GITHUB_BRANCH} ${GITHUB_REPOSITORY_URL}
 
+ARG ROCKSDB_PORTABLE=native
 RUN cd incubator-pegasus/thirdparty \
     && mkdir -p build \
-    && cmake -DCMAKE_BUILD_TYPE=Release -B build/ . \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DROCKSDB_PORTABLE=${ROCKSDB_PORTABLE} -B build/ . \
     && cmake --build build/ -j $(($(nproc)/2+1))
 
 RUN cd incubator-pegasus/thirdparty \


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1604

Explicit set PORTABLE=native to avoid building failure. The failure looks like:
```
cc1plus: error: bad value ('OFF') for '-march=' switch
cc1plus: note: valid arguments to '-march=' switch are: nocona core2 nehalem corei7
    westmere sandybridge corei7-avx ivybridge core-avx-i haswell core-avx2 broadwell
    skylake skylake-avx512 bonnell atom silvermont slm knl x86-64 eden-x2 nano nano-1000
    nano-2000 nano-3000 nano-x2 eden-x4 nano-x4 k8 k8-sse3 opteron opteron-sse3 athlon64
    athlon64-sse3 athlon-fx amdfam10 barcelona bdver1 bdver2 bdver3 bdver4 znver1 btver1
    btver2
```