### PR TITLE
refactor: use fmt:join to simplify code

### DIFF
--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -34,7 +34,6 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <set>
 
 #include "backup_types.h"
 #include "common//duplication_common.h"
@@ -46,6 +45,7 @@
 #include "common/replication_common.h"
 #include "common/replication_enums.h"
 #include "fmt/core.h"
+#include "fmt/format.h"
 #include "meta/meta_rpc_types.h"
 #include "runtime/api_layer1.h"
 #include "runtime/rpc/group_address.h"

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1138,34 +1138,13 @@ dsn::error_code replication_ddl_client::enable_backup_policy(const std::string &
     }
 }
 
-// help functions
-
-// TODO (yingchun) use join
-template <typename T>
-// make sure T support cout << T;
-std::string print_set(const std::set<T> &set)
-{
-    std::stringstream ss;
-    ss << "{";
-    auto begin = set.begin();
-    auto end = set.end();
-    for (auto it = begin; it != end; it++) {
-        if (it != begin) {
-            ss << ", ";
-        }
-        ss << *it;
-    }
-    ss << "}";
-    return ss.str();
-}
-
 static void print_policy_entry(const policy_entry &entry)
 {
     dsn::utils::table_printer tp;
     tp.add_row_name_and_data("    name", entry.policy_name);
     tp.add_row_name_and_data("    backup_provider_type", entry.backup_provider_type);
     tp.add_row_name_and_data("    backup_interval", entry.backup_interval_seconds + "s");
-    tp.add_row_name_and_data("    app_ids", print_set(entry.app_ids));
+    tp.add_row_name_and_data("    app_ids", fmt::format("{{{}}}", fmt::join(entry.app_ids, ", ")));
     tp.add_row_name_and_data("    start_time", entry.start_time);
     tp.add_row_name_and_data("    status", entry.is_disable ? "disabled" : "enabled");
     tp.add_row_name_and_data("    backup_history_count", entry.backup_history_count_to_keep);
@@ -1188,7 +1167,7 @@ static void print_backup_entry(const backup_entry &bentry)
     tp.add_row_name_and_data("    id", bentry.backup_id);
     tp.add_row_name_and_data("    start_time", start_time);
     tp.add_row_name_and_data("    end_time", end_time);
-    tp.add_row_name_and_data("    app_ids", print_set(bentry.app_ids));
+    tp.add_row_name_and_data("    app_ids", fmt::format("{{{}}}", fmt::join(bentry.app_ids, ", ")));
     tp.output(std::cout);
 }
 


### PR DESCRIPTION
This is a patch to simplify code, also to check whether the previous patch(5e9a2a9dcaa8be988e1ea8e745bd7fc8621e2609) works.

Note: In `{{{}}}`, `{{` and `}}` are used to escape, the left `{}` is used for `replacement fields`, see https://fmt.dev/latest/syntax.html.

Manual tests of the shell:
```
>>> ls_backup_policy
[1]
    name                  : p1
    backup_provider_type  : local_service
    backup_interval       : 86400s
    app_ids               : {1}
    start_time            : 01:00
    status                : enabled
    backup_history_count  : 10
...
[3]
    name                  : p3
    backup_provider_type  : local_service
    backup_interval       : 86400s
    app_ids               : {1, 2}
    start_time            : 01:00
    status                : enabled
    backup_history_count  : 10


ls backup policy succeed
>>> query_backup_policy -p p3
policy_info:
    name                  : p3
    backup_provider_type  : local_service
    backup_interval       : 86400s
    app_ids               : {1, 2}
    start_time            : 01:00
    status                : enabled
    backup_history_count  : 10
...
```