### PR TITLE
feat(slog): flush and remove all shared logs for garbage collection (cherry-pick #1594)

### DIFF
--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <iterator>
+#include <map>
 #include <utility>
 
 #include "common/duplication_common.h"
@@ -57,11 +58,11 @@ bool load_from_private_log::will_fail_fast() const
 // we try to list all files and select a new one to start (find_log_file_to_start).
 bool load_from_private_log::switch_to_next_log_file()
 {
-    auto file_map = _private_log->get_log_file_map();
-    auto next_file_it = file_map.find(_current->index() + 1);
+    const auto &file_map = _private_log->get_log_file_map();
+    const auto &next_file_it = file_map.find(_current->index() + 1);
     if (next_file_it != file_map.end()) {
         log_file_ptr file;
-        error_s es = log_utils::open_read(next_file_it->second->path(), file);
+        const auto &es = log_utils::open_read(next_file_it->second->path(), file);
         if (!es.is_ok()) {
             LOG_ERROR_PREFIX("{}", es);
             _current = nullptr;
@@ -123,11 +124,11 @@ void load_from_private_log::run()
 void load_from_private_log::find_log_file_to_start()
 {
     // `file_map` has already excluded the useless log files during replica init.
-    auto file_map = _private_log->get_log_file_map();
+    const auto &file_map = _private_log->get_log_file_map();
 
     // Reopen the files. Because the internal file handle of `file_map`
     // is cleared once WAL replay finished. They are unable to read.
-    std::map<int, log_file_ptr> new_file_map;
+    mutation_log::log_file_map_by_index new_file_map;
     for (const auto &pr : file_map) {
         log_file_ptr file;
         error_s es = log_utils::open_read(pr.second->path(), file);
@@ -141,7 +142,8 @@ void load_from_private_log::find_log_file_to_start()
     find_log_file_to_start(std::move(new_file_map));
 }
 
-void load_from_private_log::find_log_file_to_start(std::map<int, log_file_ptr> log_file_map)
+void load_from_private_log::find_log_file_to_start(
+    const mutation_log::log_file_map_by_index &log_file_map)
 {
     _current = nullptr;
     if (dsn_unlikely(log_file_map.empty())) {

--- a/src/replica/duplication/load_from_private_log.h
+++ b/src/replica/duplication/load_from_private_log.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <chrono>
-#include <map>
 
 #include "common/replication_other_types.h"
 #include "mutation_batch.h"
@@ -61,7 +60,7 @@ public:
 
     /// Find the log file that contains `_start_decree`.
     void find_log_file_to_start();
-    void find_log_file_to_start(std::map<int, log_file_ptr> log_files);
+    void find_log_file_to_start(const mutation_log::log_file_map_by_index &log_files);
 
     void replay_log_block();
 

--- a/src/replica/duplication/test/duplication_test_base.h
+++ b/src/replica/duplication/test/duplication_test_base.h
@@ -68,9 +68,9 @@ public:
         return duplicator;
     }
 
-    std::map<int, log_file_ptr> open_log_file_map(const std::string &log_dir)
+    mutation_log::log_file_map_by_index open_log_file_map(const std::string &log_dir)
     {
-        std::map<int, log_file_ptr> log_file_map;
+        mutation_log::log_file_map_by_index log_file_map;
         error_s err = log_utils::open_log_file_map(log_dir, log_file_map);
         EXPECT_EQ(err, error_s::ok());
         return log_file_map;

--- a/src/replica/log_file.cpp
+++ b/src/replica/log_file.cpp
@@ -166,15 +166,15 @@ log_file::~log_file() { close(); }
 
 log_file::log_file(
     const char *path, disk_file *handle, int index, int64_t start_offset, bool is_read)
-    : _is_read(is_read)
+    : _crc32(0),
+      _start_offset(start_offset),
+      _end_offset(start_offset),
+      _handle(handle),
+      _is_read(is_read),
+      _path(path),
+      _index(index),
+      _last_write_time(0)
 {
-    _start_offset = start_offset;
-    _end_offset = start_offset;
-    _handle = handle;
-    _path = path;
-    _index = index;
-    _crc32 = 0;
-    _last_write_time = 0;
     memset(&_header, 0, sizeof(_header));
 
     if (is_read) {
@@ -357,7 +357,7 @@ void log_file::reset_stream(size_t offset /*default = 0*/)
     }
 }
 
-decree log_file::previous_log_max_decree(const dsn::gpid &pid)
+decree log_file::previous_log_max_decree(const dsn::gpid &pid) const
 {
     auto it = _previous_log_max_decrees.find(pid);
     return it == _previous_log_max_decrees.end() ? 0 : it->second.max_decree;

--- a/src/replica/log_file.h
+++ b/src/replica/log_file.h
@@ -65,9 +65,9 @@ struct log_file_header
 // a structure to record replica's log info
 struct replica_log_info
 {
-    int64_t max_decree;
+    decree max_decree;
     int64_t valid_start_offset; // valid start offset in global space
-    replica_log_info(int64_t d, int64_t o)
+    replica_log_info(decree d, int64_t o)
     {
         max_decree = d;
         valid_start_offset = o;
@@ -184,11 +184,14 @@ public:
     // file path
     const std::string &path() const { return _path; }
     // previous decrees
-    const replica_log_info_map &previous_log_max_decrees() { return _previous_log_max_decrees; }
+    const replica_log_info_map &previous_log_max_decrees() const
+    {
+        return _previous_log_max_decrees;
+    }
     // previous decree for speicified gpid
-    decree previous_log_max_decree(const gpid &pid);
+    decree previous_log_max_decree(const gpid &pid) const;
     // file header
-    log_file_header &header() { return _header; }
+    const log_file_header &header() const { return _header; }
 
     // read file header from reader, return byte count consumed
     int read_file_header(binary_reader &reader);
@@ -213,7 +216,7 @@ private:
     friend class mock_log_file;
 
     uint32_t _crc32;
-    int64_t _start_offset; // start offset in the global space
+    const int64_t _start_offset; // start offset in the global space
     std::atomic<int64_t>
         _end_offset; // end offset in the global space: end_offset = start_offset + file_size
     class file_streamer;
@@ -221,8 +224,8 @@ private:
     std::unique_ptr<file_streamer> _stream;
     disk_file *_handle;        // file handle
     const bool _is_read;       // if opened for read or write
-    std::string _path;         // file path
-    int _index;                // file index
+    const std::string _path;   // file path
+    const int _index;          // file index
     log_file_header _header;   // file header
     uint64_t _last_write_time; // seconds from epoch time
 

--- a/src/replica/mutation_log_replay.cpp
+++ b/src/replica/mutation_log_replay.cpp
@@ -133,7 +133,7 @@ namespace replication {
                                            replay_callback callback,
                                            /*out*/ int64_t &end_offset)
 {
-    std::map<int, log_file_ptr> logs;
+    log_file_map_by_index logs;
     for (auto &fpath : log_files) {
         error_code err;
         log_file_ptr log = log_file::open_read(fpath.c_str(), err);
@@ -154,7 +154,7 @@ namespace replication {
     return replay(logs, callback, end_offset);
 }
 
-/*static*/ error_code mutation_log::replay(std::map<int, log_file_ptr> &logs,
+/*static*/ error_code mutation_log::replay(log_file_map_by_index &logs,
                                            replay_callback callback,
                                            /*out*/ int64_t &end_offset)
 {

--- a/src/replica/mutation_log_utils.cpp
+++ b/src/replica/mutation_log_utils.cpp
@@ -64,7 +64,7 @@ namespace log_utils {
 }
 
 /*extern*/
-error_s check_log_files_continuity(const std::map<int, log_file_ptr> &logs)
+error_s check_log_files_continuity(const mutation_log::log_file_map_by_index &logs)
 {
     if (logs.empty()) {
         return error_s::ok();

--- a/src/replica/mutation_log_utils.h
+++ b/src/replica/mutation_log_utils.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "replica/log_file.h"
+#include "replica/mutation_log.h"
 #include "utils/autoref_ptr.h"
 #include "utils/errors.h"
 #include "utils/string_view.h"
@@ -44,7 +45,7 @@ extern error_s open_read(string_view path, /*out*/ log_file_ptr &file);
 extern error_s list_all_files(const std::string &dir, /*out*/ std::vector<std::string> &files);
 
 inline error_s open_log_file_map(const std::vector<std::string> &log_files,
-                                 /*out*/ std::map<int, log_file_ptr> &log_file_map)
+                                 /*out*/ mutation_log::log_file_map_by_index &log_file_map)
 {
     for (const std::string &fname : log_files) {
         log_file_ptr lf;
@@ -58,7 +59,7 @@ inline error_s open_log_file_map(const std::vector<std::string> &log_files,
 }
 
 inline error_s open_log_file_map(const std::string &dir,
-                                 /*out*/ std::map<int, log_file_ptr> &log_file_map)
+                                 /*out*/ mutation_log::log_file_map_by_index &log_file_map)
 {
     std::vector<std::string> log_files;
     error_s es = list_all_files(dir, log_files);
@@ -68,11 +69,11 @@ inline error_s open_log_file_map(const std::string &dir,
     return open_log_file_map(log_files, log_file_map) << "open_log_file_map(dir)";
 }
 
-extern error_s check_log_files_continuity(const std::map<int, log_file_ptr> &logs);
+extern error_s check_log_files_continuity(const mutation_log::log_file_map_by_index &logs);
 
 inline error_s check_log_files_continuity(const std::string &dir)
 {
-    std::map<int, log_file_ptr> log_file_map;
+    mutation_log::log_file_map_by_index log_file_map;
     error_s es = open_log_file_map(dir, log_file_map);
     if (!es.is_ok()) {
         return es << "check_log_files_continuity(dir)";

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -51,7 +51,6 @@
 #include "runtime/task/task_code.h"
 #include "runtime/task/task_spec.h"
 #include "runtime/task/task_tracker.h"
-#include "utils/autoref_ptr.h"
 #include "utils/binary_reader.h"
 #include "utils/binary_writer.h"
 #include "utils/blob.h"

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -445,7 +445,7 @@ public:
                            dsn::task_tracker *tracker,
                            aio_handler &&callback,
                            int hash = 0,
-                           int64_t *pending_size = nullptr)
+                           int64_t *pending_size = nullptr) override
     {
         _mu_list.push_back(mu);
         return nullptr;

--- a/src/replica/test/mutation_log_test.cpp
+++ b/src/replica/test/mutation_log_test.cpp
@@ -26,11 +26,16 @@
 
 #include "replica/mutation_log.h"
 
+// IWYU pragma: no_include <ext/alloc_traits.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
+// IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 #include <stdio.h>
 #include <sys/types.h>
+#include <cstdint>
+#include <iostream>
+#include <limits>
 #include <unordered_map>
 
 #include "aio/aio_task.h"
@@ -40,12 +45,17 @@
 #include "replica/log_block.h"
 #include "replica/log_file.h"
 #include "replica/mutation.h"
+#include "replica/replica_stub.h"
 #include "replica/test/mock_utils.h"
 #include "replica_test_base.h"
+#include "rrdb/rrdb.code.definition.h"
 #include "utils/binary_reader.h"
 #include "utils/binary_writer.h"
 #include "utils/blob.h"
+#include "utils/defer.h"
+#include "utils/fail_point.h"
 #include "utils/filesystem.h"
+#include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/ports.h"
 
@@ -121,7 +131,7 @@ TEST(replication, log_file)
             lf->write_file_header(temp_writer, mdecrees);
             writer->add(temp_writer.get_buffer());
             ASSERT_EQ(mdecrees, lf->previous_log_max_decrees());
-            log_file_header &h = lf->header();
+            const auto &h = lf->header();
             ASSERT_EQ(100, h.start_global_offset);
         }
 
@@ -450,6 +460,83 @@ public:
             ASSERT_GE(log_files.size(), 1);
         }
     }
+
+    mutation_ptr generate_slog_mutation(const gpid &pid, const decree d, const std::string &data)
+    {
+        mutation_ptr mu(new mutation());
+        mu->data.header.ballot = 1;
+        mu->data.header.decree = d;
+        mu->data.header.pid = pid;
+        mu->data.header.last_committed_decree = d - 1;
+        mu->data.header.log_offset = 0;
+        mu->data.header.timestamp = d;
+
+        mu->data.updates.push_back(mutation_update());
+        mu->data.updates.back().code = dsn::apps::RPC_RRDB_RRDB_PUT;
+        mu->data.updates.back().data = blob::create_from_bytes(std::string(data));
+
+        mu->client_requests.push_back(nullptr);
+
+        return mu;
+    }
+
+    void generate_slog_file(const std::vector<std::pair<gpid, size_t>> &replica_mutations,
+                            mutation_log_ptr &mlog,
+                            decree &d,
+                            std::unordered_map<gpid, int64_t> &valid_start_offsets,
+                            std::pair<gpid, int64_t> &slog_file_start_offset)
+    {
+        for (size_t i = 0; i < replica_mutations.size(); ++i) {
+            const auto &pid = replica_mutations[i].first;
+
+            for (size_t j = 0; j < replica_mutations[i].second; ++j) {
+                if (i == 0) {
+                    // Record the start offset of each slog file.
+                    slog_file_start_offset.first = pid;
+                    slog_file_start_offset.second = mlog->get_global_offset();
+                }
+
+                const auto &it = valid_start_offsets.find(pid);
+                if (it == valid_start_offsets.end()) {
+                    // Add new partition with its start offset in slog.
+                    valid_start_offsets.emplace(pid, mlog->get_global_offset());
+                    mlog->set_valid_start_offset_on_open(pid, mlog->get_global_offset());
+                }
+
+                // Append a mutation.
+                auto mu = generate_slog_mutation(pid, d++, "test data");
+                mlog->append(mu, LPC_AIO_IMMEDIATE_CALLBACK, mlog->tracker(), nullptr, 0);
+            }
+        }
+
+        // Wait until all mutations are written into this file.
+        mlog->tracker()->wait_outstanding_tasks();
+    }
+
+    void generate_slog_files(const std::vector<std::vector<std::pair<gpid, size_t>>> &files,
+                             mutation_log_ptr &mlog,
+                             std::unordered_map<gpid, int64_t> &valid_start_offsets,
+                             std::vector<std::pair<gpid, int64_t>> &slog_file_start_offsets)
+    {
+        valid_start_offsets.clear();
+        slog_file_start_offsets.resize(files.size());
+
+        decree d = 1;
+        for (size_t i = 0; i < files.size(); ++i) {
+            generate_slog_file(files[i], mlog, d, valid_start_offsets, slog_file_start_offsets[i]);
+            if (i + 1 < files.size()) {
+                // Do not create a new slog file after the last file is generated.
+                mlog->create_new_log_file();
+                // Wait until file header is written.
+                mlog->tracker()->wait_outstanding_tasks();
+            }
+        }
+
+        // Close and reset `_current_log_file` since slog has been deprecated and would not be
+        // used again.
+        mlog->_current_log_file->close();
+        mlog->_current_log_file = nullptr;
+    }
 };
 
 TEST_F(mutation_log_test, replay_single_file_1000) { test_replay_single_file(1000); }
@@ -606,5 +693,182 @@ TEST_F(mutation_log_test, reset_from_while_writing)
     mlog->flush();
     ASSERT_EQ(actual.size(), expected.size());
 }
+
+TEST_F(mutation_log_test, gc_slog)
+{
+    // Remove the slog dir and create a new one.
+    const std::string slog_dir("./slog_test");
+    ASSERT_TRUE(dsn::utils::filesystem::remove_path(slog_dir));
+    ASSERT_TRUE(dsn::utils::filesystem::create_directory(slog_dir));
+
+    // Create and open slog object, which would be closed at the end of the scope.
+    mutation_log_ptr mlog = new mutation_log_shared(slog_dir, 1, false);
+    auto cleanup = dsn::defer([mlog]() { mlog->close(); });
+    ASSERT_EQ(ERR_OK, mlog->open(nullptr, nullptr));
+
+    // Each line describes a sequence of mutations written to specified replicas by
+    // specified numbers.
+    //
+    // From these sequences the decrees for each partition could be concluded as below:
+    // {1, 1}: 9 ~ 15
+    // {1, 2}: 16 ~ 22
+    // {2, 5}: 1 ~ 8, 23 ~ 38
+    // {2, 7}: 39 ~ 46
+    // {5, 6}: 47 ~ 73
+    const std::vector<std::vector<std::pair<gpid, size_t>>> files = {
+        {{{2, 5}, 8}, {{1, 1}, 7}, {{1, 2}, 2}},
+        {{{1, 2}, 5}},
+        {{{2, 5}, 16}, {{2, 7}, 8}, {{5, 6}, 27}}};
+
+    // Each line describes a progress of durable decrees for all of replicas: decrees are
+    // continuously being applied and becoming durable.
+    const std::vector<std::unordered_map<gpid, decree>> durable_decrees = {
+        {{{1, 1}, 10}, {{1, 2}, 17}, {{2, 5}, 6}, {{2, 7}, 39}, {{5, 6}, 47}},
+        {{{1, 1}, 15}, {{1, 2}, 18}, {{2, 5}, 7}, {{2, 7}, 40}, {{5, 6}, 57}},
+        {{{1, 1}, 15}, {{1, 2}, 20}, {{2, 5}, 8}, {{2, 7}, 42}, {{5, 6}, 61}},
+        {{{1, 1}, 15}, {{1, 2}, 22}, {{2, 5}, 23}, {{2, 7}, 44}, {{5, 6}, 65}},
+        {{{1, 1}, 15}, {{1, 2}, 22}, {{2, 5}, 27}, {{2, 7}, 46}, {{5, 6}, 66}},
+        {{{1, 1}, 15}, {{1, 2}, 22}, {{2, 5}, 32}, {{2, 7}, 46}, {{5, 6}, 67}},
+        {{{1, 1}, 15}, {{1, 2}, 22}, {{2, 5}, 38}, {{2, 7}, 46}, {{5, 6}, 72}},
+        {{{1, 1}, 15}, {{1, 2}, 22}, {{2, 5}, 38}, {{2, 7}, 46}, {{5, 6}, 73}},
+    };
+    const std::vector<size_t> remaining_slog_files = {3, 3, 2, 1, 1, 1, 1, 0};
+    const std::vector<std::set<gpid>> expected_prevent_gc_replicas = {
+        {{1, 1}, {1, 2}, {2, 5}, {2, 7}, {5, 6}},
+        {{1, 2}, {2, 5}, {2, 7}, {5, 6}},
+        {{1, 2}, {2, 5}, {2, 7}, {5, 6}},
+        {{2, 5}, {2, 7}, {5, 6}},
+        {{2, 5}, {5, 6}},
+        {{2, 5}, {5, 6}},
+        {{5, 6}},
+        {},
+    };
+
+    // Each line describes an action, that during a round (related to the index of
+    // `durable_decrees`), which replica should be reset to the start offset of an
+    // slog file (related to the index of `files` and `slog_file_start_offsets`).
+    const std::unordered_map<size_t, size_t> set_to_slog_file_start_offsets = {
+        {2, 1},
+    };
+
+    // Create slog files and write some data into them according to test cases.
+    std::unordered_map<gpid, int64_t> valid_start_offsets;
+    std::vector<std::pair<gpid, int64_t>> slog_file_start_offsets;
+    generate_slog_files(files, mlog, valid_start_offsets, slog_file_start_offsets);
+
+    for (size_t i = 0; i < durable_decrees.size(); ++i) {
+        std::cout << "Update No." << i << " group of durable decrees" << std::endl;
+
+        // Update the progress of durable_decrees for each partition.
+        replica_log_info_map replica_durable_decrees;
+        for (const auto &d : durable_decrees[i]) {
+            replica_durable_decrees.emplace(
+                d.first, replica_log_info(d.second, valid_start_offsets[d.first]));
+        }
+
+        // Test condition for `valid_start_offset`, see `can_gc_replica_slog`.
+        const auto &set_to_start = set_to_slog_file_start_offsets.find(i);
+        if (set_to_start != set_to_slog_file_start_offsets.end()) {
+            const auto &start_offset = slog_file_start_offsets[set_to_start->second];
+            replica_durable_decrees[start_offset.first].valid_start_offset = start_offset.second;
+        }
+
+        // Run garbage collection for a round.
+        std::set<gpid> actual_prevent_gc_replicas;
+        mlog->garbage_collection(replica_durable_decrees, actual_prevent_gc_replicas);
+
+        // Check if the number of remaining slog files after garbage collection is desired.
+        std::vector<std::string> file_list;
+        ASSERT_TRUE(dsn::utils::filesystem::get_subfiles(slog_dir, file_list, false));
+        ASSERT_EQ(remaining_slog_files[i], file_list.size());
+
+        // Check if the replicas that prevent garbage collection (i.e. cannot be removed by
+        // garbage collection) is expected.
+        ASSERT_EQ(expected_prevent_gc_replicas[i], actual_prevent_gc_replicas);
+    }
+}
+
+using gc_slog_flush_replicas_case = std::tuple<std::set<gpid>, uint64_t, size_t, size_t, size_t>;
+
+class GcSlogFlushFeplicasTest : public testing::TestWithParam<gc_slog_flush_replicas_case>
+{
+};
+
+DSN_DECLARE_uint64(log_shared_gc_flush_replicas_limit);
+
+TEST_P(GcSlogFlushFeplicasTest, FlushReplicas)
+{
+    std::set<gpid> prevent_gc_replicas;
+    size_t last_prevent_gc_replica_count;
+    uint64_t limit;
+    size_t last_limit;
+    size_t expected_flush_replicas;
+    std::tie(prevent_gc_replicas,
+             last_prevent_gc_replica_count,
+             limit,
+             last_limit,
+             expected_flush_replicas) = GetParam();
+
+    replica_stub::replica_gc_info_map replica_gc_map;
+    for (const auto &r : prevent_gc_replicas) {
+        replica_gc_map.emplace(r, replica_stub::replica_gc_info());
+    }
+
+    const auto reserved_log_shared_gc_flush_replicas_limit =
+        FLAGS_log_shared_gc_flush_replicas_limit;
+    FLAGS_log_shared_gc_flush_replicas_limit = limit;
+
+    dsn::fail::setup();
+    dsn::fail::cfg("mock_flush_replicas_for_slog_gc", "void(true)");
+
+    replica_stub stub;
+    stub._last_prevent_gc_replica_count = last_prevent_gc_replica_count;
+    stub._real_log_shared_gc_flush_replicas_limit = last_limit;
+
+    stub.flush_replicas_for_slog_gc(replica_gc_map, prevent_gc_replicas);
+    EXPECT_EQ(expected_flush_replicas, stub._mock_flush_replicas_for_test);
+
+    dsn::fail::teardown();
+
+    FLAGS_log_shared_gc_flush_replicas_limit = reserved_log_shared_gc_flush_replicas_limit;
+}
+
+const std::vector<gc_slog_flush_replicas_case> gc_slog_flush_replicas_tests = {
+    // Initially, there is no limit on flushed replicas.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 0, 0, 0, 6},
+    // Initially, there is no limit on flushed replicas.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 1, 0, 5, 6},
+    // Initially, limit is less than the number of replicas.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 0, 1, 0, 1},
+    // Initially, limit is less than the number of replicas.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 0, 2, 0, 2},
+    // Initially, limit is just equal to the number of replicas.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 0, 6, 0, 6},
+    // Initially, limit is more than the number of replicas.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 0, 7, 0, 6},
+    // No replica has been flushed during previous round.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 6, 6, 6, 2},
+    // No replica has been flushed during previous round.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 6, 1, 2, 1},
+    // The previous limit is 0.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 7, 5, 0, 5},
+    // The previous limit is infinite.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 7, 5, std::numeric_limits<size_t>::max(), 5},
+    // The number of previously flushed replicas is less than the previous limit.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 7, 5, 0, 5},
+    // The number of previously flushed replicas reaches the previous limit.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 8, 6, 2, 4},
+    // The number of previously flushed replicas reaches the previous limit.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 12, 6, 6, 6},
+    // The number of previously flushed replicas is more than the previous limit.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 9, 3, 2, 3},
+    // The number of previously flushed replicas is more than the previous limit.
+    {{{1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5}}, 9, 5, 2, 4},
+};
+
+INSTANTIATE_TEST_CASE_P(MutationLogTest,
+                        GcSlogFlushFeplicasTest,
+                        testing::ValuesIn(gc_slog_flush_replicas_tests));
+
 } // namespace replication
 } // namespace dsn

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -278,7 +278,7 @@ stateful = true
   plog_force_flush = false
 
   log_shared_file_size_mb = 128
-  log_shared_file_count_limit = 100
+  log_shared_gc_flush_replicas_limit = 64
   log_shared_batch_buffer_kb = 0
   log_shared_force_flush = false
   log_shared_pending_size_throttling_threshold_kb = 0

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2040,7 +2040,8 @@ private:
     }
 
     int64_t checkpoint_decree = 0;
-    ::dsn::error_code err = copy_checkpoint_to_dir_unsafe(tmp_dir.c_str(), &checkpoint_decree);
+    ::dsn::error_code err =
+        copy_checkpoint_to_dir_unsafe(tmp_dir.c_str(), &checkpoint_decree, flush_memtable);
     if (err != ::dsn::ERR_OK) {
         LOG_ERROR_PREFIX("copy_checkpoint_to_dir_unsafe failed with err = {}", err.to_string());
         return ::dsn::ERR_LOCAL_APP_FAILURE;

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -187,7 +187,7 @@ log_private_reserve_max_size_mb = 0
 log_private_reserve_max_time_seconds = 0
 
 log_shared_file_size_mb = 32
-log_shared_file_count_limit = 32
+log_shared_gc_flush_replicas_limit = 64
 log_shared_batch_buffer_kb = 0
 log_shared_force_flush = false
 

--- a/src/utils/autoref_ptr.h
+++ b/src/utils/autoref_ptr.h
@@ -159,6 +159,8 @@ public:
 
     void swap(ref_ptr<T> &r) noexcept { std::swap(_obj, r._obj); }
 
+    void reset(T *obj = nullptr) { *this = obj; }
+
     T *get() const { return _obj; }
 
     operator T *() const { return _obj; }

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -64,7 +64,8 @@
     } while (false)
 
 #define CHECK(x, ...) CHECK_EXPRESSION(x, x, __VA_ARGS__)
-#define CHECK_NOTNULL(p, ...) CHECK(p != nullptr, __VA_ARGS__)
+#define CHECK_NOTNULL(p, ...) CHECK((p) != nullptr, __VA_ARGS__)
+#define CHECK_NULL(p, ...) CHECK((p) == nullptr, __VA_ARGS__)
 
 // Macros for writing log message prefixed by log_prefix().
 #define LOG_DEBUG_PREFIX(...) LOG_DEBUG("[{}] {}", log_prefix(), fmt::format(__VA_ARGS__))


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1593

In https://github.com/XiaoMi/rdsn/pull/1019 we've written private logs as
WAL instead of shared logs, which also means shared log files would never
be appended with new mutations.

However, obsolete shared logs that had been applied to rocksdb were not
removed since then. There is at least 1 shared log file which is never removed.
We should change this policy of garbage collection, to delete all obsolete
shared log files.

To facilitate the garbage collection of shared log files, we also trigger checkpoints
which would flush rocksdb data to disk for each replica that has prevented shared
log files from being removed for garbage collection. It is necessary to limit the
number of submitted replicas that would be flushed at a time to avoid too much
consumption of I/O resources which might affect the processing of read/write
requests from clients.

This PR is to cherry-pick #1594 into v2.5 to solve issue #1593.