### PR TITLE
fix: generate thrift sources for scala client (cherry-pick #1662)

### DIFF
--- a/java-client/scripts/ci-test.sh
+++ b/java-client/scripts/ci-test.sh
@@ -59,8 +59,8 @@ cd ../
 
 
 pushd scripts
-echo "bash recompile_thrift.sh"
-bash recompile_thrift.sh
+echo "run recompile_thrift.sh"
+./recompile_thrift.sh
 popd
 mvn spotless:apply
 

--- a/scala-client/scripts/ci-test.sh
+++ b/scala-client/scripts/ci-test.sh
@@ -43,6 +43,10 @@ sbt scalafmtSbtCheck scalafmtCheck test:scalafmtCheck
 git clone https://github.com/apache/incubator-pegasus.git
 cd incubator-pegasus/java-client
 git checkout master
+cd scripts
+echo "run recompile_thrift.sh"
+./recompile_thrift.sh
+cd ..
 mvn clean package -DskipTests -Dcheckstyle.skip=true
 mvn clean install -DskipTests -Dcheckstyle.skip=true
 cd ..


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1663

Scala client depends on java client. Before java client is built, thrift sources
should be generated.

This PR is to cherry-pick #1662 into v2.5 to solve issue #1663.