### PR TITLE
fix(CI): Fix the "Lint Dockerfile" action failure (cherry-pick #1656)

### DIFF
--- a/docker/pegasus-build-env/ubuntu1804/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu1804/Dockerfile
@@ -61,7 +61,7 @@ RUN add-apt-repository ppa:git-core/ppa -y; \
     apt-get install pkg-config -y --no-install-recommends; \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip && pip3 install --no-cache-dir cmake
+RUN pip3 install --no-cache-dir --upgrade pip && pip3 install --no-cache-dir cmake
 
 RUN wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/0.11.0.tar.gz -P /opt/thrift && \
     cd /opt/thrift && tar xzf 0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1654

Fix the DL3042 warning by adding `--no-cache-dir`.