### PR TITLE
feat(pprof): Supports both heap profiling and heap sampling

### DIFF
--- a/src/http/pprof_http_service.cpp
+++ b/src/http/pprof_http_service.cpp
@@ -52,17 +52,19 @@
 
 namespace dsn {
 
-bool check_TCMALLOC_SAMPLE_PARAMETER() {
-    char* str = getenv("TCMALLOC_SAMPLE_PARAMETER");
+bool check_TCMALLOC_SAMPLE_PARAMETER()
+{
+    char *str = getenv("TCMALLOC_SAMPLE_PARAMETER");
     if (str == nullptr) {
         return false;
     }
-    char* endptr;
+    char *endptr;
     int val = strtol(str, &endptr, 10);
     return (*endptr == '\0' && val > 0);
 }
 
-bool has_TCMALLOC_SAMPLE_PARAMETER() {
+bool has_TCMALLOC_SAMPLE_PARAMETER()
+{
     static bool val = check_TCMALLOC_SAMPLE_PARAMETER();
     return val;
 }
@@ -367,14 +369,14 @@ void pprof_http_service::heap_handler(const http_request &req, http_response &re
     bool use_heap_profile = false;
     const std::string kSecondParam = "seconds";
     uint32_t seconds = 0;
-    const auto& iter = req.query_args.find(kSecondParam);
+    const auto &iter = req.query_args.find(kSecondParam);
     if (iter != req.query_args.end() && buf2uint32(iter->second, seconds)) {
         // This is true between calls to HeapProfilerStart() and HeapProfilerStop(), and
         // also if the program has been run with HEAPPROFILER, or some other
         // way to turn on whole-program profiling.
         if (IsHeapProfilerRunning()) {
             LOG_WARNING("heap profiling is running, dump the full profile directly");
-            char* profile = GetHeapProfile();
+            char *profile = GetHeapProfile();
             resp.status_code = http_status_code::ok;
             resp.body = profile;
             free(profile);
@@ -393,13 +395,13 @@ void pprof_http_service::heap_handler(const http_request &req, http_response &re
         resp.body = profile;
         free(profile);
     } else {
-        // The environment variable TCMALLOC_SAMPLE_PARAMETER should set to a positive value, such
-        // as 524288, before running.
         if (!has_TCMALLOC_SAMPLE_PARAMETER()) {
-            static const char *msg = "no TCMALLOC_SAMPLE_PARAMETER in env";
-            LOG_WARNING(msg);
+            static const std::string kNoEnvMsg = "The environment variable "
+                                                 "TCMALLOC_SAMPLE_PARAMETER should set to a "
+                                                 "positive value, such as 524288, before running.";
+            LOG_WARNING(kNoEnvMsg);
             resp.status_code = http_status_code::internal_server_error;
-            resp.body = msg;
+            resp.body = kNoEnvMsg;
             return;
         }
 

--- a/src/http/pprof_http_service.cpp
+++ b/src/http/pprof_http_service.cpp
@@ -364,12 +364,11 @@ void pprof_http_service::heap_handler(const http_request &req, http_response &re
     }
     auto cleanup = dsn::defer([this]() { _in_pprof_action.store(false); });
 
-    // If kSecondParam is specified with a valid value, we'll use heap profiling,
+    // If "seconds" parameter is specified with a valid value, use heap profiling,
     // otherwise, use heap sampling.
     bool use_heap_profile = false;
-    const std::string kSecondParam = "seconds";
     uint32_t seconds = 0;
-    const auto &iter = req.query_args.find(kSecondParam);
+    const auto &iter = req.query_args.find("seconds");
     if (iter != req.query_args.end() && buf2uint32(iter->second, seconds)) {
         // This is true between calls to HeapProfilerStart() and HeapProfilerStop(), and
         // also if the program has been run with HEAPPROFILER, or some other


### PR DESCRIPTION
In https://github.com/XiaoMi/rdsn/pull/433, we updated the way to get heap profile
by using
```
HeapProfilerStart(...);
sleep(seconds);
GetHeapProfile();
HeapProfilerStop();
```
instead of
```
MallocExtension::instance()->GetHeapSample(...);
```

It provides a way to analyse which pieces of code allocated (and possibly freed)
how much memory during the time the request processed on the server. However, in
the scenario of a server already in heavy memory consumption but growing very
slow, it's hard to tell which pieces of code allocated the most of the memory.
This patch adds the heap sampling back, and keep the heap profiling as well.
Both of the two ways are using the `pprof/heap` method, the difference is whether
the `seconds` parameter appears.
When the `seconds` parameter appears, using `GetHeapProfile()`, otherwise, using
`GetHeapSample()`. Remember to set environment variable TCMALLOC_SAMPLE_PARAMETER
when using heap sampling.