### PR TITLE
fix(ASAN): avoid reporting false 'odr-violation' issues (cherry-pick #1611)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -26,6 +26,8 @@ export BUILD_LATEST_DIR=${BUILD_ROOT_DIR}/latest
 export REPORT_DIR="$ROOT/test_report"
 export THIRDPARTY_ROOT=$ROOT/thirdparty
 export LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/amd64/server:${BUILD_LATEST_DIR}/output/lib:${THIRDPARTY_ROOT}/output/lib:${LD_LIBRARY_PATH}
+# Disable AddressSanitizerOneDefinitionRuleViolation, see https://github.com/google/sanitizers/issues/1017 for details.
+export ASAN_OPTIONS=detect_odr_violation=0
 
 function usage()
 {


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1645

This patch is to disable AddressSanitizerOneDefinitionRuleViolation, see
https://github.com/google/sanitizers/issues/1017 for details.

This PR is to cherry-pick #1611 into v2.5 to solve issue #1645.