### PR TITLE
feat(thirdparty): compile curl with gssapi

### DIFF
--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -221,21 +221,21 @@ dsn::error_s http_client::set_method(http_method method)
 
 dsn::error_s http_client::set_auth(http_auth_type authType)
 {
-    switch(authType){
+    switch (authType) {
     case http_auth_type::SPNEGO:
-      RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_NEGOTIATE);
-      break;
+        RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_NEGOTIATE);
+        break;
     case http_auth_type::DIGEST:
-      RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
-      break;
+        RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+        break;
     case http_auth_type::BASIC:
-      RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-      break;
+        RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        break;
     case http_auth_type::NONE:
-      break;
+        break;
     default:
-      RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_ANY);
-      break;
+        RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+        break;
     }
 
     return dsn::error_s::ok();

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -219,6 +219,28 @@ dsn::error_s http_client::set_method(http_method method)
     return dsn::error_s::ok();
 }
 
+dsn::error_s http_client::set_auth(http_auth_type authType)
+{
+    switch(authType){
+    case http_auth_type::SPNEGO:
+      RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_NEGOTIATE);
+      break;
+    case http_auth_type::DIGEST:
+      RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+      break;
+    case http_auth_type::BASIC:
+      RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+      break;
+    case http_auth_type::NONE:
+      break;
+    default:
+      RETURN_IF_SETOPT_NOT_OK(CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+      break;
+    }
+
+    return dsn::error_s::ok();
+}
+
 dsn::error_s http_client::set_timeout(long timeout_ms)
 {
     RETURN_IF_SETOPT_NOT_OK(CURLOPT_TIMEOUT_MS, timeout_ms);

--- a/src/http/http_client.h
+++ b/src/http/http_client.h
@@ -93,6 +93,9 @@ public:
     // Specify the maximum time in milliseconds that a request is allowed to complete.
     dsn::error_s set_timeout(long timeout_ms);
 
+    // Specify the http auth type which include NONE BASIC DIGEST SPNEGO
+    dsn::error_s set_auth(http_auth_type authType);
+    
     // Operations for the header fields.
     void clear_header_fields();
     void set_accept(dsn::string_view val);

--- a/src/http/http_client.h
+++ b/src/http/http_client.h
@@ -95,7 +95,7 @@ public:
 
     // Specify the http auth type which include NONE BASIC DIGEST SPNEGO
     dsn::error_s set_auth(http_auth_type authType);
-    
+
     // Operations for the header fields.
     void clear_header_fields();
     void set_accept(dsn::string_view val);

--- a/src/http/http_method.h
+++ b/src/http/http_method.h
@@ -28,6 +28,13 @@ enum class http_method
     INVALID = 100,
 };
 
+enum class http_auth_type {
+  NONE,
+  BASIC,
+  DIGEST,
+  SPNEGO,
+};
+
 ENUM_BEGIN(http_method, http_method::INVALID)
 ENUM_REG2(http_method, GET)
 ENUM_REG2(http_method, POST)

--- a/src/http/http_method.h
+++ b/src/http/http_method.h
@@ -28,11 +28,12 @@ enum class http_method
     INVALID = 100,
 };
 
-enum class http_auth_type {
-  NONE,
-  BASIC,
-  DIGEST,
-  SPNEGO,
+enum class http_auth_type
+{
+    NONE,
+    BASIC,
+    DIGEST,
+    SPNEGO,
 };
 
 ENUM_BEGIN(http_method, http_method::INVALID)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -283,16 +283,17 @@ set(CURL_OPTIONS
         --disable-manual
         --disable-pop3
         --disable-rtsp
+        --disable-shared
         --disable-smtp
         --disable-telnet
         --disable-tftp
-        --disable-shared
+        --without-libidn
         --without-librtmp
-        --without-zlib
         --without-libssh2
         --without-ssl
-        --without-libidn
+        --without-zlib
         --without-zstd
+        --with-gssapi
         )
 if (APPLE)
     set(CURL_OPTIONS
@@ -306,37 +307,7 @@ ExternalProject_Add(curl
         URL ${OSS_URL_PREFIX}/curl-8.4.0.tar.gz
         http://curl.haxx.se/download/curl-8.4.0.tar.gz
         URL_MD5 533e8a3b1228d5945a6a512537bea4c7
-        CONFIGURE_COMMAND ./configure
-        --prefix=${TP_OUTPUT}
-        --disable-alt-svc
-        --disable-dict
-        --disable-doh
-        --disable-file
-        --disable-ftp
-        --disable-gopher
-        --disable-imap
-        --disable-ipv6
-        --disable-ldap
-        --disable-ldaps
-        --disable-libcurl-option
-        --disable-manual
-        --disable-mime
-        --disable-netrc
-        --disable-parsedate
-        --disable-pop3
-        --disable-progress-meter
-        --disable-rtsp
-        --disable-smb
-        --disable-smtp
-        --disable-telnet
-        --disable-tftp
-        --without-brotli
-        --without-libidn2
-        --without-libpsl
-        --without-librtmp
-        --without-libssh2
-        --without-nghttp2
-        --with-gssapi
+        CONFIGURE_COMMAND ./configure --prefix=${TP_OUTPUT}
         ${CURL_OPTIONS}
         BUILD_IN_SOURCE 1
         )
@@ -447,6 +418,7 @@ ExternalProject_Add(abseil
         https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip
         URL_MD5 5c6193dbc82834f8e762c6a28c9cc615
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         -DABSL_FIND_GOOGLETEST=OFF
         -DCMAKE_CXX_STANDARD=14
         )

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -418,7 +418,6 @@ ExternalProject_Add(abseil
         https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip
         URL_MD5 5c6193dbc82834f8e762c6a28c9cc615
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         -DABSL_FIND_GOOGLETEST=OFF
         -DCMAKE_CXX_STANDARD=14
         )

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -306,7 +306,37 @@ ExternalProject_Add(curl
         URL ${OSS_URL_PREFIX}/curl-8.4.0.tar.gz
         http://curl.haxx.se/download/curl-8.4.0.tar.gz
         URL_MD5 533e8a3b1228d5945a6a512537bea4c7
-        CONFIGURE_COMMAND ./configure --prefix=${TP_OUTPUT}
+        CONFIGURE_COMMAND ./configure
+        --prefix=${TP_OUTPUT}
+        --disable-alt-svc
+        --disable-dict
+        --disable-doh
+        --disable-file
+        --disable-ftp
+        --disable-gopher
+        --disable-imap
+        --disable-ipv6
+        --disable-ldap
+        --disable-ldaps
+        --disable-libcurl-option
+        --disable-manual
+        --disable-mime
+        --disable-netrc
+        --disable-parsedate
+        --disable-pop3
+        --disable-progress-meter
+        --disable-rtsp
+        --disable-smb
+        --disable-smtp
+        --disable-telnet
+        --disable-tftp
+        --without-brotli
+        --without-libidn2
+        --without-libpsl
+        --without-librtmp
+        --without-libssh2
+        --without-nghttp2
+        --with-gssapi
         ${CURL_OPTIONS}
         BUILD_IN_SOURCE 1
         )


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
The key manager get eek from kms should set CURLOPT_HTTPAUTH with negotiate.

### What is changed and how does it work?
compile libcurl with gssapi

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- No code

##### Code changes

src/http/http_client.cpp
src/http/http_client.h
src/http/http_method.h
thirdparty/CMakeLists.txt
