### PR TITLE
fix: use libgcc instead of generic_fp as default stacktrace

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -28,6 +28,10 @@ export THIRDPARTY_ROOT=$ROOT/thirdparty
 export LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/amd64/server:${BUILD_LATEST_DIR}/output/lib:${THIRDPARTY_ROOT}/output/lib:${LD_LIBRARY_PATH}
 # Disable AddressSanitizerOneDefinitionRuleViolation, see https://github.com/google/sanitizers/issues/1017 for details.
 export ASAN_OPTIONS=detect_odr_violation=0
+# See https://github.com/gperftools/gperftools/wiki/gperftools'-stacktrace-capturing-methods-and-their-issues.
+# Now we choose libgcc, because of https://github.com/apache/incubator-pegasus/issues/1685.
+export TCMALLOC_STACKTRACE_METHOD=libgcc  # Can be generic_fp, generic_fp_unsafe, libunwind or libgcc
+export TCMALLOC_STACKTRACE_METHOD_VERBOSE=1
 
 function usage()
 {


### PR DESCRIPTION
This is a compromised method to resolve the crash in `stacktrace_generic_fp` as
mentioned in https://github.com/apache/incubator-pegasus/issues/1685.

Remember to set the enviroment variable `TCMALLOC_STACKTRACE_METHOD` to other value if
you see this crash stack in your enviroment.

I will reseach more about this issue to fix it fully.