### PR TITLE
feat: java client support FQDN

### DIFF
--- a/idl/bulk_load.thrift
+++ b/idl/bulk_load.thrift
@@ -98,6 +98,7 @@ struct bulk_load_request
     7:bulk_load_status  meta_bulk_load_status;
     8:bool              query_bulk_load_metadata;
     9:string            remote_root_path;
+    10:optional dsn.host_port    hp_primary_addr;
 }
 
 struct bulk_load_response
@@ -119,6 +120,7 @@ struct bulk_load_response
     8:optional bool                                     is_group_ingestion_finished;
     9:optional bool                                     is_group_bulk_load_context_cleaned_up;
     10:optional bool                                    is_group_bulk_load_paused;
+    11:optional map<dsn.host_port, partition_bulk_load_state>    hp_group_bulk_load_state;
 }
 
 // primary -> secondary
@@ -131,6 +133,7 @@ struct group_bulk_load_request
     5:string                        cluster_name;
     6:bulk_load_status              meta_bulk_load_status;
     7:string                        remote_root_path;
+    8:optional dsn.host_port                 hp_target_address;
 }
 
 struct group_bulk_load_response
@@ -218,6 +221,7 @@ struct query_bulk_load_response
     6:list<map<dsn.rpc_address, partition_bulk_load_state>> bulk_load_states;
     7:optional string                                       hint_msg;
     8:optional bool                                         is_bulk_loading;
+    9:optional list<map<dsn.host_port, partition_bulk_load_state>>   hp_bulk_load_states;
 }
 
 struct clear_bulk_load_state_request

--- a/idl/dsn.layer2.thrift
+++ b/idl/dsn.layer2.thrift
@@ -41,6 +41,9 @@ struct partition_configuration
     6:list<dsn.rpc_address>  last_drops;
     7:i64                    last_committed_decree;
     8:i32                    partition_flags;
+    9:optional dsn.host_port          hp_primary;
+    10:optional list<dsn.host_port>   hp_secondaries;
+    11:optional list<dsn.host_port>   hp_last_drops;
 }
 
 struct query_cfg_request

--- a/idl/duplication.thrift
+++ b/idl/duplication.thrift
@@ -150,6 +150,7 @@ struct duplication_sync_request
     1:dsn.rpc_address                                   node;
 
     2:map<dsn.gpid, list<duplication_confirm_entry>>    confirm_list;
+    3:dsn.host_port                                     hp_node;
 }
 
 struct duplication_sync_response

--- a/idl/meta_admin.thrift
+++ b/idl/meta_admin.thrift
@@ -76,6 +76,7 @@ struct configuration_update_request
     // the `meta_split_status` will be set
     // only used when on_config_sync
     6:optional metadata.split_status    meta_split_status;
+    7:optional dsn.host_port  hp_node;
 }
 
 // meta server (config mgr) => primary | secondary (downgrade) (w/ new config)
@@ -103,6 +104,7 @@ struct configuration_query_by_node_request
     1:dsn.rpc_address  node;
     2:optional list<metadata.replica_info> stored_replicas;
     3:optional replica_server_info info;
+    4:optional dsn.host_port  hp_node;
 }
 
 struct configuration_query_by_node_response
@@ -117,6 +119,7 @@ struct configuration_recovery_request
     1:list<dsn.rpc_address> recovery_set;
     2:bool skip_bad_nodes;
     3:bool skip_lost_partitions;
+    4:optional list<dsn.host_port> hp_recovery_set;
 }
 
 struct configuration_recovery_response
@@ -205,6 +208,7 @@ struct configuration_list_apps_response
 struct query_app_info_request
 {
     1:dsn.rpc_address meta_server;
+    2:optional dsn.host_port hp_meta_server;
 }
 
 struct query_app_info_response
@@ -280,6 +284,7 @@ struct node_info
 {
     1:node_status      status = node_status.NS_INVALID;
     2:dsn.rpc_address  address;
+    3:optional dsn.host_port  hp_address;
 }
 
 struct configuration_list_nodes_request
@@ -349,6 +354,8 @@ struct configuration_proposal_action
     // depricated now
     // new fields of this struct should start with 5
     // 4:i64 period_ts;
+    5:optional dsn.host_port hp_target;
+    6:optional dsn.host_port hp_node;
 }
 
 struct configuration_balancer_request
@@ -381,6 +388,7 @@ struct ddd_node_info
     5:i64             ballot; // collected && ballot == -1 means replica not exist on this node
     6:i64             last_committed_decree;
     7:i64             last_prepared_decree;
+    8:optional dsn.host_port hp_node;
 }
 
 struct ddd_partition_info

--- a/idl/metadata.thrift
+++ b/idl/metadata.thrift
@@ -98,6 +98,7 @@ struct replica_configuration
     // 2. false - secondary copy mutation in this prepare message asynchronously
     // NOTICE: it should always be false when update_local_configuration
     7:optional bool       split_sync_to_child = false;
+    8:optional dsn.host_port     hp_primary;
 }
 
 struct replica_info

--- a/idl/partition_split.thrift
+++ b/idl/partition_split.thrift
@@ -99,6 +99,7 @@ struct notify_catch_up_request
     2:dsn.gpid          child_gpid;
     3:i64               child_ballot;
     4:dsn.rpc_address   child_address;
+    5:optional dsn.host_port   hp_child_address;
 }
 
 struct notify_cacth_up_response
@@ -116,6 +117,7 @@ struct update_child_group_partition_count_request
     2:i32               new_partition_count;
     3:dsn.gpid          child_pid;
     4:i64               ballot;
+    5:optional dsn.host_port   hp_target_address;
 }
 
 struct update_child_group_partition_count_response
@@ -133,6 +135,7 @@ struct register_child_request
     2:dsn.layer2.partition_configuration    parent_config;
     3:dsn.layer2.partition_configuration    child_config;
     4:dsn.rpc_address                       primary_address;
+    5:optional dsn.host_port   hp_primary_address;
 }
 
 struct register_child_response

--- a/idl/replica_admin.thrift
+++ b/idl/replica_admin.thrift
@@ -70,6 +70,7 @@ struct query_disk_info_request
 {
     1:dsn.rpc_address node;
     2:string          app_name;
+    3:optional dsn.host_port hp_node;
 }
 
 // This response is from replica_server to client.

--- a/scripts/recompile_thrift.sh
+++ b/scripts/recompile_thrift.sh
@@ -30,7 +30,7 @@ rm -rf $TMP_DIR
 mkdir -p $TMP_DIR
 $THIRDPARTY_ROOT/output/bin/thrift --gen cpp:moveable_types -out $TMP_DIR ../idl/rrdb.thrift
 
-sed 's/#include "dsn_types.h"/#include "runtime\/rpc\/rpc_address.h"\n#include "runtime\/task\/task_code.h"\n#include "utils\/blob.h"/' $TMP_DIR/rrdb_types.h > ../src/include/rrdb/rrdb_types.h
+sed 's/#include "dsn_types.h"/#include "runtime\/rpc\/rpc_address.h"\n#include "runtime\/rpc\/rpc_host_port.h"\n#include "runtime\/task\/task_code.h"\n#include "utils\/blob.h"/' $TMP_DIR/rrdb_types.h > ../src/include/rrdb/rrdb_types.h
 sed 's/#include "rrdb_types.h"/#include <rrdb\/rrdb_types.h>/' $TMP_DIR/rrdb_types.cpp > ../src/base/rrdb_types.cpp
 
 rm -rf $TMP_DIR

--- a/src/common/consensus.thrift
+++ b/src/common/consensus.thrift
@@ -143,6 +143,7 @@ struct learn_request
     // be duplicated (ie. max_gced_decree < confirmed_decree), if not,
     // learnee will copy the missing logs.
     7:optional i64        max_gced_decree;
+    8:optional dsn.host_port     hp_learner;
 }
 
 struct learn_response
@@ -156,6 +157,7 @@ struct learn_response
     7:dsn.rpc_address       address; // learnee's address
     8:string                base_local_dir; // base dir of files on learnee
     9:optional string replica_disk_tag; // the disk tag of learnee located
+    10:optional dsn.host_port       hp_address; // learnee's address
 }
 
 struct learn_notify_response
@@ -180,6 +182,7 @@ struct group_check_request
     // Used to deliver child gpid and meta_split_status during partition split
     6:optional dsn.gpid     child_gpid;
     7:optional metadata.split_status meta_split_status;
+    8:optional dsn.host_port       hp_node;
 }
 
 struct group_check_response
@@ -195,5 +198,6 @@ struct group_check_response
     // if secondary pause or cancel split succeed, is_split_stopped = true
     8:optional bool       is_split_stopped;
     9:optional metadata.disk_status disk_status = metadata.disk_status.NORMAL;
+    10:optional dsn.host_port       hp_node;
 }
 

--- a/src/failure_detector/fd.thrift
+++ b/src/failure_detector/fd.thrift
@@ -30,23 +30,28 @@ namespace cpp dsn.fd
 
 struct beacon_msg
 {
-    1: i64 time;
-    2: dsn.rpc_address from_addr;
-    3: dsn.rpc_address to_addr;
-    4: optional i64 start_time;
+    1: i64                      time;
+    2: dsn.rpc_address          from_addr;
+    3: dsn.rpc_address          to_addr;
+    4: optional i64             start_time;
+    5: optional dsn.host_port   hp_from_addr;
+    6: optional dsn.host_port   hp_to_addr;
 }
 
 struct beacon_ack
 {
-    1: i64 time;
-    2: dsn.rpc_address this_node;
-    3: dsn.rpc_address primary_node;
-    4: bool is_master;
-    5: bool allowed;
+    1: i64                      time;
+    2: dsn.rpc_address          this_node;
+    3: dsn.rpc_address          primary_node;
+    4: bool                     is_master;
+    5: bool                     allowed;
+    6: optional dsn.host_port   hp_this_node;
+    7: optional dsn.host_port   hp_primary_node;
 }
 
 struct config_master_message
 {
-    1: dsn.rpc_address master;
-    2: bool is_register;
+    1: dsn.rpc_address          master;
+    2: bool                     is_register;
+    3: optional dsn.host_port   hp_master;
 }

--- a/src/nfs/nfs.thrift
+++ b/src/nfs/nfs.thrift
@@ -40,6 +40,7 @@ struct copy_request
     8: bool overwrite;
     9: optional string source_disk_tag;
     10: optional dsn.gpid pid;
+    11: optional dsn.host_port hp_source;
 }
 
 struct copy_response
@@ -60,6 +61,7 @@ struct get_file_size_request
     6: optional string source_disk_tag;
     7: optional string dest_disk_tag;
     8: optional dsn.gpid pid;
+    9: optional dsn.host_port hp_source;
 }
 
 struct get_file_size_response

--- a/src/runtime/rpc/group_host_port.h
+++ b/src/runtime/rpc/group_host_port.h
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "runtime/rpc/group_address.h"
-#include "runtime/rpc/group_host_port.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/autoref_ptr.h"
 #include "utils/fmt_logging.h"
@@ -131,7 +130,10 @@ inline rpc_group_host_port::rpc_group_host_port(const rpc_group_address *g_addr)
         CHECK_TRUE(add(host_port(addr)));
     }
     _update_leader_automatically = g_addr->is_update_leader_automatically();
-    set_leader(host_port(g_addr->leader()));
+    auto leader_addr = g_addr->leader();
+    if (rpc_address::s_invalid_address != leader_addr) {
+        set_leader(host_port(leader_addr));
+    }
 }
 
 inline rpc_group_host_port &rpc_group_host_port::operator=(const rpc_group_host_port &other)

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -41,6 +41,31 @@ class TProtocol;
 } // namespace thrift
 } // namespace apache
 
+#define FILL_HP_OPTIONAL_SECTION(OBJ_NAME, SECTION_NAME)                                           \
+    do {                                                                                           \
+        host_port hp(OBJ_NAME.SECTION_NAME);                                                       \
+        OBJ_NAME.__set_hp_##SECTION_NAME(hp);                                                      \
+    } while (false)
+
+#define FILL_HP_LIST_OPTIONAL_SECTION(OBJ_NAME, SECTION_NAME)                                      \
+    do {                                                                                           \
+        std::vector<host_port> hps;                                                                \
+        dsn::host_port::fill_host_ports_from_addresses(OBJ_NAME.SECTION_NAME, hps);                \
+        OBJ_NAME.__set_hp_##SECTION_NAME(hps);                                                     \
+    } while (false)
+
+#define FILL_OPTIONAL_HP_IF_NEEDED(OBJ_NAME, SECTION_NAME)                                         \
+    do {                                                                                           \
+        if (!OBJ_NAME.__isset.hp_##SECTION_NAME)                                                   \
+            FILL_HP_OPTIONAL_SECTION(OBJ_NAME, SECTION_NAME);                                      \
+    } while (false)
+
+#define FILL_OPTIONAL_HP_LIST_IF_NEEDED(OBJ_NAME, SECTION_NAME)                                    \
+    do {                                                                                           \
+        if (!OBJ_NAME.__isset.hp_##SECTION_NAME)                                                   \
+            FILL_HP_LIST_OPTIONAL_SECTION(OBJ_NAME, SECTION_NAME);                                 \
+    } while (false)
+
 namespace dsn {
 
 class rpc_group_host_port;
@@ -83,9 +108,16 @@ public:
     // Trere may be multiple rpc_addresses for one host_port.
     error_s resolve_addresses(std::vector<rpc_address> &addresses) const;
 
+    // This function is used for validating the format of string like "test_host:1234".
+    bool from_string(const std::string s);
+
     // for serialization in thrift format
     uint32_t read(::apache::thrift::protocol::TProtocol *iprot);
     uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
+
+    static void fill_host_ports_from_addresses(const std::vector<rpc_address> &addr_v,
+                                               /*output*/ std::vector<host_port> &hp_v);
+
 
 private:
     std::string _host;
@@ -115,6 +147,23 @@ inline bool operator==(const host_port &hp1, const host_port &hp2)
 }
 
 inline bool operator!=(const host_port &hp1, const host_port &hp2) { return !(hp1 == hp2); }
+
+inline bool operator<(const host_port &hp1, const host_port &hp2)
+{
+    if (hp1.type() != hp2.type()) {
+        return hp1.type() < hp2.type();
+    }
+
+    switch (hp1.type()) {
+    case HOST_TYPE_IPV4:
+        return hp1.host() < hp2.host() || (hp1.host() == hp2.host() && hp1.port() < hp2.port());
+    case HOST_TYPE_GROUP:
+        return reinterpret_cast<uint64_t>(hp1.group_host_port()) <
+               reinterpret_cast<uint64_t>(hp2.group_host_port());
+    default:
+        return true;
+    }
+}
 
 } // namespace dsn
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
make java client support FQDN

### What is changed and how does it work?
use class host_port to fit class rpc_address  which java client can use host to transfer thrift meassage 
