### PR TITLE
fix(admin-cli): fix the command reports incorrect ERR_INVALID_PARAMETERS error

### DIFF
--- a/admin-cli/client/meta.go
+++ b/admin-cli/client/meta.go
@@ -422,7 +422,7 @@ func (m *rpcBasedMeta) Propose(gpid *base.Gpid, action admin.ConfigType, target 
 func (m *rpcBasedMeta) StartBackupApp(tableID int, providerType string, backupPath string) (*admin.StartBackupAppResponse, error) {
 	req := &admin.StartBackupAppRequest{
 		BackupProviderType: providerType,
-		AppID:              int32(tableID)
+		AppID:              int32(tableID),
 	}
 	if backupPath != "" {
 		req.BackupPath = &backupPath

--- a/admin-cli/client/meta.go
+++ b/admin-cli/client/meta.go
@@ -422,8 +422,10 @@ func (m *rpcBasedMeta) Propose(gpid *base.Gpid, action admin.ConfigType, target 
 func (m *rpcBasedMeta) StartBackupApp(tableID int, providerType string, backupPath string) (*admin.StartBackupAppResponse, error) {
 	req := &admin.StartBackupAppRequest{
 		BackupProviderType: providerType,
-		AppID:              int32(tableID),
-		BackupPath:         &backupPath,
+		AppID:              int32(tableID)
+	}
+	if backupPath != "" {
+		req.BackupPath = &backupPath
 	}
 	var result *admin.StartBackupAppResponse
 	err := m.callMeta("StartBackupApp", req, func(resp interface{}) {

--- a/admin-cli/go.sum
+++ b/admin-cli/go.sum
@@ -41,7 +41,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
-github.com/apache/incubator-pegasus/go-client v0.0.0-20220526071020-be5634371701 h1:J9d8jaC0rKlnf8iQuImyBiDrZnl794JlGMXX8DhMNrs=
 github.com/apache/incubator-pegasus/go-client v0.0.0-20220526071020-be5634371701/go.mod h1:vOnSzVwVYmatouq8qEBX+yWV4AvoCTLRpQn6JA+qojs=
 github.com/apache/incubator-pegasus/go-client v0.0.0-20220617101220-e49a69d25a52 h1:RvSh9D6x+zfq56hk4vXZyUwjdnpAhBO6pSqcT2nRFgY=
 github.com/apache/incubator-pegasus/go-client v0.0.0-20220617101220-e49a69d25a52/go.mod h1:vOnSzVwVYmatouq8qEBX+yWV4AvoCTLRpQn6JA+qojs=


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1698

Do not set the `backupPath` field of `StartBackupAppRequest` if it's not set
to avoid an `ERR_INVALID_PARAMETERS` error from server. The error is caused
by a conflict check on server side between `StartBackupAppRequest.backupPath`
and `[block_service.hdfs_service].{args}`, the latter has defined a default
backup path.