### PR TITLE
fix(ut): fix flaky unit test test_rename_path_while_writing

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -247,6 +247,7 @@ jobs:
       - name: Tar files
         run: |
           tar -zxvf release__builder.tar
+          rm -f release__builder.tar
       - name: Unit Testing
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
@@ -386,6 +387,7 @@ jobs:
       - name: Tar files
         run: |
           tar -zxvf release_address_builder.tar
+          rm -f release_address_builder.tar
       - name: Unit Testing
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
@@ -527,6 +529,7 @@ jobs:
 #      - name: Tar files
 #        run: |
 #          tar -zxvf release_undefined_builder.tar
+#          rm -f release_undefined_builder.tar
 #      - name: Unit Testing
 #        run: |
 #          export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
@@ -639,6 +642,7 @@ jobs:
       - name: Tar files
         run: |
           tar -zxvf release_jemalloc_builder.tar
+          rm -f release_jemalloc_builder.tar
       - name: Unit Testing
         run: |
           export LD_LIBRARY_PATH=`pwd`/thirdparty/output/lib:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server

--- a/src/test_util/test_util.h
+++ b/src/test_util/test_util.h
@@ -59,7 +59,7 @@ void create_local_test_file(const std::string &full_name, dsn::replication::file
 
 #define ASSERT_IN_TIME_WITH_FIXED_INTERVAL(expr, sec)                                              \
     do {                                                                                           \
-        AssertEventually(expr, sec, WaitBackoff::NONE);                                            \
+        AssertEventually(expr, sec, ::pegasus::WaitBackoff::NONE);                                 \
         NO_PENDING_FATALS();                                                                       \
     } while (0)
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1631

Add retry logic for test `HDFSClientTest.test_rename_path_while_writing`, fix an
used-after-free ASAN issue and remove tar files after downloading from artifacts
to reduce space consumption.