### PR TITLE
chore(CI): remove the "Check issue" from Standardization Lint

### DIFF
--- a/.github/workflows/standardization_lint.yaml
+++ b/.github/workflows/standardization_lint.yaml
@@ -50,18 +50,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
 
-  related_issue:
-    name: Check issue
-    runs-on: ubuntu-latest
-    steps:
-      - uses: neofinancial/ticket-check-action@v1.3.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          titleFormat: '%title%'
-          quiet: true
-          bodyRegex: '#(\d+)'
-          bodyURLRegex: 'http(s?):\/\/(github.com)(\/apache)(\/incubator-pegasus)(\/issues)\/\d+'
-
   dockerfile_linter:
     name: Lint Dockerfile
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1551

Remove the "Check issue" from Standardization Lint because it makes other
linter failed becuse the action `neofinancial/ticket-check-action@v1.3.0`
is not allowed for Apache repos.

In fact, the issue checker is just an optional, we shall keep the pull
requests description clarify when submit or update, but an issue link is
not necessary.