### PR TITLE
chore(version): update the version of pegasus server and client of each language to 2.5.0 (cherry-pick #1660)

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -29,7 +29,7 @@
   </parent>
   <groupId>org.apache.pegasus</groupId>
   <artifactId>pegasus-client</artifactId>
-  <version>2.4-SNAPSHOT</version>
+  <version>2.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Pegasus Java Client</name>
 

--- a/nodejs-client/package.json
+++ b/nodejs-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus-nodejs-client",
-  "version": "1.0.14",
+  "version": "2.5.0",
   "description": "offical pegasus nodejs client",
   "main": "index.js",
   "scripts": {

--- a/python-client/pypegasus/__init__.py
+++ b/python-client/pypegasus/__init__.py
@@ -18,4 +18,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-__version__ = '0.0.1.2'
+__version__ = '2.5.0'

--- a/scala-client/build.sbt
+++ b/scala-client/build.sbt
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-version := "2.2.0-3-release"
+version := "2.5.0-SNAPSHOT"
 
 organization := "org.apache"
 
@@ -54,6 +54,6 @@ credentials += Credentials(
 
 libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "21.0",
-  "org.apache.pegasus" % "pegasus-client" % "2.4-SNAPSHOT",
+  "org.apache.pegasus" % "pegasus-client" % "2.5.0-SNAPSHOT",
   "org.scalatest" %% "scalatest" % "3.0.3" % Test
 )

--- a/src/client_lib/mutation.cpp
+++ b/src/client_lib/mutation.cpp
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "../base/pegasus_utils.h"
-#include "utils/enum_helper.h"
+#include "utils/string_view.h"
 
 using namespace ::dsn;
 

--- a/src/client_lib/mutation.cpp
+++ b/src/client_lib/mutation.cpp
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "../base/pegasus_utils.h"
-#include "utils/string_view.h"
+#include "utils/enum_helper.h"
 
 using namespace ::dsn;
 

--- a/src/include/pegasus/version.h
+++ b/src/include/pegasus/version.h
@@ -18,4 +18,4 @@
  */
 
 #pragma once
-#define PEGASUS_VERSION "2.4.0-SNAPSHOT"
+#define PEGASUS_VERSION "2.5.0-SNAPSHOT"


### PR DESCRIPTION
Upgrade the version of pegasus server and clients:

- upgrade the version to 2.5.0-SPAPSHOT for cpp server, java and scala client;
- upgrade the version to 2.5.0 for python and nodejs client;
- no need to upgrader version for go client, since it has been bound to git branch.

All of the server and clients would be released on [v2.5](https://github.com/apache/incubator-pegasus/tree/v2.5).

This PR is to cherry-pick #1660 into v2.5.