### PR TITLE
refactor(regex): Use std::regex instead of boost::regex

### DIFF
--- a/cmake_modules/BaseFunctions.cmake
+++ b/cmake_modules/BaseFunctions.cmake
@@ -319,7 +319,7 @@ function(dsn_setup_thirdparty_libs)
 
   set(CMAKE_PREFIX_PATH ${THIRDPARTY_INSTALL_DIR};${CMAKE_PREFIX_PATH})
   message(STATUS "CMAKE_PREFIX_PATH = ${CMAKE_PREFIX_PATH}")
-  find_package(Boost COMPONENTS system filesystem regex REQUIRED)
+  find_package(Boost COMPONENTS system filesystem REQUIRED)
   include_directories(${Boost_INCLUDE_DIRS})
 
   find_library(THRIFT_LIB NAMES libthrift.a PATHS ${THIRDPARTY_INSTALL_DIR}/lib NO_DEFAULT_PATH)

--- a/src/aio/test/CMakeLists.txt
+++ b/src/aio/test/CMakeLists.txt
@@ -35,7 +35,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS gtest dsn_runtime dsn_aio test_utils rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES

--- a/src/base/test/CMakeLists.txt
+++ b/src/base/test/CMakeLists.txt
@@ -33,7 +33,7 @@ set(MY_PROJ_LIBS
         pegasus_base
         gtest)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES config.ini run.sh)
 

--- a/src/block_service/test/CMakeLists.txt
+++ b/src/block_service/test/CMakeLists.txt
@@ -40,7 +40,7 @@ set(MY_PROJ_LIBS
     test_utils
     rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES
     config-test.ini

--- a/src/client/test/CMakeLists.txt
+++ b/src/client/test/CMakeLists.txt
@@ -29,7 +29,7 @@ set(MY_PROJ_LIBS
     gtest
     rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES
     "${CMAKE_CURRENT_SOURCE_DIR}/run.sh"

--- a/src/common/test/CMakeLists.txt
+++ b/src/common/test/CMakeLists.txt
@@ -32,7 +32,7 @@ set(MY_PROJ_LIBS
         gtest
         rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES
         config-test.ini

--- a/src/failure_detector/test/CMakeLists.txt
+++ b/src/failure_detector/test/CMakeLists.txt
@@ -43,7 +43,7 @@ set(MY_PROJ_LIBS
     hashtable
     rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES

--- a/src/geo/bench/CMakeLists.txt
+++ b/src/geo/bench/CMakeLists.txt
@@ -38,7 +38,7 @@ set(MY_PROJ_LIBS
         dsn_utils
         )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "config.ini")
 

--- a/src/geo/test/CMakeLists.txt
+++ b/src/geo/test/CMakeLists.txt
@@ -37,7 +37,7 @@ set(MY_PROJ_LIBS
         dsn_utils
         gtest)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 add_definitions(-Wno-attributes)
 

--- a/src/http/test/CMakeLists.txt
+++ b/src/http/test/CMakeLists.txt
@@ -29,7 +29,7 @@ set(MY_PROJ_LIBS
     rocksdb
     )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES
     "${CMAKE_CURRENT_SOURCE_DIR}/run.sh"

--- a/src/meta/CMakeLists.txt
+++ b/src/meta/CMakeLists.txt
@@ -55,7 +55,7 @@ set(MY_PROJ_LIBS
     hdfs
     rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES "")

--- a/src/meta/test/CMakeLists.txt
+++ b/src/meta/test/CMakeLists.txt
@@ -60,7 +60,7 @@ set(MY_PROJ_LIBS
         gtest
         hdfs)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES clear.sh run.sh config-test.ini suite1 suite2)

--- a/src/meta/test/balancer_simulator/CMakeLists.txt
+++ b/src/meta/test/balancer_simulator/CMakeLists.txt
@@ -40,7 +40,7 @@ set(MY_PROJ_LIBS
     hashtable
     gtest)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES "")

--- a/src/meta/test/meta_state/CMakeLists.txt
+++ b/src/meta/test/meta_state/CMakeLists.txt
@@ -42,7 +42,7 @@ set(MY_PROJ_LIBS
     gtest
     )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES

--- a/src/nfs/test/CMakeLists.txt
+++ b/src/nfs/test/CMakeLists.txt
@@ -35,7 +35,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS dsn_nfs dsn_runtime gtest dsn_aio rocksdb test_utils)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES

--- a/src/perf_counter/test/CMakeLists.txt
+++ b/src/perf_counter/test/CMakeLists.txt
@@ -35,7 +35,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS gtest dsn_runtime rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES

--- a/src/redis_protocol/proxy/CMakeLists.txt
+++ b/src/redis_protocol/proxy/CMakeLists.txt
@@ -38,7 +38,7 @@ set(MY_PROJ_LIBS pegasus.rproxylib
 
 set(MY_BINPLACES "config.ini")
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Avoid megabytes of warnings like:
 # thirdparty/output/include/s2/s1angle.h:288:28: error:

--- a/src/redis_protocol/proxy_ut/CMakeLists.txt
+++ b/src/redis_protocol/proxy_ut/CMakeLists.txt
@@ -27,7 +27,7 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_PROJ_LIBS pegasus.rproxylib
                 pegasus_base

--- a/src/replica/CMakeLists.txt
+++ b/src/replica/CMakeLists.txt
@@ -77,7 +77,7 @@ set(MY_PROJ_LIBS
     PocoJSON
     rocksdb)
 
-set(MY_BOOST_LIBS Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES "")

--- a/src/replica/backup/test/CMakeLists.txt
+++ b/src/replica/backup/test/CMakeLists.txt
@@ -32,7 +32,7 @@ set(MY_PROJ_LIBS dsn_meta_server
         gtest
         rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES
         config-test.ini

--- a/src/replica/bulk_load/test/CMakeLists.txt
+++ b/src/replica/bulk_load/test/CMakeLists.txt
@@ -30,7 +30,7 @@ set(MY_PROJ_LIBS dsn_meta_server
         test_utils
         rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex rocksdb test_utils)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem rocksdb test_utils)
 
 set(MY_BINPLACES
         config-test.ini

--- a/src/replica/duplication/test/CMakeLists.txt
+++ b/src/replica/duplication/test/CMakeLists.txt
@@ -33,7 +33,7 @@ set(MY_PROJ_LIBS dsn_meta_server
         test_utils
         rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES
         config-test.ini

--- a/src/replica/split/test/CMakeLists.txt
+++ b/src/replica/split/test/CMakeLists.txt
@@ -29,7 +29,7 @@ set(MY_PROJ_LIBS dsn_meta_server
         gtest
 )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES
         config-test.ini

--- a/src/replica/storage/simple_kv/CMakeLists.txt
+++ b/src/replica/storage/simple_kv/CMakeLists.txt
@@ -39,7 +39,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS dsn_replica_server dsn_meta_server dsn_client dsn_runtime hashtable rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(INI_FILES "")
 file(GLOB

--- a/src/replica/storage/simple_kv/test/CMakeLists.txt
+++ b/src/replica/storage/simple_kv/test/CMakeLists.txt
@@ -42,7 +42,7 @@ set(MY_PROJ_LIBS dsn_replica_server
                  dsn_utils
                  rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 FILE(GLOB CASE_FILES "case-*")

--- a/src/replica/test/CMakeLists.txt
+++ b/src/replica/test/CMakeLists.txt
@@ -50,7 +50,7 @@ set(MY_PROJ_LIBS dsn_meta_server
                  test_utils
                  rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 #Extra files that will be installed
 set(MY_BINPLACES clear.sh run.sh config-test.ini)

--- a/src/runtime/test/CMakeLists.txt
+++ b/src/runtime/test/CMakeLists.txt
@@ -36,7 +36,7 @@ set(MY_PROJ_LIBS gtest
                  rocksdb
                  )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config-test-corrupt-message.ini"

--- a/src/sample/CMakeLists.txt
+++ b/src/sample/CMakeLists.txt
@@ -23,11 +23,7 @@ set(MY_PROJ_LIBS
     pegasus_client_static
     )
 
-set(MY_BOOST_LIBS
-    Boost::filesystem
-    Boost::system
-    Boost::regex
-    )
+set(MY_BOOST_LIBS Boost::filesystem Boost::system)
 
 set(MY_BINPLACES config.ini run.sh)
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -53,7 +53,7 @@ set(MY_PROJ_LIBS
     hashtable
     )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config.ini")
 

--- a/src/server/test/CMakeLists.txt
+++ b/src/server/test/CMakeLists.txt
@@ -63,7 +63,7 @@ set(MY_PROJ_LIBS
 add_definitions(-DPEGASUS_UNIT_TEST)
 add_definitions(-DENABLE_FAIL)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES config.ini run.sh)
 

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -59,11 +59,7 @@ set(MY_PROJ_LIBS
 
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config.ini")
 
-set(MY_BOOST_LIBS
-    Boost::system
-    Boost::filesystem 
-    Boost::regex # dsn_replica_server.so needs
-    )
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 SET(CMAKE_INSTALL_RPATH ".")
 SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)

--- a/src/test/bench_test/CMakeLists.txt
+++ b/src/test/bench_test/CMakeLists.txt
@@ -36,7 +36,7 @@ set(MY_PROJ_LIBS
         krb5
         )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "config.ini")
 

--- a/src/test/function_test/backup_restore/CMakeLists.txt
+++ b/src/test/function_test/backup_restore/CMakeLists.txt
@@ -32,7 +32,7 @@ set(MY_PROJ_LIBS
     function_test_utils
     )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "../config.ini" "../run.sh")
 

--- a/src/test/function_test/base_api/CMakeLists.txt
+++ b/src/test/function_test/base_api/CMakeLists.txt
@@ -40,7 +40,7 @@ set(MY_PROJ_LIBS
     test_utils
     )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "../config.ini" "../run.sh")
 

--- a/src/test/function_test/bulk_load/CMakeLists.txt
+++ b/src/test/function_test/bulk_load/CMakeLists.txt
@@ -40,7 +40,7 @@ set(MY_PROJ_LIBS
     test_utils
     rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "../config.ini" "../run.sh")
 

--- a/src/test/function_test/detect_hotspot/CMakeLists.txt
+++ b/src/test/function_test/detect_hotspot/CMakeLists.txt
@@ -39,7 +39,7 @@ set(MY_PROJ_LIBS
     function_test_utils
     )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "../config.ini" "../run.sh")
 

--- a/src/test/function_test/partition_split/CMakeLists.txt
+++ b/src/test/function_test/partition_split/CMakeLists.txt
@@ -40,7 +40,7 @@ set(MY_PROJ_LIBS
     test_utils
     )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "../config.ini" "../run.sh")
 

--- a/src/test/function_test/recovery/CMakeLists.txt
+++ b/src/test/function_test/recovery/CMakeLists.txt
@@ -39,7 +39,7 @@ set(MY_PROJ_LIBS
     function_test_utils
     )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "../config.ini" "../run.sh")
 

--- a/src/test/function_test/restore/CMakeLists.txt
+++ b/src/test/function_test/restore/CMakeLists.txt
@@ -40,7 +40,7 @@ set(MY_PROJ_LIBS
     test_utils
     )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "../config.ini" "../run.sh")
 

--- a/src/test/function_test/throttle/CMakeLists.txt
+++ b/src/test/function_test/throttle/CMakeLists.txt
@@ -40,7 +40,7 @@ set(MY_PROJ_LIBS
     test_utils
     )
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES "../config.ini" "../run.sh")
 

--- a/src/test/kill_test/CMakeLists.txt
+++ b/src/test/kill_test/CMakeLists.txt
@@ -41,7 +41,7 @@ set(MY_PROJ_LIBS
     )
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config.ini")
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 if (UNIX)
     SET(CMAKE_INSTALL_RPATH ".")

--- a/src/test/pressure_test/CMakeLists.txt
+++ b/src/test/pressure_test/CMakeLists.txt
@@ -37,7 +37,7 @@ set(MY_PROJ_LIBS
 
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config-pressure.ini")
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 if (UNIX)
     SET(CMAKE_INSTALL_RPATH ".")

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -29,7 +29,7 @@ set(MY_PROJ_NAME dsn_utils)
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_PROJ_LIBS dsn_http rocksdb)
 

--- a/src/utils/fail_point.cpp
+++ b/src/utils/fail_point.cpp
@@ -30,17 +30,15 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include <algorithm>
-#include <iterator>
 #include <regex>
 #include <string>
 #include <vector>
 
+#include "absl/strings/string_view.h"
 #include "fail_point_impl.h"
 #include "utils/fail_point.h"
 #include "utils/fmt_logging.h"
 #include "utils/rand.h"
-#include "absl/strings/string_view.h"
 
 namespace dsn {
 namespace fail {

--- a/src/utils/fail_point.cpp
+++ b/src/utils/fail_point.cpp
@@ -28,19 +28,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// IWYU pragma: no_include <boost/regex/v4/basic_regex.hpp>
-// IWYU pragma: no_include <boost/regex/v4/match_flags.hpp>
-// IWYU pragma: no_include <boost/regex/v4/match_results.hpp>
-// IWYU pragma: no_include <boost/regex/v4/perl_matcher_common.hpp>
-// IWYU pragma: no_include <boost/regex/v4/perl_matcher_non_recursive.hpp>
-#include <boost/regex/v4/regex.hpp>
-// IWYU pragma: no_include <boost/regex/v4/regex_fwd.hpp>
-// IWYU pragma: no_include <boost/regex/v4/regex_match.hpp>
-// IWYU pragma: no_include <boost/regex/v4/sub_match.hpp>
 #include <stdint.h>
 #include <stdio.h>
 #include <algorithm>
 #include <iterator>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -115,13 +107,13 @@ bool fail_point::parse_from_string(absl::string_view action)
     _max_cnt = -1;
     _freq = 100;
 
-    boost::regex regex(R"((\d+\%)?(\d+\*)?(\w+)(\((.*)\))?)");
-    boost::smatch match;
+    std::regex regex(R"((\d+\%)?(\d+\*)?(\w+)(\((.*)\))?)");
+    std::smatch match;
 
     std::string tmp(action.data(), action.length());
-    if (boost::regex_match(tmp, match, regex)) {
+    if (std::regex_match(tmp, match, regex)) {
         if (match.size() == 6) {
-            boost::ssub_match sub_match = match[1];
+            std::ssub_match sub_match = match[1];
             if (!sub_match.str().empty()) {
                 sscanf(sub_match.str().data(), "%d%%", &_freq);
             }

--- a/src/utils/long_adder_bench/CMakeLists.txt
+++ b/src/utils/long_adder_bench/CMakeLists.txt
@@ -29,7 +29,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS dsn_runtime dsn_utils rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES "")

--- a/src/utils/test/CMakeLists.txt
+++ b/src/utils/test/CMakeLists.txt
@@ -36,7 +36,7 @@ set(MY_PROJ_LIBS dsn_http
                  test_utils
                  rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config-bad-section.ini"

--- a/src/utils/test/nth_element_bench/CMakeLists.txt
+++ b/src/utils/test/nth_element_bench/CMakeLists.txt
@@ -29,7 +29,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS dsn_runtime dsn_utils rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES "")

--- a/src/zookeeper/test/CMakeLists.txt
+++ b/src/zookeeper/test/CMakeLists.txt
@@ -41,7 +41,7 @@ set(MY_PROJ_LIBS
     gtest
     rocksdb)
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 # Extra files that will be installed
 set(MY_BINPLACES

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -61,7 +61,7 @@ ExternalProject_Add(boost
         URL ${OSS_URL_PREFIX}/boost_1_69_0.tar.bz2
         https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2
         URL_MD5 a1332494397bf48332cb152abfefcec2
-        CONFIGURE_COMMAND ./bootstrap.sh --prefix=. --with-libraries=system,filesystem,regex --with-toolset=gcc
+        CONFIGURE_COMMAND ./bootstrap.sh --prefix=. --with-libraries=system,filesystem --with-toolset=gcc
         BUILD_COMMAND ./b2 toolset=gcc cxxflags=-fPIC cxxstd=11 install
         INSTALL_COMMAND cp -R include/boost ${TP_OUTPUT}/include && cp -R lib ${TP_OUTPUT}/
         BUILD_IN_SOURCE 1


### PR DESCRIPTION
This patch removes to build and link Boost::filesystem library, and use std::regex
instead of boost::regex.