### PR TITLE
fix(log): not redacted hotkey log

### DIFF
--- a/src/server/hotkey_collector.cpp
+++ b/src/server/hotkey_collector.cpp
@@ -196,7 +196,7 @@ inline void hotkey_collector::change_state_by_result()
         if (!_result.hot_hash_key.empty()) {
             change_state_to_finished();
             LOG_ERROR_PREFIX("Find the hotkey: {}",
-                             pegasus::utils::c_escape_sensitive_string(_result.hot_hash_key));
+                             pegasus::utils::c_escape_string(_result.hot_hash_key));
         }
         break;
     default:
@@ -277,7 +277,7 @@ void hotkey_collector::on_start_detect(dsn::replication::detect_hotkey_response 
         hint = fmt::format("{} hotkey result has been found: {}, you can send a stop rpc to "
                            "restart hotkey detection",
                            dsn::enum_to_string(_hotkey_type),
-                           pegasus::utils::c_escape_sensitive_string(_result.hot_hash_key));
+                           pegasus::utils::c_escape_string(_result.hot_hash_key));
         break;
     case hotkey_collector_state::STOPPED:
         change_state_to_coarse_detecting();
@@ -314,7 +314,7 @@ void hotkey_collector::query_result(dsn::replication::detect_hotkey_response &re
         LOG_INFO_PREFIX(hint);
     } else {
         resp.err = dsn::ERR_OK;
-        resp.__set_hotkey_result(pegasus::utils::c_escape_sensitive_string(_result.hot_hash_key));
+        resp.__set_hotkey_result(pegasus::utils::c_escape_string(_result.hot_hash_key));
     }
 }
 

--- a/src/server/hotkey_collector.cpp
+++ b/src/server/hotkey_collector.cpp
@@ -314,6 +314,9 @@ void hotkey_collector::query_result(dsn::replication::detect_hotkey_response &re
         LOG_INFO_PREFIX(hint);
     } else {
         resp.err = dsn::ERR_OK;
+        // Hot key should not be encrypted, thus use `c_escape_string` instead of
+        // `c_escape_sensitive_string` (otherwise it would be overwritten with
+        // "<redacted>").
         resp.__set_hotkey_result(pegasus::utils::c_escape_string(_result.hot_hash_key));
     }
 }

--- a/src/server/hotkey_collector.cpp
+++ b/src/server/hotkey_collector.cpp
@@ -196,7 +196,7 @@ inline void hotkey_collector::change_state_by_result()
         if (!_result.hot_hash_key.empty()) {
             change_state_to_finished();
             LOG_ERROR_PREFIX("Find the hotkey: {}",
-                             pegasus::utils::c_escape_string(_result.hot_hash_key));
+                             pegasus::utils::c_escape_sensitive_string(_result.hot_hash_key));
         }
         break;
     default:
@@ -277,7 +277,7 @@ void hotkey_collector::on_start_detect(dsn::replication::detect_hotkey_response 
         hint = fmt::format("{} hotkey result has been found: {}, you can send a stop rpc to "
                            "restart hotkey detection",
                            dsn::enum_to_string(_hotkey_type),
-                           pegasus::utils::c_escape_string(_result.hot_hash_key));
+                           pegasus::utils::c_escape_sensitive_string(_result.hot_hash_key));
         break;
     case hotkey_collector_state::STOPPED:
         change_state_to_coarse_detecting();


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
The hotkey log should not redacted when encrytion are at set.

### What is changed and how does it work?
Modify ‘c_escape_sensitive_string’ back to ‘c_escape_string’

- Unit test