### PR TITLE
refactor(file_system): remove useless read/write_file()

### DIFF
--- a/src/utils/filesystem.cpp
+++ b/src/utils/filesystem.cpp
@@ -48,7 +48,6 @@
 #include <sys/stat.h>
 // IWYU pragma: no_include <bits/struct_stat.h>
 #include <unistd.h>
-#include <istream>
 #include <memory>
 
 #include "utils/defer.h"
@@ -830,36 +829,6 @@ std::pair<error_code, bool> is_directory_empty(const std::string &dirname)
     return res;
 }
 
-error_code read_file(const std::string &fname, std::string &buf)
-{
-    if (!file_exists(fname)) {
-        LOG_ERROR("file({}) doesn't exist", fname);
-        return ERR_FILE_OPERATION_FAILED;
-    }
-
-    int64_t file_sz = 0;
-    if (!file_size(fname, file_sz)) {
-        LOG_ERROR("get file({}) size failed", fname);
-        return ERR_FILE_OPERATION_FAILED;
-    }
-
-    buf.resize(file_sz);
-    std::ifstream fin(fname, std::ifstream::in);
-    if (!fin.is_open()) {
-        LOG_ERROR("open file({}) failed", fname);
-        return ERR_FILE_OPERATION_FAILED;
-    }
-    fin.read(&buf[0], file_sz);
-    CHECK_EQ_MSG(file_sz,
-                 fin.gcount(),
-                 "read file({}) failed, file_size = {} but read size = {}",
-                 fname,
-                 file_sz,
-                 fin.gcount());
-    fin.close();
-    return ERR_OK;
-}
-
 bool verify_file(const std::string &fname,
                  FileDataType type,
                  const std::string &expected_md5,
@@ -930,20 +899,6 @@ bool create_directory(const std::string &path, std::string &absolute_path, std::
         err_msg = fmt::format("Fail to get absolute path from {}.", path);
         return false;
     }
-    return true;
-}
-
-bool write_file(const std::string &fname, std::string &buf)
-{
-    if (!file_exists(fname)) {
-        LOG_ERROR("file({}) doesn't exist", fname);
-        return false;
-    }
-
-    std::ofstream fstream;
-    fstream.open(fname.c_str());
-    fstream << buf;
-    fstream.close();
     return true;
 }
 

--- a/src/utils/filesystem.h
+++ b/src/utils/filesystem.h
@@ -146,9 +146,6 @@ error_code deprecated_md5sum(const std::string &file_path, /*out*/ std::string &
 //          B is represent wheter the directory is empty, true means empty, otherwise false
 std::pair<error_code, bool> is_directory_empty(const std::string &dirname);
 
-// TODO(yingchun): remove it!
-error_code read_file(const std::string &fname, /*out*/ std::string &buf);
-
 // compare file metadata calculated by fname with expected md5 and file_size
 bool verify_file(const std::string &fname,
                  FileDataType type,
@@ -161,9 +158,6 @@ bool verify_file_size(const std::string &fname, FileDataType type, const int64_t
 bool create_directory(const std::string &path,
                       /*out*/ std::string &absolute_path,
                       /*out*/ std::string &err_msg);
-
-// TODO(yingchun): remove it!
-bool write_file(const std::string &fname, std::string &buf);
 
 // check if directory is readable and writable
 // call `create_directory` before to make `path` exist


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/887

Remove `read_file()` and `write_file()` from `dsn::utils::filesystem` namespace.