### PR TITLE
fix(build): fix compilation error on MacOS for C++14

### DIFF
--- a/cmake_modules/BaseFunctions.cmake
+++ b/cmake_modules/BaseFunctions.cmake
@@ -204,7 +204,7 @@ function(dsn_setup_compiler_flags)
   # We want access to the PRI* print format macros.
   add_definitions(-D__STDC_FORMAT_MACROS)
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -gdwarf-4" CACHE STRING "" FORCE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -gdwarf-4" CACHE STRING "" FORCE)
 
   #  -Wall: Enable all warnings.
   add_compile_options(-Wall)

--- a/cmake_modules/BaseFunctions.cmake
+++ b/cmake_modules/BaseFunctions.cmake
@@ -147,6 +147,7 @@ function(dsn_add_project)
   endif()
   ms_add_project("${MY_PROJ_TYPE}" "${MY_PROJ_NAME}" "${MY_PROJ_SRC}" "${MY_PROJ_LIBS}" "${MY_BINPLACES}")
   define_file_basename_for_sources(${MY_PROJ_NAME})
+  target_compile_features(${MY_PROJ_NAME} PRIVATE cxx_std_14)
 endfunction(dsn_add_project)
 
 function(dsn_add_static_library)

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -25,8 +25,8 @@
  */
 
 // IWYU pragma: no_include <boost/detail/basic_pointerbuf.hpp>
+// IWYU pragma: no_include <ext/alloc_traits.h>
 #include <boost/lexical_cast.hpp>
-#include <ext/alloc_traits.h>
 #include <algorithm> // for std::remove_if
 #include <chrono>
 #include <functional>


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1647
 
The standard followed by [v2.5](https://github.com/apache/incubator-pegasus/tree/v2.5)
would be C++14. However, Compilation on MacOS failed due to some errors, such as:
- no member named 'make_unique' in namespace 'std'
- initialized lambda captures are a C++14 extension
- 'ext/alloc_traits.h' file not found

Most of the errors are about C++14. `cmake` directives should be fixed to make C++14
compilation on MacOS work well.