### PR TITLE
chore(thirdparty): Bump gperftools to 2.13

### DIFF
--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -120,7 +120,7 @@ if [ "$use_jemalloc" == "on" ]; then
     copy_file ./thirdparty/output/lib/libjemalloc.so.2 ${pack}/bin
     copy_file ./thirdparty/output/lib/libprofiler.so.0 ${pack}/bin
 else
-    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so.4 ${pack}/bin
+    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so ${pack}/bin
 fi
 
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/bin

--- a/scripts/pack_tools.sh
+++ b/scripts/pack_tools.sh
@@ -129,7 +129,7 @@ if [ "$use_jemalloc" == "on" ]; then
     copy_file ./thirdparty/output/lib/libjemalloc.so.2 ${pack}/lib/
     copy_file ./thirdparty/output/lib/libprofiler.so.0 ${pack}/lib/
 else
-    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so.4 ${pack}/lib/
+    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so ${pack}/lib/
 fi
 
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/lib/

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -97,11 +97,12 @@ ExternalProject_Get_property(googletest SOURCE_DIR)
 set(googletest_SRC ${SOURCE_DIR})
 
 ExternalProject_Add(gperftools
-        URL ${OSS_URL_PREFIX}/gperftools-2.7.tar.gz
-        https://github.com/gperftools/gperftools/releases/download/gperftools-2.7/gperftools-2.7.tar.gz
-        URL_MD5 c6a852a817e9160c79bdb2d3101b4601
-        CONFIGURE_COMMAND ./configure --prefix=${TP_OUTPUT} --enable-static=no --enable-frame-pointers=yes
-        BUILD_IN_SOURCE 1
+        URL ${OSS_URL_PREFIX}/gperftools-2.13.tar.gz
+        https://github.com/gperftools/gperftools/releases/download/gperftools-2.13/gperftools-2.13.tar.gz
+        URL_MD5 4e218a40a354748c50d054c285caaae8
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
+        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
         )
 
 set(HDFS_CLIENT_DIR "hadoop-hdfs-project/hadoop-hdfs-native-client")

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -100,9 +100,8 @@ ExternalProject_Add(gperftools
         URL ${OSS_URL_PREFIX}/gperftools-2.13.tar.gz
         https://github.com/gperftools/gperftools/releases/download/gperftools-2.13/gperftools-2.13.tar.gz
         URL_MD5 4e218a40a354748c50d054c285caaae8
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
-        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+        CONFIGURE_COMMAND ./configure --prefix=${TP_OUTPUT} --enable-static=no --enable-frame-pointers=yes
+        BUILD_IN_SOURCE 1
         )
 
 set(HDFS_CLIENT_DIR "hadoop-hdfs-project/hadoop-hdfs-native-client")


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1604

Upgrade gperftools to 2.13 which is the latest release.