### PR TITLE
build(thirdparty): bump libcurl from 7.47.0 to 8.4.0

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -308,9 +308,9 @@ if (APPLE)
             )
 endif ()
 ExternalProject_Add(curl
-        URL ${OSS_URL_PREFIX}/curl-8.3.0.tar.gz
-        http://curl.haxx.se/download/curl-8.3.0.tar.gz
-        URL_MD5 7e614827c4165bf30f9770577259561e
+        URL ${OSS_URL_PREFIX}/curl-8.4.0.tar.gz
+        http://curl.haxx.se/download/curl-8.4.0.tar.gz
+        URL_MD5 533e8a3b1228d5945a6a512537bea4c7
         CONFIGURE_COMMAND ./configure --prefix=${TP_OUTPUT}
         ${CURL_OPTIONS}
         BUILD_IN_SOURCE 1

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -297,17 +297,20 @@ set(CURL_OPTIONS
         --without-libssh2
         --without-ssl
         --without-libidn
+        --without-zstd
         )
 if (APPLE)
     set(CURL_OPTIONS
-	    ${CURL_OPTIONS}
-	    --without-nghttp2
-	    )
+            ${CURL_OPTIONS}
+            --without-nghttp2
+            --without-libidn2
+            --without-brotli
+            )
 endif ()
 ExternalProject_Add(curl
-        URL ${OSS_URL_PREFIX}/curl-7.47.0.tar.gz
-        http://curl.haxx.se/download/curl-7.47.0.tar.gz
-        URL_MD5 5109d1232d208dfd712c0272b8360393
+        URL ${OSS_URL_PREFIX}/curl-8.3.0.tar.gz
+        http://curl.haxx.se/download/curl-8.3.0.tar.gz
+        URL_MD5 7e614827c4165bf30f9770577259561e
         CONFIGURE_COMMAND ./configure --prefix=${TP_OUTPUT}
         ${CURL_OPTIONS}
         BUILD_IN_SOURCE 1


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1604

In pegasus, both [prometheus-cpp](https://github.com/jupp0r/prometheus-cpp)
and [http client](https://github.com/apache/incubator-pegasus/pull/1583) are
based on [libcurl](https://curl.se/libcurl/c/).

Above all, an important version 8.4.0 for libcurl, which has fixed severity HIGH
security problem(https://github.com/curl/curl/discussions/12026), would be
released in Oct 11.

Therefore, we should bump libcurl from 7.47.0 to 8.4.0.
