### PR TITLE
fix(rocksdb): update rocksdb to fix build failure on lower OpenSSL version

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -365,8 +365,8 @@ option(ROCKSDB_PORTABLE "Minimum CPU arch to support, or 0 = current CPU, 1 = ba
 # The v8.5.3-pegasus-encrypt branch is based on the v8.5.3 tag of facebook/rocksdb and add
 # the encryption feature.
 ExternalProject_Add(rocksdb
-        URL https://github.com/pegasus-kv/rocksdb/archive/090c3d9fd1b99c633abc5ab4de2f75d4c6b6528d.zip
-        URL_MD5 1e556d77ae853b22f62dd2e82e915937
+        URL https://github.com/pegasus-kv/rocksdb/archive/e72106597e6b7924485cadc2433b66029f1aaf17.zip
+        URL_MD5 6f6daef703586ce788643bbb8a984fff
         DEPENDS jemalloc
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
         -DFAIL_ON_WARNINGS=OFF


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1575

Fix a build error on lower OpenSSL version, the error looks like:
```
2023-09-19T02:53:45.4093185Z #11 924.7 /root/incubator-pegasus/thirdparty/build/Source/rocksdb/encryption/encryption.cc: In function 'const EVP_CIPHER* rocksdb::encryption::GetEVPCipher(rocksdb::encryption::EncryptionMethod)':
2023-09-19T02:53:45.4094191Z #11 924.7 /root/incubator-pegasus/thirdparty/build/Source/rocksdb/encryption/encryption.cc:112:44: error: cannot convert 'rocksdb::Status' to 'const EVP_CIPHER* {aka const evp_cipher_st*}' in return
2023-09-19T02:53:45.4094713Z #11 924.7            std::string(OPENSSL_VERSION_TEXT));
2023-09-19T02:53:45.4094991Z #11 924.7                                             ^
2023-09-19T02:53:45.5599505Z #11 924.7 gmake[5]: *** [CMakeFiles/rocksdb.dir/encryption/encryption.cc.o] Error 1
2023-09-19T02:53:45.5599938Z #11 924.7 gmake[4]: *** [CMakeFiles/rocksdb.dir/all] Error 2
2023-09-19T02:53:45.5600266Z #11 924.7 gmake[4]: *** Waiting for unfinished jobs....
```