### PR TITLE
chore(CI): unify to use Ubuntu 22.04 for CI

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -259,7 +259,7 @@ jobs:
     needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup cache
@@ -370,7 +370,7 @@ jobs:
     needs: build_ASAN
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v3
@@ -401,7 +401,7 @@ jobs:
 #    needs: cpp_clang_format_linter
 #    runs-on: ubuntu-latest
 #    container:
-#      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+#      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
 #    steps:
 #      - uses: actions/checkout@v3
 #      - name: Setup cache
@@ -508,7 +508,7 @@ jobs:
 #    needs: build_UBSAN
 #    runs-on: ubuntu-latest
 #    container:
-#      image: apache/pegasus:thirdparties-bin-test-ubuntu1804-${{ github.base_ref }}
+#      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
 #      options: --cap-add=SYS_PTRACE
 #    steps:
 #      - uses: actions/checkout@v3

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         osversion:
-          - ubuntu1804
+          - ubuntu2204
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1604

Prior to this patch, the `thirdparties-bin-test-${OS}-${branch}` docker images are
only built for Ubuntu 18.04 for CI purpose, but some CI jobs use Ubuntu 22.04 image,
it may cause the CI failed because the Ubuntu 22.04 image is outdated (for example,
lack of or outdated of some thirdparties).
This patch unify to build and use `thirdparties-bin-test-2204-${branch}` docker image.