### PR TITLE
feature(aio): use rocksdb APIs to re-implement the aio module

### DIFF
--- a/src/aio/CMakeLists.txt
+++ b/src/aio/CMakeLists.txt
@@ -33,7 +33,7 @@ set(MY_PROJ_SRC "")
 #"GLOB" for non - recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_LIBS dsn_runtime)
+set(MY_PROJ_LIBS dsn_runtime rocksdb)
 
 #Extra files that will be installed
 set(MY_BINPLACES "")

--- a/src/aio/aio_provider.h
+++ b/src/aio/aio_provider.h
@@ -27,9 +27,16 @@
 #pragma once
 
 #include <stdint.h>
+#include <memory>
+#include <string>
 
 #include "utils/error_code.h"
 #include "utils/factory_store.h"
+
+namespace rocksdb {
+class RandomAccessFile;
+class RandomRWFile;
+} // namespace rocksdb
 
 namespace dsn {
 
@@ -60,12 +67,13 @@ public:
     explicit aio_provider(disk_engine *disk);
     virtual ~aio_provider() = default;
 
-    virtual linux_fd_t open(const char *file_name, int flag, int pmode) = 0;
-
-    virtual error_code close(linux_fd_t fd) = 0;
-    virtual error_code flush(linux_fd_t fd) = 0;
-    virtual error_code write(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) = 0;
+    virtual std::unique_ptr<rocksdb::RandomAccessFile> open_read_file(const std::string &fname) = 0;
     virtual error_code read(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) = 0;
+
+    virtual std::unique_ptr<rocksdb::RandomRWFile> open_write_file(const std::string &fname) = 0;
+    virtual error_code write(const aio_context &aio_ctx, /*out*/ uint64_t *processed_bytes) = 0;
+    virtual error_code flush(rocksdb::RandomRWFile *rwf) = 0;
+    virtual error_code close(rocksdb::RandomRWFile *rwf) = 0;
 
     // Submits the aio_task to the underlying disk-io executor.
     // This task may not be executed immediately, call `aio_task::wait`

--- a/src/aio/file_io.h
+++ b/src/aio/file_io.h
@@ -28,6 +28,7 @@
 
 #include <stdint.h>
 #include <list>
+#include <string>
 #include <utility>
 
 #include "aio/aio_task.h"
@@ -47,6 +48,13 @@ class task_tracker;
 
 namespace file {
 
+enum class FileOpenType
+{
+    kReadOnly = 0,
+    kWriteOnly
+};
+
+// TODO(yingchun): consider to return a smart pointer
 /// open file
 ///
 /// \param file_name filename of the file.
@@ -55,7 +63,7 @@ namespace file {
 ///
 /// \return file handle
 ///
-extern disk_file *open(const char *file_name, int flag, int pmode);
+extern disk_file *open(const std::string &fname, FileOpenType type);
 
 /// close the file handle
 extern error_code close(disk_file *file);

--- a/src/aio/native_linux_aio_provider.cpp
+++ b/src/aio/native_linux_aio_provider.cpp
@@ -26,19 +26,17 @@
 
 #include "native_linux_aio_provider.h"
 
-#include <errno.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <memory>
-
 #include "aio/aio_provider.h"
 #include "aio/disk_engine.h"
+#include "rocksdb/env.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
 #include "runtime/service_engine.h"
 #include "runtime/task/async_calls.h"
+#include "utils/env.h"
 #include "utils/fmt_logging.h"
 #include "utils/latency_tracer.h"
 #include "utils/ports.h"
-#include "utils/safe_strerror_posix.h"
 
 namespace dsn {
 
@@ -46,87 +44,101 @@ native_linux_aio_provider::native_linux_aio_provider(disk_engine *disk) : aio_pr
 
 native_linux_aio_provider::~native_linux_aio_provider() {}
 
-linux_fd_t native_linux_aio_provider::open(const char *file_name, int flag, int pmode)
+std::unique_ptr<rocksdb::RandomAccessFile>
+native_linux_aio_provider::open_read_file(const std::string &fname)
 {
-    auto fd = ::open(file_name, flag, pmode);
-    if (fd == DSN_INVALID_FILE_HANDLE) {
-        LOG_ERROR("create file '{}' failed, err = {}", file_name, utils::safe_strerror(errno));
+    std::unique_ptr<rocksdb::RandomAccessFile> rfile;
+    auto s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)
+                 ->NewRandomAccessFile(fname, &rfile, rocksdb::EnvOptions());
+    if (!s.ok()) {
+        LOG_ERROR("open read file '{}' failed, err = {}", fname, s.ToString());
     }
-    return linux_fd_t(fd);
+    return rfile;
 }
 
-error_code native_linux_aio_provider::close(linux_fd_t fd)
+std::unique_ptr<rocksdb::RandomRWFile>
+native_linux_aio_provider::open_write_file(const std::string &fname)
 {
-    if (fd.is_invalid() || ::close(fd.fd) == 0) {
-        return ERR_OK;
+    // rocksdb::NewRandomRWFile() doesn't act as the docs described, it will not create the
+    // file if it not exists, and an error Status will be returned, so we try to create the
+    // file by ReopenWritableFile() if it not exist.
+    auto s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)->FileExists(fname);
+    if (!s.ok() && !s.IsNotFound()) {
+        LOG_ERROR("failed to check whether the file '{}' exist, err = {}", fname, s.ToString());
+        return nullptr;
     }
 
-    LOG_ERROR("close file failed, err = {}", utils::safe_strerror(errno));
-    return ERR_FILE_OPERATION_FAILED;
+    if (s.IsNotFound()) {
+        std::unique_ptr<rocksdb::WritableFile> cfile;
+        s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)
+                ->ReopenWritableFile(fname, &cfile, rocksdb::EnvOptions());
+        if (!s.ok()) {
+            LOG_ERROR("failed to create file '{}', err = {}", fname, s.ToString());
+            return nullptr;
+        }
+    }
+
+    // Open the file for write as RandomRWFile, to support un-sequential write.
+    std::unique_ptr<rocksdb::RandomRWFile> wfile;
+    s = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive)
+            ->NewRandomRWFile(fname, &wfile, rocksdb::EnvOptions());
+    if (!s.ok()) {
+        LOG_ERROR("open write file '{}' failed, err = {}", fname, s.ToString());
+    }
+    return wfile;
 }
 
-error_code native_linux_aio_provider::flush(linux_fd_t fd)
+error_code native_linux_aio_provider::close(rocksdb::RandomRWFile *wf)
 {
-    if (fd.is_invalid() || ::fsync(fd.fd) == 0) {
-        return ERR_OK;
+    auto s = wf->Close();
+    if (!s.ok()) {
+        LOG_ERROR("close file failed, err = {}", s.ToString());
+        return ERR_FILE_OPERATION_FAILED;
     }
 
-    LOG_ERROR("flush file failed, err = {}", utils::safe_strerror(errno));
-    return ERR_FILE_OPERATION_FAILED;
+    return ERR_OK;
+}
+
+error_code native_linux_aio_provider::flush(rocksdb::RandomRWFile *wf)
+{
+    auto s = wf->Fsync();
+    if (!s.ok()) {
+        LOG_ERROR("flush file failed, err = {}", s.ToString());
+        return ERR_FILE_OPERATION_FAILED;
+    }
+
+    return ERR_OK;
 }
 
 error_code native_linux_aio_provider::write(const aio_context &aio_ctx,
                                             /*out*/ uint64_t *processed_bytes)
 {
-    dsn::error_code resp = ERR_OK;
-    uint64_t buffer_offset = 0;
-    do {
-        // ret is the written data size
-        auto ret = ::pwrite(aio_ctx.dfile->native_handle().fd,
-                            (char *)aio_ctx.buffer + buffer_offset,
-                            aio_ctx.buffer_size - buffer_offset,
-                            aio_ctx.file_offset + buffer_offset);
-        if (dsn_unlikely(ret < 0)) {
-            if (errno == EINTR) {
-                LOG_WARNING("write failed with errno={} and will retry it.",
-                            utils::safe_strerror(errno));
-                continue;
-            }
-            resp = ERR_FILE_OPERATION_FAILED;
-            LOG_ERROR("write failed with errno={}, return {}.", utils::safe_strerror(errno), resp);
-            return resp;
-        }
+    rocksdb::Slice data((const char *)(aio_ctx.buffer), aio_ctx.buffer_size);
+    auto s = aio_ctx.dfile->wfile()->Write(aio_ctx.file_offset, data);
+    if (!s.ok()) {
+        LOG_ERROR("write file failed, err = {}", s.ToString());
+        return ERR_FILE_OPERATION_FAILED;
+    }
 
-        buffer_offset += ret;
-        if (dsn_unlikely(buffer_offset != aio_ctx.buffer_size)) {
-            LOG_WARNING(
-                "write incomplete, request_size={}, total_write_size={}, this_write_size={}, "
-                "and will retry it.",
-                aio_ctx.buffer_size,
-                buffer_offset,
-                ret);
-        }
-    } while (dsn_unlikely(buffer_offset < aio_ctx.buffer_size));
-
-    *processed_bytes = buffer_offset;
-    return resp;
+    *processed_bytes = aio_ctx.buffer_size;
+    return ERR_OK;
 }
 
 error_code native_linux_aio_provider::read(const aio_context &aio_ctx,
                                            /*out*/ uint64_t *processed_bytes)
 {
-    auto ret = ::pread(aio_ctx.dfile->native_handle().fd,
-                       aio_ctx.buffer,
-                       aio_ctx.buffer_size,
-                       aio_ctx.file_offset);
-    if (dsn_unlikely(ret < 0)) {
-        LOG_WARNING("write failed with errno={} and will retry it.", utils::safe_strerror(errno));
+    rocksdb::Slice result;
+    auto s = aio_ctx.dfile->rfile()->Read(
+        aio_ctx.file_offset, aio_ctx.buffer_size, &result, (char *)(aio_ctx.buffer));
+    if (!s.ok()) {
+        LOG_ERROR("read file failed, err = {}", s.ToString());
         return ERR_FILE_OPERATION_FAILED;
     }
-    if (ret == 0) {
+
+    if (result.empty()) {
         return ERR_HANDLE_EOF;
     }
-    *processed_bytes = static_cast<uint64_t>(ret);
+    *processed_bytes = result.size();
     return ERR_OK;
 }
 

--- a/src/aio/test/CMakeLists.txt
+++ b/src/aio/test/CMakeLists.txt
@@ -33,7 +33,7 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_LIBS gtest dsn_runtime dsn_aio rocksdb)
+set(MY_PROJ_LIBS gtest dsn_runtime dsn_aio test_utils rocksdb)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
 

--- a/src/aio/test/config.ini
+++ b/src/aio/test/config.ini
@@ -43,3 +43,8 @@ tool = nativerun
 pause_on_start = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
+
+[aio_test]
+op_buffer_size = 12
+total_op_count = 100
+op_count_per_batch = 10

--- a/src/meta/meta_state_service_simple.cpp
+++ b/src/meta/meta_state_service_simple.cpp
@@ -26,7 +26,6 @@
 
 #include "meta_state_service_simple.h"
 
-#include <fcntl.h>
 #include <string.h>
 #include <algorithm>
 #include <set>
@@ -44,7 +43,6 @@
 #include "utils/binary_reader.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
-#include "utils/ports.h"
 #include "utils/strings.h"
 #include "utils/utils.h"
 
@@ -314,7 +312,7 @@ error_code meta_state_service_simple::initialize(const std::vector<std::string> 
         }
     }
 
-    _log = file::open(log_path.c_str(), O_RDWR | O_CREAT | O_BINARY, 0666);
+    _log = file::open(log_path, file::FileOpenType::kWriteOnly);
     if (!_log) {
         LOG_ERROR("open file failed: {}", log_path);
         return ERR_FILE_OPERATION_FAILED;

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -27,7 +27,6 @@
 #include "nfs_client_impl.h"
 
 // IWYU pragma: no_include <ext/alloc_traits.h>
-#include <fcntl.h>
 #include <mutex>
 
 #include "nfs/nfs_code_definition.h"
@@ -38,7 +37,6 @@
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
-#include "utils/ports.h"
 #include "utils/string_conv.h"
 #include "utils/token_buckets.h"
 
@@ -460,8 +458,7 @@ void nfs_client_impl::continue_write()
         // double check
         zauto_lock l(fc->user_req->user_req_lock);
         if (!fc->file_holder->file_handle) {
-            fc->file_holder->file_handle =
-                file::open(file_path.c_str(), O_RDWR | O_CREAT | O_BINARY, 0666);
+            fc->file_holder->file_handle = file::open(file_path, file::FileOpenType::kWriteOnly);
         }
     }
 
@@ -470,6 +467,10 @@ void nfs_client_impl::continue_write()
         LOG_ERROR("open file {} failed", file_path);
         handle_completion(fc->user_req, ERR_FILE_OPERATION_FAILED);
     } else {
+        LOG_DEBUG("nfs: copy to file {} [{}, {}]",
+                  file_path,
+                  reqc->response.offset,
+                  reqc->response.offset + reqc->response.size);
         zauto_lock l(reqc->lock);
         if (reqc->is_valid) {
             reqc->local_write_task = file::write(fc->file_holder->file_handle,

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -26,7 +26,6 @@
 
 #include "nfs/nfs_server_impl.h"
 
-#include <fcntl.h>
 #include <chrono>
 #include <cstdint>
 #include <mutex>
@@ -41,7 +40,6 @@
 #include "utils/env.h"
 #include "utils/filesystem.h"
 #include "utils/flags.h"
-#include "utils/ports.h"
 #include "utils/string_conv.h"
 #include "utils/utils.h"
 
@@ -93,7 +91,7 @@ void nfs_service_impl::on_copy(const ::dsn::service::copy_request &request,
         zauto_lock l(_handles_map_lock);
         auto it = _handles_map.find(file_path); // find file handle cache first
         if (it == _handles_map.end()) {
-            dfile = file::open(file_path.c_str(), O_RDONLY | O_BINARY, 0);
+            dfile = file::open(file_path, file::FileOpenType::kReadOnly);
             if (dfile == nullptr) {
                 LOG_ERROR("[nfs_service] open file {} failed", file_path);
                 ::dsn::service::copy_response resp;

--- a/src/replica/duplication/test/load_from_private_log_test.cpp
+++ b/src/replica/duplication/test/load_from_private_log_test.cpp
@@ -16,8 +16,8 @@
 // under the License.
 
 // IWYU pragma: no_include <ext/alloc_traits.h>
-#include <fcntl.h>
 #include <fmt/core.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
@@ -54,7 +54,6 @@
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
-#include "utils/ports.h"
 
 #define BOOST_NO_CXX11_SCOPED_ENUMS
 #include <boost/filesystem/operations.hpp>
@@ -459,7 +458,7 @@ TEST_F(load_fail_mode_test, fail_skip_real_corrupted_file)
         int64_t file_size;
         ASSERT_TRUE(utils::filesystem::file_size(
             log_path, dsn::utils::FileDataType::kSensitive, file_size));
-        auto wfile = file::open(log_path.c_str(), O_RDWR | O_CREAT | O_BINARY, 0666);
+        auto wfile = file::open(log_path, file::FileOpenType::kWriteOnly);
         ASSERT_NE(wfile, nullptr);
 
         const char buf[] = "xxxxxx";

--- a/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
@@ -35,7 +35,6 @@
 
 #include "simple_kv.server.impl.h"
 
-#include <fcntl.h>
 #include <fmt/core.h>
 #include <inttypes.h>
 #include <rocksdb/slice.h>
@@ -61,7 +60,6 @@
 #include "utils/blob.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
-#include "utils/ports.h"
 #include "utils/utils.h"
 
 namespace dsn {
@@ -249,7 +247,7 @@ void simple_kv_service_impl::recover(const std::string &name, int64_t version)
         return ERR_OK;
     }
 
-    auto wfile = file::open(fname.c_str(), O_RDWR | O_CREAT | O_BINARY, 0666);
+    auto wfile = file::open(fname, file::FileOpenType::kWriteOnly);
     CHECK_NOTNULL(wfile, "");
 
 #define WRITE_DATA_SIZE(data, size)                                                                \

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
@@ -25,7 +25,6 @@
 */
 #include "simple_kv.server.impl.h"
 
-#include <fcntl.h>
 #include <fmt/core.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -49,7 +48,6 @@
 #include "utils/blob.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
-#include "utils/ports.h"
 #include "utils/threadpool_code.h"
 #include "utils/utils.h"
 
@@ -254,7 +252,7 @@ void simple_kv_service_impl::recover(const std::string &name, int64_t version)
     }
 
     std::string fname = fmt::format("{}/checkpoint.{}", data_dir(), last_commit);
-    auto wfile = file::open(fname.c_str(), O_RDWR | O_CREAT | O_BINARY, 0666);
+    auto wfile = file::open(fname, file::FileOpenType::kWriteOnly);
     CHECK_NOTNULL(wfile, "");
 
 #define WRITE_DATA_SIZE(data, size)                                                                \

--- a/src/replica/test/mutation_log_test.cpp
+++ b/src/replica/test/mutation_log_test.cpp
@@ -26,7 +26,6 @@
 
 #include "replica/mutation_log.h"
 
-#include <fcntl.h>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-param-test.h>
@@ -70,7 +69,7 @@ using namespace ::dsn::replication;
 
 static void overwrite_file(const char *file, int offset, const void *buf, int size)
 {
-    auto wfile = file::open(file, O_RDWR | O_CREAT | O_BINARY, 0666);
+    auto wfile = file::open(file, file::FileOpenType::kWriteOnly);
     ASSERT_NE(wfile, nullptr);
     auto t = ::dsn::file::write(wfile,
                                 (const char *)buf,

--- a/src/runtime/test/CMakeLists.txt
+++ b/src/runtime/test/CMakeLists.txt
@@ -33,6 +33,7 @@ set(MY_PROJ_LIBS gtest
                  dsn_runtime
                  dsn_aio
                  dsn_meta_server
+                 rocksdb
                  )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/runtime/test/task_test.cpp
+++ b/src/runtime/test/task_test.cpp
@@ -17,7 +17,6 @@
 
 #include "runtime/task/task.h"
 
-#include <fcntl.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
@@ -66,7 +65,7 @@ public:
 
     static void test_signal_finished_task()
     {
-        disk_file *fp = file::open("config-test.ini", O_RDONLY | O_BINARY, 0);
+        disk_file *fp = file::open("config-test.ini", file::FileOpenType::kReadOnly);
 
         // this aio task is enqueued into read-queue of disk_engine
         char buffer[128];
@@ -80,6 +79,7 @@ public:
         // signal a finished task won't cause failure
         t->signal_waiters(); // signal_waiters may return false
         t->signal_waiters();
+        ASSERT_EQ(ERR_OK, file::close(fp));
     }
 };
 

--- a/src/test_util/test_util.cpp
+++ b/src/test_util/test_util.cpp
@@ -18,7 +18,6 @@
 #include "test_util.h"
 
 #include <gtest/gtest-spi.h>
-#include <stdint.h>
 #include <chrono>
 #include <ostream>
 #include <thread>

--- a/src/test_util/test_util.h
+++ b/src/test_util/test_util.h
@@ -19,10 +19,15 @@
 
 #pragma once
 
-#include <gtest/gtest.h>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
 #include <functional>
+#include <gtest/gtest.h>
 #include <string>
 
+#include "fmt/core.h"
+#include "runtime/api_layer1.h"
 #include "utils/flags.h"
 #include "utils/test_macros.h"
 
@@ -41,6 +46,23 @@ class encrypt_data_test_base : public testing::TestWithParam<bool>
 {
 public:
     encrypt_data_test_base() { FLAGS_encrypt_data_at_rest = GetParam(); }
+};
+
+class stop_watch
+{
+public:
+    stop_watch() { _start_ms = dsn_now_ms(); }
+    void stop_and_output(const std::string &msg)
+    {
+        auto duration_ms =
+            std::chrono::duration_cast<std::chrono::duration<double>>(
+                std::chrono::milliseconds(static_cast<int64_t>(dsn_now_ms() - _start_ms)))
+                .count();
+        fmt::print(stdout, "{}, cost {} ms\n", msg, duration_ms);
+    }
+
+private:
+    uint64_t _start_ms = 0;
 };
 
 void create_local_test_file(const std::string &full_name, dsn::replication::file_meta *fm);

--- a/src/utils/test/env.cpp
+++ b/src/utils/test/env.cpp
@@ -47,8 +47,8 @@
 #include <string>
 
 #include "test_util/test_util.h"
-#include "utils/enum_helper.h"
 #include "utils/env.h"
+#include "utils/error_code.h"
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/rand.h"


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1575

This is a dependent work to implement encryption at rest, we can use the capacity of
rocksdb encryption after this patch.

- Use rocksdb APIs to implement class `native_linux_aio_provider`. Both of the
  implementations are using `pread()` and `pwrite()` system calls, so there isn't
  significant performance changes, see the newly added simple benchmark performance
  comparation below.
- Separate the file read and write operations for class `aio_provider`