### PR TITLE
refactor(filesystem): refactor file_utils unit tests

### DIFF
--- a/src/utils/filesystem.h
+++ b/src/utils/filesystem.h
@@ -67,7 +67,7 @@ namespace filesystem {
 
 // TODO(yingchun): Consider using rocksdb APIs to rewrite the following functions.
 
-int get_normalized_path(const std::string &path, std::string &npath);
+void get_normalized_path(const std::string &path, std::string &npath);
 
 bool get_absolute_path(const std::string &path1, std::string &path2);
 

--- a/src/utils/test/file_utils.cpp
+++ b/src/utils/test/file_utils.cpp
@@ -25,877 +25,327 @@
  */
 
 // IWYU pragma: no_include <gtest/gtest-message.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
+#include <rocksdb/env.h>
+#include <rocksdb/slice.h>
+#include <rocksdb/status.h>
 #include <stdint.h>
 #include <time.h>
 #include <fstream>
 #include <string>
 #include <vector>
 
+#include "test_util/test_util.h"
 #include "utils/env.h"
 #include "utils/error_code.h"
 #include "utils/filesystem.h"
 
-static void file_utils_test_setup()
+class file_utils : public pegasus::encrypt_data_test_base
 {
-    std::string path;
-    bool ret;
+public:
+    void file_utils_test_setup()
+    {
+        std::string path = "./file_utils_temp.txt";
+        ASSERT_TRUE(dsn::utils::filesystem::remove_path(path));
+        ASSERT_FALSE(dsn::utils::filesystem::file_exists(path));
 
-    path = "./file_utils_temp.txt";
-    ret = dsn::utils::filesystem::remove_path(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::file_exists(path);
-    EXPECT_FALSE(ret);
-
-    path = "./file_utils_temp";
-    ret = dsn::utils::filesystem::remove_path(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::directory_exists(path);
-    EXPECT_FALSE(ret);
-}
-
-static void file_utils_test_get_process_image_path()
-{
-    std::string path;
-    std::string imagepath;
-    dsn::error_code ret;
-    // int pid;
-
-    if (!dsn::utils::filesystem::get_current_directory(imagepath)) {
-        EXPECT_TRUE(false);
+        path = "./file_utils_temp";
+        ASSERT_TRUE(dsn::utils::filesystem::remove_path(path));
+        ASSERT_FALSE(dsn::utils::filesystem::directory_exists(path));
     }
-    imagepath = dsn::utils::filesystem::path_combine(imagepath, "dsn_utils_tests");
-
-    ret = dsn::utils::filesystem::get_current_process_image_path(path);
-    EXPECT_TRUE(ret == dsn::ERR_OK);
-    // TODO: not always true when running dir is not where the test resides
-    // EXPECT_TRUE(path == imagepath); // e: vs E:
-}
-
-static void file_utils_test_get_normalized_path()
-{
-    int ret;
-    std::string path;
-    std::string npath;
-
-    path = "\\\\?\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "c:\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "c:";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "\\\\?\\c:\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "\\\\?\\c:";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "c:\\a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "c:\\\\a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "c:\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "c:\\\\a\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "c:\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "c:\\\\a\\\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "c:\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "\\\\?\\c:\\a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "\\\\?\\c:\\\\a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\?\\c:\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "\\\\?\\c:\\\\a\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\?\\c:\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "\\\\?\\c:\\\\a\\\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\?\\c:\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "\\\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "\\\\\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "\\\\a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "\\\\\\a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "\\\\a\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "\\\\\\a\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "\\\\\\a\\\\";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "/";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "//";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\");
-#else
-    EXPECT_TRUE(npath == "/");
-#endif
-
-    path = "//?/";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\?\\");
-#else
-    EXPECT_TRUE(npath == "/?");
-#endif
-
-    path = "//a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\a");
-#else
-    EXPECT_TRUE(npath == "/a");
-#endif
-
-    path = "//a/";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\a");
-#else
-    EXPECT_TRUE(npath == "/a");
-#endif
-
-    path = "//a//";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\a");
-#else
-    EXPECT_TRUE(npath == "/a");
-#endif
-
-    path = "c:/";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "c:\\");
-#else
-    EXPECT_TRUE(npath == "c:");
-#endif
-
-    path = "c://";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "c:\\");
-#else
-    EXPECT_TRUE(npath == "c:");
-#endif
-
-    path = "c:/a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "c:\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "c:/a/";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "c:\\a");
-#else
-    EXPECT_TRUE(npath == "c:/a");
-#endif
-
-    path = "c://a/";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "c:\\a");
-#else
-    EXPECT_TRUE(npath == "c:/a");
-#endif
-
-    path = "c://a//";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "c:\\a");
-#else
-    EXPECT_TRUE(npath == "c:/a");
-#endif
-
-    path = "/////////////////////////////////////////////////////////////////";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\");
-#else
-    EXPECT_TRUE(npath == "/");
-#endif
-
-    path = "/////////////////////////////////////////////////////////////////a/////////////////b///"
-           "////////";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "\\\\a\\b");
-#else
-    EXPECT_TRUE(npath == "/a/b");
-#endif
-
-    path = ".";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "./";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == ".");
-
-    path = "./a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == ".\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = ".//a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == ".\\a");
-#else
-    EXPECT_TRUE(npath == "./a");
-#endif
-
-    path = "./a/";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == ".\\a");
-#else
-    EXPECT_TRUE(npath == "./a");
-#endif
-
-    path = "./a/b";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == ".\\a\\b");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "./a/b/";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == ".\\a\\b");
-#else
-    EXPECT_TRUE(npath == "./a/b");
-#endif
-
-    path = ".///a////b///";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == ".\\a\\b");
-#else
-    EXPECT_TRUE(npath == "./a/b");
-#endif
-
-    path = "..";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == path);
-
-    path = "../";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_TRUE(npath == "..");
-
-    path = "../a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "..\\a");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "..//a";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "..\\a");
-#else
-    EXPECT_TRUE(npath == "../a");
-#endif
-
-    path = "../a/";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "..\\a");
-#else
-    EXPECT_TRUE(npath == "../a");
-#endif
-
-    path = "../a/b";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "..\\a\\b");
-#else
-    EXPECT_TRUE(npath == path);
-#endif
-
-    path = "../a/b/";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "..\\a\\b");
-#else
-    EXPECT_TRUE(npath == "../a/b");
-#endif
-
-    path = "..///a////b///";
-    ret = dsn::utils::filesystem::get_normalized_path(path, npath);
-    EXPECT_TRUE(ret == 0);
-#ifdef _WIN32
-    EXPECT_TRUE(npath == "..\\a\\b");
-#else
-    EXPECT_TRUE(npath == "../a/b");
-#endif
-}
-
-static void file_utils_test_get_current_directory()
-{
-    std::string path;
-    bool ret;
-
-    path = "";
-    ret = dsn::utils::filesystem::get_current_directory(path);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE(!path.empty());
-}
-
-static void file_utils_test_path_combine()
-{
-    std::string path;
-    std::string path1;
-    std::string path2;
-
-    path1 = "";
-    path2 = "";
-    path = dsn::utils::filesystem::path_combine(path1, path2);
-    EXPECT_TRUE(path == "");
-
-    path1 = "c:";
-    path2 = "Windows\\explorer.exe";
-    path = dsn::utils::filesystem::path_combine(path1, path2);
-#ifdef _WIN32
-    EXPECT_TRUE(path == "c:Windows\\explorer.exe");
-#else
-    EXPECT_TRUE(path == "c:/Windows\\explorer.exe");
-#endif
-
-    path1 = "c:";
-    path2 = "\\Windows\\explorer.exe";
-    path = dsn::utils::filesystem::path_combine(path1, path2);
-#ifdef _WIN32
-    EXPECT_TRUE(path == "c:\\Windows\\explorer.exe");
-#else
-    EXPECT_TRUE(path == "c:/Windows\\explorer.exe");
-#endif
-
-    path1 = "c:\\";
-    path2 = "\\Windows\\explorer.exe";
-    path = dsn::utils::filesystem::path_combine(path1, path2);
-#ifdef _WIN32
-    EXPECT_TRUE(path == "c:\\Windows\\explorer.exe");
-#else
-    EXPECT_TRUE(path == "c:\\/Windows\\explorer.exe");
-#endif
-
-    path1 = "/bin";
-    path2 = "ls";
-    path = dsn::utils::filesystem::path_combine(path1, path2);
-#ifdef _WIN32
-    EXPECT_TRUE(path == "\\bin\\ls");
-#else
-    EXPECT_TRUE(path == "/bin/ls");
-#endif
-
-    path1 = "/bin/";
-    path2 = "ls";
-    path = dsn::utils::filesystem::path_combine(path1, path2);
-#ifdef _WIN32
-    EXPECT_TRUE(path == "\\bin\\ls");
-#else
-    EXPECT_TRUE(path == "/bin/ls");
-#endif
-
-    path1 = "/bin";
-    path2 = "/ls";
-    path = dsn::utils::filesystem::path_combine(path1, path2);
-#ifdef _WIN32
-    EXPECT_TRUE(path == "\\bin\\ls");
-#else
-    EXPECT_TRUE(path == "/bin/ls");
-#endif
-
-    path1 = "/bin/";
-    path2 = "/ls";
-    path = dsn::utils::filesystem::path_combine(path1, path2);
-#ifdef _WIN32
-    EXPECT_TRUE(path == "\\bin\\ls");
-#else
-    EXPECT_TRUE(path == "/bin/ls");
-#endif
-}
-
-static void file_utils_test_get_file_name()
-{
-    std::string path1;
-    std::string path2;
-
-    path1 = "";
-    path2 = dsn::utils::filesystem::get_file_name(path1);
-    EXPECT_TRUE(path2 == "");
-
-    path1 = "c:";
-    path2 = dsn::utils::filesystem::get_file_name(path1);
-#ifdef _WIN32
-    EXPECT_TRUE(path2 == "");
-#else
-    EXPECT_TRUE(path2 == "c:");
-#endif
-
-    path1 = "c:\\";
-    path2 = dsn::utils::filesystem::get_file_name(path1);
-    EXPECT_TRUE(path2 == "");
-
-    path1 = "c:1.txt";
-    path2 = dsn::utils::filesystem::get_file_name(path1);
-#ifdef _WIN32
-    EXPECT_TRUE(path2 == "1.txt");
-#else
-    EXPECT_TRUE(path2 == "c:1.txt");
-#endif
-
-    path1 = "c:\\1.txt";
-    path2 = dsn::utils::filesystem::get_file_name(path1);
-    EXPECT_TRUE(path2 == "1.txt");
-
-    path1 = "c:\\Windows\\1.txt";
-    path2 = dsn::utils::filesystem::get_file_name(path1);
-    EXPECT_TRUE(path2 == "1.txt");
-
-    path1 = "/bin/";
-    path2 = dsn::utils::filesystem::get_file_name(path1);
-    EXPECT_TRUE(path2 == "");
-
-    path1 = "/bin/ls";
-    path2 = dsn::utils::filesystem::get_file_name(path1);
-    EXPECT_TRUE(path2 == "ls");
-}
-
-static void file_utils_test_create()
-{
-    std::string path;
-    bool ret;
-
-    path = "./file_utils_temp.txt";
-    ret = dsn::utils::filesystem::create_file(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::file_exists(path);
-    EXPECT_TRUE(ret);
-
-    time_t current_time = ::time(nullptr);
-    EXPECT_TRUE(current_time != 1);
-
-    std::ofstream myfile(path.c_str(), std::ios::out | std::ios::app | std::ios::binary);
-    EXPECT_TRUE(myfile.is_open());
-    myfile << "Hello world!";
-    myfile.close();
-
-    time_t last_write_time;
-    ret = dsn::utils::filesystem::last_write_time(path, last_write_time);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE((last_write_time != -1) && (last_write_time >= current_time));
-
-    path = "./file_utils_temp";
-    ret = dsn::utils::filesystem::create_directory(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::directory_exists(path);
-    EXPECT_TRUE(ret);
-
-    path = "./file_utils_temp/a/b/c/d//";
-    ret = dsn::utils::filesystem::create_directory(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::directory_exists(path);
-    EXPECT_TRUE(ret);
-
-    path = "./file_utils_temp/a/1.txt";
-    ret = dsn::utils::filesystem::create_file(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::file_exists(path);
-    EXPECT_TRUE(ret);
-
-    path = "./file_utils_temp/a/1.txt";
-    ret = dsn::utils::filesystem::create_file(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::file_exists(path);
-    EXPECT_TRUE(ret);
-
-    path = "./file_utils_temp/a/2.txt";
-    ret = dsn::utils::filesystem::create_file(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::file_exists(path);
-    EXPECT_TRUE(ret);
-
-    path = "./file_utils_temp/b/c/d/1.txt";
-    ret = dsn::utils::filesystem::create_file(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::file_exists(path);
-    EXPECT_TRUE(ret);
-}
-
-static void file_utils_test_file_size()
-{
-    std::string path;
-    int64_t sz;
-    bool ret;
-
-    path = "./file_utils_temp.txt";
-    ret = dsn::utils::filesystem::file_size(path, dsn::utils::FileDataType::kNonSensitive, sz);
-    ASSERT_TRUE(ret);
-    ASSERT_EQ(12, sz);
-
-    path = "./file_utils_temp2.txt";
-    ret = dsn::utils::filesystem::file_size(path, dsn::utils::FileDataType::kNonSensitive, sz);
-    EXPECT_FALSE(ret);
-}
-
-static void file_utils_test_path_exists()
-{
-    std::string path;
-    bool ret;
-
-    path = "c:\\";
-    ret = dsn::utils::filesystem::path_exists(path);
-#ifdef _WIN32
-    EXPECT_TRUE(ret);
-#else
-    EXPECT_FALSE(ret);
-#endif
-
-    path = "c:\\";
-    ret = dsn::utils::filesystem::directory_exists(path);
-#ifdef _WIN32
-    EXPECT_TRUE(ret);
-#else
-    EXPECT_FALSE(ret);
-#endif
-
-    path = "c:\\";
-    ret = dsn::utils::filesystem::file_exists(path);
-#ifdef _WIN32
-    EXPECT_FALSE(ret);
-#else
-    EXPECT_FALSE(ret);
-#endif
-
-    path = "/";
-    ret = dsn::utils::filesystem::path_exists(path);
-    EXPECT_TRUE(ret);
-
-    path = "/";
-    ret = dsn::utils::filesystem::directory_exists(path);
-    EXPECT_TRUE(ret);
-
-    path = "/";
-    ret = dsn::utils::filesystem::file_exists(path);
-    EXPECT_FALSE(ret);
-
-    path = "./not_exists_not_exists";
-    ret = dsn::utils::filesystem::path_exists(path);
-    EXPECT_FALSE(ret);
-
-    path = "c:\\Windows\\System32\\notepad.exe";
-    ret = dsn::utils::filesystem::path_exists(path);
-#ifdef _WIN32
-    EXPECT_TRUE(ret);
-#else
-    EXPECT_FALSE(ret);
-#endif
-
-    path = "c:\\Windows\\System32\\notepad.exe";
-    ret = dsn::utils::filesystem::directory_exists(path);
-    EXPECT_FALSE(ret);
-
-    path = "c:\\Windows\\System32\\notepad.exe";
-    ret = dsn::utils::filesystem::file_exists(path);
-#ifdef _WIN32
-    EXPECT_TRUE(ret);
-#else
-    EXPECT_FALSE(ret);
-#endif
-
-    path = "/bin/ls";
-    ret = dsn::utils::filesystem::path_exists(path);
-#ifdef _WIN32
-    EXPECT_FALSE(ret);
-#else
-    EXPECT_TRUE(ret);
-#endif
-
-    path = "/bin/ls";
-    ret = dsn::utils::filesystem::directory_exists(path);
-    EXPECT_FALSE(ret);
-
-    path = "/bin/ls";
-    ret = dsn::utils::filesystem::file_exists(path);
-#ifdef _WIN32
-    EXPECT_FALSE(ret);
-#else
-    EXPECT_TRUE(ret);
-#endif
-}
-
-static void file_utils_test_get_paths()
-{
-    std::string path;
-    bool ret;
-    std::vector<std::string> file_list;
-
-    path = ".";
-    ret = dsn::utils::filesystem::get_subfiles(path, file_list, false);
-    EXPECT_TRUE(ret);
-#ifdef _WIN32
-    EXPECT_TRUE(file_list.size() >= 3);
-#else
-    EXPECT_TRUE(file_list.size() >= 2);
-#endif
-    file_list.clear();
-
-    path = ".";
-    ret = dsn::utils::filesystem::get_subfiles(path, file_list, true);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE(file_list.size() >= 3);
-    file_list.clear();
-
-    path = "../../";
-    ret = dsn::utils::filesystem::get_subfiles(path, file_list, true);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE(file_list.size() >= 3);
-    file_list.clear();
-
-    path = "./file_utils_temp/";
-    ret = dsn::utils::filesystem::get_subfiles(path, file_list, true);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE(file_list.size() == 3);
-    file_list.clear();
-
-    path = "./file_utils_temp/";
-    ret = dsn::utils::filesystem::get_subdirectories(path, file_list, true);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE(file_list.size() == 7);
-    file_list.clear();
-
-    path = "./file_utils_temp/";
-    ret = dsn::utils::filesystem::get_subdirectories(path, file_list, false);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE(file_list.size() == 2);
-    file_list.clear();
-
-    path = "./file_utils_temp/";
-    ret = dsn::utils::filesystem::get_subpaths(path, file_list, true);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE(file_list.size() == 10);
-    file_list.clear();
-
-    path = "./file_utils_temp/";
-    ret = dsn::utils::filesystem::get_subpaths(path, file_list, false);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE(file_list.size() == 2);
-    file_list.clear();
-
-    path = "./file_utils_temp/a/";
-    ret = dsn::utils::filesystem::get_subfiles(path, file_list, false);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE(file_list.size() == 2);
-    file_list.clear();
-
-    path = "./file_utils_temp/a/";
-    ret = dsn::utils::filesystem::get_subpaths(path, file_list, false);
-    EXPECT_TRUE(ret);
-    EXPECT_TRUE(file_list.size() == 3);
-    file_list.clear();
-}
-
-static void file_utils_test_rename()
-{
-    std::string path;
-    std::string path2;
-    bool ret;
-
-    path = "./file_utils_temp/b/c/d/1.txt";
-    path2 = "./file_utils_temp/b/c/d/2.txt";
-    ret = dsn::utils::filesystem::rename_path(path, path2);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::file_exists(path);
-    EXPECT_FALSE(ret);
-    ret = dsn::utils::filesystem::file_exists(path2);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::rename_path(path, path2);
-    EXPECT_FALSE(ret);
-}
-
-static void file_utils_test_remove()
-{
-    std::string path;
-    std::vector<std::string> file_list;
-    bool ret;
-
-    path = "./file_utils_temp.txt";
-    ret = dsn::utils::filesystem::remove_path(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::file_exists(path);
-    EXPECT_FALSE(ret);
-
-    path = "./file_utils_temp/a/2.txt";
-    ret = dsn::utils::filesystem::remove_path(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::remove_path(path);
-    EXPECT_TRUE(ret);
-
-    path = "./file_utils_temp/";
-    ret = dsn::utils::filesystem::remove_path(path);
-    EXPECT_TRUE(ret);
-    ret = dsn::utils::filesystem::directory_exists(path);
-    EXPECT_FALSE(ret);
-}
-
-static void file_utils_test_cleanup() {}
-
-TEST(core, file_utils)
+
+    void file_utils_test_get_process_image_path()
+    {
+        std::string imagepath;
+        ASSERT_TRUE(dsn::utils::filesystem::get_current_directory(imagepath));
+        imagepath = dsn::utils::filesystem::path_combine(imagepath, "dsn_utils_tests");
+
+        std::string path;
+        ASSERT_EQ(dsn::ERR_OK, dsn::utils::filesystem::get_current_process_image_path(path));
+    }
+
+    void file_utils_test_get_normalized_path()
+    {
+        struct same_normalized_paths
+        {
+            std::string path;
+        } same_normalized_path_tests[] = {{"\\\\?\\"},
+                                          {"c:\\"},
+                                          {"c:"},
+                                          {"\\\\?\\c:\\"},
+                                          {"\\\\?\\c:"},
+                                          {"c:\\a"},
+                                          {"c:\\\\a"},
+                                          {"c:\\\\a\\"},
+                                          {"c:\\\\a\\\\"},
+                                          {"\\\\?\\c:\\a"},
+                                          {"\\\\?\\c:\\\\a"},
+                                          {"\\\\?\\c:\\\\a\\"},
+                                          {"\\\\?\\c:\\\\a\\\\"},
+                                          {"\\"},
+                                          {"\\\\"},
+                                          {"\\\\\\"},
+                                          {"\\\\a"},
+                                          {"\\\\\\a"},
+                                          {"\\\\a\\"},
+                                          {"\\\\\\a\\"},
+                                          {"\\\\\\a\\\\"},
+                                          {"/"},
+                                          {"c:/a"},
+                                          {"."},
+                                          {"./a"},
+                                          {"./a/b"},
+                                          {".."},
+                                          {"../a"},
+                                          {"../a/b"}};
+        for (const auto &test : same_normalized_path_tests) {
+            std::string npath;
+            dsn::utils::filesystem::get_normalized_path(test.path, npath);
+            ASSERT_EQ(test.path, npath);
+        }
+
+        struct normalized_paths
+        {
+            std::string path;
+            std::string normalized_path;
+        } normalized_path_tests[] = {
+            {"//", "/"},
+            {"//?/", "/?"},
+            {"//a", "/a"},
+            {"//a/", "/a"},
+            {"//a//", "/a"},
+            {"c:/", "c:"},
+            {"c://", "c:"},
+            {"c:/a/", "c:/a"},
+            {"c://a/", "c:/a"},
+            {"c://a//", "c:/a"},
+            {"/////////////////////////////////////////////////////////////////", "/"},
+            {"/////////////////////////////////////////////////////////////////a/////////////////"
+             "b///"
+             "////////",
+             "/a/b"},
+            {"./", "."},
+            {".//a", "./a"},
+            {"./a/", "./a"},
+            {"./a/b/", "./a/b"},
+            {".///a////b///", "./a/b"},
+            {"../", ".."},
+            {"..//a", "../a"},
+            {"../a/", "../a"},
+            {"../a/b/", "../a/b"},
+            {"..///a////b///", "../a/b"}};
+        for (const auto &test : normalized_path_tests) {
+            std::string npath;
+            dsn::utils::filesystem::get_normalized_path(test.path, npath);
+            ASSERT_EQ(test.normalized_path, npath) << test.path;
+        }
+    }
+
+    void file_utils_test_get_current_directory()
+    {
+        std::string path;
+        ASSERT_TRUE(dsn::utils::filesystem::get_current_directory(path));
+        ASSERT_TRUE(!path.empty());
+    }
+
+    void file_utils_test_path_combine()
+    {
+        struct combine_paths
+        {
+            std::string path1;
+            std::string path2;
+            std::string combined_path;
+        } tests[] = {{"", "", ""},
+                     {"c:", "Windows\\explorer.exe", "c:/Windows\\explorer.exe"},
+                     {"c:", "\\Windows\\explorer.exe", "c:/Windows\\explorer.exe"},
+                     {"c:\\", "\\Windows\\explorer.exe", "c:\\/Windows\\explorer.exe"},
+                     {"/bin", "ls", "/bin/ls"},
+                     {"/bin/", "ls", "/bin/ls"},
+                     {"/bin", "/ls", "/bin/ls"},
+                     {"/bin/", "/ls", "/bin/ls"}};
+        for (const auto &test : tests) {
+            std::string path = dsn::utils::filesystem::path_combine(test.path1, test.path2);
+            ASSERT_EQ(test.combined_path, path) << test.path1 << " + " << test.path2;
+        }
+    }
+
+    void file_utils_test_get_file_name()
+    {
+        struct combine_paths
+        {
+            std::string path;
+            std::string file_name;
+        } tests[] = {{"", ""},
+                     {"c:", "c:"},
+                     {"c:\\", ""},
+                     {"c:1.txt", "c:1.txt"},
+                     {"c:\\1.txt", "1.txt"},
+                     {"c:\\Windows\\1.txt", "1.txt"},
+                     {"/bin/", ""},
+                     {"/bin/ls", "ls"}};
+        for (const auto &test : tests) {
+            std::string file_name = dsn::utils::filesystem::get_file_name(test.path);
+            ASSERT_EQ(test.file_name, file_name) << test.path;
+        }
+    }
+
+    void file_utils_test_create()
+    {
+        std::string path = "./file_utils_temp.txt";
+        ASSERT_TRUE(dsn::utils::filesystem::create_file(path));
+        ASSERT_TRUE(dsn::utils::filesystem::file_exists(path));
+
+        time_t current_time = ::time(nullptr);
+        ASSERT_NE(current_time, 1);
+
+        auto s = rocksdb::WriteStringToFile(
+            dsn::utils::PegasusEnv(dsn::utils::FileDataType::kNonSensitive),
+            rocksdb::Slice("Hello world!"),
+            path,
+            /* should_sync */ true);
+        ASSERT_TRUE(s.ok()) << s.ToString();
+
+        time_t last_write_time;
+        ASSERT_TRUE(dsn::utils::filesystem::last_write_time(path, last_write_time));
+        ASSERT_NE(last_write_time, -1);
+        ASSERT_GE(last_write_time, current_time);
+
+        path = "./file_utils_temp";
+        ASSERT_TRUE(dsn::utils::filesystem::create_directory(path));
+        ASSERT_TRUE(dsn::utils::filesystem::directory_exists(path));
+
+        path = "./file_utils_temp/a/b/c/d//";
+        ASSERT_TRUE(dsn::utils::filesystem::create_directory(path));
+        ASSERT_TRUE(dsn::utils::filesystem::directory_exists(path));
+
+        struct create_files
+        {
+            std::string filename;
+        } tests[] = {{"./file_utils_temp/a/1.txt"},
+                     {"./file_utils_temp/a/2.txt"},
+                     {"./file_utils_temp/b/c/d/1.txt"}};
+        for (const auto &test : tests) {
+            ASSERT_TRUE(dsn::utils::filesystem::create_file(test.filename)) << test.filename;
+            ASSERT_TRUE(dsn::utils::filesystem::file_exists(test.filename)) << test.filename;
+        }
+    }
+
+    void file_utils_test_file_size()
+    {
+        std::string path = "./file_utils_temp.txt";
+        int64_t sz;
+        ASSERT_TRUE(
+            dsn::utils::filesystem::file_size(path, dsn::utils::FileDataType::kNonSensitive, sz));
+        ASSERT_EQ(12, sz);
+
+        path = "./file_utils_temp2.txt";
+        ASSERT_FALSE(
+            dsn::utils::filesystem::file_size(path, dsn::utils::FileDataType::kNonSensitive, sz));
+    }
+
+    void file_utils_test_path_exists()
+    {
+        std::string path = "/";
+        ASSERT_TRUE(dsn::utils::filesystem::path_exists(path));
+        ASSERT_TRUE(dsn::utils::filesystem::directory_exists(path));
+        ASSERT_FALSE(dsn::utils::filesystem::file_exists(path));
+
+        path = "./not_exists_not_exists";
+        ASSERT_FALSE(dsn::utils::filesystem::path_exists(path));
+
+        path = "/bin/ls";
+        ASSERT_TRUE(dsn::utils::filesystem::path_exists(path));
+        ASSERT_FALSE(dsn::utils::filesystem::directory_exists(path));
+        ASSERT_TRUE(dsn::utils::filesystem::file_exists(path));
+    }
+
+    void file_utils_test_get_paths()
+    {
+        std::string path = ".";
+        std::vector<std::string> file_list;
+        ASSERT_TRUE(dsn::utils::filesystem::get_subfiles(path, file_list, false));
+        ASSERT_GE(file_list.size(), 2);
+        file_list.clear();
+
+        path = ".";
+        ASSERT_TRUE(dsn::utils::filesystem::get_subfiles(path, file_list, true));
+        ASSERT_GE(file_list.size(), 3);
+        file_list.clear();
+
+        path = "../../";
+        ASSERT_TRUE(dsn::utils::filesystem::get_subfiles(path, file_list, true));
+        ASSERT_GE(file_list.size(), 3);
+        file_list.clear();
+
+        path = "./file_utils_temp/";
+        ASSERT_TRUE(dsn::utils::filesystem::get_subfiles(path, file_list, true));
+        ASSERT_EQ(file_list.size(), 3);
+        file_list.clear();
+
+        path = "./file_utils_temp/";
+        ASSERT_TRUE(dsn::utils::filesystem::get_subdirectories(path, file_list, true));
+        ASSERT_EQ(file_list.size(), 7);
+        file_list.clear();
+
+        path = "./file_utils_temp/";
+        ASSERT_TRUE(dsn::utils::filesystem::get_subdirectories(path, file_list, false));
+        ASSERT_EQ(file_list.size(), 2);
+        file_list.clear();
+
+        path = "./file_utils_temp/";
+        ASSERT_TRUE(dsn::utils::filesystem::get_subpaths(path, file_list, true));
+        ASSERT_EQ(file_list.size(), 10);
+        file_list.clear();
+
+        path = "./file_utils_temp/";
+        ASSERT_TRUE(dsn::utils::filesystem::get_subpaths(path, file_list, false));
+        ASSERT_EQ(file_list.size(), 2);
+        file_list.clear();
+
+        path = "./file_utils_temp/a/";
+        ASSERT_TRUE(dsn::utils::filesystem::get_subfiles(path, file_list, false));
+        ASSERT_EQ(file_list.size(), 2);
+        file_list.clear();
+
+        path = "./file_utils_temp/a/";
+        ASSERT_TRUE(dsn::utils::filesystem::get_subpaths(path, file_list, false));
+        ASSERT_EQ(file_list.size(), 3);
+        file_list.clear();
+    }
+
+    void file_utils_test_rename()
+    {
+        std::string path = "./file_utils_temp/b/c/d/1.txt";
+        std::string path2 = "./file_utils_temp/b/c/d/2.txt";
+        ASSERT_TRUE(dsn::utils::filesystem::rename_path(path, path2));
+        ASSERT_FALSE(dsn::utils::filesystem::file_exists(path));
+        ASSERT_TRUE(dsn::utils::filesystem::file_exists(path2));
+        ASSERT_FALSE(dsn::utils::filesystem::rename_path(path, path2));
+    }
+
+    void file_utils_test_remove()
+    {
+        std::string path = "./file_utils_temp.txt";
+        ASSERT_TRUE(dsn::utils::filesystem::remove_path(path));
+        ASSERT_FALSE(dsn::utils::filesystem::file_exists(path));
+
+        path = "./file_utils_temp/a/2.txt";
+        ASSERT_TRUE(dsn::utils::filesystem::remove_path(path));
+        ASSERT_TRUE(dsn::utils::filesystem::remove_path(path));
+
+        path = "./file_utils_temp/";
+        ASSERT_TRUE(dsn::utils::filesystem::remove_path(path));
+        ASSERT_FALSE(dsn::utils::filesystem::directory_exists(path));
+    }
+
+    void file_utils_test_cleanup() {}
+};
+
+INSTANTIATE_TEST_CASE_P(, file_utils, ::testing::Values(false));
+
+TEST_P(file_utils, basic)
 {
     file_utils_test_setup();
     file_utils_test_get_process_image_path();


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/887

- Remove the useless return value of `get_normalized_path()`
- Simplify the code of file_utils.cpp