### PR TITLE
chore: update NOTICE year to 2023 (cherry-pick #1671)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Pegasus
-Copyright 2022 The Apache Software Foundation
+Copyright 2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
This PR is to cherry-pick #1671 into v2.5.