### PR TITLE
build(thirdparty): bump fmtlib to 10.1.1

### DIFF
--- a/cmake_modules/BaseFunctions.cmake
+++ b/cmake_modules/BaseFunctions.cmake
@@ -388,11 +388,9 @@ function(dsn_common_setup)
 
   set(BUILD_SHARED_LIBS OFF)
 
-  include(CheckCXXCompilerFlag)
-  CHECK_CXX_COMPILER_FLAG("-std=c++1y" COMPILER_SUPPORTS_CXX1Y)
-  if(NOT ${COMPILER_SUPPORTS_CXX1Y})
-    message(FATAL_ERROR "You need a compiler with C++1y support.")
-  endif()
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 
   dsn_setup_system_libs()
   dsn_setup_compiler_flags()

--- a/src/base/idl_utils.h
+++ b/src/base/idl_utils.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "rrdb/rrdb_types.h"
+#include "utils/fmt_utils.h"
 
 namespace pegasus {
 
@@ -40,3 +41,11 @@ inline bool cas_is_check_operand_needed(dsn::apps::cas_check_type::type type)
 }
 
 } // namespace pegasus
+
+namespace dsn {
+namespace apps {
+USER_DEFINED_ENUM_FORMATTER(cas_check_type::type)
+USER_DEFINED_ENUM_FORMATTER(filter_type::type)
+USER_DEFINED_ENUM_FORMATTER(mutate_operation::type)
+} // namespace apps
+} // namespace dsn

--- a/src/base/value_field.h
+++ b/src/base/value_field.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "utils/fmt_utils.h"
+
 namespace pegasus {
 
 enum value_field_type
@@ -28,6 +30,7 @@ enum value_field_type
     USER_DATA,
     FIELD_COUNT,
 };
+USER_DEFINED_ENUM_FORMATTER(value_field_type)
 
 struct value_field
 {

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -45,7 +45,7 @@
 #include "common/replication.codes.h"
 #include "common/replication_common.h"
 #include "common/replication_enums.h"
-#include "fmt/ostream.h"
+#include "fmt/core.h"
 #include "meta/meta_rpc_types.h"
 #include "runtime/api_layer1.h"
 #include "runtime/rpc/group_address.h"

--- a/src/client/test/ddl_client_test.cpp
+++ b/src/client/test/ddl_client_test.cpp
@@ -15,14 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <fmt/ostream.h>
+#include <fmt/core.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <algorithm>
 #include <deque>
-#include <iosfwd>
 #include <memory>
 #include <vector>
 

--- a/src/client_lib/pegasus_client_impl.cpp
+++ b/src/client_lib/pegasus_client_impl.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <fmt/core.h>
 #include <pegasus/error.h>
 #include <algorithm>
 #include <chrono>

--- a/src/common/duplication_common.h
+++ b/src/common/duplication_common.h
@@ -28,6 +28,7 @@
 #include "runtime/rpc/rpc_holder.h"
 #include "utils/errors.h"
 #include "utils/flags.h"
+#include "utils/fmt_utils.h"
 
 namespace dsn {
 namespace replication {
@@ -87,5 +88,7 @@ struct duplication_constants
     const static std::string kDuplicationEnvMasterMetasKey;
 };
 
+USER_DEFINED_ENUM_FORMATTER(duplication_fail_mode::type)
+USER_DEFINED_ENUM_FORMATTER(duplication_status::type)
 } // namespace replication
 } // namespace dsn

--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -37,13 +37,13 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <iosfwd>
 #include <utility>
+
+#include <fmt/std.h> // IWYU pragma: keep
 
 #include "common/gpid.h"
 #include "common/replication_enums.h"
 #include "fmt/core.h"
-#include "fmt/ostream.h"
 #include "perf_counter/perf_counter.h"
 #include "replica_admin_types.h"
 #include "runtime/api_layer1.h"

--- a/src/common/gpid.h
+++ b/src/common/gpid.h
@@ -29,6 +29,8 @@
 #include <ostream>
 #include <thrift/protocol/TProtocol.h>
 
+#include "utils/fmt_utils.h"
+
 namespace dsn {
 
 // Group-Partition-ID.
@@ -90,6 +92,8 @@ private:
 };
 
 } // namespace dsn
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::gpid);
 
 namespace std {
 template <>

--- a/src/common/replication_enums.h
+++ b/src/common/replication_enums.h
@@ -32,6 +32,7 @@
 #include "consensus_types.h"
 #include "meta_admin_types.h"
 #include "replica_admin_types.h"
+#include "utils/fmt_utils.h"
 
 namespace dsn {
 ENUM_BEGIN2(app_status::type, app_status, app_status::AS_INVALID)
@@ -163,4 +164,18 @@ ENUM_REG(replication::manual_compaction_status::QUEUING)
 ENUM_REG(replication::manual_compaction_status::RUNNING)
 ENUM_REG(replication::manual_compaction_status::FINISHED)
 ENUM_END2(replication::manual_compaction_status::type, manual_compaction_status)
+
+USER_DEFINED_ENUM_FORMATTER(app_status::type)
+namespace replication {
+USER_DEFINED_ENUM_FORMATTER(bulk_load_status::type)
+USER_DEFINED_ENUM_FORMATTER(config_type::type)
+USER_DEFINED_ENUM_FORMATTER(detect_action::type)
+USER_DEFINED_ENUM_FORMATTER(disk_migration_status::type)
+USER_DEFINED_ENUM_FORMATTER(disk_status::type)
+USER_DEFINED_ENUM_FORMATTER(learner_status::type)
+USER_DEFINED_ENUM_FORMATTER(learn_type::type)
+USER_DEFINED_ENUM_FORMATTER(manual_compaction_status::type)
+USER_DEFINED_ENUM_FORMATTER(meta_function_level::type)
+USER_DEFINED_ENUM_FORMATTER(partition_status::type)
+} // namespace replication
 } // namespace dsn

--- a/src/http/http_message_parser.cpp
+++ b/src/http/http_message_parser.cpp
@@ -138,7 +138,9 @@ http_message_parser::http_message_parser()
             header->hdr_type = http_method::HTTP_METHOD_POST;
             header->context.u.is_request = 1;
         } else {
-            LOG_ERROR("invalid http type {} and method {}", parser->type, parser->method);
+            // Bit fields don't work with "perfect" forwarding, see
+            // https://github.com/fmtlib/fmt/issues/1284
+            LOG_ERROR("invalid http type {} and method {}", +parser->type, +parser->method);
             return 1;
         }
         return 0;

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -17,7 +17,6 @@
 
 #include "http_server.h"
 
-#include <fmt/ostream.h>
 #include <stdint.h>
 #include <string.h>
 #include <memory>

--- a/src/include/pegasus/client.h
+++ b/src/include/pegasus/client.h
@@ -28,6 +28,8 @@
 #include <functional>
 #include <memory>
 
+#include "utils/fmt_utils.h"
+
 namespace pegasus {
 
 class rrdb_client;
@@ -1216,4 +1218,6 @@ public:
     static pegasus_client *get_client(const char *cluster_name, const char *app_name);
 };
 
+USER_DEFINED_ENUM_FORMATTER(pegasus_client::filter_type)
+USER_DEFINED_ENUM_FORMATTER(pegasus_client::cas_check_type)
 } // namespace pegasus

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -16,10 +16,8 @@
 // under the License.
 
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <algorithm>
 #include <cstdint>
-#include <iosfwd>
 #include <queue>
 #include <type_traits>
 

--- a/src/meta/meta_backup_service.h
+++ b/src/meta/meta_backup_service.h
@@ -41,11 +41,13 @@
 #include "runtime/task/task_tracker.h"
 #include "utils/api_utilities.h"
 #include "utils/error_code.h"
+#include "utils/fmt_utils.h"
 #include "utils/zlocks.h"
 
 namespace dsn {
 class message_ex;
 class rpc_address;
+
 namespace dist {
 namespace block_service {
 class block_filesystem;
@@ -420,3 +422,5 @@ private:
 };
 } // namespace replication
 } // namespace dsn
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::replication::backup_start_time);

--- a/src/meta/meta_options.cpp
+++ b/src/meta/meta_options.cpp
@@ -38,6 +38,7 @@
 #include <map>
 #include <utility>
 
+#include "common/replication_enums.h" // IWYU pragma: keep
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/strings.h"

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -26,8 +26,7 @@
 
 // IWYU pragma: no_include <boost/detail/basic_pointerbuf.hpp>
 #include <boost/lexical_cast.hpp>
-// IWYU pragma: no_include <ext/alloc_traits.h>
-#include <fmt/ostream.h>
+#include <ext/alloc_traits.h>
 #include <algorithm> // for std::remove_if
 #include <chrono>
 #include <functional>

--- a/src/meta/meta_state_service_utils_impl.h
+++ b/src/meta/meta_state_service_utils_impl.h
@@ -17,12 +17,12 @@
 
 #pragma once
 
+#include "common/replication.codes.h"
+#include "meta/meta_state_service.h"
+#include "meta_state_service_utils.h"
 #include "runtime/pipeline.h"
 #include "utils/fmt_logging.h"
-
-#include "meta_state_service_utils.h"
-#include "meta/meta_state_service.h"
-#include "common/replication.codes.h"
+#include "utils/fmt_utils.h"
 
 namespace dsn {
 namespace replication {
@@ -61,6 +61,7 @@ struct op_type
         return op_type_to_string_map[v - 1];
     }
 };
+USER_DEFINED_ENUM_FORMATTER(op_type::type)
 
 /// Base class for all operations.
 struct operation : pipeline::environment

--- a/src/meta/meta_state_service_zookeeper.cpp
+++ b/src/meta/meta_state_service_zookeeper.cpp
@@ -390,8 +390,9 @@ void meta_state_service_zookeeper::visit_zookeeper_internal(ref_this,
 {
     zookeeper_session::zoo_opcontext *op =
         reinterpret_cast<zookeeper_session::zoo_opcontext *>(result);
-    LOG_DEBUG(
-        "visit zookeeper internal: ans({}), call type({})", zerror(op->_output.error), op->_optype);
+    LOG_DEBUG("visit zookeeper internal: ans({}), call type({})",
+              zerror(op->_output.error),
+              static_cast<int>(op->_optype));
 
     switch (op->_optype) {
     case zookeeper_session::ZOO_OPERATION::ZOO_CREATE:

--- a/src/meta/test/meta_service_test.cpp
+++ b/src/meta/test/meta_service_test.cpp
@@ -15,11 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <fmt/ostream.h>
+#include <fmt/core.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
-#include <iosfwd>
 #include <memory>
 #include <vector>
 

--- a/src/perf_counter/perf_counter.h
+++ b/src/perf_counter/perf_counter.h
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "utils/autoref_ptr.h"
+#include "utils/fmt_utils.h"
 
 typedef enum dsn_perf_counter_type_t {
     COUNTER_TYPE_NUMBER,
@@ -42,6 +43,7 @@ typedef enum dsn_perf_counter_type_t {
     COUNTER_TYPE_COUNT,
     COUNTER_TYPE_INVALID
 } dsn_perf_counter_type_t;
+USER_DEFINED_ENUM_FORMATTER(dsn_perf_counter_type_t)
 
 typedef enum dsn_perf_counter_percentile_type_t {
     COUNTER_PERCENTILE_50,

--- a/src/replica/backup/cold_backup_context.cpp
+++ b/src/replica/backup/cold_backup_context.cpp
@@ -1029,7 +1029,7 @@ void cold_backup_context::on_upload_file_complete(const std::string &local_filen
     } else {
         CHECK_GT(total, 0.0);
         update_progress(static_cast<int>(complete_size / total * 1000));
-        LOG_INFO("{}: the progress of upload checkpoint is {}", name, _progress);
+        LOG_INFO("{}: the progress of upload checkpoint is {}", name, _progress.load());
     }
     if (is_ready_for_upload()) {
         std::vector<std::string> upload_files;

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -16,9 +16,7 @@
 // under the License.
 
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <functional>
-#include <iosfwd>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/src/replica/prepare_list.h
+++ b/src/replica/prepare_list.h
@@ -34,6 +34,7 @@
 #include "replica/mutation.h"
 #include "replica/replica_base.h"
 #include "utils/error_code.h"
+#include "utils/fmt_utils.h"
 
 namespace dsn {
 namespace replication {
@@ -45,6 +46,7 @@ enum commit_type
     COMMIT_ALL_READY       // commit (last_committed, ...<all is_commit_ready mutations> ...]
     // - only valid when partition_status::PS_SECONDARY or partition_status::PS_PRIMARY
 };
+USER_DEFINED_ENUM_FORMATTER(commit_type)
 
 // prepare_list origins from the concept of `prepared list` in PacificA.
 // It stores an continuous and ordered list of mutations.

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -27,11 +27,9 @@
 #include "replica.h"
 
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <rocksdb/status.h>
 #include <algorithm>
 #include <functional>
-#include <iosfwd>
 #include <set>
 
 #include "backup/replica_backup_manager.h"

--- a/src/replica/replica_learn.cpp
+++ b/src/replica/replica_learn.cpp
@@ -46,6 +46,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/std.h> // IWYU pragma: keep
+
 #include "aio/aio_task.h"
 #include "common/fs_manager.h"
 #include "common/gpid.h"

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -36,7 +36,6 @@
 #include <boost/algorithm/string/replace.hpp>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -32,7 +32,6 @@
 //   replica_stub(singleton) --> replica --> replication_app_base
 //
 
-#include <gtest/gtest_prod.h>
 #include <stdint.h>
 #include <atomic>
 #include <functional>
@@ -43,6 +42,8 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+#include <gtest/gtest_prod.h>
 
 #include "block_service/block_service_manager.h"
 #include "bulk_load_types.h"
@@ -71,12 +72,14 @@
 #include "utils/autoref_ptr.h"
 #include "utils/error_code.h"
 #include "utils/flags.h"
+#include "utils/fmt_utils.h"
 #include "utils/zlocks.h"
 
 namespace dsn {
 class command_deregister;
 class message_ex;
 class nfs_node;
+
 namespace service {
 class copy_request;
 class copy_response;
@@ -306,6 +309,7 @@ private:
         NS_Connecting,
         NS_Connected
     };
+    friend USER_DEFINED_ENUM_FORMATTER(replica_stub::replica_node_state);
 
     enum replica_life_cycle
     {

--- a/src/replica/replication_app_base.h
+++ b/src/replica/replication_app_base.h
@@ -39,6 +39,7 @@
 #include "replica/replica_base.h"
 #include "replica_admin_types.h"
 #include "utils/error_code.h"
+#include "utils/fmt_utils.h"
 #include "utils/ports.h"
 
 namespace dsn {
@@ -313,6 +314,6 @@ protected:
 
     explicit replication_app_base(replication::replica *replica);
 };
-
+USER_DEFINED_ENUM_FORMATTER(replication_app_base::chkpt_apply_mode)
 } // namespace replication
 } // namespace dsn

--- a/src/replica/storage/simple_kv/test/case.cpp
+++ b/src/replica/storage/simple_kv/test/case.cpp
@@ -42,7 +42,6 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/lexical_cast.hpp>
 #include <fmt/core.h>
-#include <fmt/format.h>
 #include <fmt/printf.h>
 #include <inttypes.h>
 #include <algorithm>

--- a/src/replica/storage/simple_kv/test/case.h
+++ b/src/replica/storage/simple_kv/test/case.h
@@ -46,6 +46,7 @@
 #include "meta_admin_types.h"
 #include "runtime/rpc/rpc_address.h"
 #include "utils/error_code.h"
+#include "utils/fmt_utils.h"
 #include "utils/singleton.h"
 #include "utils/zlocks.h"
 
@@ -441,6 +442,7 @@ private:
     dsn::replication::config_type::type _config_type;
     rpc_address _config_node;
 };
+USER_DEFINED_ENUM_FORMATTER(client_case_line::client_type)
 
 class test_case : public dsn::utils::singleton<test_case>
 {
@@ -505,3 +507,5 @@ private:
 }
 }
 }
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::replication::test::event);

--- a/src/replica/storage/simple_kv/test/common.h
+++ b/src/replica/storage/simple_kv/test/common.h
@@ -47,6 +47,7 @@
 #include "common/replication_other_types.h"
 #include "metadata_types.h"
 #include "runtime/rpc/rpc_address.h"
+#include "utils/fmt_utils.h"
 
 namespace dsn {
 class partition_configuration;
@@ -213,3 +214,7 @@ struct parti_config
 }
 }
 }
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::replication::test::parti_config);
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::replication::test::replica_id);
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::replication::test::state_snapshot);

--- a/src/replica/test/replica_disk_migrate_test.cpp
+++ b/src/replica/test/replica_disk_migrate_test.cpp
@@ -18,11 +18,9 @@
  */
 
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
-#include <iosfwd>
 #include <map>
 #include <memory>
 #include <set>

--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -242,7 +242,7 @@ void asio_udp_provider::send_message(message_ex *request)
         [=](const boost::system::error_code &error, std::size_t bytes_transferred) {
             if (error) {
                 LOG_WARNING("send udp packet to ep {}:{} failed, message = {}",
-                            ep.address(),
+                            ep.address().to_string(),
                             ep.port(),
                             error.message());
                 // we do not handle failure here, rpc matcher would handle timeouts

--- a/src/runtime/rpc/network.h
+++ b/src/runtime/rpc/network.h
@@ -39,6 +39,7 @@
 #include "runtime/task/task_spec.h"
 #include "utils/autoref_ptr.h"
 #include "utils/error_code.h"
+#include "utils/fmt_utils.h"
 #include "utils/join_point.h"
 #include "utils/link.h"
 #include "utils/synchronize.h"
@@ -282,6 +283,8 @@ protected:
         SS_CONNECTED,
         SS_DISCONNECTED
     };
+    friend USER_DEFINED_ENUM_FORMATTER(rpc_session::session_state);
+
     mutable utils::ex_lock_nr _lock; // [
     volatile session_state _connect_state;
 

--- a/src/runtime/rpc/rpc_address.h
+++ b/src/runtime/rpc/rpc_address.h
@@ -27,12 +27,14 @@
 #pragma once
 
 #include <arpa/inet.h> // IWYU pragma: keep
-
 #include <cstddef>
 #include <cstdint>
+// IWYU pragma: no_include <experimental/string_view>
 #include <functional>
 #include <sstream>
 #include <string>
+
+#include "utils/fmt_utils.h"
 
 namespace apache {
 namespace thrift {
@@ -47,6 +49,7 @@ typedef enum dsn_host_type_t {
     HOST_TYPE_IPV4 = 1,
     HOST_TYPE_GROUP = 2,
 } dsn_host_type_t;
+USER_DEFINED_ENUM_FORMATTER(dsn_host_type_t)
 
 namespace dsn {
 
@@ -207,6 +210,8 @@ private:
 };
 
 } // namespace dsn
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::rpc_address);
 
 namespace std {
 

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -30,6 +30,7 @@
 #include "runtime/rpc/rpc_address.h"
 #include "utils/errors.h"
 #include "utils/fmt_logging.h"
+#include "utils/fmt_utils.h"
 
 namespace apache {
 namespace thrift {
@@ -115,6 +116,8 @@ inline bool operator==(const host_port &hp1, const host_port &hp2)
 inline bool operator!=(const host_port &hp1, const host_port &hp2) { return !(hp1 == hp2); }
 
 } // namespace dsn
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::host_port);
 
 namespace std {
 template <>

--- a/src/runtime/rpc/thrift_message_parser.cpp
+++ b/src/runtime/rpc/thrift_message_parser.cpp
@@ -46,6 +46,7 @@
 #include "utils/crc.h"
 #include "utils/endians.h"
 #include "utils/fmt_logging.h"
+#include "utils/fmt_utils.h"
 #include "utils/string_view.h"
 #include "utils/strings.h"
 
@@ -428,3 +429,5 @@ thrift_message_parser::thrift_message_parser()
 thrift_message_parser::~thrift_message_parser() = default;
 
 } // namespace dsn
+
+USER_DEFINED_STRUCTURE_FORMATTER(apache::thrift::protocol::TMessageType);

--- a/src/runtime/security/negotiation_manager.cpp
+++ b/src/runtime/security/negotiation_manager.cpp
@@ -21,7 +21,6 @@
 
 #include "client_negotiation.h"
 #include "failure_detector/fd.code.definition.h"
-#include "fmt/core.h"
 #include "http/http_server.h"
 #include "negotiation_utils.h"
 #include "runtime/rpc/network.h"

--- a/src/runtime/task/task_code.h
+++ b/src/runtime/task/task_code.h
@@ -31,6 +31,7 @@
 #include <string>
 
 #include "utils/enum_helper.h"
+#include "utils/fmt_utils.h"
 #include "utils/ports.h"
 #include "utils/threadpool_code.h"
 
@@ -53,6 +54,7 @@ typedef enum dsn_task_type_t {
     TASK_TYPE_COUNT,
     TASK_TYPE_INVALID
 } dsn_task_type_t;
+USER_DEFINED_ENUM_FORMATTER(dsn_task_type_t)
 
 ENUM_BEGIN(dsn_task_type_t, TASK_TYPE_INVALID)
 ENUM_REG(TASK_TYPE_RPC_REQUEST)
@@ -115,9 +117,12 @@ public:
 
     const char *to_string() const;
 
-    constexpr bool operator==(const task_code &r) { return _internal_code == r._internal_code; }
+    constexpr bool operator==(const task_code &r) const
+    {
+        return _internal_code == r._internal_code;
+    }
 
-    constexpr bool operator!=(const task_code &r) { return !(*this == r); }
+    constexpr bool operator!=(const task_code &r) const { return !(*this == r); }
 
     constexpr operator int() const { return _internal_code; }
 
@@ -202,3 +207,5 @@ DEFINE_TASK_CODE(TASK_CODE_INVALID, TASK_PRIORITY_COMMON, THREAD_POOL_DEFAULT)
 DEFINE_TASK_CODE(TASK_CODE_EXEC_INLINED, TASK_PRIORITY_COMMON, THREAD_POOL_DEFAULT)
 
 } // namespace dsn
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::task_code);

--- a/src/runtime/task/task_spec.h
+++ b/src/runtime/task/task_spec.h
@@ -48,6 +48,7 @@
 #include "utils/enum_helper.h"
 #include "utils/exp_delay.h"
 #include "utils/extensible_object.h"
+#include "utils/fmt_utils.h"
 #include "utils/join_point.h"
 #include "utils/threadpool_code.h"
 
@@ -85,6 +86,7 @@ typedef enum grpc_mode_t {
     GRPC_COUNT,
     GRPC_INVALID
 } grpc_mode_t;
+USER_DEFINED_ENUM_FORMATTER(grpc_mode_t)
 
 ENUM_BEGIN(grpc_mode_t, GRPC_INVALID)
 ENUM_REG(GRPC_TO_LEADER)
@@ -99,6 +101,7 @@ typedef enum throttling_mode_t {
     TM_COUNT,
     TM_INVALID
 } throttling_mode_t;
+USER_DEFINED_ENUM_FORMATTER(throttling_mode_t)
 
 ENUM_BEGIN(throttling_mode_t, TM_INVALID)
 ENUM_REG(TM_NONE)
@@ -128,11 +131,13 @@ ENUM_END(dsn_msg_serialize_format)
 DEFINE_CUSTOMIZED_ID_TYPE(network_header_format)
 DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_INVALID)
 DEFINE_CUSTOMIZED_ID(network_header_format, NET_HDR_DSN)
+USER_DEFINED_ENUM_FORMATTER(network_header_format)
 
 // define network channel types for RPC
 DEFINE_CUSTOMIZED_ID_TYPE(rpc_channel)
 DEFINE_CUSTOMIZED_ID(rpc_channel, RPC_CHANNEL_TCP)
 DEFINE_CUSTOMIZED_ID(rpc_channel, RPC_CHANNEL_UDP)
+USER_DEFINED_ENUM_FORMATTER(rpc_channel)
 
 class aio_task;
 class message_ex;

--- a/src/server/available_detector.cpp
+++ b/src/server/available_detector.cpp
@@ -19,6 +19,7 @@
 
 #include "available_detector.h"
 
+#include <fmt/core.h>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <pegasus/error.h>
 #include <stdlib.h>
@@ -29,6 +30,8 @@
 #include <sstream>
 #include <type_traits>
 #include <utility>
+
+#include <fmt/std.h> // IWYU pragma: keep
 
 #include "base/pegasus_key_schema.h"
 #include "client/replication_ddl_client.h"

--- a/src/server/compaction_filter_rule.h
+++ b/src/server/compaction_filter_rule.h
@@ -19,15 +19,17 @@
 
 #pragma once
 
-#include <gtest/gtest_prod.h>
 #include <stdint.h>
 #include <string>
+
+#include <gtest/gtest_prod.h>
 
 #include "base/pegasus_value_schema.h"
 #include "common/json_helper.h"
 #include "utils/blob.h"
 #include "utils/enum_helper.h"
 #include "utils/factory_store.h"
+#include "utils/fmt_utils.h"
 #include "utils/string_view.h"
 
 namespace pegasus {
@@ -86,6 +88,7 @@ enum string_match_type
     SMT_MATCH_POSTFIX,
     SMT_INVALID,
 };
+USER_DEFINED_ENUM_FORMATTER(string_match_type)
 ENUM_BEGIN(string_match_type, SMT_INVALID)
 ENUM_REG(SMT_MATCH_ANYWHERE)
 ENUM_REG(SMT_MATCH_PREFIX)

--- a/src/server/pegasus_event_listener.cpp
+++ b/src/server/pegasus_event_listener.cpp
@@ -20,10 +20,8 @@
 #include "pegasus_event_listener.h"
 
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <rocksdb/compaction_job_stats.h>
 #include <rocksdb/table_properties.h>
-#include <iosfwd>
 #include <string>
 
 #include "common/gpid.h"

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -20,13 +20,11 @@
 #include "pegasus_mutation_duplicator.h"
 
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <pegasus/error.h>
 #include <sys/types.h>
 #include <chrono>
 #include <cstdint>
 #include <functional>
-#include <iosfwd>
 #include <memory>
 #include <tuple>
 #include <utility>

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -45,6 +45,7 @@
 #include <ostream>
 #include <set>
 
+#include "base/idl_utils.h" // IWYU pragma: keep
 #include "base/pegasus_key_schema.h"
 #include "base/pegasus_utils.h"
 #include "base/pegasus_value_schema.h"
@@ -3051,7 +3052,7 @@ std::string pegasus_server_impl::compression_type_to_str(rocksdb::CompressionTyp
     case rocksdb::kZSTD:
         return "zstd";
     default:
-        LOG_ERROR_PREFIX("Unsupported compression type: {}.", type);
+        LOG_ERROR_PREFIX("Unsupported compression type: {}.", static_cast<int>(type));
         return "<unsupported>";
     }
 }

--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <fmt/core.h>
 #include <rocksdb/status.h>
 #include <stdio.h>
 #include <thrift/transport/TTransportException.h>

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -18,10 +18,8 @@
  */
 
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <rocksdb/status.h>
 #include <algorithm>
-#include <iosfwd>
 #include <string>
 
 #include "base/pegasus_rpc_types.h"

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -21,6 +21,7 @@
 
 #include <gtest/gtest_prod.h>
 
+#include "base/idl_utils.h"
 #include "base/pegasus_key_schema.h"
 #include "logging_utils.h"
 #include "meta_store.h"
@@ -270,8 +271,7 @@ public:
         if (!is_check_type_supported(update.check_type)) {
             LOG_ERROR_PREFIX("invalid argument for check_and_set: decree = {}, error = {}",
                              decree,
-                             "check type {} not supported",
-                             update.check_type);
+                             fmt::format("check type {} not supported", update.check_type));
             resp.error = rocksdb::Status::kInvalidArgument;
             // we should write empty record to update rocksdb's last flushed decree
             return empty_put(decree);
@@ -391,8 +391,7 @@ public:
         if (!is_check_type_supported(update.check_type)) {
             LOG_ERROR_PREFIX("invalid argument for check_and_mutate: decree = {}, error = {}",
                              decree,
-                             "check type {} not supported",
-                             update.check_type);
+                             fmt::format("check type {} not supported", update.check_type));
             resp.error = rocksdb::Status::kInvalidArgument;
             // we should write empty record to update rocksdb's last flushed decree
             return empty_put(decree);

--- a/src/server/result_writer.cpp
+++ b/src/server/result_writer.cpp
@@ -21,7 +21,6 @@
 
 #include <pegasus/error.h>
 #include <chrono>
-#include <type_traits>
 #include <utility>
 
 #include "pegasus/client.h"

--- a/src/server/test/capacity_unit_calculator_test.cpp
+++ b/src/server/test/capacity_unit_calculator_test.cpp
@@ -17,13 +17,14 @@
  * under the License.
  */
 
-#include <algorithm>
+#include <fmt/core.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
-#include <memory>
 #include <rocksdb/status.h>
 #include <stdint.h>
+#include <algorithm>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/server/test/hashkey_transform_test.cpp
+++ b/src/server/test/hashkey_transform_test.cpp
@@ -19,6 +19,7 @@
 
 #include "server/hashkey_transform.h"
 
+#include <fmt/core.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>

--- a/src/server/test/hotkey_collector_test.cpp
+++ b/src/server/test/hotkey_collector_test.cpp
@@ -17,6 +17,7 @@
 
 #include "server/hotkey_collector.h"
 
+#include <fmt/core.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>

--- a/src/server/test/pegasus_server_write_test.cpp
+++ b/src/server/test/pegasus_server_write_test.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <fmt/core.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>

--- a/src/server/test/pegasus_write_service_impl_test.cpp
+++ b/src/server/test/pegasus_write_service_impl_test.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <fmt/core.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>

--- a/src/server/test/pegasus_write_service_test.cpp
+++ b/src/server/test/pegasus_write_service_test.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <fmt/core.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>

--- a/src/server/test/rocksdb_wrapper_test.cpp
+++ b/src/server/test/rocksdb_wrapper_test.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <fmt/core.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -26,6 +26,7 @@
 #include <thread>
 
 #include <boost/algorithm/string.hpp>
+#include <fmt/ostream.h>
 #include <rocksdb/db.h>
 #include <rocksdb/env.h>
 #include <rocksdb/sst_dump_tool.h>
@@ -48,6 +49,7 @@
 #include "perf_counter/perf_counter_utils.h"
 #include "remote_cmd/remote_command.h"
 #include "tools/mutation_log_tool.h"
+#include "utils/fmt_utils.h"
 #include "utils/string_view.h"
 #include "utils/strings.h"
 #include "utils/synchronize.h"
@@ -73,6 +75,8 @@ enum scan_data_operator
     SCAN_GEN_GEO,
     SCAN_AND_MULTI_SET
 };
+USER_DEFINED_ENUM_FORMATTER(scan_data_operator)
+
 class top_container
 {
 public:

--- a/src/shell/commands/bulk_load.cpp
+++ b/src/shell/commands/bulk_load.cpp
@@ -22,10 +22,10 @@
 #include <boost/lexical_cast.hpp>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <getopt.h>
 #include <s2/third_party/absl/base/port.h>
 #include <stdio.h>
+#include <algorithm>
 #include <cstdint>
 #include <iostream>
 #include <map>

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -21,7 +21,6 @@
 #include <boost/cstdint.hpp>
 #include <boost/lexical_cast.hpp>
 #include <fmt/core.h>
-#include <fmt/format.h>
 #include <fmt/printf.h>
 #include <getopt.h>
 #include <inttypes.h>

--- a/src/shell/commands/detect_hotkey.cpp
+++ b/src/shell/commands/detect_hotkey.cpp
@@ -16,10 +16,8 @@
 // under the License.
 
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <s2/third_party/absl/base/port.h>
 #include <stdio.h>
-#include <iosfwd>
 #include <memory>
 #include <set>
 #include <string>

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -20,7 +20,6 @@
 // IWYU pragma: no_include <bits/getopt_core.h>
 // IWYU pragma: no_include <bits/std_abs.h>
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <getopt.h>
 #include <s2/third_party/absl/base/port.h>
 #include <stdio.h>

--- a/src/test/function_test/base_api_test/test_batch_get.cpp
+++ b/src/test/function_test/base_api_test/test_batch_get.cpp
@@ -17,6 +17,7 @@
 * under the License.
 */
 
+#include <fmt/core.h>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>

--- a/src/utils/api_utilities.h
+++ b/src/utils/api_utilities.h
@@ -34,6 +34,7 @@
 #include <stdarg.h>
 
 #include "ports.h"
+#include "utils/fmt_utils.h"
 
 /*!
 @defgroup logging Logging Service
@@ -56,6 +57,8 @@ typedef enum dsn_log_level_t {
     LOG_LEVEL_COUNT,
     LOG_LEVEL_INVALID
 } dsn_log_level_t;
+
+USER_DEFINED_ENUM_FORMATTER(dsn_log_level_t)
 
 // logs with level smaller than this start_level will not be logged
 extern dsn_log_level_t dsn_log_start_level;

--- a/src/utils/error_code.h
+++ b/src/utils/error_code.h
@@ -30,6 +30,7 @@
 #include <ostream>
 #include <string>
 
+#include "utils/fmt_utils.h"
 #include "utils/ports.h"
 
 namespace apache {
@@ -53,9 +54,12 @@ public:
 
     const char *to_string() const;
 
-    constexpr bool operator==(const error_code &r) { return _internal_code == r._internal_code; }
+    constexpr bool operator==(const error_code &r) const
+    {
+        return _internal_code == r._internal_code;
+    }
 
-    constexpr bool operator!=(const error_code &r) { return !(*this == r); }
+    constexpr bool operator!=(const error_code &r) const { return !(*this == r); }
 
     constexpr operator int() const { return _internal_code; }
 
@@ -177,3 +181,5 @@ DEFINE_ERR_CODE(ERR_RDB_CORRUPTION)
 
 DEFINE_ERR_CODE(ERR_DISK_IO_ERROR)
 } // namespace dsn
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::error_code);

--- a/src/utils/errors.h
+++ b/src/utils/errors.h
@@ -31,6 +31,7 @@
 #include "utils/api_utilities.h"
 #include "utils/error_code.h"
 #include "utils/fmt_logging.h"
+#include "utils/fmt_utils.h"
 #include "utils/ports.h"
 #include "utils/smart_pointers.h"
 #include "utils/string_view.h"
@@ -218,6 +219,8 @@ private:
 };
 
 } // namespace dsn
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::error_s);
 
 #define FMT_ERR(ec, msg, args...) error_s::make(ec, fmt::format(msg, ##args))
 

--- a/src/utils/fail_point_impl.h
+++ b/src/utils/fail_point_impl.h
@@ -30,12 +30,14 @@
 
 #pragma once
 
-#include "utils/fail_point.h"
-#include "utils/api_utilities.h"
-#include "utils/ports.h"
 #include <mutex>
 #include <unordered_map>
 #include <utility>
+
+#include "utils/api_utilities.h"
+#include "utils/fail_point.h"
+#include "utils/fmt_utils.h"
+#include "utils/ports.h"
 
 namespace dsn {
 namespace fail {
@@ -97,6 +99,7 @@ private:
     int _freq{100};
     int _max_cnt{-1}; // TODO(wutao1): not thread-safe
 };
+USER_DEFINED_ENUM_FORMATTER(fail_point::task_type)
 
 struct fail_point_registry
 {

--- a/src/utils/fmt_utils.h
+++ b/src/utils/fmt_utils.h
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <fmt/ostream.h>
+
+#define USER_DEFINED_STRUCTURE_FORMATTER(type)                                                     \
+    template <>                                                                                    \
+    struct fmt::formatter<type> : ostream_formatter                                                \
+    {                                                                                              \
+    }
+
+#define USER_DEFINED_ENUM_FORMATTER(type)                                                          \
+    inline auto format_as(type e)->int { return e; }

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -617,8 +617,8 @@ void metric_timer::on_timer(const boost::system::error_code &ec)
     } while (0)
 
     if (dsn_unlikely(!!ec)) {
-        CHECK_EQ_MSG(ec,
-                     boost::system::errc::operation_canceled,
+        CHECK_EQ_MSG(static_cast<int>(boost::system::errc::operation_canceled),
+                     ec.value(),
                      "failed to exec on_timer with an error that cannot be handled: {}",
                      ec.message());
 

--- a/src/utils/string_view.h
+++ b/src/utils/string_view.h
@@ -49,6 +49,7 @@
 #include <string>
 
 #include "ports.h"
+#include "utils/fmt_utils.h"
 
 namespace dsn {
 
@@ -428,3 +429,5 @@ inline bool operator!=(string_view x, string_view y) noexcept { return !(x == y)
 std::ostream &operator<<(std::ostream &o, string_view piece);
 
 } // namespace dsn
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::string_view);

--- a/src/utils/test/fmt_logging_test.cpp
+++ b/src/utils/test/fmt_logging_test.cpp
@@ -25,11 +25,9 @@
  */
 
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
-#include <iosfwd>
 
 #include "common/gpid.h"
 #include "common/replication.codes.h"

--- a/src/utils/test/nth_element_test.cpp
+++ b/src/utils/test/nth_element_test.cpp
@@ -17,6 +17,7 @@
 
 #include "utils/nth_element.h"
 
+#include <fmt/core.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>

--- a/src/utils/threadpool_code.h
+++ b/src/utils/threadpool_code.h
@@ -29,6 +29,7 @@
 #include <ostream>
 
 #include "ports.h"
+#include "utils/fmt_utils.h"
 
 namespace dsn {
 class threadpool_code
@@ -66,3 +67,5 @@ private:
 DEFINE_THREAD_POOL_CODE(THREAD_POOL_INVALID)
 DEFINE_THREAD_POOL_CODE(THREAD_POOL_DEFAULT)
 }
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::threadpool_code);

--- a/src/zookeeper/lock_struct.h
+++ b/src/zookeeper/lock_struct.h
@@ -42,6 +42,7 @@
 #include "runtime/task/future_types.h"
 #include "utils/autoref_ptr.h"
 #include "utils/distributed_lock_service.h"
+#include "utils/fmt_utils.h"
 #include "utils/thread_access_checker.h"
 
 namespace dsn {
@@ -57,6 +58,7 @@ enum lock_state
     unlocking,
     state_count
 };
+USER_DEFINED_ENUM_FORMATTER(lock_state)
 
 struct zoolock_pair
 {

--- a/src/zookeeper/zookeeper_session.h
+++ b/src/zookeeper/zookeeper_session.h
@@ -44,6 +44,7 @@
 #include "runtime/service_app.h"
 #include "utils/autoref_ptr.h"
 #include "utils/blob.h"
+#include "utils/fmt_utils.h"
 #include "utils/synchronize.h"
 
 struct String_vector;
@@ -205,3 +206,5 @@ private:
 };
 }
 }
+
+USER_DEFINED_STRUCTURE_FORMATTER(::dsn::dist::zookeeper_session);

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -278,9 +278,8 @@ ExternalProject_Add(fds
 
 # fmtlib >=6.x requires c++14 support, do not update this library for now
 ExternalProject_Add(fmt
-        URL ${OSS_URL_PREFIX}/fmt-5.3.0.tar.gz
-        https://github.com/fmtlib/fmt/archive/refs/tags/5.3.0.tar.gz
-        URL_MD5 1015bf3ff2a140dfe03de50ee2469401
+        URL https://github.com/fmtlib/fmt/archive/refs/tags/10.1.1.tar.gz
+        URL_MD5 0d41a16f1b3878d44e6fd7ff1f6cc45a
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
         -DCMAKE_BUILD_TYPE=release
         -DFMT_TEST=false


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1604

- Add ecplicit formatters for user defined types. Because since fmtlib 8.0:
  > Format string compilation now requires `format` functions of `formatter` specializations for user-defined types to be `const`.

  See https://github.com/fmtlib/fmt/releases/tag/8.0.0