### PR TITLE
feat(build): build RocksDB with encryption enabled

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -379,6 +379,7 @@ ExternalProject_Add(rocksdb
         -DWITH_TESTS=OFF
         -DWITH_GFLAGS=OFF
         -DUSE_RTTI=ON
+        -DWITH_OPENSSL=ON  # enable encryption
         -DCMAKE_BUILD_TYPE=Release
         -DWITH_JEMALLOC=${USE_JEMALLOC}
         -DJEMALLOC_ROOT_DIR=${TP_OUTPUT}


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1575

Set option -DWITH_OPENSSL=ON to build rocksdb with encryption feature enabled.