### PR TITLE
feat(thirdparty): Introduce abseil

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -413,5 +413,6 @@ ExternalProject_Add(http-parser
 ExternalProject_Add(abseil
         URL https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip
         URL_MD5 5c6193dbc82834f8e762c6a28c9cc615
-        -DABSL_FIND_GOOGLETEST=OFF
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
+	-DABSL_FIND_GOOGLETEST=OFF
         )

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -411,7 +411,7 @@ ExternalProject_Add(http-parser
         )
 
 ExternalProject_Add(abseil
-        URL ${OSS_URL_PREFIX}/abseil-20230802.1.zip.zip
+        URL ${OSS_URL_PREFIX}/abseil-20230802.1.zip
         https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip
         URL_MD5 5c6193dbc82834f8e762c6a28c9cc615
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -414,5 +414,5 @@ ExternalProject_Add(abseil
         URL https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip
         URL_MD5 5c6193dbc82834f8e762c6a28c9cc615
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
-	-DABSL_FIND_GOOGLETEST=OFF
+        -DABSL_FIND_GOOGLETEST=OFF
         )

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -409,3 +409,9 @@ ExternalProject_Add(http-parser
         INSTALL_COMMAND cp -R http_parser.h ${TP_OUTPUT}/include/nodejs/http_parser.h
         BUILD_IN_SOURCE 1
         )
+
+ExternalProject_Add(abseil
+        URL https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip
+        URL_MD5 5c6193dbc82834f8e762c6a28c9cc615
+        -DABSL_FIND_GOOGLETEST=OFF
+        )

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -415,4 +415,5 @@ ExternalProject_Add(abseil
         URL_MD5 5c6193dbc82834f8e762c6a28c9cc615
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
         -DABSL_FIND_GOOGLETEST=OFF
+        -DCMAKE_CXX_STANDARD=14
         )

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -411,7 +411,8 @@ ExternalProject_Add(http-parser
         )
 
 ExternalProject_Add(abseil
-        URL https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip
+        URL ${OSS_URL_PREFIX}/abseil-20230802.1.zip.zip
+        https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip
         URL_MD5 5c6193dbc82834f8e762c6a28c9cc615
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
         -DABSL_FIND_GOOGLETEST=OFF


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Introduce abseil as thridparty for using abseil_strings method  

### What is changed and how does it work?
Abseil LTS 20230802.1 is introduced to thridparty/CMakelist.txt and to complie.

##### Related changes
kms key manager client need to use Abseil_strings some methods.
