### PR TITLE
fix(java-client): use junit5 instead of junit3/junit4

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -58,8 +58,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compileSource>1.8</compileSource>
     <releaseTarget>8</releaseTarget>
-    <junit.engine.version>5.3.2</junit.engine.version>
-    <junit.platform.runner.version>1.3.0</junit.platform.runner.version>
+    <junit.api.version>5.9.3</junit.api.version>
+    <junit.jupiter.engine.version>5.9.3</junit.jupiter.engine.version>
     <guava.version>28.1-jre</guava.version>
     <mockito.version>2.24.5</mockito.version>
     <dropwizard.version>3.1.2</dropwizard.version>
@@ -87,15 +87,21 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.engine.version}</version>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <version>${junit.platform.runner.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.api.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.engine.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -119,6 +119,12 @@
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <version>${dropwizard.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -165,6 +171,10 @@
           <groupId>jline</groupId>
           <artifactId>jline</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -205,6 +215,10 @@
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/java-client/src/test/java/org/apache/pegasus/base/TestRpcAddress.java
+++ b/java-client/src/test/java/org/apache/pegasus/base/TestRpcAddress.java
@@ -19,9 +19,13 @@
 
 package org.apache.pegasus.base;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.pegasus.rpc.async.HostNameResolver;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestRpcAddress {
   @Test
@@ -29,31 +33,31 @@ public class TestRpcAddress {
     HostNameResolver hostNameResolver = new HostNameResolver();
     rpc_address[] addrs = hostNameResolver.resolve("127.0.0.1:34601");
 
-    Assert.assertNotNull(addrs);
-    Assert.assertEquals(addrs.length, 1);
-    Assert.assertEquals(addrs[0].get_ip(), "127.0.0.1");
-    Assert.assertEquals(addrs[0].get_port(), 34601);
+    assertNotNull(addrs);
+    assertEquals(addrs.length, 1);
+    assertEquals(addrs[0].get_ip(), "127.0.0.1");
+    assertEquals(addrs[0].get_port(), 34601);
 
     addrs = hostNameResolver.resolve("www.baidu.com:80");
-    Assert.assertNotNull(addrs);
-    Assert.assertTrue(addrs.length >= 1);
+    assertNotNull(addrs);
+    assertTrue(addrs.length >= 1);
 
     addrs = hostNameResolver.resolve("abcabcabcabc:34601");
-    Assert.assertNull(addrs);
+    assertNull(addrs);
 
     try {
       addrs = hostNameResolver.resolve("localhost");
     } catch (IllegalArgumentException e) {
       e.printStackTrace();
-      Assert.assertNull(addrs);
+      assertNull(addrs);
     }
   }
 
   @Test
   public void testFromString() throws Exception {
     rpc_address addr = new rpc_address();
-    Assert.assertTrue(addr.fromString("127.0.0.1:34601"));
-    Assert.assertEquals(addr.get_ip(), "127.0.0.1");
-    Assert.assertEquals(addr.get_port(), 34601);
+    assertTrue(addr.fromString("127.0.0.1:34601"));
+    assertEquals(addr.get_ip(), "127.0.0.1");
+    assertEquals(addr.get_port(), 34601);
   }
 }

--- a/java-client/src/test/java/org/apache/pegasus/client/PegasusScannerTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/PegasusScannerTest.java
@@ -18,6 +18,12 @@
  */
 package org.apache.pegasus.client;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -30,11 +36,9 @@ import java.util.Random;
 import java.util.TreeMap;
 import java.util.concurrent.Future;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class PegasusScannerTest {
   static char[] CCH =
@@ -48,7 +52,7 @@ public class PegasusScannerTest {
   private static TreeMap<String, TreeMap<String, String>> base;
   private static String expectedHashKey;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws PException {
     client = PegasusClientFactory.getSingletonClient();
     random = new Random();
@@ -83,7 +87,7 @@ public class PegasusScannerTest {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownTestCase() throws PException {
     clearDatabase();
   }
@@ -95,10 +99,10 @@ public class PegasusScannerTest {
     PegasusScannerInterface scanner =
         client.getScanner(
             tableName, expectedHashKey.getBytes(), new byte[] {}, new byte[] {}, options);
-    Assert.assertNotNull(scanner);
+    assertNotNull(scanner);
     Pair<Pair<byte[], byte[]>, byte[]> item;
     while ((item = scanner.next()) != null) {
-      Assert.assertEquals(expectedHashKey, new String(item.getLeft().getLeft()));
+      assertEquals(expectedHashKey, new String(item.getLeft().getLeft()));
       checkAndPutSortMap(
           data,
           expectedHashKey,
@@ -116,13 +120,13 @@ public class PegasusScannerTest {
     PegasusScannerInterface scanner =
         client.getScanner(
             tableName, expectedHashKey.getBytes(), new byte[] {}, new byte[] {}, options);
-    Assert.assertNotNull(scanner);
+    assertNotNull(scanner);
     Pair<Pair<byte[], byte[]>, byte[]> item;
     int count = 0;
     while (scanner.hasNext()) {
       item = scanner.next();
       count++;
-      Assert.assertEquals(expectedHashKey, new String(item.getLeft().getLeft()));
+      assertEquals(expectedHashKey, new String(item.getLeft().getLeft()));
       checkAndPutSortMap(
           data,
           expectedHashKey,
@@ -131,14 +135,14 @@ public class PegasusScannerTest {
       if ((item = scanner.next()) != null) {
         count++;
       }
-      Assert.assertEquals(expectedHashKey, new String(item.getLeft().getLeft()));
+      assertEquals(expectedHashKey, new String(item.getLeft().getLeft()));
       checkAndPutSortMap(
           data,
           expectedHashKey,
           new String(item.getLeft().getRight()),
           new String(item.getRight()));
     }
-    Assert.assertEquals(1000, count);
+    assertEquals(1000, count);
     scanner.close();
     compareSortMap(data, base.get(expectedHashKey), expectedHashKey);
   }
@@ -158,10 +162,10 @@ public class PegasusScannerTest {
     PegasusScannerInterface scanner =
         client.getScanner(
             tableName, expectedHashKey.getBytes(), start.getBytes(), stop.getBytes(), options);
-    Assert.assertNotNull(scanner);
+    assertNotNull(scanner);
     Pair<Pair<byte[], byte[]>, byte[]> item;
     while ((item = scanner.next()) != null) {
-      Assert.assertEquals(expectedHashKey, new String(item.getLeft().getLeft()));
+      assertEquals(expectedHashKey, new String(item.getLeft().getLeft()));
       checkAndPutSortMap(
           data,
           expectedHashKey,
@@ -188,10 +192,10 @@ public class PegasusScannerTest {
     PegasusScannerInterface scanner =
         client.getScanner(
             tableName, expectedHashKey.getBytes(), start.getBytes(), stop.getBytes(), options);
-    Assert.assertNotNull(scanner);
+    assertNotNull(scanner);
     Pair<Pair<byte[], byte[]>, byte[]> item;
     while ((item = scanner.next()) != null) {
-      Assert.assertEquals(expectedHashKey, new String(item.getLeft().getLeft()));
+      assertEquals(expectedHashKey, new String(item.getLeft().getLeft()));
       checkAndPutSortMap(
           data,
           expectedHashKey,
@@ -215,11 +219,11 @@ public class PegasusScannerTest {
     PegasusScannerInterface scanner =
         client.getScanner(
             tableName, expectedHashKey.getBytes(), start.getBytes(), start.getBytes(), options);
-    Assert.assertNotNull(scanner);
+    assertNotNull(scanner);
     Pair<Pair<byte[], byte[]>, byte[]> item = scanner.next();
-    Assert.assertEquals(start, new String(item.getLeft().getRight()));
+    assertEquals(start, new String(item.getLeft().getRight()));
     item = scanner.next();
-    Assert.assertNull(item);
+    assertNull(item);
     scanner.close();
   }
 
@@ -235,9 +239,9 @@ public class PegasusScannerTest {
     PegasusScannerInterface scanner =
         client.getScanner(
             tableName, expectedHashKey.getBytes(), start.getBytes(), start.getBytes(), options);
-    Assert.assertNotNull(scanner);
+    assertNotNull(scanner);
     Pair<Pair<byte[], byte[]>, byte[]> item = scanner.next();
-    Assert.assertNull(item);
+    assertNull(item);
     scanner.close();
   }
 
@@ -255,9 +259,9 @@ public class PegasusScannerTest {
     PegasusScannerInterface scanner =
         client.getScanner(
             tableName, expectedHashKey.getBytes(), stop.getBytes(), start.getBytes(), options);
-    Assert.assertNotNull(scanner);
+    assertNotNull(scanner);
     Pair<Pair<byte[], byte[]>, byte[]> item = scanner.next();
-    Assert.assertNull(item);
+    assertNull(item);
     scanner.close();
   }
 
@@ -266,11 +270,11 @@ public class PegasusScannerTest {
     ScanOptions options = new ScanOptions();
     TreeMap<String, TreeMap<String, String>> data = new TreeMap<String, TreeMap<String, String>>();
     List<PegasusScannerInterface> scanners = client.getUnorderedScanners(tableName, 3, options);
-    Assert.assertTrue(scanners.size() <= 3);
+    assertTrue(scanners.size() <= 3);
 
     for (int i = scanners.size() - 1; i >= 0; i--) {
       PegasusScannerInterface scanner = scanners.get(i);
-      Assert.assertNotNull(scanner);
+      assertNotNull(scanner);
       Pair<Pair<byte[], byte[]>, byte[]> item;
       while ((item = scanner.next()) != null) {
         checkAndPut(
@@ -289,11 +293,11 @@ public class PegasusScannerTest {
     ScanOptions options = new ScanOptions();
     TreeMap<String, TreeMap<String, String>> data = new TreeMap<String, TreeMap<String, String>>();
     List<PegasusScannerInterface> scanners = client.getUnorderedScanners(tableName, 3, options);
-    Assert.assertTrue(scanners.size() <= 3);
+    assertTrue(scanners.size() <= 3);
 
     for (int i = scanners.size() - 1; i >= 0; i--) {
       PegasusScannerInterface scanner = scanners.get(i);
-      Assert.assertNotNull(scanner);
+      assertNotNull(scanner);
       Future<Pair<Pair<byte[], byte[]>, byte[]>> item;
       while (true) {
         item = scanner.asyncNext();
@@ -307,7 +311,7 @@ public class PegasusScannerTest {
               new String(pair.getRight()));
         } catch (Exception e) {
           e.printStackTrace();
-          Assert.assertTrue(false);
+          assertTrue(false);
         }
       }
     }
@@ -328,7 +332,7 @@ public class PegasusScannerTest {
       TreeMap<String, TreeMap<String, String>> data =
           new TreeMap<String, TreeMap<String, String>>();
       List<PegasusScannerInterface> scanners = client.getUnorderedScanners(tableName, 1, options);
-      Assert.assertTrue(scanners.size() <= 1);
+      assertTrue(scanners.size() <= 1);
       System.out.println(
           "start to scan " + totalKvSize + " kv-pairs with scan batch size " + batchSize);
       start_time_ms = System.currentTimeMillis();
@@ -342,7 +346,7 @@ public class PegasusScannerTest {
         }
       } catch (Exception e) {
         e.printStackTrace();
-        Assert.assertTrue(false);
+        assertTrue(false);
       }
       end_time_ms = System.currentTimeMillis();
       System.out.println("consuing time: " + (end_time_ms - start_time_ms) + "ms");
@@ -357,10 +361,10 @@ public class PegasusScannerTest {
     TreeMap<String, String> data = new TreeMap<String, String>();
     List<PegasusScannerInterface> scanners = client.getUnorderedScanners(tableName, 1, options);
     PegasusScannerInterface scanner = scanners.get(0);
-    Assert.assertNotNull(scanner);
+    assertNotNull(scanner);
     Pair<Pair<byte[], byte[]>, byte[]> item;
     while ((item = scanner.next()) != null) {
-      Assert.assertArrayEquals(expectedHashKey.getBytes(), item.getLeft().getLeft());
+      assertArrayEquals(expectedHashKey.getBytes(), item.getLeft().getLeft());
       checkAndPutSortMap(
           data,
           expectedHashKey,
@@ -402,10 +406,10 @@ public class PegasusScannerTest {
           }
         }
       } catch (PException e) {
-        Assertions.assertTrue(e.getMessage().contains("encounter unknown error"));
+        assertTrue(e.getMessage().contains("encounter unknown error"));
       }
     }
-    Assertions.assertEquals(1, items.size());
+    assertEquals(1, items.size());
     items.clear();
 
     // test encounter rpc error
@@ -426,10 +430,10 @@ public class PegasusScannerTest {
           break;
         }
       } catch (PException e) {
-        Assertions.assertTrue(e.getMessage().contains("scan failed with error rpc"));
+        assertTrue(e.getMessage().contains("scan failed with error rpc"));
       }
     }
-    Assertions.assertEquals(100, items.size());
+    assertEquals(100, items.size());
   }
 
   private void mockEncounterErrorForTest(PegasusScannerInterface scanner) {
@@ -462,8 +466,8 @@ public class PegasusScannerTest {
   private static void clearDatabase() throws PException {
     ScanOptions options = new ScanOptions();
     List<PegasusScannerInterface> scanners = client.getUnorderedScanners(tableName, 1, options);
-    Assert.assertEquals(1, scanners.size());
-    Assert.assertNotNull(scanners.get(0));
+    assertEquals(1, scanners.size());
+    assertNotNull(scanners.get(0));
 
     Pair<Pair<byte[], byte[]>, byte[]> item;
     while ((item = scanners.get(0).next()) != null) {
@@ -472,17 +476,17 @@ public class PegasusScannerTest {
     scanners.get(0).close();
 
     scanners = client.getUnorderedScanners(tableName, 1, options);
-    Assert.assertEquals(1, scanners.size());
-    Assert.assertNotNull(scanners.get(0));
+    assertEquals(1, scanners.size());
+    assertNotNull(scanners.get(0));
     item = scanners.get(0).next();
     scanners.get(0).close();
-    Assert.assertNull(
+    assertNull(
+        item,
         item == null
             ? null
             : String.format(
                 "Database is cleared but not empty, hashKey=%s, sortKey=%s",
-                new String(item.getLeft().getLeft()), new String(item.getLeft().getRight())),
-        item);
+                new String(item.getLeft().getLeft()), new String(item.getLeft().getRight())));
   }
 
   private static String randomString() {
@@ -504,22 +508,25 @@ public class PegasusScannerTest {
       sortMap = new TreeMap<>();
       data.put(hashKey, sortMap);
     } else {
-      Assert.assertNull(
+      assertNull(
+          sortMap.get(sortKey),
           String.format(
               "Duplicate: hashKey=%s, sortKye=%s, oldValue=%s, newValue=%s",
-              hashKey, sortKey, sortMap.get(sortKey), value),
-          sortMap.get(sortKey));
+              hashKey, sortKey, sortMap.get(sortKey), value));
     }
     sortMap.put(sortKey, value);
   }
 
   private static void checkAndPutSortMap(
       TreeMap<String, String> data, String hashKey, String sortKey, String value) {
-    Assert.assertNull(
+    assertNull(
         String.format(
+            data.get(sortKey),
             "Duplicate: hashKey=%s, sortKye=%s, oldValue=%s, newValue=%s",
-            hashKey, sortKey, data.get(sortKey), value),
-        data.get(sortKey));
+            hashKey,
+            sortKey,
+            data.get(sortKey),
+            value));
     data.put(sortKey, value);
   }
 
@@ -534,41 +541,41 @@ public class PegasusScannerTest {
       Map.Entry<String, TreeMap<String, String>> kv2 =
           iterator2.hasNext() ? iterator2.next() : null;
       if (kv1 == null) {
-        Assert.assertNull(
-            kv2 == null ? null : String.format("Only in base: hashKey=%s", kv2.getKey()), kv2);
+        assertNull(
+            kv2, kv2 == null ? null : String.format("Only in base: hashKey=%s", kv2.getKey()));
         break;
       }
-      Assert.assertNotNull(String.format("Only in data: hashKey=%s", kv1.getKey()), kv2);
-      Assert.assertEquals(
-          String.format("Diff: dataHashKey=%s, baseHashKey=%s", kv1.getKey(), kv2.getKey()),
+      assertNotNull(kv2, String.format("Only in data: hashKey=%s", kv1.getKey()));
+      assertEquals(
           kv1.getKey(),
-          kv2.getKey());
+          kv2.getKey(),
+          String.format("Diff: dataHashKey=%s, baseHashKey=%s", kv1.getKey(), kv2.getKey()));
       Iterator<Map.Entry<String, String>> iterator3 = kv1.getValue().entrySet().iterator();
       Iterator<Map.Entry<String, String>> iterator4 = kv2.getValue().entrySet().iterator();
       while (true) {
         Map.Entry<String, String> kv3 = iterator3.hasNext() ? iterator3.next() : null;
         Map.Entry<String, String> kv4 = iterator4.hasNext() ? iterator4.next() : null;
         if (kv3 == null) {
-          Assert.assertNull(
+          assertNull(
+              kv4,
               kv4 == null
                   ? null
                   : String.format(
                       "Only in base: hashKey=%s, sortKey=%s, value=%s",
-                      kv1.getKey(), kv4.getKey(), kv4.getValue()),
-              kv4);
+                      kv1.getKey(), kv4.getKey(), kv4.getValue()));
           break;
         }
-        Assert.assertNotNull(
+        assertNotNull(
+            kv4,
             String.format(
                 "Only in data: hashKey=%s, sortKey=%s, value=%s",
-                kv1.getKey(), kv3.getKey(), kv3.getValue()),
-            kv4);
-        Assert.assertEquals(
+                kv1.getKey(), kv3.getKey(), kv3.getValue()));
+        assertEquals(
+            kv3,
+            kv4,
             String.format(
                 "Diff: hashKey=%s, dataSortKey=%s, dataValue=%s, baseSortKey=%s, baseValue=%s",
-                kv1.getKey(), kv3.getKey(), kv3.getValue(), kv4.getKey(), kv4.getValue()),
-            kv3,
-            kv4);
+                kv1.getKey(), kv3.getKey(), kv3.getValue(), kv4.getKey(), kv4.getValue()));
       }
     }
   }
@@ -581,26 +588,26 @@ public class PegasusScannerTest {
       Map.Entry<String, String> kv1 = iterator1.hasNext() ? iterator1.next() : null;
       Map.Entry<String, String> kv2 = iterator2.hasNext() ? iterator2.next() : null;
       if (kv1 == null) {
-        Assert.assertNull(
+        assertNull(
+            kv2,
             kv2 == null
                 ? null
                 : String.format(
                     "Only in base: hashKey=%s, sortKey=%s, value=%s",
-                    hashKey, kv2.getKey(), kv2.getValue()),
-            kv2);
+                    hashKey, kv2.getKey(), kv2.getValue()));
         break;
       }
-      Assert.assertNotNull(
+      assertNotNull(
+          kv2,
           String.format(
               "Only in data: hashKey=%s, sortKey=%s, value=%s",
-              hashKey, kv1.getKey(), kv1.getValue()),
-          kv2);
-      Assert.assertEquals(
+              hashKey, kv1.getKey(), kv1.getValue()));
+      assertEquals(
+          kv1,
+          kv2,
           String.format(
               "Diff: hashKey=%s, dataSortKey=%s, dataValue=%s, baseSortKey=%s, baseValue=%s",
-              hashKey, kv1.getKey(), kv1.getValue(), kv2.getKey(), kv2.getValue()),
-          kv1,
-          kv2);
+              hashKey, kv1.getKey(), kv1.getValue(), kv2.getKey(), kv2.getValue()));
     }
   }
 }

--- a/java-client/src/test/java/org/apache/pegasus/client/PegasusScannerTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/PegasusScannerTest.java
@@ -523,10 +523,7 @@ public class PegasusScannerTest {
         data.get(sortKey),
         String.format(
             "Duplicate: hashKey=%s, sortKye=%s, oldValue=%s, newValue=%s",
-            hashKey,
-            sortKey,
-            data.get(sortKey),
-            value));
+            hashKey, sortKey, data.get(sortKey), value));
     data.put(sortKey, value);
   }
 

--- a/java-client/src/test/java/org/apache/pegasus/client/PegasusScannerTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/PegasusScannerTest.java
@@ -520,8 +520,8 @@ public class PegasusScannerTest {
   private static void checkAndPutSortMap(
       TreeMap<String, String> data, String hashKey, String sortKey, String value) {
     assertNull(
+        data.get(sortKey),
         String.format(
-            data.get(sortKey),
             "Duplicate: hashKey=%s, sortKye=%s, oldValue=%s, newValue=%s",
             hashKey,
             sortKey,

--- a/java-client/src/test/java/org/apache/pegasus/client/TestAdminClient.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestAdminClient.java
@@ -20,7 +20,11 @@
 package org.apache.pegasus.client;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.List;
@@ -28,10 +32,9 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pegasus.replication.app_info;
 import org.apache.pegasus.rpc.async.MetaHandler;
 import org.apache.pegasus.rpc.async.MetaSession;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestAdminClient {
   PegasusAdminClientInterface toolsClient;
@@ -41,7 +44,7 @@ public class TestAdminClient {
   final int tableOpTimeoutMs = 66000;
   ClientOptions clientOptions;
 
-  @Before
+  @BeforeEach
   public void Setup() throws PException {
     this.clientOptions =
         ClientOptions.builder()
@@ -53,7 +56,7 @@ public class TestAdminClient {
     toolsClient = PegasusAdminClientFactory.createClient(this.clientOptions);
   }
 
-  @After
+  @AfterEach
   public void after() {
     toolsClient.close();
   }
@@ -68,11 +71,11 @@ public class TestAdminClient {
 
     boolean isAppHealthy = toolsClient.isAppHealthy(appName, this.tableReplicaCount);
 
-    Assert.assertTrue(isAppHealthy);
+    assertTrue(isAppHealthy);
 
     int fakeReplicaCount = 5;
     isAppHealthy = toolsClient.isAppHealthy(appName, fakeReplicaCount);
-    Assert.assertFalse(isAppHealthy);
+    assertFalse(isAppHealthy);
   }
 
   @Test
@@ -107,7 +110,7 @@ public class TestAdminClient {
       return;
     }
 
-    Assert.fail();
+    fail();
   }
 
   @Test
@@ -121,7 +124,7 @@ public class TestAdminClient {
         new HashMap<>(),
         this.tableOpTimeoutMs);
     boolean isAppHealthy = toolsClient.isAppHealthy(appName, this.tableReplicaCount);
-    Assert.assertTrue(isAppHealthy);
+    assertTrue(isAppHealthy);
 
     toolsClient.dropApp(appName, tableOpTimeoutMs);
 
@@ -134,7 +137,7 @@ public class TestAdminClient {
       return;
     }
     pClient.close();
-    Assert.fail("expected PException for openTable");
+    fail("expected PException for openTable");
   }
 
   @Test
@@ -149,20 +152,20 @@ public class TestAdminClient {
         new HashMap<>(),
         this.tableOpTimeoutMs);
     boolean isAppHealthy = toolsClient.isAppHealthy(appName, this.tableReplicaCount);
-    Assert.assertTrue(isAppHealthy);
+    assertTrue(isAppHealthy);
 
     appInfoList.clear();
     appInfoList = toolsClient.listApps(ListAppInfoType.LT_AVAILABLE_APPS);
-    Assert.assertEquals(size1 + 1, appInfoList.size());
+    assertEquals(size1 + 1, appInfoList.size());
     appInfoList.clear();
     appInfoList = toolsClient.listApps(ListAppInfoType.LT_ALL_APPS);
     int size2 = appInfoList.size();
     toolsClient.dropApp(appName, this.tableOpTimeoutMs);
     appInfoList.clear();
     appInfoList = toolsClient.listApps(ListAppInfoType.LT_AVAILABLE_APPS);
-    Assert.assertEquals(size1, appInfoList.size());
+    assertEquals(size1, appInfoList.size());
     appInfoList.clear();
     appInfoList = toolsClient.listApps(ListAppInfoType.LT_ALL_APPS);
-    Assert.assertEquals(size2, appInfoList.size());
+    assertEquals(size2, appInfoList.size());
   }
 }

--- a/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Created by mi on 16-3-22. */
@@ -2388,8 +2387,8 @@ public class TestBasic {
     List<byte[]> remainingSortKey = new ArrayList<byte[]>();
     List<Pair<byte[], byte[]>> remainingValue = new ArrayList<Pair<byte[], byte[]>>();
 
-    Assertions.assertNull(
-        Assertions.assertDoesNotThrow(
+    assertNull(
+        assertDoesNotThrow(
             () -> {
               client.multiSet(tableName, "delRange".getBytes(), values);
               client.delRange(
@@ -2418,17 +2417,17 @@ public class TestBasic {
     for (Pair<byte[], byte[]> pair : remainingValue) {
       valueStr.add(new String(pair.getValue()));
     }
-    Assertions.assertEquals(10, valueStr.size());
-    Assertions.assertTrue(valueStr.contains("v_90"));
-    Assertions.assertTrue(valueStr.contains("v_91"));
-    Assertions.assertTrue(valueStr.contains("v_92"));
-    Assertions.assertTrue(valueStr.contains("v_93"));
-    Assertions.assertTrue(valueStr.contains("v_94"));
-    Assertions.assertTrue(valueStr.contains("v_95"));
-    Assertions.assertTrue(valueStr.contains("v_96"));
-    Assertions.assertTrue(valueStr.contains("v_97"));
-    Assertions.assertTrue(valueStr.contains("v_98"));
-    Assertions.assertTrue(valueStr.contains("v_99"));
+    assertEquals(10, valueStr.size());
+    assertTrue(valueStr.contains("v_90"));
+    assertTrue(valueStr.contains("v_91"));
+    assertTrue(valueStr.contains("v_92"));
+    assertTrue(valueStr.contains("v_93"));
+    assertTrue(valueStr.contains("v_94"));
+    assertTrue(valueStr.contains("v_95"));
+    assertTrue(valueStr.contains("v_96"));
+    assertTrue(valueStr.contains("v_97"));
+    assertTrue(valueStr.contains("v_98"));
+    assertTrue(valueStr.contains("v_99"));
     remainingValue.clear();
     valueStr.clear();
 
@@ -2436,7 +2435,7 @@ public class TestBasic {
     delRangeOptions.sortKeyFilterType = FilterType.FT_MATCH_POSTFIX;
     delRangeOptions.sortKeyFilterPattern = "k_93".getBytes();
 
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> {
           client.delRange(
               tableName,
@@ -2449,8 +2448,8 @@ public class TestBasic {
     for (Pair<byte[], byte[]> pair : remainingValue) {
       valueStr.add(new String(pair.getValue()));
     }
-    Assertions.assertEquals(9, valueStr.size());
-    Assertions.assertTrue(!valueStr.contains("v_93"));
+    assertEquals(9, valueStr.size());
+    assertTrue(!valueStr.contains("v_93"));
     remainingValue.clear();
     valueStr.clear();
 
@@ -2459,7 +2458,7 @@ public class TestBasic {
     delRangeOptions.stopInclusive = true;
     delRangeOptions.sortKeyFilterType = FilterType.FT_NO_FILTER;
     delRangeOptions.sortKeyFilterPattern = null;
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> {
           client.delRange(
               tableName,
@@ -2474,20 +2473,20 @@ public class TestBasic {
       valueStr.add(new String(pair.getValue()));
     }
 
-    Assertions.assertEquals(5, valueStr.size());
-    Assertions.assertTrue(valueStr.contains("v_90"));
-    Assertions.assertTrue(valueStr.contains("v_96"));
-    Assertions.assertTrue(valueStr.contains("v_97"));
-    Assertions.assertTrue(valueStr.contains("v_98"));
-    Assertions.assertTrue(valueStr.contains("v_99"));
+    assertEquals(5, valueStr.size());
+    assertTrue(valueStr.contains("v_90"));
+    assertTrue(valueStr.contains("v_96"));
+    assertTrue(valueStr.contains("v_97"));
+    assertTrue(valueStr.contains("v_98"));
+    assertTrue(valueStr.contains("v_99"));
     remainingValue.clear();
     valueStr.clear();
 
     DelRangeOptions delRangeOptions2 = new DelRangeOptions();
     // test hashKey can't be null or ""
-    Assertions.assertEquals(
+    assertEquals(
         "{version}: Invalid parameter: hash key can't be empty",
-        Assertions.assertThrows(
+        assertThrows(
                 PException.class,
                 () -> {
                   client.delRange(
@@ -2495,9 +2494,9 @@ public class TestBasic {
                 })
             .getMessage());
 
-    Assertions.assertEquals(
+    assertEquals(
         "{version}: Invalid parameter: hash key can't be empty",
-        Assertions.assertThrows(
+        assertThrows(
                 PException.class,
                 () -> {
                   client.delRange(
@@ -2506,8 +2505,8 @@ public class TestBasic {
             .getMessage());
 
     // test sortKey can be null, means delete from first to last
-    Assertions.assertNull(
-        Assertions.assertDoesNotThrow(
+    assertNull(
+        assertDoesNotThrow(
             () -> {
               client.multiSet(tableName, "delRange".getBytes(), values);
               client.delRange(tableName, "delRange".getBytes(), null, null, delRangeOptions2);
@@ -2515,7 +2514,7 @@ public class TestBasic {
               return delRangeOptions2.nextSortKey;
             }));
 
-    Assertions.assertEquals(remainingValue.size(), 0);
+    assertEquals(remainingValue.size(), 0);
   }
 
   @Test
@@ -2712,7 +2711,7 @@ public class TestBasic {
     assertFalse(caseD1.allFetched);
     assertEquals(5, caseD1.keys.size());
     for (int i = 0; i <= 4; i++) {
-      Assertions.assertEquals("persistent_" + i, new String(caseD1.keys.get(i)));
+      assertEquals("persistent_" + i, new String(caseD1.keys.get(i)));
     }
     // case D1: maxFetchCount < 0, return all valid record
     PegasusTableInterface.MultiGetSortKeysResult caseD2 =
@@ -2720,7 +2719,7 @@ public class TestBasic {
     assertTrue(caseD2.allFetched);
     assertEquals(10, caseD2.keys.size());
     for (int i = 0; i <= 9; i++) {
-      Assertions.assertEquals("persistent_" + i, new String(caseD2.keys.get(i)));
+      assertEquals("persistent_" + i, new String(caseD2.keys.get(i)));
     }
   }
 
@@ -2756,15 +2755,15 @@ public class TestBasic {
       int stopIndex,
       boolean expectAllFetched,
       PegasusTable.ScanRangeResult actuallyRes) {
-    Assertions.assertEquals(expectAllFetched, actuallyRes.allFetched);
-    Assertions.assertEquals(stopIndex - startIndex + 1, actuallyRes.results.size());
+    assertEquals(expectAllFetched, actuallyRes.allFetched);
+    assertEquals(stopIndex - startIndex + 1, actuallyRes.results.size());
     for (int i = startIndex; i <= stopIndex; i++) {
-      Assertions.assertEquals(
+      assertEquals(
           "hashKey", new String(actuallyRes.results.get(i - startIndex).getLeft().getKey()));
-      Assertions.assertEquals(
+      assertEquals(
           "persistent_" + i,
           new String(actuallyRes.results.get(i - startIndex).getLeft().getValue()));
-      Assertions.assertEquals(
+      assertEquals(
           "persistent_" + i + "_value",
           new String(actuallyRes.results.get(i - startIndex).getRight()));
     }
@@ -2797,7 +2796,7 @@ public class TestBasic {
       }
 
       Throwable exception =
-          Assertions.assertThrows(
+          assertThrows(
               PException.class,
               () -> {
                 client.multiSet(tableName, hashKey.getBytes(), multiValues2);
@@ -2816,7 +2815,7 @@ public class TestBasic {
       CheckAndMutateOptions options = new CheckAndMutateOptions();
       options.returnCheckValue = true;
       Throwable exception2 =
-          Assertions.assertThrows(
+          assertThrows(
               PException.class,
               () -> {
                 client.checkAndMutate(
@@ -2865,7 +2864,6 @@ public class TestBasic {
               .getMessage()
               .contains(
                   "request=[hashKey[:32]=\"TestHash_0\",sortKey[:32]=\"\",sortKeyCount=3,valueLength=-1]"));
-
     } catch (Throwable e) {
       fail();
     }

--- a/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
@@ -20,10 +20,12 @@ package org.apache.pegasus.client;
 
 /** @author qinzuoyan */
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -2847,13 +2849,13 @@ public class TestBasic {
       sortKeys.add("basic_test_sort_key_2".getBytes());
 
       tb.multiSet(hashKey.getBytes(), multiValues3, 5000);
-      Assertions.assertDoesNotThrow(
+      assertDoesNotThrow(
           () -> {
             tb.multiSet(hashKey.getBytes(), multiValues3, 5000);
           });
 
       Throwable exception3 =
-          Assertions.assertThrows(
+          assertThrows(
               PException.class,
               () -> {
                 client.multiDel(tableName, hashKey.getBytes(), sortKeys);

--- a/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
@@ -19,6 +19,14 @@
 package org.apache.pegasus.client;
 
 /** @author qinzuoyan */
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import io.netty.util.concurrent.Future;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -27,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -52,79 +59,78 @@ public class TestBasic {
 
   @Test
   public void testGenerateKey() throws PException {
-    Assert.assertEquals(
+    assertEquals(
         "00010A0BFEFF", bytesToHex(new byte[] {0x00, 0x01, 0x0A, 0x0B, (byte) 0xFE, (byte) 0xFF}));
 
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x00}, PegasusClient.generateKey(new byte[] {}, new byte[] {}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x01, 0x44}, PegasusClient.generateKey(new byte[] {0x44}, new byte[] {}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x00, 0x55}, PegasusClient.generateKey(new byte[] {}, new byte[] {0x55}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x01, 0x44, 0x55},
         PegasusClient.generateKey(new byte[] {0x44}, new byte[] {0x55}));
     try {
       byte[] k = PegasusClient.generateKey(new byte[64 * 1024], new byte[] {0x55});
-      Assert.assertTrue(false);
+      assertTrue(false);
     } catch (Exception e) {
     }
 
-    Assert.assertArrayEquals(
-        new byte[] {0x00, 0x01}, PegasusClient.generateNextBytes(new byte[] {}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(new byte[] {0x00, 0x01}, PegasusClient.generateNextBytes(new byte[] {}));
+    assertArrayEquals(
         new byte[] {0x00, 0x01, 0x0B}, PegasusClient.generateNextBytes(new byte[] {0x0A}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x01, (byte) 0xFF},
         PegasusClient.generateNextBytes(new byte[] {(byte) 0xFE}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x02}, PegasusClient.generateNextBytes(new byte[] {(byte) 0xFF}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x02, 0x0B},
         PegasusClient.generateNextBytes(new byte[] {0x0A, (byte) 0xFF}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x03},
         PegasusClient.generateNextBytes(new byte[] {(byte) 0xFF, (byte) 0xFF}));
     try {
       byte[] k = PegasusClient.generateNextBytes(new byte[64 * 1024]);
-      Assert.assertTrue(false);
+      assertTrue(false);
     } catch (Exception e) {
     }
 
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x01}, PegasusClient.generateNextBytes(new byte[] {}, new byte[] {}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x01, 0x45},
         PegasusClient.generateNextBytes(new byte[] {0x44}, new byte[] {}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x00, 0x56},
         PegasusClient.generateNextBytes(new byte[] {}, new byte[] {0x55}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x01, 0x44, 0x56},
         PegasusClient.generateNextBytes(new byte[] {0x44}, new byte[] {0x55}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x01, 0x45},
         PegasusClient.generateNextBytes(new byte[] {0x44}, new byte[] {(byte) 0xFF}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x02},
         PegasusClient.generateNextBytes(new byte[] {(byte) 0xFF}, new byte[] {}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x01, (byte) 0xFF, 0x56},
         PegasusClient.generateNextBytes(new byte[] {(byte) 0xFF}, new byte[] {0x55}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x02},
         PegasusClient.generateNextBytes(new byte[] {(byte) 0xFF}, new byte[] {(byte) 0xFF}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x02},
         PegasusClient.generateNextBytes(
             new byte[] {(byte) 0xFF}, new byte[] {(byte) 0xFF, (byte) 0xFF}));
-    Assert.assertArrayEquals(
+    assertArrayEquals(
         new byte[] {0x00, 0x03},
         PegasusClient.generateNextBytes(
             new byte[] {(byte) 0xFF, (byte) 0xFF}, new byte[] {(byte) 0xFF}));
     try {
       byte[] k = PegasusClient.generateNextBytes(new byte[64 * 1024], new byte[0]);
-      Assert.assertTrue(false);
+      assertTrue(false);
     } catch (Exception e) {
     }
   }
@@ -133,11 +139,11 @@ public class TestBasic {
   public void testGetSingletonClient() throws PException {
     PegasusClientInterface client = PegasusClientFactory.getSingletonClient();
     PegasusClientInterface client1 = PegasusClientFactory.getSingletonClient();
-    Assert.assertEquals(client, client1);
+    assertEquals(client, client1);
     try {
       PegasusClientInterface client2 =
           PegasusClientFactory.getSingletonClient("resource:///xxx.properties");
-      Assert.assertTrue(false);
+      assertTrue(false);
     } catch (PException e) {
     }
     PegasusClientFactory.closeSingletonClient();
@@ -156,39 +162,39 @@ public class TestBasic {
 
       // check exist
       boolean exist = client.exist(tableName, hashKey, "basic_test_sort_key_1".getBytes());
-      Assert.assertTrue(exist);
+      assertTrue(exist);
 
       exist = client.exist(tableName, hashKey, "basic_test_sort_key_2".getBytes());
-      Assert.assertFalse(exist);
+      assertFalse(exist);
 
       // check sortkey count
       long sortKeyCount = client.sortKeyCount(tableName, hashKey);
-      Assert.assertEquals(1, sortKeyCount);
+      assertEquals(1, sortKeyCount);
 
       // get
       byte[] value = client.get(tableName, hashKey, "basic_test_sort_key_1".getBytes());
-      Assert.assertArrayEquals("basic_test_value_1".getBytes(), value);
+      assertArrayEquals("basic_test_value_1".getBytes(), value);
 
       value = client.get(tableName, hashKey, "basic_test_sort_key_2".getBytes());
-      Assert.assertEquals(null, value);
+      assertEquals(null, value);
 
       // del
       client.del(tableName, hashKey, "basic_test_sort_key_1".getBytes());
 
       // check exist
       exist = client.exist(tableName, hashKey, "basic_test_sort_key_1".getBytes());
-      Assert.assertFalse(exist);
+      assertFalse(exist);
 
       // check sortkey count
       sortKeyCount = client.sortKeyCount(tableName, hashKey);
-      Assert.assertEquals(0, sortKeyCount);
+      assertEquals(0, sortKeyCount);
 
       // check deleted
       value = client.get(tableName, hashKey, "basic_test_sort_key_1".getBytes());
-      Assert.assertEquals(null, value);
+      assertEquals(null, value);
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -211,14 +217,14 @@ public class TestBasic {
 
       // check exist
       boolean exist = client.exist(tableName, hashKey, "basic_test_sort_key_1".getBytes());
-      Assert.assertTrue(exist);
+      assertTrue(exist);
 
       exist = client.exist(tableName, hashKey, "basic_test_sort_key_5".getBytes());
-      Assert.assertFalse(exist);
+      assertFalse(exist);
 
       // check sortkey count
       long sortKeyCount = client.sortKeyCount(tableName, hashKey);
-      Assert.assertEquals(4, sortKeyCount);
+      assertEquals(4, sortKeyCount);
 
       // multi get
       List<byte[]> sortKeys = new ArrayList<byte[]>();
@@ -229,63 +235,63 @@ public class TestBasic {
       sortKeys.add("basic_test_sort_key_4".getBytes());
       List<Pair<byte[], byte[]>> newValues = new ArrayList<Pair<byte[], byte[]>>();
       boolean ret = client.multiGet(tableName, hashKey, sortKeys, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(4, newValues.size());
-      Assert.assertArrayEquals("basic_test_sort_key_1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("basic_test_value_1".getBytes(), newValues.get(0).getValue());
-      Assert.assertArrayEquals("basic_test_sort_key_2".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("basic_test_value_2".getBytes(), newValues.get(1).getValue());
-      Assert.assertArrayEquals("basic_test_sort_key_3".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("basic_test_value_3".getBytes(), newValues.get(2).getValue());
-      Assert.assertArrayEquals("basic_test_sort_key_4".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("basic_test_value_4".getBytes(), newValues.get(3).getValue());
+      assertTrue(ret);
+      assertEquals(4, newValues.size());
+      assertArrayEquals("basic_test_sort_key_1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("basic_test_value_1".getBytes(), newValues.get(0).getValue());
+      assertArrayEquals("basic_test_sort_key_2".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("basic_test_value_2".getBytes(), newValues.get(1).getValue());
+      assertArrayEquals("basic_test_sort_key_3".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("basic_test_value_3".getBytes(), newValues.get(2).getValue());
+      assertArrayEquals("basic_test_sort_key_4".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("basic_test_value_4".getBytes(), newValues.get(3).getValue());
 
       // multi get with count limit
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, sortKeys, 1, 0, newValues);
-      Assert.assertFalse(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("basic_test_sort_key_1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("basic_test_value_1".getBytes(), newValues.get(0).getValue());
+      assertFalse(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("basic_test_sort_key_1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("basic_test_value_1".getBytes(), newValues.get(0).getValue());
 
       // multi get with empty sortKeys
       sortKeys.clear();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, sortKeys, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(4, newValues.size());
-      Assert.assertArrayEquals("basic_test_sort_key_1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("basic_test_value_1".getBytes(), newValues.get(0).getValue());
-      Assert.assertArrayEquals("basic_test_sort_key_2".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("basic_test_value_2".getBytes(), newValues.get(1).getValue());
-      Assert.assertArrayEquals("basic_test_sort_key_3".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("basic_test_value_3".getBytes(), newValues.get(2).getValue());
-      Assert.assertArrayEquals("basic_test_sort_key_4".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("basic_test_value_4".getBytes(), newValues.get(3).getValue());
+      assertTrue(ret);
+      assertEquals(4, newValues.size());
+      assertArrayEquals("basic_test_sort_key_1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("basic_test_value_1".getBytes(), newValues.get(0).getValue());
+      assertArrayEquals("basic_test_sort_key_2".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("basic_test_value_2".getBytes(), newValues.get(1).getValue());
+      assertArrayEquals("basic_test_sort_key_3".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("basic_test_value_3".getBytes(), newValues.get(2).getValue());
+      assertArrayEquals("basic_test_sort_key_4".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("basic_test_value_4".getBytes(), newValues.get(3).getValue());
 
       // multi get with null sortKeys
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(4, newValues.size());
-      Assert.assertArrayEquals("basic_test_sort_key_1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("basic_test_value_1".getBytes(), newValues.get(0).getValue());
-      Assert.assertArrayEquals("basic_test_sort_key_2".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("basic_test_value_2".getBytes(), newValues.get(1).getValue());
-      Assert.assertArrayEquals("basic_test_sort_key_3".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("basic_test_value_3".getBytes(), newValues.get(2).getValue());
-      Assert.assertArrayEquals("basic_test_sort_key_4".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("basic_test_value_4".getBytes(), newValues.get(3).getValue());
+      assertTrue(ret);
+      assertEquals(4, newValues.size());
+      assertArrayEquals("basic_test_sort_key_1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("basic_test_value_1".getBytes(), newValues.get(0).getValue());
+      assertArrayEquals("basic_test_sort_key_2".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("basic_test_value_2".getBytes(), newValues.get(1).getValue());
+      assertArrayEquals("basic_test_sort_key_3".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("basic_test_value_3".getBytes(), newValues.get(2).getValue());
+      assertArrayEquals("basic_test_sort_key_4".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("basic_test_value_4".getBytes(), newValues.get(3).getValue());
 
       // multi get sort keys
       sortKeys.clear();
       ret = client.multiGetSortKeys(tableName, hashKey, sortKeys);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(4, sortKeys.size());
-      Assert.assertArrayEquals("basic_test_sort_key_1".getBytes(), sortKeys.get(0));
-      Assert.assertArrayEquals("basic_test_sort_key_2".getBytes(), sortKeys.get(1));
-      Assert.assertArrayEquals("basic_test_sort_key_3".getBytes(), sortKeys.get(2));
-      Assert.assertArrayEquals("basic_test_sort_key_4".getBytes(), sortKeys.get(3));
+      assertTrue(ret);
+      assertEquals(4, sortKeys.size());
+      assertArrayEquals("basic_test_sort_key_1".getBytes(), sortKeys.get(0));
+      assertArrayEquals("basic_test_sort_key_2".getBytes(), sortKeys.get(1));
+      assertArrayEquals("basic_test_sort_key_3".getBytes(), sortKeys.get(2));
+      assertArrayEquals("basic_test_sort_key_4".getBytes(), sortKeys.get(3));
 
       // multi del
       sortKeys.clear();
@@ -296,17 +302,17 @@ public class TestBasic {
 
       // check sortkey count
       sortKeyCount = client.sortKeyCount(tableName, hashKey);
-      Assert.assertEquals(2, sortKeyCount);
+      assertEquals(2, sortKeyCount);
 
       // check deleted
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("basic_test_sort_key_3".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("basic_test_value_3".getBytes(), newValues.get(0).getValue());
-      Assert.assertArrayEquals("basic_test_sort_key_4".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("basic_test_value_4".getBytes(), newValues.get(1).getValue());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("basic_test_sort_key_3".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("basic_test_value_3".getBytes(), newValues.get(0).getValue());
+      assertArrayEquals("basic_test_sort_key_4".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("basic_test_value_4".getBytes(), newValues.get(1).getValue());
 
       // multi del all
       sortKeys.clear();
@@ -317,19 +323,19 @@ public class TestBasic {
 
       // check sortkey count
       sortKeyCount = client.sortKeyCount(tableName, hashKey);
-      Assert.assertEquals(0, sortKeyCount);
+      assertEquals(0, sortKeyCount);
 
       // check deleted by multiGet
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // check deleted by multiGetSortKeys
       sortKeys.clear();
       ret = client.multiGetSortKeys(tableName, hashKey, sortKeys);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, sortKeys.size());
+      assertTrue(ret);
+      assertEquals(0, sortKeys.size());
 
       // multi set many kvs
       values.clear();
@@ -343,30 +349,30 @@ public class TestBasic {
       // multi get with no limit
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, 0, 0, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(200, newValues.size());
+      assertTrue(ret);
+      assertEquals(200, newValues.size());
       for (int i = 1; i <= 200; i++) {
         String sortKey = "basic_test_sort_key_" + String.format("%03d", i);
         String value = "basic_test_value_" + String.valueOf(i);
-        Assert.assertArrayEquals(sortKey.getBytes(), newValues.get(i - 1).getKey());
-        Assert.assertArrayEquals(value.getBytes(), newValues.get(i - 1).getValue());
+        assertArrayEquals(sortKey.getBytes(), newValues.get(i - 1).getKey());
+        assertArrayEquals(value.getBytes(), newValues.get(i - 1).getValue());
       }
 
       // multi del all
       sortKeys.clear();
       for (int i = 1; i <= 200; i++) {
         String sortKey = "basic_test_sort_key_" + String.format("%03d", i);
-        Assert.assertArrayEquals(sortKey.getBytes(), newValues.get(i - 1).getKey());
+        assertArrayEquals(sortKey.getBytes(), newValues.get(i - 1).getKey());
         sortKeys.add(sortKey.getBytes());
       }
       client.multiDel(tableName, hashKey, sortKeys);
 
       // check sortkey count
       sortKeyCount = client.sortKeyCount(tableName, hashKey);
-      Assert.assertEquals(0, sortKeyCount);
+      assertEquals(0, sortKeyCount);
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -398,29 +404,29 @@ public class TestBasic {
 
       // check sortkey count
       long sortKeyCount = client.sortKeyCount(tableName, hashKey);
-      Assert.assertEquals(13, sortKeyCount);
+      assertEquals(13, sortKeyCount);
 
       // [null, null)
       MultiGetOptions options = new MultiGetOptions();
-      Assert.assertTrue(options.startInclusive);
-      Assert.assertFalse(options.stopInclusive);
+      assertTrue(options.startInclusive);
+      assertFalse(options.stopInclusive);
       List<Pair<byte[], byte[]>> newValues = new ArrayList<Pair<byte[], byte[]>>();
       boolean ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(13, newValues.size());
-      Assert.assertArrayEquals("".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("2".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(4).getKey());
-      Assert.assertArrayEquals("3".getBytes(), newValues.get(5).getKey());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(6).getKey());
-      Assert.assertArrayEquals("4".getBytes(), newValues.get(7).getKey());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(8).getKey());
-      Assert.assertArrayEquals("5".getBytes(), newValues.get(9).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(10).getKey());
-      Assert.assertArrayEquals("6".getBytes(), newValues.get(11).getKey());
-      Assert.assertArrayEquals("7".getBytes(), newValues.get(12).getKey());
+      assertTrue(ret);
+      assertEquals(13, newValues.size());
+      assertArrayEquals("".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("2".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(4).getKey());
+      assertArrayEquals("3".getBytes(), newValues.get(5).getKey());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(6).getKey());
+      assertArrayEquals("4".getBytes(), newValues.get(7).getKey());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(8).getKey());
+      assertArrayEquals("5".getBytes(), newValues.get(9).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(10).getKey());
+      assertArrayEquals("6".getBytes(), newValues.get(11).getKey());
+      assertArrayEquals("7".getBytes(), newValues.get(12).getKey());
 
       // [null, null]
       options = new MultiGetOptions();
@@ -428,21 +434,21 @@ public class TestBasic {
       options.stopInclusive = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(13, newValues.size());
-      Assert.assertArrayEquals("".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("2".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(4).getKey());
-      Assert.assertArrayEquals("3".getBytes(), newValues.get(5).getKey());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(6).getKey());
-      Assert.assertArrayEquals("4".getBytes(), newValues.get(7).getKey());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(8).getKey());
-      Assert.assertArrayEquals("5".getBytes(), newValues.get(9).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(10).getKey());
-      Assert.assertArrayEquals("6".getBytes(), newValues.get(11).getKey());
-      Assert.assertArrayEquals("7".getBytes(), newValues.get(12).getKey());
+      assertTrue(ret);
+      assertEquals(13, newValues.size());
+      assertArrayEquals("".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("2".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(4).getKey());
+      assertArrayEquals("3".getBytes(), newValues.get(5).getKey());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(6).getKey());
+      assertArrayEquals("4".getBytes(), newValues.get(7).getKey());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(8).getKey());
+      assertArrayEquals("5".getBytes(), newValues.get(9).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(10).getKey());
+      assertArrayEquals("6".getBytes(), newValues.get(11).getKey());
+      assertArrayEquals("7".getBytes(), newValues.get(12).getKey());
 
       // (null, null)
       options = new MultiGetOptions();
@@ -450,20 +456,20 @@ public class TestBasic {
       options.stopInclusive = false;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(12, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("2".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("3".getBytes(), newValues.get(4).getKey());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(5).getKey());
-      Assert.assertArrayEquals("4".getBytes(), newValues.get(6).getKey());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(7).getKey());
-      Assert.assertArrayEquals("5".getBytes(), newValues.get(8).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(9).getKey());
-      Assert.assertArrayEquals("6".getBytes(), newValues.get(10).getKey());
-      Assert.assertArrayEquals("7".getBytes(), newValues.get(11).getKey());
+      assertTrue(ret);
+      assertEquals(12, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("2".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("3".getBytes(), newValues.get(4).getKey());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(5).getKey());
+      assertArrayEquals("4".getBytes(), newValues.get(6).getKey());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(7).getKey());
+      assertArrayEquals("5".getBytes(), newValues.get(8).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(9).getKey());
+      assertArrayEquals("6".getBytes(), newValues.get(10).getKey());
+      assertArrayEquals("7".getBytes(), newValues.get(11).getKey());
 
       // (null, null]
       options = new MultiGetOptions();
@@ -471,20 +477,20 @@ public class TestBasic {
       options.stopInclusive = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(12, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("2".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("3".getBytes(), newValues.get(4).getKey());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(5).getKey());
-      Assert.assertArrayEquals("4".getBytes(), newValues.get(6).getKey());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(7).getKey());
-      Assert.assertArrayEquals("5".getBytes(), newValues.get(8).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(9).getKey());
-      Assert.assertArrayEquals("6".getBytes(), newValues.get(10).getKey());
-      Assert.assertArrayEquals("7".getBytes(), newValues.get(11).getKey());
+      assertTrue(ret);
+      assertEquals(12, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("2".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("3".getBytes(), newValues.get(4).getKey());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(5).getKey());
+      assertArrayEquals("4".getBytes(), newValues.get(6).getKey());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(7).getKey());
+      assertArrayEquals("5".getBytes(), newValues.get(8).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(9).getKey());
+      assertArrayEquals("6".getBytes(), newValues.get(10).getKey());
+      assertArrayEquals("7".getBytes(), newValues.get(11).getKey());
 
       // [null, 1]
       options = new MultiGetOptions();
@@ -492,10 +498,10 @@ public class TestBasic {
       options.stopInclusive = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
 
       // [null, 1)
       options = new MultiGetOptions();
@@ -503,9 +509,9 @@ public class TestBasic {
       options.stopInclusive = false;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("".getBytes(), newValues.get(0).getKey());
 
       // (null, 1]
       options = new MultiGetOptions();
@@ -513,9 +519,9 @@ public class TestBasic {
       options.stopInclusive = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
 
       // (null, 1)
       options = new MultiGetOptions();
@@ -523,8 +529,8 @@ public class TestBasic {
       options.stopInclusive = false;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // [1, 1]
       options = new MultiGetOptions();
@@ -532,9 +538,9 @@ public class TestBasic {
       options.stopInclusive = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
 
       // [1, 1)
       options = new MultiGetOptions();
@@ -542,8 +548,8 @@ public class TestBasic {
       options.stopInclusive = false;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // (1, 1]
       options = new MultiGetOptions();
@@ -551,8 +557,8 @@ public class TestBasic {
       options.stopInclusive = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // (1, 1)
       options = new MultiGetOptions();
@@ -560,8 +566,8 @@ public class TestBasic {
       options.stopInclusive = false;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // [2, 1]
       options = new MultiGetOptions();
@@ -569,8 +575,8 @@ public class TestBasic {
       options.stopInclusive = false;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "2".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-anywhere("-")
       options = new MultiGetOptions();
@@ -578,13 +584,13 @@ public class TestBasic {
       options.sortKeyFilterPattern = "-".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(5, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(4).getKey());
+      assertTrue(ret);
+      assertEquals(5, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(4).getKey());
 
       // match-anywhere("1")
       options = new MultiGetOptions();
@@ -592,10 +598,10 @@ public class TestBasic {
       options.sortKeyFilterPattern = "1".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
 
       // match-anywhere("1-")
       options = new MultiGetOptions();
@@ -603,9 +609,9 @@ public class TestBasic {
       options.sortKeyFilterPattern = "1-".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
 
       // match-anywhere("abc")
       options = new MultiGetOptions();
@@ -613,10 +619,10 @@ public class TestBasic {
       options.sortKeyFilterPattern = "abc".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
 
       // match-prefix("1")
       options = new MultiGetOptions();
@@ -624,10 +630,10 @@ public class TestBasic {
       options.sortKeyFilterPattern = "1".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
 
       // match-prefix("1") in [0, 1)
       options = new MultiGetOptions();
@@ -637,8 +643,8 @@ public class TestBasic {
       options.stopInclusive = false;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "0".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("1") in [0, 1]
       options = new MultiGetOptions();
@@ -648,9 +654,9 @@ public class TestBasic {
       options.stopInclusive = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "0".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
 
       // match-prefix("1") in [1, 2]
       options = new MultiGetOptions();
@@ -660,10 +666,10 @@ public class TestBasic {
       options.stopInclusive = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "2".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
 
       // match-prefix("1") in (1, 2]
       options = new MultiGetOptions();
@@ -673,9 +679,9 @@ public class TestBasic {
       options.stopInclusive = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "2".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
 
       // match-prefix("1") in (1-abcdefg, 2]
       options = new MultiGetOptions();
@@ -687,8 +693,8 @@ public class TestBasic {
       ret =
           client.multiGet(
               tableName, hashKey, "1-abcdefg".getBytes(), "2".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("1-")
       options = new MultiGetOptions();
@@ -696,9 +702,9 @@ public class TestBasic {
       options.sortKeyFilterPattern = "1-".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
 
       // match-prefix("1-x")
       options = new MultiGetOptions();
@@ -706,8 +712,8 @@ public class TestBasic {
       options.sortKeyFilterPattern = "1-x".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("abc")
       options = new MultiGetOptions();
@@ -715,8 +721,8 @@ public class TestBasic {
       options.sortKeyFilterPattern = "abc".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("efg")
       options = new MultiGetOptions();
@@ -724,8 +730,8 @@ public class TestBasic {
       options.sortKeyFilterPattern = "efg".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("ijk")
       options = new MultiGetOptions();
@@ -733,8 +739,8 @@ public class TestBasic {
       options.sortKeyFilterPattern = "ijk".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("lnm")
       options = new MultiGetOptions();
@@ -742,8 +748,8 @@ public class TestBasic {
       options.sortKeyFilterPattern = "lmn".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-postfix("5-hijklmn")
       options = new MultiGetOptions();
@@ -751,9 +757,9 @@ public class TestBasic {
       options.sortKeyFilterPattern = "5-hijklmn".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(0).getKey());
 
       // match-postfix("1")
       options = new MultiGetOptions();
@@ -761,9 +767,9 @@ public class TestBasic {
       options.sortKeyFilterPattern = "1".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
 
       // match-postfix("1-")
       options = new MultiGetOptions();
@@ -771,8 +777,8 @@ public class TestBasic {
       options.sortKeyFilterPattern = "1-".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-postfix("1-x")
       options = new MultiGetOptions();
@@ -780,8 +786,8 @@ public class TestBasic {
       options.sortKeyFilterPattern = "1-x".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-postfix("abc")
       options = new MultiGetOptions();
@@ -789,8 +795,8 @@ public class TestBasic {
       options.sortKeyFilterPattern = "abc".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-postfix("efg")
       options = new MultiGetOptions();
@@ -798,10 +804,10 @@ public class TestBasic {
       options.sortKeyFilterPattern = "efg".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
 
       // match-postfix("ijk")
       options = new MultiGetOptions();
@@ -809,9 +815,9 @@ public class TestBasic {
       options.sortKeyFilterPattern = "ijk".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(0).getKey());
 
       // match-postfix("lmn")
       options = new MultiGetOptions();
@@ -819,10 +825,10 @@ public class TestBasic {
       options.sortKeyFilterPattern = "lmn".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(1).getKey());
 
       // match-postfix("5-hijklmn")
       options = new MultiGetOptions();
@@ -830,20 +836,20 @@ public class TestBasic {
       options.sortKeyFilterPattern = "5-hijklmn".getBytes();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(0).getKey());
 
       // maxCount = 4
       options = new MultiGetOptions();
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, 4, -1, newValues);
-      Assert.assertFalse(ret);
-      Assert.assertEquals(4, newValues.size());
-      Assert.assertArrayEquals("".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("2".getBytes(), newValues.get(3).getKey());
+      assertFalse(ret);
+      assertEquals(4, newValues.size());
+      assertArrayEquals("".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("2".getBytes(), newValues.get(3).getKey());
 
       // maxCount = 1
       options = new MultiGetOptions();
@@ -851,9 +857,9 @@ public class TestBasic {
       ret =
           client.multiGet(
               tableName, hashKey, "5".getBytes(), "6".getBytes(), options, 1, -1, newValues);
-      Assert.assertFalse(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("5".getBytes(), newValues.get(0).getKey());
+      assertFalse(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("5".getBytes(), newValues.get(0).getKey());
 
       // multi del all
       List<byte[]> sortKeys = new ArrayList<byte[]>();
@@ -874,10 +880,10 @@ public class TestBasic {
 
       // check sortkey count
       sortKeyCount = client.sortKeyCount(tableName, hashKey);
-      Assert.assertEquals(0, sortKeyCount);
+      assertEquals(0, sortKeyCount);
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -909,30 +915,30 @@ public class TestBasic {
 
       // check sortkey count
       long sortKeyCount = client.sortKeyCount(tableName, hashKey);
-      Assert.assertEquals(13, sortKeyCount);
+      assertEquals(13, sortKeyCount);
 
       // [null, null)
       MultiGetOptions options = new MultiGetOptions();
-      Assert.assertTrue(options.startInclusive);
-      Assert.assertFalse(options.stopInclusive);
+      assertTrue(options.startInclusive);
+      assertFalse(options.stopInclusive);
       options.reverse = true;
       List<Pair<byte[], byte[]>> newValues = new ArrayList<Pair<byte[], byte[]>>();
       boolean ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(13, newValues.size());
-      Assert.assertArrayEquals("".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("2".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(4).getKey());
-      Assert.assertArrayEquals("3".getBytes(), newValues.get(5).getKey());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(6).getKey());
-      Assert.assertArrayEquals("4".getBytes(), newValues.get(7).getKey());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(8).getKey());
-      Assert.assertArrayEquals("5".getBytes(), newValues.get(9).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(10).getKey());
-      Assert.assertArrayEquals("6".getBytes(), newValues.get(11).getKey());
-      Assert.assertArrayEquals("7".getBytes(), newValues.get(12).getKey());
+      assertTrue(ret);
+      assertEquals(13, newValues.size());
+      assertArrayEquals("".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("2".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(4).getKey());
+      assertArrayEquals("3".getBytes(), newValues.get(5).getKey());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(6).getKey());
+      assertArrayEquals("4".getBytes(), newValues.get(7).getKey());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(8).getKey());
+      assertArrayEquals("5".getBytes(), newValues.get(9).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(10).getKey());
+      assertArrayEquals("6".getBytes(), newValues.get(11).getKey());
+      assertArrayEquals("7".getBytes(), newValues.get(12).getKey());
 
       // [null, null]
       options = new MultiGetOptions();
@@ -941,21 +947,21 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(13, newValues.size());
-      Assert.assertArrayEquals("".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("2".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(4).getKey());
-      Assert.assertArrayEquals("3".getBytes(), newValues.get(5).getKey());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(6).getKey());
-      Assert.assertArrayEquals("4".getBytes(), newValues.get(7).getKey());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(8).getKey());
-      Assert.assertArrayEquals("5".getBytes(), newValues.get(9).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(10).getKey());
-      Assert.assertArrayEquals("6".getBytes(), newValues.get(11).getKey());
-      Assert.assertArrayEquals("7".getBytes(), newValues.get(12).getKey());
+      assertTrue(ret);
+      assertEquals(13, newValues.size());
+      assertArrayEquals("".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("2".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(4).getKey());
+      assertArrayEquals("3".getBytes(), newValues.get(5).getKey());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(6).getKey());
+      assertArrayEquals("4".getBytes(), newValues.get(7).getKey());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(8).getKey());
+      assertArrayEquals("5".getBytes(), newValues.get(9).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(10).getKey());
+      assertArrayEquals("6".getBytes(), newValues.get(11).getKey());
+      assertArrayEquals("7".getBytes(), newValues.get(12).getKey());
 
       // (null, null)
       options = new MultiGetOptions();
@@ -964,20 +970,20 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(12, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("2".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("3".getBytes(), newValues.get(4).getKey());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(5).getKey());
-      Assert.assertArrayEquals("4".getBytes(), newValues.get(6).getKey());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(7).getKey());
-      Assert.assertArrayEquals("5".getBytes(), newValues.get(8).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(9).getKey());
-      Assert.assertArrayEquals("6".getBytes(), newValues.get(10).getKey());
-      Assert.assertArrayEquals("7".getBytes(), newValues.get(11).getKey());
+      assertTrue(ret);
+      assertEquals(12, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("2".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("3".getBytes(), newValues.get(4).getKey());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(5).getKey());
+      assertArrayEquals("4".getBytes(), newValues.get(6).getKey());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(7).getKey());
+      assertArrayEquals("5".getBytes(), newValues.get(8).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(9).getKey());
+      assertArrayEquals("6".getBytes(), newValues.get(10).getKey());
+      assertArrayEquals("7".getBytes(), newValues.get(11).getKey());
 
       // (null, null]
       options = new MultiGetOptions();
@@ -986,20 +992,20 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(12, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("2".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("3".getBytes(), newValues.get(4).getKey());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(5).getKey());
-      Assert.assertArrayEquals("4".getBytes(), newValues.get(6).getKey());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(7).getKey());
-      Assert.assertArrayEquals("5".getBytes(), newValues.get(8).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(9).getKey());
-      Assert.assertArrayEquals("6".getBytes(), newValues.get(10).getKey());
-      Assert.assertArrayEquals("7".getBytes(), newValues.get(11).getKey());
+      assertTrue(ret);
+      assertEquals(12, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("2".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("3".getBytes(), newValues.get(4).getKey());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(5).getKey());
+      assertArrayEquals("4".getBytes(), newValues.get(6).getKey());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(7).getKey());
+      assertArrayEquals("5".getBytes(), newValues.get(8).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(9).getKey());
+      assertArrayEquals("6".getBytes(), newValues.get(10).getKey());
+      assertArrayEquals("7".getBytes(), newValues.get(11).getKey());
 
       // [null, 1]
       options = new MultiGetOptions();
@@ -1008,10 +1014,10 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1".getBytes(), newValues.get(1).getKey());
 
       // [null, 1)
       options = new MultiGetOptions();
@@ -1020,9 +1026,9 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("".getBytes(), newValues.get(0).getKey());
 
       // (null, 1]
       options = new MultiGetOptions();
@@ -1031,9 +1037,9 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
 
       // (null, 1)
       options = new MultiGetOptions();
@@ -1042,8 +1048,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // [1, 1]
       options = new MultiGetOptions();
@@ -1052,9 +1058,9 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
 
       // [1, 1)
       options = new MultiGetOptions();
@@ -1063,8 +1069,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // (1, 1]
       options = new MultiGetOptions();
@@ -1073,8 +1079,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // (1, 1)
       options = new MultiGetOptions();
@@ -1083,8 +1089,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // [2, 1]
       options = new MultiGetOptions();
@@ -1093,8 +1099,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "2".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-anywhere("-")
       options = new MultiGetOptions();
@@ -1103,13 +1109,13 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(5, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(3).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(4).getKey());
+      assertTrue(ret);
+      assertEquals(5, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(3).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(4).getKey());
 
       // match-anywhere("1")
       options = new MultiGetOptions();
@@ -1118,10 +1124,10 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
 
       // match-anywhere("1-")
       options = new MultiGetOptions();
@@ -1130,9 +1136,9 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
 
       // match-anywhere("abc")
       options = new MultiGetOptions();
@@ -1141,10 +1147,10 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
 
       // match-prefix("1")
       options = new MultiGetOptions();
@@ -1153,10 +1159,10 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
 
       // match-prefix("1") in [0, 1)
       options = new MultiGetOptions();
@@ -1167,8 +1173,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "0".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("1") in [0, 1]
       options = new MultiGetOptions();
@@ -1179,9 +1185,9 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "0".getBytes(), "1".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
 
       // match-prefix("1") in [1, 2]
       options = new MultiGetOptions();
@@ -1192,10 +1198,10 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "2".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(1).getKey());
 
       // match-prefix("1") in (1, 2]
       options = new MultiGetOptions();
@@ -1206,9 +1212,9 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, "1".getBytes(), "2".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
 
       // match-prefix("1") in (1-abcdefg, 2]
       options = new MultiGetOptions();
@@ -1221,8 +1227,8 @@ public class TestBasic {
       ret =
           client.multiGet(
               tableName, hashKey, "1-abcdefg".getBytes(), "2".getBytes(), options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("1-")
       options = new MultiGetOptions();
@@ -1231,9 +1237,9 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
 
       // match-prefix("1-x")
       options = new MultiGetOptions();
@@ -1242,8 +1248,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("abc")
       options = new MultiGetOptions();
@@ -1252,8 +1258,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("efg")
       options = new MultiGetOptions();
@@ -1262,8 +1268,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("ijk")
       options = new MultiGetOptions();
@@ -1272,8 +1278,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-prefix("lnm")
       options = new MultiGetOptions();
@@ -1282,8 +1288,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-postfix("5-hijklmn")
       options = new MultiGetOptions();
@@ -1292,9 +1298,9 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(0).getKey());
 
       // match-postfix("1")
       options = new MultiGetOptions();
@@ -1303,9 +1309,9 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("1".getBytes(), newValues.get(0).getKey());
 
       // match-postfix("1-")
       options = new MultiGetOptions();
@@ -1314,8 +1320,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-postfix("1-x")
       options = new MultiGetOptions();
@@ -1324,8 +1330,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-postfix("abc")
       options = new MultiGetOptions();
@@ -1334,8 +1340,8 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(0, newValues.size());
+      assertTrue(ret);
+      assertEquals(0, newValues.size());
 
       // match-postfix("efg")
       options = new MultiGetOptions();
@@ -1344,10 +1350,10 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("1-abcdefg".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("2-abcdefg".getBytes(), newValues.get(1).getKey());
 
       // match-postfix("ijk")
       options = new MultiGetOptions();
@@ -1356,9 +1362,9 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("3-efghijk".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("3-efghijk".getBytes(), newValues.get(0).getKey());
 
       // match-postfix("lmn")
       options = new MultiGetOptions();
@@ -1367,10 +1373,10 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(2, newValues.size());
-      Assert.assertArrayEquals("4-hijklmn".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(1).getKey());
+      assertTrue(ret);
+      assertEquals(2, newValues.size());
+      assertArrayEquals("4-hijklmn".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(1).getKey());
 
       // match-postfix("5-hijklmn")
       options = new MultiGetOptions();
@@ -1379,21 +1385,21 @@ public class TestBasic {
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, newValues);
-      Assert.assertTrue(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(0).getKey());
+      assertTrue(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(0).getKey());
 
       // maxCount = 4
       options = new MultiGetOptions();
       options.reverse = true;
       newValues.clear();
       ret = client.multiGet(tableName, hashKey, null, null, options, 4, -1, newValues);
-      Assert.assertFalse(ret);
-      Assert.assertEquals(4, newValues.size());
-      Assert.assertArrayEquals("5".getBytes(), newValues.get(0).getKey());
-      Assert.assertArrayEquals("5-hijklmn".getBytes(), newValues.get(1).getKey());
-      Assert.assertArrayEquals("6".getBytes(), newValues.get(2).getKey());
-      Assert.assertArrayEquals("7".getBytes(), newValues.get(3).getKey());
+      assertFalse(ret);
+      assertEquals(4, newValues.size());
+      assertArrayEquals("5".getBytes(), newValues.get(0).getKey());
+      assertArrayEquals("5-hijklmn".getBytes(), newValues.get(1).getKey());
+      assertArrayEquals("6".getBytes(), newValues.get(2).getKey());
+      assertArrayEquals("7".getBytes(), newValues.get(3).getKey());
 
       // maxCount = 1
       options = new MultiGetOptions();
@@ -1404,9 +1410,9 @@ public class TestBasic {
       ret =
           client.multiGet(
               tableName, hashKey, "5".getBytes(), "6".getBytes(), options, 1, -1, newValues);
-      Assert.assertFalse(ret);
-      Assert.assertEquals(1, newValues.size());
-      Assert.assertArrayEquals("6".getBytes(), newValues.get(0).getKey());
+      assertFalse(ret);
+      assertEquals(1, newValues.size());
+      assertArrayEquals("6".getBytes(), newValues.get(0).getKey());
 
       // multi del all
       List<byte[]> sortKeys = new ArrayList<byte[]>();
@@ -1427,10 +1433,10 @@ public class TestBasic {
 
       // check sortkey count
       sortKeyCount = client.sortKeyCount(tableName, hashKey);
-      Assert.assertEquals(0, sortKeyCount);
+      assertEquals(0, sortKeyCount);
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1467,19 +1473,19 @@ public class TestBasic {
               tableName,
               "TestBasic_testBatchSetGetDel_hash_key_1".getBytes(),
               "basic_test_sort_key".getBytes());
-      Assert.assertTrue(exist);
+      assertTrue(exist);
       exist =
           client.exist(
               tableName,
               "TestBasic_testBatchSetGetDel_hash_key_2".getBytes(),
               "basic_test_sort_key".getBytes());
-      Assert.assertTrue(exist);
+      assertTrue(exist);
       exist =
           client.exist(
               tableName,
               "TestBasic_testBatchSetGetDel_hash_key_3".getBytes(),
               "basic_test_sort_key".getBytes());
-      Assert.assertTrue(exist);
+      assertTrue(exist);
 
       // batch get
       List<Pair<byte[], byte[]>> keys = new ArrayList<Pair<byte[], byte[]>>();
@@ -1497,23 +1503,23 @@ public class TestBasic {
               "basic_test_sort_key".getBytes()));
       List<byte[]> values = new ArrayList<byte[]>();
       client.batchGet(tableName, keys, values);
-      Assert.assertEquals(3, values.size());
-      Assert.assertArrayEquals("basic_test_value_1".getBytes(), values.get(0));
-      Assert.assertArrayEquals("basic_test_value_2".getBytes(), values.get(1));
-      Assert.assertArrayEquals("basic_test_value_3".getBytes(), values.get(2));
+      assertEquals(3, values.size());
+      assertArrayEquals("basic_test_value_1".getBytes(), values.get(0));
+      assertArrayEquals("basic_test_value_2".getBytes(), values.get(1));
+      assertArrayEquals("basic_test_value_3".getBytes(), values.get(2));
 
       // batch del
       client.batchDel(tableName, keys);
 
       // check deleted
       client.batchGet(tableName, keys, values);
-      Assert.assertEquals(3, values.size());
-      Assert.assertNull(values.get(0));
-      Assert.assertNull(values.get(1));
-      Assert.assertNull(values.get(2));
+      assertEquals(3, values.size());
+      assertNull(values.get(0));
+      assertNull(values.get(1));
+      assertNull(values.get(2));
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1544,11 +1550,11 @@ public class TestBasic {
               "basic_test_value_3".getBytes()));
       List<PException> resultsBatchSet = new ArrayList<PException>();
       int count = client.batchSet2(tableName, items, resultsBatchSet);
-      Assert.assertEquals(3, count);
-      Assert.assertEquals(3, resultsBatchSet.size());
-      Assert.assertNull(resultsBatchSet.get(0));
-      Assert.assertNull(resultsBatchSet.get(1));
-      Assert.assertNull(resultsBatchSet.get(2));
+      assertEquals(3, count);
+      assertEquals(3, resultsBatchSet.size());
+      assertNull(resultsBatchSet.get(0));
+      assertNull(resultsBatchSet.get(1));
+      assertNull(resultsBatchSet.get(2));
 
       // check exist
       boolean exist =
@@ -1556,19 +1562,19 @@ public class TestBasic {
               tableName,
               "TestBasic_testBatchSetGetDel2_hash_key_1".getBytes(),
               "basic_test_sort_key".getBytes());
-      Assert.assertTrue(exist);
+      assertTrue(exist);
       exist =
           client.exist(
               tableName,
               "TestBasic_testBatchSetGetDel2_hash_key_2".getBytes(),
               "basic_test_sort_key".getBytes());
-      Assert.assertTrue(exist);
+      assertTrue(exist);
       exist =
           client.exist(
               tableName,
               "TestBasic_testBatchSetGetDel2_hash_key_3".getBytes(),
               "basic_test_sort_key".getBytes());
-      Assert.assertTrue(exist);
+      assertTrue(exist);
 
       // batch get
       List<Pair<byte[], byte[]>> keys = new ArrayList<Pair<byte[], byte[]>>();
@@ -1586,34 +1592,34 @@ public class TestBasic {
               "basic_test_sort_key".getBytes()));
       List<Pair<PException, byte[]>> resultsBatchGet = new ArrayList<Pair<PException, byte[]>>();
       count = client.batchGet2(tableName, keys, resultsBatchGet);
-      Assert.assertEquals(3, count);
-      Assert.assertEquals(3, resultsBatchGet.size());
-      Assert.assertNull(resultsBatchGet.get(0).getLeft());
-      Assert.assertArrayEquals("basic_test_value_1".getBytes(), resultsBatchGet.get(0).getRight());
-      Assert.assertNull(resultsBatchGet.get(1).getLeft());
-      Assert.assertArrayEquals("basic_test_value_2".getBytes(), resultsBatchGet.get(1).getRight());
-      Assert.assertNull(resultsBatchGet.get(2).getLeft());
-      Assert.assertArrayEquals("basic_test_value_3".getBytes(), resultsBatchGet.get(2).getRight());
+      assertEquals(3, count);
+      assertEquals(3, resultsBatchGet.size());
+      assertNull(resultsBatchGet.get(0).getLeft());
+      assertArrayEquals("basic_test_value_1".getBytes(), resultsBatchGet.get(0).getRight());
+      assertNull(resultsBatchGet.get(1).getLeft());
+      assertArrayEquals("basic_test_value_2".getBytes(), resultsBatchGet.get(1).getRight());
+      assertNull(resultsBatchGet.get(2).getLeft());
+      assertArrayEquals("basic_test_value_3".getBytes(), resultsBatchGet.get(2).getRight());
 
       // batch del
       List<PException> resultsBatchDel = new ArrayList<PException>();
       count = client.batchDel2(tableName, keys, resultsBatchDel);
-      Assert.assertEquals(3, count);
-      Assert.assertEquals(3, resultsBatchSet.size());
-      Assert.assertNull(resultsBatchSet.get(0));
-      Assert.assertNull(resultsBatchSet.get(1));
-      Assert.assertNull(resultsBatchSet.get(2));
+      assertEquals(3, count);
+      assertEquals(3, resultsBatchSet.size());
+      assertNull(resultsBatchSet.get(0));
+      assertNull(resultsBatchSet.get(1));
+      assertNull(resultsBatchSet.get(2));
 
       // check deleted
       List<byte[]> values = new ArrayList<byte[]>();
       client.batchGet(tableName, keys, values);
-      Assert.assertEquals(3, values.size());
-      Assert.assertNull(values.get(0));
-      Assert.assertNull(values.get(1));
-      Assert.assertNull(values.get(2));
+      assertEquals(3, values.size());
+      assertNull(values.get(0));
+      assertNull(values.get(1));
+      assertNull(values.get(2));
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1659,47 +1665,35 @@ public class TestBasic {
       keys.add(Pair.of("TestBasic_testBatchMultiSetGetDel_hash_key_4".getBytes(), nullSortKeys));
       List<HashKeyData> values = new ArrayList<HashKeyData>();
       client.batchMultiGet(tableName, keys, values);
-      Assert.assertEquals(4, values.size());
+      assertEquals(4, values.size());
 
-      Assert.assertTrue(values.get(0).isAllFetched());
-      Assert.assertArrayEquals(keys.get(0).getLeft(), values.get(0).hashKey);
-      Assert.assertEquals(3, values.get(0).values.size());
-      Assert.assertArrayEquals(
-          "basic_test_sort_key_1".getBytes(), values.get(0).values.get(0).getLeft());
-      Assert.assertArrayEquals(
-          "basic_test_value_1".getBytes(), values.get(0).values.get(0).getRight());
-      Assert.assertArrayEquals(
-          "basic_test_sort_key_2".getBytes(), values.get(0).values.get(1).getLeft());
-      Assert.assertArrayEquals(
-          "basic_test_value_2".getBytes(), values.get(0).values.get(1).getRight());
-      Assert.assertArrayEquals(
-          "basic_test_sort_key_3".getBytes(), values.get(0).values.get(2).getLeft());
-      Assert.assertArrayEquals(
-          "basic_test_value_3".getBytes(), values.get(0).values.get(2).getRight());
+      assertTrue(values.get(0).isAllFetched());
+      assertArrayEquals(keys.get(0).getLeft(), values.get(0).hashKey);
+      assertEquals(3, values.get(0).values.size());
+      assertArrayEquals("basic_test_sort_key_1".getBytes(), values.get(0).values.get(0).getLeft());
+      assertArrayEquals("basic_test_value_1".getBytes(), values.get(0).values.get(0).getRight());
+      assertArrayEquals("basic_test_sort_key_2".getBytes(), values.get(0).values.get(1).getLeft());
+      assertArrayEquals("basic_test_value_2".getBytes(), values.get(0).values.get(1).getRight());
+      assertArrayEquals("basic_test_sort_key_3".getBytes(), values.get(0).values.get(2).getLeft());
+      assertArrayEquals("basic_test_value_3".getBytes(), values.get(0).values.get(2).getRight());
 
-      Assert.assertTrue(values.get(1).isAllFetched());
-      Assert.assertArrayEquals(keys.get(1).getLeft(), values.get(1).hashKey);
-      Assert.assertEquals(2, values.get(1).values.size());
-      Assert.assertArrayEquals(
-          "basic_test_sort_key_1".getBytes(), values.get(1).values.get(0).getLeft());
-      Assert.assertArrayEquals(
-          "basic_test_value_1".getBytes(), values.get(1).values.get(0).getRight());
-      Assert.assertArrayEquals(
-          "basic_test_sort_key_2".getBytes(), values.get(1).values.get(1).getLeft());
-      Assert.assertArrayEquals(
-          "basic_test_value_2".getBytes(), values.get(1).values.get(1).getRight());
+      assertTrue(values.get(1).isAllFetched());
+      assertArrayEquals(keys.get(1).getLeft(), values.get(1).hashKey);
+      assertEquals(2, values.get(1).values.size());
+      assertArrayEquals("basic_test_sort_key_1".getBytes(), values.get(1).values.get(0).getLeft());
+      assertArrayEquals("basic_test_value_1".getBytes(), values.get(1).values.get(0).getRight());
+      assertArrayEquals("basic_test_sort_key_2".getBytes(), values.get(1).values.get(1).getLeft());
+      assertArrayEquals("basic_test_value_2".getBytes(), values.get(1).values.get(1).getRight());
 
-      Assert.assertTrue(values.get(2).isAllFetched());
-      Assert.assertArrayEquals(keys.get(2).getLeft(), values.get(2).hashKey);
-      Assert.assertEquals(1, values.get(2).values.size());
-      Assert.assertArrayEquals(
-          "basic_test_sort_key_1".getBytes(), values.get(2).values.get(0).getLeft());
-      Assert.assertArrayEquals(
-          "basic_test_value_1".getBytes(), values.get(2).values.get(0).getRight());
+      assertTrue(values.get(2).isAllFetched());
+      assertArrayEquals(keys.get(2).getLeft(), values.get(2).hashKey);
+      assertEquals(1, values.get(2).values.size());
+      assertArrayEquals("basic_test_sort_key_1".getBytes(), values.get(2).values.get(0).getLeft());
+      assertArrayEquals("basic_test_value_1".getBytes(), values.get(2).values.get(0).getRight());
 
-      Assert.assertTrue(values.get(3).isAllFetched());
-      Assert.assertArrayEquals(keys.get(3).getLeft(), values.get(3).hashKey);
-      Assert.assertEquals(0, values.get(3).values.size());
+      assertTrue(values.get(3).isAllFetched());
+      assertArrayEquals(keys.get(3).getLeft(), values.get(3).hashKey);
+      assertEquals(0, values.get(3).values.size());
 
       // batch multi del
       List<Pair<byte[], List<byte[]>>> delKeys = new ArrayList<Pair<byte[], List<byte[]>>>();
@@ -1715,14 +1709,14 @@ public class TestBasic {
 
       // check deleted
       client.batchMultiGet(tableName, keys, values);
-      Assert.assertEquals(4, values.size());
-      Assert.assertEquals(0, values.get(0).values.size());
-      Assert.assertEquals(0, values.get(1).values.size());
-      Assert.assertEquals(0, values.get(2).values.size());
-      Assert.assertEquals(0, values.get(3).values.size());
+      assertEquals(4, values.size());
+      assertEquals(0, values.get(0).values.size());
+      assertEquals(0, values.get(1).values.size());
+      assertEquals(0, values.get(2).values.size());
+      assertEquals(0, values.get(3).values.size());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1759,11 +1753,11 @@ public class TestBasic {
           .addData("basic_test_sort_key_1".getBytes(), "basic_test_value_1".getBytes());
       List<PException> resultsBatchMultiSet = new ArrayList<PException>();
       int count = client.batchMultiSet2(tableName, items, resultsBatchMultiSet);
-      Assert.assertEquals(3, count);
-      Assert.assertEquals(3, resultsBatchMultiSet.size());
-      Assert.assertNull(resultsBatchMultiSet.get(0));
-      Assert.assertNull(resultsBatchMultiSet.get(1));
-      Assert.assertNull(resultsBatchMultiSet.get(2));
+      assertEquals(3, count);
+      assertEquals(3, resultsBatchMultiSet.size());
+      assertNull(resultsBatchMultiSet.get(0));
+      assertNull(resultsBatchMultiSet.get(1));
+      assertNull(resultsBatchMultiSet.get(2));
 
       // batch multi get
       List<Pair<byte[], List<byte[]>>> keys = new ArrayList<Pair<byte[], List<byte[]>>>();
@@ -1775,64 +1769,60 @@ public class TestBasic {
       List<Pair<PException, HashKeyData>> resultsBatchMultiGet =
           new ArrayList<Pair<PException, HashKeyData>>();
       count = client.batchMultiGet2(tableName, keys, resultsBatchMultiGet);
-      Assert.assertEquals(4, count);
-      Assert.assertEquals(4, resultsBatchMultiGet.size());
+      assertEquals(4, count);
+      assertEquals(4, resultsBatchMultiGet.size());
 
-      Assert.assertNull(resultsBatchMultiGet.get(0).getLeft());
-      Assert.assertArrayEquals(
-          keys.get(0).getLeft(), resultsBatchMultiGet.get(0).getRight().hashKey);
-      Assert.assertEquals(3, resultsBatchMultiGet.get(0).getRight().values.size());
-      Assert.assertArrayEquals(
+      assertNull(resultsBatchMultiGet.get(0).getLeft());
+      assertArrayEquals(keys.get(0).getLeft(), resultsBatchMultiGet.get(0).getRight().hashKey);
+      assertEquals(3, resultsBatchMultiGet.get(0).getRight().values.size());
+      assertArrayEquals(
           "basic_test_sort_key_1".getBytes(),
           resultsBatchMultiGet.get(0).getRight().values.get(0).getLeft());
-      Assert.assertArrayEquals(
+      assertArrayEquals(
           "basic_test_value_1".getBytes(),
           resultsBatchMultiGet.get(0).getRight().values.get(0).getRight());
-      Assert.assertArrayEquals(
+      assertArrayEquals(
           "basic_test_sort_key_2".getBytes(),
           resultsBatchMultiGet.get(0).getRight().values.get(1).getLeft());
-      Assert.assertArrayEquals(
+      assertArrayEquals(
           "basic_test_value_2".getBytes(),
           resultsBatchMultiGet.get(0).getRight().values.get(1).getRight());
-      Assert.assertArrayEquals(
+      assertArrayEquals(
           "basic_test_sort_key_3".getBytes(),
           resultsBatchMultiGet.get(0).getRight().values.get(2).getLeft());
-      Assert.assertArrayEquals(
+      assertArrayEquals(
           "basic_test_value_3".getBytes(),
           resultsBatchMultiGet.get(0).getRight().values.get(2).getRight());
 
-      Assert.assertNull(resultsBatchMultiGet.get(1).getLeft());
-      Assert.assertArrayEquals(
-          keys.get(1).getLeft(), resultsBatchMultiGet.get(1).getRight().hashKey);
-      Assert.assertEquals(2, resultsBatchMultiGet.get(1).getRight().values.size());
-      Assert.assertArrayEquals(
+      assertNull(resultsBatchMultiGet.get(1).getLeft());
+      assertArrayEquals(keys.get(1).getLeft(), resultsBatchMultiGet.get(1).getRight().hashKey);
+      assertEquals(2, resultsBatchMultiGet.get(1).getRight().values.size());
+      assertArrayEquals(
           "basic_test_sort_key_1".getBytes(),
           resultsBatchMultiGet.get(1).getRight().values.get(0).getLeft());
-      Assert.assertArrayEquals(
+      assertArrayEquals(
           "basic_test_value_1".getBytes(),
           resultsBatchMultiGet.get(1).getRight().values.get(0).getRight());
-      Assert.assertArrayEquals(
+      assertArrayEquals(
           "basic_test_sort_key_2".getBytes(),
           resultsBatchMultiGet.get(1).getRight().values.get(1).getLeft());
-      Assert.assertArrayEquals(
+      assertArrayEquals(
           "basic_test_value_2".getBytes(),
           resultsBatchMultiGet.get(1).getRight().values.get(1).getRight());
 
-      Assert.assertNull(resultsBatchMultiGet.get(2).getLeft());
-      Assert.assertArrayEquals(
-          keys.get(2).getLeft(), resultsBatchMultiGet.get(2).getRight().hashKey);
-      Assert.assertEquals(1, resultsBatchMultiGet.get(2).getRight().values.size());
-      Assert.assertArrayEquals(
+      assertNull(resultsBatchMultiGet.get(2).getLeft());
+      assertArrayEquals(keys.get(2).getLeft(), resultsBatchMultiGet.get(2).getRight().hashKey);
+      assertEquals(1, resultsBatchMultiGet.get(2).getRight().values.size());
+      assertArrayEquals(
           "basic_test_sort_key_1".getBytes(),
           resultsBatchMultiGet.get(2).getRight().values.get(0).getLeft());
-      Assert.assertArrayEquals(
+      assertArrayEquals(
           "basic_test_value_1".getBytes(),
           resultsBatchMultiGet.get(2).getRight().values.get(0).getRight());
 
-      Assert.assertNull(resultsBatchMultiGet.get(3).getLeft());
-      Assert.assertArrayEquals(
-          keys.get(3).getLeft(), resultsBatchMultiGet.get(3).getRight().hashKey);
-      Assert.assertEquals(0, resultsBatchMultiGet.get(3).getRight().values.size());
+      assertNull(resultsBatchMultiGet.get(3).getLeft());
+      assertArrayEquals(keys.get(3).getLeft(), resultsBatchMultiGet.get(3).getRight().hashKey);
+      assertEquals(0, resultsBatchMultiGet.get(3).getRight().values.size());
 
       // batch multi del
       List<Pair<byte[], List<byte[]>>> delKeys = new ArrayList<Pair<byte[], List<byte[]>>>();
@@ -1846,23 +1836,23 @@ public class TestBasic {
       delKeys.add(Pair.of("TestBasic_testBatchMultiSetGetDel2_hash_key_3".getBytes(), delSortKeys));
       List<PException> resultsBatchMultiDel = new ArrayList<PException>();
       count = client.batchMultiDel2(tableName, delKeys, resultsBatchMultiDel);
-      Assert.assertEquals(3, count);
-      Assert.assertEquals(3, resultsBatchMultiSet.size());
-      Assert.assertNull(resultsBatchMultiSet.get(0));
-      Assert.assertNull(resultsBatchMultiSet.get(1));
-      Assert.assertNull(resultsBatchMultiSet.get(2));
+      assertEquals(3, count);
+      assertEquals(3, resultsBatchMultiSet.size());
+      assertNull(resultsBatchMultiSet.get(0));
+      assertNull(resultsBatchMultiSet.get(1));
+      assertNull(resultsBatchMultiSet.get(2));
 
       // check deleted
       List<HashKeyData> values = new ArrayList<HashKeyData>();
       client.batchMultiGet(tableName, keys, values);
-      Assert.assertEquals(4, values.size());
-      Assert.assertEquals(0, values.get(0).values.size());
-      Assert.assertEquals(0, values.get(1).values.size());
-      Assert.assertEquals(0, values.get(2).values.size());
-      Assert.assertEquals(0, values.get(3).values.size());
+      assertEquals(4, values.size());
+      assertEquals(0, values.get(0).values.size());
+      assertEquals(0, values.get(1).values.size());
+      assertEquals(0, values.get(2).values.size());
+      assertEquals(0, values.get(3).values.size());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1881,130 +1871,128 @@ public class TestBasic {
     // Exist
     System.out.println("Test exist");
     try {
-      Assert.assertFalse(tb.asyncExist(key.getBytes(), key.getBytes(), 0).await().getNow());
-      Assert.assertFalse(tb.asyncExist(null, null, 0).await().getNow());
-      Assert.assertFalse(tb.asyncExist(null, key.getBytes(), 0).await().getNow());
-      Assert.assertFalse(tb.asyncExist(key.getBytes(), null, 0).await().getNow());
+      assertFalse(tb.asyncExist(key.getBytes(), key.getBytes(), 0).await().getNow());
+      assertFalse(tb.asyncExist(null, null, 0).await().getNow());
+      assertFalse(tb.asyncExist(null, key.getBytes(), 0).await().getNow());
+      assertFalse(tb.asyncExist(key.getBytes(), null, 0).await().getNow());
     } catch (Throwable e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
-      Assert.assertNull(
-          tb.asyncSet(key.getBytes(), key.getBytes(), key.getBytes(), 0).await().getNow());
-      Assert.assertTrue(tb.asyncExist(key.getBytes(), key.getBytes(), 0).await().getNow());
+      assertNull(tb.asyncSet(key.getBytes(), key.getBytes(), key.getBytes(), 0).await().getNow());
+      assertTrue(tb.asyncExist(key.getBytes(), key.getBytes(), 0).await().getNow());
     } catch (Throwable e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     // SortKeyCount
     System.out.println("Test sortkeycount");
     try {
       Long ans = tb.asyncSortKeyCount(key.getBytes(), 0).await().getNow();
-      Assert.assertEquals(1, (long) ans);
+      assertEquals(1, (long) ans);
 
-      Assert.assertNull(tb.asyncDel(key.getBytes(), key.getBytes(), 0).await().getNow());
+      assertNull(tb.asyncDel(key.getBytes(), key.getBytes(), 0).await().getNow());
       ans = tb.asyncSortKeyCount(key.getBytes(), 0).await().getNow();
-      Assert.assertEquals(0, (long) ans);
+      assertEquals(0, (long) ans);
 
       Future<Long> future = tb.asyncSortKeyCount(null, 0).await();
-      Assert.assertFalse(future.isSuccess());
-      Assert.assertTrue(future.cause() instanceof PException);
+      assertFalse(future.isSuccess());
+      assertTrue(future.cause() instanceof PException);
     } catch (Throwable e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     // Get
     System.out.println("Test get");
     try {
-      Assert.assertNull(tb.asyncGet(null, null, 0).await().getNow());
-      Assert.assertNull(tb.asyncGet(null, key.getBytes(), 0).await().getNow());
-      Assert.assertNull(tb.asyncGet(key.getBytes(), null, 0).await().getNow());
-      Assert.assertNull(tb.asyncGet(key.getBytes(), key.getBytes(), 0).await().getNow());
+      assertNull(tb.asyncGet(null, null, 0).await().getNow());
+      assertNull(tb.asyncGet(null, key.getBytes(), 0).await().getNow());
+      assertNull(tb.asyncGet(key.getBytes(), null, 0).await().getNow());
+      assertNull(tb.asyncGet(key.getBytes(), key.getBytes(), 0).await().getNow());
 
-      Assert.assertNull(
-          tb.asyncSet(key.getBytes(), key.getBytes(), key.getBytes(), 0).await().getNow());
-      Assert.assertArrayEquals(
+      assertNull(tb.asyncSet(key.getBytes(), key.getBytes(), key.getBytes(), 0).await().getNow());
+      assertArrayEquals(
           key.getBytes(), tb.asyncGet(key.getBytes(), key.getBytes(), 0).await().getNow());
 
-      Assert.assertNull(tb.asyncDel(key.getBytes(), key.getBytes(), 0).await().getNow());
+      assertNull(tb.asyncDel(key.getBytes(), key.getBytes(), 0).await().getNow());
     } catch (Throwable e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     // Set & ttl
     System.out.println("Test set & ttl");
     try {
-      Assert.assertNull(
+      assertNull(
           tb.asyncSet(key.getBytes(), key.getBytes(), key.getBytes(), 5, 1).await().getNow());
-      Assert.assertArrayEquals(
+      assertArrayEquals(
           key.getBytes(), tb.asyncGet(key.getBytes(), key.getBytes(), 0).await().getNow());
 
       Integer ttlSeconds = tb.asyncTTL(key.getBytes(), key.getBytes(), 0).await().getNow();
-      Assert.assertEquals(5, (int) ttlSeconds);
+      assertEquals(5, (int) ttlSeconds);
 
       Thread.sleep(6000);
-      Assert.assertFalse(tb.asyncExist(key.getBytes(), key.getBytes(), 0).await().getNow());
+      assertFalse(tb.asyncExist(key.getBytes(), key.getBytes(), 0).await().getNow());
     } catch (Throwable e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     // multiGet exeception handle
     System.out.println("Test multiget exception handle");
     try {
       Future<PegasusTableInterface.MultiGetResult> f = tb.asyncMultiGet(null, null, 0).await();
-      Assert.assertFalse(f.isSuccess());
-      Assert.assertTrue(f.cause() instanceof PException);
+      assertFalse(f.isSuccess());
+      assertTrue(f.cause() instanceof PException);
 
       f = tb.asyncMultiGet("".getBytes(), null, 0).await();
-      Assert.assertFalse(f.isSuccess());
-      Assert.assertTrue(f.cause() instanceof PException);
+      assertFalse(f.isSuccess());
+      assertTrue(f.cause() instanceof PException);
     } catch (Throwable e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     // multiset exception handle
     System.out.println("Test multiset exception handle");
     try {
       Future<Void> f = tb.asyncMultiSet(null, null, 0).await();
-      Assert.assertFalse(f.isSuccess());
-      Assert.assertTrue(f.cause() instanceof PException);
+      assertFalse(f.isSuccess());
+      assertTrue(f.cause() instanceof PException);
 
       f = tb.asyncMultiSet("hehe".getBytes(), null, 0).await();
-      Assert.assertFalse(f.isSuccess());
-      Assert.assertTrue(f.cause() instanceof PException);
+      assertFalse(f.isSuccess());
+      assertTrue(f.cause() instanceof PException);
 
       f = tb.asyncMultiSet("hehe".getBytes(), new ArrayList<Pair<byte[], byte[]>>(), 0).await();
-      Assert.assertFalse(f.isSuccess());
-      Assert.assertTrue(f.cause() instanceof PException);
+      assertFalse(f.isSuccess());
+      assertTrue(f.cause() instanceof PException);
     } catch (Throwable e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     // multiDel exception handle
     System.out.println("Test multidel exception handle");
     try {
       Future<Void> f = tb.asyncMultiDel(null, null, 0).await();
-      Assert.assertFalse(f.isSuccess());
-      Assert.assertTrue(f.cause() instanceof PException);
+      assertFalse(f.isSuccess());
+      assertTrue(f.cause() instanceof PException);
 
       f = tb.asyncMultiDel("hehe".getBytes(), null, 0).await();
-      Assert.assertFalse(f.isSuccess());
-      Assert.assertTrue(f.cause() instanceof PException);
+      assertFalse(f.isSuccess());
+      assertTrue(f.cause() instanceof PException);
 
       f = tb.asyncMultiDel("hehe".getBytes(), new ArrayList<byte[]>(), 0).await();
-      Assert.assertFalse(f.isSuccess());
-      Assert.assertTrue(f.cause() instanceof PException);
+      assertFalse(f.isSuccess());
+      assertTrue(f.cause() instanceof PException);
     } catch (Throwable e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     // Set/get pipeline
@@ -2024,15 +2012,15 @@ public class TestBasic {
 
       for (int i = 0; i < totalNumber; ++i) {
         fl.get(i).await();
-        Assert.assertTrue(fl.get(i).isSuccess());
+        assertTrue(fl.get(i).isSuccess());
       }
 
       Long sortCount = tb.asyncSortKeyCount(asyncHashPrefix.getBytes(), 0).await().getNow();
-      Assert.assertEquals(totalNumber, (long) sortCount);
+      assertEquals(totalNumber, (long) sortCount);
 
       PegasusTableInterface.MultiGetSortKeysResult result =
           tb.asyncMultiGetSortKeys(asyncHashPrefix.getBytes(), 150, 1000000, 0).await().getNow();
-      Assert.assertEquals(totalNumber, result.keys.size());
+      assertEquals(totalNumber, result.keys.size());
 
       ArrayList<Future<byte[]>> fl2 = new ArrayList<Future<byte[]>>();
       for (byte[] sortKey : result.keys) {
@@ -2044,7 +2032,7 @@ public class TestBasic {
         byte[] value = fl2.get(i).await().getNow();
         String formatted = String.format("%03d", i);
         String expectValue = asyncValuePrefix + "_" + formatted;
-        Assert.assertArrayEquals(expectValue.getBytes(), value);
+        assertArrayEquals(expectValue.getBytes(), value);
       }
 
       fl.clear();
@@ -2055,15 +2043,15 @@ public class TestBasic {
 
       for (Future<Void> f : fl) {
         f.await();
-        Assert.assertTrue(f.isSuccess());
+        assertTrue(f.isSuccess());
       }
 
       Long sortKeyCount = tb.sortKeyCount(asyncHashPrefix.getBytes(), 0);
-      Assert.assertEquals(0, (long) sortKeyCount);
+      assertEquals(0, (long) sortKeyCount);
 
     } catch (Throwable e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
   }
 
@@ -2082,7 +2070,7 @@ public class TestBasic {
           public void operationComplete(Future<Void> future) throws Exception {
             if (future.isSuccess()) {
               System.out.println("set succeed");
-              Assert.fail();
+              fail();
             } else {
               assert future.cause() instanceof PException;
             }
@@ -2111,7 +2099,7 @@ public class TestBasic {
       table.multiSet(hashKey, values, 0);
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     try {
@@ -2122,22 +2110,22 @@ public class TestBasic {
       options.batchSize = 10;
       Map<String, String> data = new HashMap<String, String>();
       PegasusScannerInterface scanner = table.getScanner(hashKey, null, null, options);
-      Assert.assertNotNull(scanner);
+      assertNotNull(scanner);
       Pair<Pair<byte[], byte[]>, byte[]> item;
       while ((item = scanner.next()) != null) {
-        Assert.assertArrayEquals(hashKey, item.getLeft().getLeft());
-        Assert.assertArrayEquals("a".getBytes(), item.getRight());
+        assertArrayEquals(hashKey, item.getLeft().getLeft());
+        assertArrayEquals("a".getBytes(), item.getRight());
         data.put(new String(item.getLeft().getRight()), new String(item.getRight()));
       }
-      Assert.assertEquals(5, data.size());
-      Assert.assertTrue(data.containsKey("m_1"));
-      Assert.assertTrue(data.containsKey("m_2"));
-      Assert.assertTrue(data.containsKey("m_3"));
-      Assert.assertTrue(data.containsKey("m_4"));
-      Assert.assertTrue(data.containsKey("m_5"));
+      assertEquals(5, data.size());
+      assertTrue(data.containsKey("m_1"));
+      assertTrue(data.containsKey("m_2"));
+      assertTrue(data.containsKey("m_3"));
+      assertTrue(data.containsKey("m_4"));
+      assertTrue(data.containsKey("m_5"));
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     try {
@@ -2148,22 +2136,22 @@ public class TestBasic {
       options.batchSize = 3;
       Map<String, String> data = new HashMap<String, String>();
       PegasusScannerInterface scanner = table.getScanner(hashKey, null, null, options);
-      Assert.assertNotNull(scanner);
+      assertNotNull(scanner);
       Pair<Pair<byte[], byte[]>, byte[]> item;
       while ((item = scanner.next()) != null) {
-        Assert.assertArrayEquals(hashKey, item.getLeft().getLeft());
-        Assert.assertArrayEquals("a".getBytes(), item.getRight());
+        assertArrayEquals(hashKey, item.getLeft().getLeft());
+        assertArrayEquals("a".getBytes(), item.getRight());
         data.put(new String(item.getLeft().getRight()), new String(item.getRight()));
       }
-      Assert.assertEquals(5, data.size());
-      Assert.assertTrue(data.containsKey("m_1"));
-      Assert.assertTrue(data.containsKey("m_2"));
-      Assert.assertTrue(data.containsKey("m_3"));
-      Assert.assertTrue(data.containsKey("m_4"));
-      Assert.assertTrue(data.containsKey("m_5"));
+      assertEquals(5, data.size());
+      assertTrue(data.containsKey("m_1"));
+      assertTrue(data.containsKey("m_2"));
+      assertTrue(data.containsKey("m_3"));
+      assertTrue(data.containsKey("m_4"));
+      assertTrue(data.containsKey("m_5"));
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     try {
@@ -2175,7 +2163,7 @@ public class TestBasic {
       table.multiDel(hashKey, sortKeys, 0);
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -2201,7 +2189,7 @@ public class TestBasic {
       table.multiSet(hashKey, values, 0);
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     try {
@@ -2212,23 +2200,23 @@ public class TestBasic {
       options.batchSize = 10;
       Map<String, String> data = new HashMap<String, String>();
       List<PegasusScannerInterface> scanners = table.getUnorderedScanners(1, options);
-      Assert.assertEquals(1, scanners.size());
+      assertEquals(1, scanners.size());
       PegasusScannerInterface scanner = scanners.get(0);
       Pair<Pair<byte[], byte[]>, byte[]> item;
       while ((item = scanner.next()) != null) {
-        Assert.assertArrayEquals(hashKey, item.getLeft().getLeft());
-        Assert.assertArrayEquals("a".getBytes(), item.getRight());
+        assertArrayEquals(hashKey, item.getLeft().getLeft());
+        assertArrayEquals("a".getBytes(), item.getRight());
         data.put(new String(item.getLeft().getRight()), new String(item.getRight()));
       }
-      Assert.assertEquals(5, data.size());
-      Assert.assertTrue(data.containsKey("m_1"));
-      Assert.assertTrue(data.containsKey("m_2"));
-      Assert.assertTrue(data.containsKey("m_3"));
-      Assert.assertTrue(data.containsKey("m_4"));
-      Assert.assertTrue(data.containsKey("m_5"));
+      assertEquals(5, data.size());
+      assertTrue(data.containsKey("m_1"));
+      assertTrue(data.containsKey("m_2"));
+      assertTrue(data.containsKey("m_3"));
+      assertTrue(data.containsKey("m_4"));
+      assertTrue(data.containsKey("m_5"));
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     try {
@@ -2239,23 +2227,23 @@ public class TestBasic {
       options.batchSize = 3;
       Map<String, String> data = new HashMap<String, String>();
       List<PegasusScannerInterface> scanners = table.getUnorderedScanners(1, options);
-      Assert.assertEquals(1, scanners.size());
+      assertEquals(1, scanners.size());
       PegasusScannerInterface scanner = scanners.get(0);
       Pair<Pair<byte[], byte[]>, byte[]> item;
       while ((item = scanner.next()) != null) {
-        Assert.assertArrayEquals(hashKey, item.getLeft().getLeft());
-        Assert.assertArrayEquals("a".getBytes(), item.getRight());
+        assertArrayEquals(hashKey, item.getLeft().getLeft());
+        assertArrayEquals("a".getBytes(), item.getRight());
         data.put(new String(item.getLeft().getRight()), new String(item.getRight()));
       }
-      Assert.assertEquals(5, data.size());
-      Assert.assertTrue(data.containsKey("m_1"));
-      Assert.assertTrue(data.containsKey("m_2"));
-      Assert.assertTrue(data.containsKey("m_3"));
-      Assert.assertTrue(data.containsKey("m_4"));
-      Assert.assertTrue(data.containsKey("m_5"));
+      assertEquals(5, data.size());
+      assertTrue(data.containsKey("m_1"));
+      assertTrue(data.containsKey("m_2"));
+      assertTrue(data.containsKey("m_3"));
+      assertTrue(data.containsKey("m_4"));
+      assertTrue(data.containsKey("m_5"));
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     try {
@@ -2267,7 +2255,7 @@ public class TestBasic {
       table.multiDel(hashKey, sortKeys, 0);
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -2291,10 +2279,10 @@ public class TestBasic {
       value = client.get("temp", "createClient".getBytes(), "createClient_0".getBytes());
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
-    Assert.assertTrue(new String(value).equals("createClient_0"));
+    assertTrue(new String(value).equals("createClient_0"));
 
     // test getSingletonClient(ClientOptions options)
     PegasusClientInterface singletonClient = null;
@@ -2309,10 +2297,10 @@ public class TestBasic {
           singletonClient.get("temp", "getSingletonClient".getBytes(), "createClient_1".getBytes());
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
-    Assert.assertTrue(new String(value).equals("createClient_1"));
+    assertTrue(new String(value).equals("createClient_1"));
 
     // test getSingletonClient(ClientOptions options) --> same clientOptions
     PegasusClientInterface singletonClient1 = null;
@@ -2328,11 +2316,11 @@ public class TestBasic {
               "temp", "getSingletonClient".getBytes(), "createClient_2".getBytes());
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
-    Assert.assertTrue(new String(value).equals("createClient_2"));
-    Assert.assertTrue(singletonClient1 == singletonClient);
+    assertTrue(new String(value).equals("createClient_2"));
+    assertTrue(singletonClient1 == singletonClient);
 
     // test getSingletonClient(ClientOptions options) --> different clientOptions,but values of
     // clientOptions is same
@@ -2349,11 +2337,11 @@ public class TestBasic {
               "temp", "getSingletonClient".getBytes(), "createClient_3".getBytes());
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
-    Assert.assertTrue(new String(value).equals("createClient_3"));
-    Assert.assertTrue(singletonClient1 == singletonClient);
+    assertTrue(new String(value).equals("createClient_3"));
+    assertTrue(singletonClient1 == singletonClient);
 
     // test getSingletonClient(ClientOptions options) --> different clientOptions,and values of
     // clientOptions is different
@@ -2374,7 +2362,7 @@ public class TestBasic {
               "temp", "getSingletonClient".getBytes(), "createClient_4".getBytes());
     } catch (Exception e) {
       // if values of clientOptions is different,the code's right logic is "throw exception"
-      Assert.assertTrue(true);
+      assertTrue(true);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -2540,7 +2528,7 @@ public class TestBasic {
   }
 
   private void testWriteSizeLimit(PegasusClientInterface client) {
-    Assert.assertNotNull(client);
+    assertNotNull(client);
     String tableName = "temp";
     // test hashKey size > 1024
     String hashKeyExceed = RandomStringUtils.random(1025, true, true);
@@ -2549,7 +2537,7 @@ public class TestBasic {
     try {
       client.set(tableName, hashKeyExceed.getBytes(), sortKey.getBytes(), value.getBytes());
     } catch (PException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage()
               .contains("Exceed the hashKey length threshold = 1024,hashKeyLength = 1025"));
     }
@@ -2560,7 +2548,7 @@ public class TestBasic {
     try {
       client.set(tableName, hashKey.getBytes(), sortKeyExceed.getBytes(), value.getBytes());
     } catch (PException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage()
               .contains("Exceed the sort key length threshold = 1024,sortKeyLength = 1025"));
     }
@@ -2570,7 +2558,7 @@ public class TestBasic {
     try {
       client.set(tableName, hashKey.getBytes(), sortKey.getBytes(), valueExceed.getBytes());
     } catch (PException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage()
               .contains("Exceed the value length threshold = 409600,valueLength = 409601"));
     }
@@ -2584,7 +2572,7 @@ public class TestBasic {
     try {
       client.multiSet(tableName, hashKey.getBytes(), multiValues);
     } catch (PException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().contains("Exceed the value count threshold = 1000,valueCount = 2000"));
     }
 
@@ -2598,8 +2586,7 @@ public class TestBasic {
     try {
       client.multiSet(tableName, hashKey.getBytes(), multiValues2);
     } catch (PException e) {
-      Assert.assertTrue(
-          e.getMessage().contains("Exceed the multi value length threshold = 1048576"));
+      assertTrue(e.getMessage().contains("Exceed the multi value length threshold = 1048576"));
     }
 
     // test mutations value count > 1000
@@ -2622,7 +2609,7 @@ public class TestBasic {
               mutations,
               options);
     } catch (PException e) {
-      Assert.assertTrue(
+      assertTrue(
           e.getMessage().contains("Exceed the value count threshold = 1000,valueCount = 1500"));
     }
 
@@ -2645,8 +2632,7 @@ public class TestBasic {
               mutations2,
               options);
     } catch (PException e) {
-      Assert.assertTrue(
-          e.getMessage().contains("Exceed the multi value length threshold = 1048576"));
+      assertTrue(e.getMessage().contains("Exceed the multi value length threshold = 1048576"));
     }
   }
 
@@ -2702,8 +2688,8 @@ public class TestBasic {
     PegasusTable.ScanRangeResult caseC1 =
         table.scanRange(
             hashKey.getBytes(), "".getBytes(), "expired_7".getBytes(), new ScanOptions(), 3, 0);
-    Assert.assertTrue(caseC1.allFetched);
-    Assert.assertEquals(0, caseC1.results.size()); // among "" and "expired_7" has 0 valid record
+    assertTrue(caseC1.allFetched);
+    assertEquals(0, caseC1.results.size()); // among "" and "expired_7" has 0 valid record
     // case C2: scan limit record by "" and "persistent_7", if valid record count < maxFetchCount,
     // it only return valid record
     PegasusTable.ScanRangeResult caseC2 =
@@ -2721,16 +2707,16 @@ public class TestBasic {
     // case D1: maxFetchCount > 0, return maxFetchCount valid record
     PegasusTableInterface.MultiGetSortKeysResult caseD1 =
         table.multiGetSortKeys(hashKey.getBytes(), 5, -1, 0);
-    Assert.assertFalse(caseD1.allFetched);
-    Assert.assertEquals(5, caseD1.keys.size());
+    assertFalse(caseD1.allFetched);
+    assertEquals(5, caseD1.keys.size());
     for (int i = 0; i <= 4; i++) {
       Assertions.assertEquals("persistent_" + i, new String(caseD1.keys.get(i)));
     }
     // case D1: maxFetchCount < 0, return all valid record
     PegasusTableInterface.MultiGetSortKeysResult caseD2 =
         table.multiGetSortKeys(hashKey.getBytes(), 10, -1, 0);
-    Assert.assertTrue(caseD2.allFetched);
-    Assert.assertEquals(10, caseD2.keys.size());
+    assertTrue(caseD2.allFetched);
+    assertEquals(10, caseD2.keys.size());
     for (int i = 0; i <= 9; i++) {
       Assertions.assertEquals("persistent_" + i, new String(caseD2.keys.get(i)));
     }
@@ -2814,7 +2800,7 @@ public class TestBasic {
               () -> {
                 client.multiSet(tableName, hashKey.getBytes(), multiValues2);
               });
-      Assert.assertTrue(
+      assertTrue(
           exception
               .getMessage()
               .contains(
@@ -2840,7 +2826,7 @@ public class TestBasic {
                     mutations,
                     options);
               });
-      Assert.assertTrue(
+      assertTrue(
           exception2
               .getMessage()
               .contains(
@@ -2872,14 +2858,14 @@ public class TestBasic {
               () -> {
                 client.multiDel(tableName, hashKey.getBytes(), sortKeys);
               });
-      Assert.assertTrue(
+      assertTrue(
           exception3
               .getMessage()
               .contains(
                   "request=[hashKey[:32]=\"TestHash_0\",sortKey[:32]=\"\",sortKeyCount=3,valueLength=-1]"));
 
     } catch (Throwable e) {
-      Assert.fail();
+      fail();
     }
   }
 }

--- a/java-client/src/test/java/org/apache/pegasus/client/TestBatch.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestBatch.java
@@ -18,6 +18,10 @@
  */
 package org.apache.pegasus.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.netty.util.concurrent.Future;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,8 +40,7 @@ import org.apache.pegasus.client.request.MultiSet;
 import org.apache.pegasus.client.request.MultiSetBatch;
 import org.apache.pegasus.client.request.Set;
 import org.apache.pegasus.client.request.SetBatch;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestBatch {
 
@@ -70,18 +73,18 @@ public class TestBatch {
     GetBatch getBatch = new GetBatch(table, 1000);
     getBatch.commit(gets, getResults);
 
-    Assertions.assertNull(getResults.get(0));
-    Assertions.assertNull(getResults.get(1));
-    Assertions.assertEquals("valueSet3", new String(getResults.get(2)));
-    Assertions.assertEquals("valueSet4WithTTL", new String(getResults.get(3)));
+    assertNull(getResults.get(0));
+    assertNull(getResults.get(1));
+    assertEquals("valueSet3", new String(getResults.get(2)));
+    assertEquals("valueSet4WithTTL", new String(getResults.get(3)));
 
     Thread.sleep(11000);
 
     List<Pair<PException, byte[]>> getResultsWithExp = new ArrayList<>();
     getBatch.commitWaitAllComplete(gets, getResultsWithExp);
-    Assertions.assertNull(getResultsWithExp.get(2).getKey());
-    Assertions.assertEquals("valueSet3", new String(getResultsWithExp.get(2).getRight()));
-    Assertions.assertNull(getResultsWithExp.get(3).getRight());
+    assertNull(getResultsWithExp.get(2).getKey());
+    assertEquals("valueSet3", new String(getResultsWithExp.get(2).getRight()));
+    assertNull(getResultsWithExp.get(3).getRight());
 
     PegasusClientFactory.closeSingletonClient();
   }
@@ -124,24 +127,24 @@ public class TestBatch {
     MultiGetBatch multiGetBatch = new MultiGetBatch(table, 1000);
     multiGetBatch.commit(multiGets, multiGetResults);
 
-    Assertions.assertEquals(0, multiGetResults.get(0).getValues().size());
-    Assertions.assertEquals(0, multiGetResults.get(1).getValues().size());
-    Assertions.assertTrue(multiGetResults.get(2).isAllFetched());
+    assertEquals(0, multiGetResults.get(0).getValues().size());
+    assertEquals(0, multiGetResults.get(1).getValues().size());
+    assertTrue(multiGetResults.get(2).isAllFetched());
     for (int i = 0; i < 3; i++) {
-      Assertions.assertEquals(
+      assertEquals(
           "sortKeyMultiSet" + i, new String(multiGetResults.get(2).getValues().get(i).getKey()));
-      Assertions.assertEquals(
+      assertEquals(
           "valueMultiSet" + i, new String(multiGetResults.get(2).getValues().get(i).getRight()));
     }
 
     List<Pair<PException, MultiGetResult>> multiGetResultsWithExp = new ArrayList<>();
     multiGetBatch.commitWaitAllComplete(multiGets, multiGetResultsWithExp);
     for (int i = 0; i < 3; i++) {
-      Assertions.assertNull(multiGetResultsWithExp.get(2).getLeft());
-      Assertions.assertEquals(
+      assertNull(multiGetResultsWithExp.get(2).getLeft());
+      assertEquals(
           "sortKeyMultiSet" + i,
           new String(multiGetResultsWithExp.get(2).getRight().getValues().get(i).getKey()));
-      Assertions.assertEquals(
+      assertEquals(
           "valueMultiSet" + i,
           new String(multiGetResultsWithExp.get(2).getRight().getValues().get(i).getRight()));
     }
@@ -184,8 +187,8 @@ public class TestBatch {
 
     incrementBatch.commit(increments, incrResults);
 
-    Assertions.assertEquals(1, incrResults.get(0).longValue());
-    Assertions.assertEquals(3, incrResults.get(1).longValue());
+    assertEquals(1, incrResults.get(0).longValue());
+    assertEquals(3, incrResults.get(1).longValue());
 
     PegasusClientFactory.closeSingletonClient();
   }

--- a/java-client/src/test/java/org/apache/pegasus/client/TestBatchGetByPartitions.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestBatchGetByPartitions.java
@@ -19,12 +19,15 @@
 
 package org.apache.pegasus.client;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestBatchGetByPartitions {
   volatile boolean isRunning = false;
@@ -51,23 +54,23 @@ public class TestBatchGetByPartitions {
     List<PException> result = new ArrayList<>();
     table.batchSet2(batchSetItems, result, 0);
     for (int i = 0; i < totalTestKeyNum; ++i) {
-      Assert.assertNull(result.get(i));
+      assertNull(result.get(i));
     }
 
     List<Pair<PException, byte[]>> getResult = new ArrayList<>();
     int resultCount = table.batchGetByPartitions(pairs, getResult, 0);
-    Assert.assertEquals(totalTestKeyNum, resultCount);
+    assertEquals(totalTestKeyNum, resultCount);
 
     for (int i = 0; i < totalTestKeyNum; ++i) {
-      Assert.assertNull(getResult.get(i).getLeft());
-      Assert.assertArrayEquals(getResult.get(i).getRight(), values.get(i));
+      assertNull(getResult.get(i).getLeft());
+      assertArrayEquals(getResult.get(i).getRight(), values.get(i));
     }
   }
 
   @Test
   public void testStableQpsForPegasusShellShow() throws Exception {
     // only for auxiliary test
-    Assume.assumeTrue(false);
+    assumeTrue(false);
 
     String tableName = "temp";
     PegasusTableInterface table = PegasusClientFactory.getSingletonClient().openTable(tableName);
@@ -88,7 +91,7 @@ public class TestBatchGetByPartitions {
     List<PException> result = new ArrayList<>();
     table.batchSet2(batchSetItems, result, 0);
     for (int i = 0; i < totalTestKeyNum; ++i) {
-      Assert.assertNull(result.get(i));
+      assertNull(result.get(i));
     }
 
     Runnable testRunnable =

--- a/java-client/src/test/java/org/apache/pegasus/client/TestBench.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestBench.java
@@ -18,13 +18,17 @@
  */
 package org.apache.pegasus.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 /** Created by mi on 16-3-23. */
 public class TestBench {
@@ -34,8 +38,8 @@ public class TestBench {
 
     ScanOptions options = new ScanOptions();
     List<PegasusScannerInterface> scanners = client.getUnorderedScanners(tableName, 1, options);
-    Assert.assertEquals(1, scanners.size());
-    Assert.assertNotNull(scanners.get(0));
+    assertEquals(1, scanners.size());
+    assertNotNull(scanners.get(0));
 
     Pair<Pair<byte[], byte[]>, byte[]> item;
     while ((item = scanners.get(0).next()) != null) {
@@ -44,22 +48,21 @@ public class TestBench {
     scanners.get(0).close();
 
     scanners = client.getUnorderedScanners(tableName, 1, options);
-    Assert.assertEquals(1, scanners.size());
-    Assert.assertNotNull(scanners.get(0));
+    assertEquals(1, scanners.size());
+    assertNotNull(scanners.get(0));
     item = scanners.get(0).next();
     scanners.get(0).close();
-    Assert.assertNull(
+    assertNull(
         item == null
             ? null
             : String.format(
                 "Database is cleared but not empty, hashKey=%s, sortKey=%s",
-                new String(item.getLeft().getLeft()), new String(item.getLeft().getRight())),
-        item);
+                new String(item.getLeft().getLeft()), new String(item.getLeft().getRight())));
 
     PegasusClientFactory.closeSingletonClient();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownTestCase() throws PException {
     clearDatabase();
   }
@@ -152,8 +155,8 @@ public class TestBench {
         long begin_time = System.nanoTime();
         byte[] value = client.get(tableName, keys.get(i), null);
         long end_time = System.nanoTime();
-        Assert.assertTrue(value != null);
-        Assert.assertTrue(Arrays.equals(values.get(i), value));
+        assertTrue(value != null);
+        assertTrue(Arrays.equals(values.get(i), value));
         long dur_time = end_time - begin_time;
         if (dur_time < min_time) {
           min_time = dur_time;

--- a/java-client/src/test/java/org/apache/pegasus/client/TestBench.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestBench.java
@@ -53,6 +53,7 @@ public class TestBench {
     item = scanners.get(0).next();
     scanners.get(0).close();
     assertNull(
+        item,
         item == null
             ? null
             : String.format(

--- a/java-client/src/test/java/org/apache/pegasus/client/TestCheckAndMutate.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestCheckAndMutate.java
@@ -18,10 +18,15 @@
  */
 package org.apache.pegasus.client;
 
-/** @author huangwei */
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import org.junit.jupiter.api.Test;
+
+/** @author huangwei */
 public class TestCheckAndMutate {
   @Test
   public void testValueNotExist() throws PException {
@@ -48,11 +53,11 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
 
@@ -67,12 +72,12 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = false;
       mutations.set("k1".getBytes(), "v1".getBytes());
@@ -85,15 +90,15 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertFalse(result.isCheckValueReturned());
+      assertFalse(result.isMutateSucceed());
+      assertFalse(result.isCheckValueReturned());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -115,11 +120,11 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k2".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k2".getBytes(), "v2".getBytes());
@@ -132,17 +137,17 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k2".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -165,17 +170,17 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -206,11 +211,11 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -224,12 +229,12 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v2".getBytes());
@@ -242,17 +247,17 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -275,18 +280,18 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v3".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -317,11 +322,11 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -335,12 +340,12 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "v1".getBytes());
 
@@ -355,17 +360,17 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -388,18 +393,18 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v3".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -430,11 +435,11 @@ public class TestCheckAndMutate {
               "v".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -448,12 +453,12 @@ public class TestCheckAndMutate {
               "v".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -465,12 +470,12 @@ public class TestCheckAndMutate {
               "".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v2".getBytes());
@@ -483,12 +488,12 @@ public class TestCheckAndMutate {
               "".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v111v".getBytes());
@@ -501,12 +506,12 @@ public class TestCheckAndMutate {
               "2".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v111v".getBytes(), value);
+      assertArrayEquals("v111v".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v2".getBytes());
@@ -519,12 +524,12 @@ public class TestCheckAndMutate {
               "111".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v111v".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v111v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v3".getBytes());
@@ -537,12 +542,12 @@ public class TestCheckAndMutate {
               "y".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -554,12 +559,12 @@ public class TestCheckAndMutate {
               "v2v".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -571,17 +576,17 @@ public class TestCheckAndMutate {
               "v2".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v3".getBytes(), value);
+      assertArrayEquals("v3".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -604,18 +609,18 @@ public class TestCheckAndMutate {
               "333".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v333v".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v333v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -646,11 +651,11 @@ public class TestCheckAndMutate {
               "v".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -664,12 +669,12 @@ public class TestCheckAndMutate {
               "v".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -681,12 +686,12 @@ public class TestCheckAndMutate {
               "".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v2".getBytes());
@@ -699,12 +704,12 @@ public class TestCheckAndMutate {
               "".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v111v".getBytes());
@@ -717,12 +722,12 @@ public class TestCheckAndMutate {
               "v".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v111v".getBytes(), value);
+      assertArrayEquals("v111v".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v2".getBytes());
@@ -735,12 +740,12 @@ public class TestCheckAndMutate {
               "111".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v111v".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v111v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v111v".getBytes(), value);
+      assertArrayEquals("v111v".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v2".getBytes());
@@ -753,12 +758,12 @@ public class TestCheckAndMutate {
               "v111".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v111v".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v111v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v3".getBytes());
@@ -771,12 +776,12 @@ public class TestCheckAndMutate {
               "y".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -788,12 +793,12 @@ public class TestCheckAndMutate {
               "v2v".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -805,17 +810,17 @@ public class TestCheckAndMutate {
               "v2".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v3".getBytes(), value);
+      assertArrayEquals("v3".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -838,18 +843,18 @@ public class TestCheckAndMutate {
               "v333".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v333v".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v333v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -880,11 +885,11 @@ public class TestCheckAndMutate {
               "v".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -898,12 +903,12 @@ public class TestCheckAndMutate {
               "v".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -915,12 +920,12 @@ public class TestCheckAndMutate {
               "".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v2".getBytes());
@@ -933,12 +938,12 @@ public class TestCheckAndMutate {
               "".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v111v".getBytes());
@@ -951,12 +956,12 @@ public class TestCheckAndMutate {
               "2".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v111v".getBytes(), value);
+      assertArrayEquals("v111v".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v2".getBytes());
@@ -969,12 +974,12 @@ public class TestCheckAndMutate {
               "111".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v111v".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v111v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v111v".getBytes(), value);
+      assertArrayEquals("v111v".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -986,12 +991,12 @@ public class TestCheckAndMutate {
               "111v".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v111v".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v111v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v3".getBytes());
@@ -1004,12 +1009,12 @@ public class TestCheckAndMutate {
               "y".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -1021,12 +1026,12 @@ public class TestCheckAndMutate {
               "2v2".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -1038,17 +1043,17 @@ public class TestCheckAndMutate {
               "v2".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v3".getBytes(), value);
+      assertArrayEquals("v3".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -1071,18 +1076,18 @@ public class TestCheckAndMutate {
               "333v".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v333v".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v333v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1113,11 +1118,11 @@ public class TestCheckAndMutate {
               "".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -1131,12 +1136,12 @@ public class TestCheckAndMutate {
               "".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -1148,12 +1153,12 @@ public class TestCheckAndMutate {
               "".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "v2".getBytes());
@@ -1166,17 +1171,17 @@ public class TestCheckAndMutate {
               "v1".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -1199,18 +1204,18 @@ public class TestCheckAndMutate {
               "v3".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v3".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -1233,12 +1238,12 @@ public class TestCheckAndMutate {
               "v2".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       // v2 <= v2
       options.returnCheckValue = true;
@@ -1252,12 +1257,12 @@ public class TestCheckAndMutate {
               "v2".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v3".getBytes(), value);
+      assertArrayEquals("v3".getBytes(), value);
 
       // v3 <= v4
       options.returnCheckValue = true;
@@ -1271,12 +1276,12 @@ public class TestCheckAndMutate {
               "v4".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v3".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       // v4 >= v4
       options.returnCheckValue = true;
@@ -1290,12 +1295,12 @@ public class TestCheckAndMutate {
               "v4".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v4".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v4".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v5".getBytes(), value);
+      assertArrayEquals("v5".getBytes(), value);
 
       // v5 >= v4
       options.returnCheckValue = true;
@@ -1309,12 +1314,12 @@ public class TestCheckAndMutate {
               "v4".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v5".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v5".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v6".getBytes(), value);
+      assertArrayEquals("v6".getBytes(), value);
 
       // v6 > v5
       options.returnCheckValue = true;
@@ -1328,17 +1333,17 @@ public class TestCheckAndMutate {
               "v5".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v6".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v6".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v7".getBytes(), value);
+      assertArrayEquals("v7".getBytes(), value);
 
       client.del(tableName, hashKey, "k5".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1370,11 +1375,11 @@ public class TestCheckAndMutate {
               "1".getBytes(),
               mutations,
               options);
-      Assert.assertFalse(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -1388,15 +1393,15 @@ public class TestCheckAndMutate {
             "1".getBytes(),
             mutations,
             options);
-        Assert.fail();
+        fail();
       } catch (PException ex) {
-        Assert.assertTrue(ex.getMessage(), ex.getMessage().endsWith("rocksdb error: 4"));
+        assertTrue(ex.getMessage().endsWith("rocksdb error: 4"), ex.getMessage());
 
       } catch (Exception ex) {
-        Assert.fail();
+        fail();
       }
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "1".getBytes());
 
@@ -1410,12 +1415,12 @@ public class TestCheckAndMutate {
               "1".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("1".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("2".getBytes(), value);
+      assertArrayEquals("2".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "3".getBytes());
@@ -1428,15 +1433,15 @@ public class TestCheckAndMutate {
             "".getBytes(),
             mutations,
             options);
-        Assert.fail();
+        fail();
       } catch (PException ex) {
-        Assert.assertTrue(ex.getMessage(), ex.getMessage().endsWith("rocksdb error: 4"));
+        assertTrue(ex.getMessage().endsWith("rocksdb error: 4"), ex.getMessage());
 
       } catch (Exception ex) {
-        Assert.fail();
+        fail();
       }
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("2".getBytes(), value);
+      assertArrayEquals("2".getBytes(), value);
 
       options.returnCheckValue = true;
       try {
@@ -1448,15 +1453,15 @@ public class TestCheckAndMutate {
             "v1".getBytes(),
             mutations,
             options);
-        Assert.fail();
+        fail();
       } catch (PException ex) {
-        Assert.assertTrue(ex.getMessage(), ex.getMessage().endsWith("rocksdb error: 4"));
+        assertTrue(ex.getMessage().endsWith("rocksdb error: 4"), ex.getMessage());
 
       } catch (Exception ex) {
-        Assert.fail();
+        fail();
       }
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("2".getBytes(), value);
+      assertArrayEquals("2".getBytes(), value);
 
       options.returnCheckValue = true;
 
@@ -1469,15 +1474,15 @@ public class TestCheckAndMutate {
             "88888888888888888888888888888888888888888888888".getBytes(),
             mutations,
             options);
-        Assert.fail();
+        fail();
       } catch (PException ex) {
-        Assert.assertTrue(ex.getMessage(), ex.getMessage().endsWith("rocksdb error: 4"));
+        assertTrue(ex.getMessage().endsWith("rocksdb error: 4"), ex.getMessage());
 
       } catch (Exception ex) {
-        Assert.fail();
+        fail();
       }
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("2".getBytes(), value);
+      assertArrayEquals("2".getBytes(), value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "0".getBytes());
 
@@ -1492,12 +1497,12 @@ public class TestCheckAndMutate {
               "0".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("0".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("0".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("-1".getBytes(), value);
+      assertArrayEquals("-1".getBytes(), value);
 
       options.returnCheckValue = true;
       mutations.set("k1".getBytes(), "-2".getBytes());
@@ -1510,17 +1515,17 @@ public class TestCheckAndMutate {
               "-1".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("-1".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("-1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("-2".getBytes(), value);
+      assertArrayEquals("-2".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -1544,18 +1549,18 @@ public class TestCheckAndMutate {
               "3".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("3".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("4".getBytes(), value);
+      assertArrayEquals("4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     try {
@@ -1578,12 +1583,12 @@ public class TestCheckAndMutate {
               "2".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("1".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("2".getBytes(), value);
+      assertArrayEquals("2".getBytes(), value);
 
       // 2 <= 2
       options.returnCheckValue = true;
@@ -1597,12 +1602,12 @@ public class TestCheckAndMutate {
               "2".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("2".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("3".getBytes(), value);
+      assertArrayEquals("3".getBytes(), value);
 
       // 3 <= 4
       options.returnCheckValue = true;
@@ -1616,12 +1621,12 @@ public class TestCheckAndMutate {
               "4".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("3".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("4".getBytes(), value);
+      assertArrayEquals("4".getBytes(), value);
 
       // 4 >= 4
       options.returnCheckValue = true;
@@ -1635,12 +1640,12 @@ public class TestCheckAndMutate {
               "4".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("4".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("4".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("5".getBytes(), value);
+      assertArrayEquals("5".getBytes(), value);
 
       // 5 >= 4
       options.returnCheckValue = true;
@@ -1654,12 +1659,12 @@ public class TestCheckAndMutate {
               "4".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("5".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("5".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("6".getBytes(), value);
+      assertArrayEquals("6".getBytes(), value);
 
       // 6 > 5
       options.returnCheckValue = true;
@@ -1673,17 +1678,17 @@ public class TestCheckAndMutate {
               "5".getBytes(),
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("6".getBytes(), result.getCheckValue());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("6".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("7".getBytes(), value);
+      assertArrayEquals("7".getBytes(), value);
 
       client.del(tableName, hashKey, "k5".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1715,14 +1720,14 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
   }
 
@@ -1751,15 +1756,15 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       Thread.sleep(12000);
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       // use the same mutations(the second time to call getMutations())
       result =
@@ -1771,19 +1776,19 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     } catch (InterruptedException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
   }
 
@@ -1812,12 +1817,12 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       Thread.sleep(12000);
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       mutations = new Mutations();
       options.returnCheckValue = true;
@@ -1837,16 +1842,16 @@ public class TestCheckAndMutate {
               null,
               mutations,
               options);
-      Assert.assertTrue(result.isMutateSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isMutateSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException | InterruptedException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();

--- a/java-client/src/test/java/org/apache/pegasus/client/TestCheckAndSet.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestCheckAndSet.java
@@ -19,8 +19,12 @@
 package org.apache.pegasus.client;
 
 /** @author qinzuoyan */
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 /** Created by mi on 18-7-17. */
 public class TestCheckAndSet {
@@ -48,11 +52,11 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -65,12 +69,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = false;
       result =
@@ -83,15 +87,15 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertFalse(result.isCheckValueReturned());
+      assertFalse(result.isSetSucceed());
+      assertFalse(result.isCheckValueReturned());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     try {
@@ -112,11 +116,11 @@ public class TestCheckAndSet {
               "k2".getBytes(),
               "".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k2".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -129,17 +133,17 @@ public class TestCheckAndSet {
               "k2".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k2".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     try {
@@ -161,17 +165,17 @@ public class TestCheckAndSet {
               "k4".getBytes(),
               "v4".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -201,11 +205,11 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -220,12 +224,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -238,17 +242,17 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     try {
@@ -270,18 +274,18 @@ public class TestCheckAndSet {
               "k4".getBytes(),
               "v4".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v3".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -311,11 +315,11 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -330,12 +334,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "v1".getBytes());
 
@@ -350,17 +354,17 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     try {
@@ -382,18 +386,18 @@ public class TestCheckAndSet {
               "k4".getBytes(),
               "v4".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v3".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -423,11 +427,11 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -442,12 +446,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -460,12 +464,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -478,12 +482,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -496,12 +500,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v111v".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v111v".getBytes(), value);
+      assertArrayEquals("v111v".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -514,12 +518,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v111v".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v111v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -532,12 +536,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v3".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -550,12 +554,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v3".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -568,17 +572,17 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v3".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v3".getBytes(), value);
+      assertArrayEquals("v3".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     try {
@@ -600,18 +604,18 @@ public class TestCheckAndSet {
               "k4".getBytes(),
               "v4".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v333v".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v333v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -641,11 +645,11 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -660,12 +664,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -678,12 +682,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -696,12 +700,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -714,12 +718,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v111v".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v111v".getBytes(), value);
+      assertArrayEquals("v111v".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -732,12 +736,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v111v".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v111v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v111v".getBytes(), value);
+      assertArrayEquals("v111v".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -750,12 +754,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v111v".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v111v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -768,12 +772,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v3".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -786,12 +790,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v3".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -804,17 +808,17 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v3".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v3".getBytes(), value);
+      assertArrayEquals("v3".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     try {
@@ -836,18 +840,18 @@ public class TestCheckAndSet {
               "k4".getBytes(),
               "v4".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v333v".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v333v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -877,11 +881,11 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -896,12 +900,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -914,12 +918,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -932,12 +936,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -950,12 +954,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v111v".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v111v".getBytes(), value);
+      assertArrayEquals("v111v".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -968,12 +972,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v111v".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v111v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v111v".getBytes(), value);
+      assertArrayEquals("v111v".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -986,12 +990,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v111v".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v111v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -1004,12 +1008,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v3".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -1022,12 +1026,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v3".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -1040,17 +1044,17 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v3".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v3".getBytes(), value);
+      assertArrayEquals("v3".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     try {
@@ -1072,18 +1076,18 @@ public class TestCheckAndSet {
               "k4".getBytes(),
               "v4".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v333v".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v333v".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1113,11 +1117,11 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -1132,12 +1136,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -1150,12 +1154,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v1".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -1168,17 +1172,17 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     try {
@@ -1200,18 +1204,18 @@ public class TestCheckAndSet {
               "k4".getBytes(),
               "v4".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v3".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     try {
@@ -1233,12 +1237,12 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "v2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v1".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       // v2 <= v2
       options.returnCheckValue = true;
@@ -1252,12 +1256,12 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "v3".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v2".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v3".getBytes(), value);
+      assertArrayEquals("v3".getBytes(), value);
 
       // v3 <= v4
       options.returnCheckValue = true;
@@ -1271,12 +1275,12 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "v4".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v3".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v4".getBytes(), value);
+      assertArrayEquals("v4".getBytes(), value);
 
       // v4 >= v4
       options.returnCheckValue = true;
@@ -1290,12 +1294,12 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "v5".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v4".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v4".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v5".getBytes(), value);
+      assertArrayEquals("v5".getBytes(), value);
 
       // v5 >= v4
       options.returnCheckValue = true;
@@ -1309,12 +1313,12 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "v6".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v5".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v5".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v6".getBytes(), value);
+      assertArrayEquals("v6".getBytes(), value);
 
       // v6 > v5
       options.returnCheckValue = true;
@@ -1328,17 +1332,17 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "v7".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("v6".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("v6".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("v7".getBytes(), value);
+      assertArrayEquals("v7".getBytes(), value);
 
       client.del(tableName, hashKey, "k5".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1368,11 +1372,11 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "2".getBytes(),
               options);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertFalse(result.isCheckValueExist());
+      assertFalse(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertFalse(result.isCheckValueExist());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
@@ -1387,15 +1391,15 @@ public class TestCheckAndSet {
             "k1".getBytes(),
             "2".getBytes(),
             options);
-        Assert.fail();
+        assertTrue(false);
       } catch (PException ex) {
-        Assert.assertTrue(ex.getMessage(), ex.getMessage().endsWith("rocksdb error: 4"));
+        assertTrue(ex.getMessage().endsWith("rocksdb error: 4"), ex.getMessage());
 
       } catch (Exception ex) {
-        Assert.fail();
+        assertTrue(false);
       }
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("".getBytes(), value);
+      assertArrayEquals("".getBytes(), value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "1".getBytes());
 
@@ -1410,12 +1414,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("1".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("2".getBytes(), value);
+      assertArrayEquals("2".getBytes(), value);
 
       options.returnCheckValue = true;
       try {
@@ -1428,15 +1432,15 @@ public class TestCheckAndSet {
             "k1".getBytes(),
             "3".getBytes(),
             options);
-        Assert.assertTrue(false);
+        assertTrue(false);
       } catch (PException ex) {
-        Assert.assertTrue(ex.getMessage(), ex.getMessage().endsWith("rocksdb error: 4"));
+        assertTrue(ex.getMessage().endsWith("rocksdb error: 4"), ex.getMessage());
 
       } catch (Exception ex) {
-        Assert.assertTrue(false);
+        assertTrue(false);
       }
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("2".getBytes(), value);
+      assertArrayEquals("2".getBytes(), value);
 
       options.returnCheckValue = true;
       try {
@@ -1449,15 +1453,15 @@ public class TestCheckAndSet {
             "k1".getBytes(),
             "3".getBytes(),
             options);
-        Assert.assertTrue(false);
+        assertTrue(false);
       } catch (PException ex) {
-        Assert.assertTrue(ex.getMessage(), ex.getMessage().endsWith("rocksdb error: 4"));
+        assertTrue(ex.getMessage().endsWith("rocksdb error: 4"), ex.getMessage());
 
       } catch (Exception ex) {
-        Assert.assertTrue(false);
+        assertTrue(false);
       }
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("2".getBytes(), value);
+      assertArrayEquals("2".getBytes(), value);
 
       options.returnCheckValue = true;
       try {
@@ -1470,15 +1474,15 @@ public class TestCheckAndSet {
             "k1".getBytes(),
             "3".getBytes(),
             options);
-        Assert.assertTrue(false);
+        assertTrue(false);
       } catch (PException ex) {
-        Assert.assertTrue(ex.getMessage(), ex.getMessage().endsWith("rocksdb error: 4"));
+        assertTrue(ex.getMessage().endsWith("rocksdb error: 4"), ex.getMessage());
 
       } catch (Exception ex) {
-        Assert.assertTrue(false);
+        assertTrue(false);
       }
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("2".getBytes(), value);
+      assertArrayEquals("2".getBytes(), value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "0".getBytes());
 
@@ -1493,12 +1497,12 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "-1".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("0".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("0".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("-1".getBytes(), value);
+      assertArrayEquals("-1".getBytes(), value);
 
       options.returnCheckValue = true;
       result =
@@ -1511,17 +1515,17 @@ public class TestCheckAndSet {
               "k1".getBytes(),
               "-2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("-1".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("-1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("-2".getBytes(), value);
+      assertArrayEquals("-2".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     try {
@@ -1543,18 +1547,18 @@ public class TestCheckAndSet {
               "k4".getBytes(),
               "4".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("3".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k4".getBytes());
-      Assert.assertArrayEquals("4".getBytes(), value);
+      assertArrayEquals("4".getBytes(), value);
 
       client.del(tableName, hashKey, "k3".getBytes());
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     try {
@@ -1576,12 +1580,12 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "2".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("1".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("1".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("2".getBytes(), value);
+      assertArrayEquals("2".getBytes(), value);
 
       // 2 <= 2
       options.returnCheckValue = true;
@@ -1595,12 +1599,12 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "3".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("2".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("2".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("3".getBytes(), value);
+      assertArrayEquals("3".getBytes(), value);
 
       // 3 <= 4
       options.returnCheckValue = true;
@@ -1614,12 +1618,12 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "4".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("3".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("3".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("4".getBytes(), value);
+      assertArrayEquals("4".getBytes(), value);
 
       // 4 >= 4
       options.returnCheckValue = true;
@@ -1633,12 +1637,12 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "5".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("4".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("4".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("5".getBytes(), value);
+      assertArrayEquals("5".getBytes(), value);
 
       // 5 >= 4
       options.returnCheckValue = true;
@@ -1652,12 +1656,12 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "6".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("5".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("5".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("6".getBytes(), value);
+      assertArrayEquals("6".getBytes(), value);
 
       // 6 > 5
       options.returnCheckValue = true;
@@ -1671,17 +1675,17 @@ public class TestCheckAndSet {
               "k5".getBytes(),
               "7".getBytes(),
               options);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertTrue(result.isCheckValueReturned());
-      Assert.assertTrue(result.isCheckValueExist());
-      Assert.assertArrayEquals("6".getBytes(), result.getCheckValue());
+      assertTrue(result.isSetSucceed());
+      assertTrue(result.isCheckValueReturned());
+      assertTrue(result.isCheckValueExist());
+      assertArrayEquals("6".getBytes(), result.getCheckValue());
       value = client.get(tableName, hashKey, "k5".getBytes());
-      Assert.assertArrayEquals("7".getBytes(), value);
+      assertArrayEquals("7".getBytes(), value);
 
       client.del(tableName, hashKey, "k5".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1702,41 +1706,41 @@ public class TestCheckAndSet {
       result =
           client.compareExchange(
               tableName, hashKey, "k1".getBytes(), "".getBytes(), "v1".getBytes(), 0);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertNull(result.getActualValue());
+      assertFalse(result.isSetSucceed());
+      assertNull(result.getActualValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertNull(value);
+      assertNull(value);
 
       client.set(tableName, hashKey, "k1".getBytes(), "".getBytes());
 
       result =
           client.compareExchange(
               tableName, hashKey, "k1".getBytes(), "".getBytes(), "v1".getBytes(), 0);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertNull(result.getActualValue());
+      assertTrue(result.isSetSucceed());
+      assertNull(result.getActualValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       result =
           client.compareExchange(
               tableName, hashKey, "k1".getBytes(), "".getBytes(), "v2".getBytes(), 0);
-      Assert.assertFalse(result.isSetSucceed());
-      Assert.assertArrayEquals("v1".getBytes(), result.getActualValue());
+      assertFalse(result.isSetSucceed());
+      assertArrayEquals("v1".getBytes(), result.getActualValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v1".getBytes(), value);
+      assertArrayEquals("v1".getBytes(), value);
 
       result =
           client.compareExchange(
               tableName, hashKey, "k1".getBytes(), "v1".getBytes(), "v2".getBytes(), 0);
-      Assert.assertTrue(result.isSetSucceed());
-      Assert.assertNull(result.getActualValue());
+      assertTrue(result.isSetSucceed());
+      assertNull(result.getActualValue());
       value = client.get(tableName, hashKey, "k1".getBytes());
-      Assert.assertArrayEquals("v2".getBytes(), value);
+      assertArrayEquals("v2".getBytes(), value);
 
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      Assert.fail();
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();

--- a/java-client/src/test/java/org/apache/pegasus/client/TestCheckAndSet.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestCheckAndSet.java
@@ -176,7 +176,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -253,7 +253,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     try {
@@ -365,7 +365,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     try {
@@ -583,7 +583,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     try {
@@ -616,7 +616,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -819,7 +819,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     try {
@@ -852,7 +852,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1055,7 +1055,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     try {
@@ -1088,7 +1088,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k4".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();
@@ -1183,7 +1183,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     try {
@@ -1392,12 +1392,12 @@ public class TestCheckAndSet {
             "k1".getBytes(),
             "2".getBytes(),
             options);
-        assertTrue(false);
+        fail();
       } catch (PException ex) {
         assertTrue(ex.getMessage().endsWith("rocksdb error: 4"), ex.getMessage());
 
       } catch (Exception ex) {
-        assertTrue(false);
+        fail();
       }
       value = client.get(tableName, hashKey, "k1".getBytes());
       assertArrayEquals("".getBytes(), value);
@@ -1741,7 +1741,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     PegasusClientFactory.closeSingletonClient();

--- a/java-client/src/test/java/org/apache/pegasus/client/TestCheckAndSet.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestCheckAndSet.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 
@@ -95,7 +96,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     try {
@@ -143,7 +144,7 @@ public class TestCheckAndSet {
       client.del(tableName, hashKey, "k1".getBytes());
     } catch (PException e) {
       e.printStackTrace();
-      assertTrue(false);
+      fail();
     }
 
     try {

--- a/java-client/src/test/java/org/apache/pegasus/client/TestFutureGroup.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestFutureGroup.java
@@ -18,18 +18,17 @@
  */
 package org.apache.pegasus.client;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 public class TestFutureGroup {
-
-  @Rule public TestName name = new TestName();
 
   private static final class TestEventExecutor extends SingleThreadEventExecutor {
     TestEventExecutor() {
@@ -48,7 +47,7 @@ public class TestFutureGroup {
   }
 
   @Test
-  public void testBlockingOperationException() throws Exception {
+  public void testBlockingOperationException(TestInfo testInfo) throws Exception {
     // ensure pegasus client will throw PException when BlockingOperationException is thrown.
 
     TestEventExecutor executor = new TestEventExecutor();
@@ -65,7 +64,7 @@ public class TestFutureGroup {
             group.waitAllCompleteOrOneFail(10000);
           } catch (PException e) {
             success.set(false);
-            System.err.println(name.getMethodName() + ": " + e.toString());
+            System.err.println(testInfo.getDisplayName() + ": " + e.toString());
           }
           executed.set(true);
         });
@@ -81,11 +80,11 @@ public class TestFutureGroup {
       Thread.sleep(100);
     }
 
-    Assert.assertFalse(success.get());
+    assertFalse(success.get());
   }
 
   @Test
-  public void testFutureWaitTimeout() throws Exception {
+  public void testFutureWaitTimeout(TestInfo testInfo) throws Exception {
     TestEventExecutor executor = new TestEventExecutor();
     Promise<Void> promise = executor.newPromise();
 
@@ -96,9 +95,9 @@ public class TestFutureGroup {
       group.waitAllCompleteOrOneFail(10);
     } catch (PException e) {
       // must throw exception
-      System.err.println(name.getMethodName() + ": " + e.toString());
+      System.err.println(testInfo.getDisplayName() + ": " + e.toString());
       return;
     }
-    Assert.fail();
+    fail();
   }
 }

--- a/java-client/src/test/java/org/apache/pegasus/client/TestIncr.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestIncr.java
@@ -19,8 +19,10 @@
 package org.apache.pegasus.client;
 
 /** @author qinzuoyan */
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 /** Created by mi on 18-7-10. */
 public class TestIncr {
@@ -41,23 +43,23 @@ public class TestIncr {
 
       System.out.println("incr to empty value ...");
       long result = client.incr(tableName, hashKey, sortKey, 100);
-      Assert.assertEquals(100, result);
+      assertEquals(100, result);
       ttlSeconds = client.ttl(tableName, hashKey, sortKey);
-      Assert.assertEquals(-1, ttlSeconds);
+      assertEquals(-1, ttlSeconds);
       System.out.println("incr to empty value ok");
 
       System.out.println("incr zero ...");
       result = client.incr(tableName, hashKey, sortKey, 0);
-      Assert.assertEquals(100, result);
+      assertEquals(100, result);
       ttlSeconds = client.ttl(tableName, hashKey, sortKey);
-      Assert.assertEquals(-1, ttlSeconds);
+      assertEquals(-1, ttlSeconds);
       System.out.println("incr zero ok");
 
       System.out.println("incr negative ...");
       result = client.incr(tableName, hashKey, sortKey, -1);
-      Assert.assertEquals(99, result);
+      assertEquals(99, result);
       ttlSeconds = client.ttl(tableName, hashKey, sortKey);
-      Assert.assertEquals(-1, ttlSeconds);
+      assertEquals(-1, ttlSeconds);
       System.out.println("incr negative ok");
 
       System.out.println("del value ...");
@@ -66,40 +68,40 @@ public class TestIncr {
 
       System.out.println("incr to un-exist value ...");
       result = client.incr(tableName, hashKey, sortKey, 200);
-      Assert.assertEquals(200, result);
+      assertEquals(200, result);
       ttlSeconds = client.ttl(tableName, hashKey, sortKey);
-      Assert.assertEquals(-1, ttlSeconds);
+      assertEquals(-1, ttlSeconds);
       System.out.println("incr to un-exist value ok");
 
       System.out.println("incr with ttlSeconds > 0 ...");
       result = client.incr(tableName, hashKey, sortKey, 1, 10);
-      Assert.assertEquals(201, result);
+      assertEquals(201, result);
       ttlSeconds = client.ttl(tableName, hashKey, sortKey);
-      Assert.assertTrue(ttlSeconds > 0);
-      Assert.assertTrue(ttlSeconds <= 10);
+      assertTrue(ttlSeconds > 0);
+      assertTrue(ttlSeconds <= 10);
       System.out.println("incr with ttlSeconds > 0 ok");
 
       System.out.println("incr with ttlSeconds == 0 ...");
       result = client.incr(tableName, hashKey, sortKey, 1);
-      Assert.assertEquals(202, result);
+      assertEquals(202, result);
       ttlSeconds = client.ttl(tableName, hashKey, sortKey);
-      Assert.assertTrue(ttlSeconds > 0);
-      Assert.assertTrue(ttlSeconds <= 10);
+      assertTrue(ttlSeconds > 0);
+      assertTrue(ttlSeconds <= 10);
       System.out.println("incr with ttlSeconds == 0 ok");
 
       System.out.println("incr with ttlSeconds > 0 ...");
       result = client.incr(tableName, hashKey, sortKey, 1, 20);
-      Assert.assertEquals(203, result);
+      assertEquals(203, result);
       ttlSeconds = client.ttl(tableName, hashKey, sortKey);
-      Assert.assertTrue(ttlSeconds > 10);
-      Assert.assertTrue(ttlSeconds <= 20);
+      assertTrue(ttlSeconds > 10);
+      assertTrue(ttlSeconds <= 20);
       System.out.println("incr with ttlSeconds > 0 ok");
 
       System.out.println("incr with ttlSeconds == -1 ...");
       result = client.incr(tableName, hashKey, sortKey, 1, -1);
-      Assert.assertEquals(204, result);
+      assertEquals(204, result);
       ttlSeconds = client.ttl(tableName, hashKey, sortKey);
-      Assert.assertEquals(-1, ttlSeconds);
+      assertEquals(-1, ttlSeconds);
       System.out.println("incr with ttlSeconds == -1 ok");
 
       System.out.println("del value ...");
@@ -107,7 +109,7 @@ public class TestIncr {
       System.out.println("del value ok");
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     PegasusClientFactory.closeSingletonClient();

--- a/java-client/src/test/java/org/apache/pegasus/client/TestMultiThread.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestMultiThread.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pegasus.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Created by mi on 16-3-23. */
 public class TestMultiThread {
@@ -63,7 +65,7 @@ public class TestMultiThread {
             client.set(TABLE_NAME, key.getBytes(), null, value.getBytes(), 0);
           } catch (PException e) {
             e.printStackTrace();
-            Assert.assertTrue(false);
+            assertTrue(false);
           }
           --left_put;
           ++key_cursor;
@@ -77,7 +79,7 @@ public class TestMultiThread {
             }
           } catch (PException e) {
             e.printStackTrace();
-            Assert.assertTrue(false);
+            assertTrue(false);
           }
         }
       }
@@ -101,7 +103,7 @@ public class TestMultiThread {
       for (int v : values) {
         expected_sum += v;
       }
-      Assert.assertEquals(expected_sum, value_sum);
+      assertEquals(expected_sum, value_sum);
     }
   }
 

--- a/java-client/src/test/java/org/apache/pegasus/client/TestNoOperate.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestNoOperate.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pegasus.client;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Created by weijiesun on 16-11-24. */
 public class TestNoOperate {

--- a/java-client/src/test/java/org/apache/pegasus/client/TestPException.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestPException.java
@@ -19,6 +19,9 @@
 
 package org.apache.pegasus.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import io.netty.util.concurrent.DefaultPromise;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -31,8 +34,7 @@ import org.apache.pegasus.operator.rrdb_put_operator;
 import org.apache.pegasus.rpc.InternalTableOptions;
 import org.apache.pegasus.rpc.async.ClusterManager;
 import org.apache.pegasus.rpc.async.TableHandler;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestPException {
   private String metaList = "127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603";
@@ -43,7 +45,7 @@ public class TestPException {
     PException ex = PException.threadInterrupted("test", new InterruptedException("intxxx"));
     String exceptionInfo =
         "{version}: org.apache.pegasus.rpc.ReplicationException: ERR_THREAD_INTERRUPTED: [table=test] Thread was interrupted: intxxx";
-    Assert.assertEquals(exceptionInfo, ex.getMessage());
+    assertEquals(exceptionInfo, ex.getMessage());
   }
 
   @Test
@@ -54,7 +56,7 @@ public class TestPException {
         String.format(
             "{version}: org.apache.pegasus.rpc.ReplicationException: ERR_TIMEOUT: [metaServer=%s, table=test, request=%s, timeout=1000ms] Timeout on Future await: tmxxx",
             metaList, request.toString());
-    Assert.assertEquals(exceptionInfo, ex.getMessage());
+    assertEquals(exceptionInfo, ex.getMessage());
   }
 
   @Test
@@ -62,10 +64,10 @@ public class TestPException {
     // Test the constructors of PException
 
     PException ex = new PException("test");
-    Assert.assertEquals("{version}: test", ex.getMessage());
+    assertEquals("{version}: test", ex.getMessage());
 
     ex = new PException("test", new TimeoutException());
-    Assert.assertEquals("{version}: test", ex.getMessage());
+    assertEquals("{version}: test", ex.getMessage());
   }
 
   @Test
@@ -96,12 +98,12 @@ public class TestPException {
           String.format(
               "org.apache.pegasus.client.PException: {version}: org.apache.pegasus.rpc.ReplicationException: ERR_OBJECT_NOT_FOUND: [metaServer=%s,table=temp,operation=put,request=%s,replicaServer=%s,gpid=(%s),timeout=%dms] The replica server doesn't serve this partition!",
               client.getMetaList(), request.toString(), server, gpid.toString(), timeout);
-      Assert.assertEquals(e.getMessage(), msg);
+      assertEquals(e.getMessage(), msg);
       return;
     } catch (InterruptedException e) {
-      Assert.fail();
+      fail();
     }
-    Assert.fail();
+    fail();
   }
 
   @Test
@@ -132,7 +134,7 @@ public class TestPException {
           String.format(
               "org.apache.pegasus.client.PException: {version}: org.apache.pegasus.rpc.ReplicationException: ERR_TIMEOUT: [metaServer=%s,table=temp,operation=put,request=%s,replicaServer=%s,gpid=(%s),timeout=1000ms] The operation is timed out!",
               client.getMetaList(), request.toString(), server, gpid.toString());
-      Assert.assertEquals(e.getMessage(), msg);
+      assertEquals(e.getMessage(), msg);
     }
   }
 }

--- a/java-client/src/test/java/org/apache/pegasus/client/TestPing.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestPing.java
@@ -18,11 +18,17 @@
  */
 package org.apache.pegasus.client;
 
-import java.util.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Created by mi on 16-3-22. */
 public class TestPing {
@@ -59,12 +65,12 @@ public class TestPing {
 
       System.out.println("get value ...");
       byte[] result = client.get(tableName, hashKey, sortKey);
-      Assert.assertTrue(Arrays.equals(value, result));
+      assertTrue(Arrays.equals(value, result));
       System.out.println("get value ok");
 
       System.out.println("get ttl ...");
       int ttl = client.ttl(tableName, hashKey, sortKey);
-      Assert.assertEquals(-1, ttl);
+      assertEquals(-1, ttl);
       System.out.println("get ttl ok");
 
       System.out.println("multi get ...");
@@ -75,14 +81,14 @@ public class TestPing {
       sortKeys.add(sortKey);
       List<Pair<byte[], byte[]>> values = new ArrayList<Pair<byte[], byte[]>>();
       boolean getAll = client.multiGet(tableName, hashKey, sortKeys, values);
-      Assert.assertTrue(getAll);
-      Assert.assertEquals(2, values.size());
-      Assert.assertEquals(sortKey, values.get(0).getKey());
-      Assert.assertArrayEquals(sortKey, values.get(0).getKey());
-      Assert.assertArrayEquals(value, values.get(0).getValue());
-      Assert.assertEquals(sortKey1, values.get(1).getKey());
-      Assert.assertArrayEquals(sortKey1, values.get(1).getKey());
-      Assert.assertArrayEquals(value1, values.get(1).getValue());
+      assertTrue(getAll);
+      assertEquals(2, values.size());
+      assertEquals(sortKey, values.get(0).getKey());
+      assertArrayEquals(sortKey, values.get(0).getKey());
+      assertArrayEquals(value, values.get(0).getValue());
+      assertEquals(sortKey1, values.get(1).getKey());
+      assertArrayEquals(sortKey1, values.get(1).getKey());
+      assertArrayEquals(value1, values.get(1).getValue());
       System.out.println("multi get ok");
 
       System.out.println("multi get partial ...");
@@ -94,18 +100,18 @@ public class TestPing {
         sortKeys.add(p.getKey());
       }
       getAll = client.multiGet(tableName, hashKey, sortKeys, 5, 1000000, values);
-      Assert.assertFalse(getAll);
-      Assert.assertEquals(5, values.size());
-      Assert.assertEquals(sortKey, values.get(0).getKey());
-      Assert.assertArrayEquals(sortKey, values.get(0).getKey());
-      Assert.assertArrayEquals(value, values.get(0).getValue());
-      Assert.assertEquals(sortKey1, values.get(1).getKey());
-      Assert.assertArrayEquals(sortKey1, values.get(1).getKey());
-      Assert.assertArrayEquals(value1, values.get(1).getValue());
+      assertFalse(getAll);
+      assertEquals(5, values.size());
+      assertEquals(sortKey, values.get(0).getKey());
+      assertArrayEquals(sortKey, values.get(0).getKey());
+      assertArrayEquals(value, values.get(0).getValue());
+      assertEquals(sortKey1, values.get(1).getKey());
+      assertArrayEquals(sortKey1, values.get(1).getKey());
+      assertArrayEquals(value1, values.get(1).getValue());
       for (int i = 2; i < 5; ++i) {
-        Assert.assertEquals(setValues.get(i - 2).getKey(), values.get(i).getKey());
-        Assert.assertArrayEquals(setValues.get(i - 2).getKey(), values.get(i).getKey());
-        Assert.assertArrayEquals(setValues.get(i - 2).getValue(), values.get(i).getValue());
+        assertEquals(setValues.get(i - 2).getKey(), values.get(i).getKey());
+        assertArrayEquals(setValues.get(i - 2).getKey(), values.get(i).getKey());
+        assertArrayEquals(setValues.get(i - 2).getValue(), values.get(i).getValue());
       }
       System.out.println("multi get partial ok");
 
@@ -115,11 +121,11 @@ public class TestPing {
 
       System.out.println("get deleted value ...");
       result = client.get(tableName, hashKey, sortKey);
-      Assert.assertEquals(result, null);
+      assertEquals(result, null);
       System.out.println("get deleted value ok");
     } catch (PException e) {
       e.printStackTrace();
-      Assert.assertTrue(false);
+      assertTrue(false);
     }
 
     client.close();

--- a/java-client/src/test/java/org/apache/pegasus/client/TestPingZK.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestPingZK.java
@@ -18,14 +18,16 @@
  */
 package org.apache.pegasus.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.google.common.io.ByteStreams;
 import java.io.InputStream;
 import java.util.Arrays;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** @author qinzuoyan */
 public class TestPingZK {
@@ -73,7 +75,7 @@ public class TestPingZK {
 
     System.out.println("get value ...");
     byte[] result = client.get(tableName, hashKey, sortKey);
-    Assert.assertTrue(Arrays.equals(value, result));
+    assertTrue(Arrays.equals(value, result));
     System.out.println("get value ok");
 
     System.out.println("del value ...");
@@ -82,7 +84,7 @@ public class TestPingZK {
 
     System.out.println("get deleted value ...");
     result = client.get(tableName, hashKey, sortKey);
-    Assert.assertEquals(result, null);
+    assertEquals(result, null);
     System.out.println("get deleted value ok");
 
     System.out.println("set value ...");

--- a/java-client/src/test/java/org/apache/pegasus/client/TestTimeout.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestTimeout.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pegasus.client;
 
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 
 public class TestTimeout {
   @Test

--- a/java-client/src/test/java/org/apache/pegasus/metrics/MetricsPoolTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/metrics/MetricsPoolTest.java
@@ -18,18 +18,19 @@
  */
 package org.apache.pegasus.metrics;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
-import junit.framework.Assert;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Created by weijiesun on 18-3-9. */
 public class MetricsPoolTest {
-  @Before
+  @BeforeEach
   public void before() {
     r = new MetricRegistry();
   }
@@ -48,7 +49,7 @@ public class MetricsPoolTest {
     pool.genJsonsFromMeter("TestName", m, builder);
 
     JSONArray array = new JSONArray("[" + builder.toString() + "]");
-    Assert.assertEquals(1, array.length());
+    assertEquals(1, array.length());
 
     String[] metrics = {
       "TestName.cps-1sec", "TestName.cps-1min", "TestName.cps-5min", "TestName.cps-15min"
@@ -57,11 +58,11 @@ public class MetricsPoolTest {
     for (int i = 0; i < array.length(); ++i) {
       JSONObject j = array.getJSONObject(i);
 
-      Assert.assertEquals(tags, j.getString("tags"));
-      Assert.assertEquals(metrics[i], j.getString("metric"));
-      Assert.assertEquals("GAUGE", j.getString("counterType"));
-      Assert.assertEquals(20, j.getInt("step"));
-      Assert.assertEquals(host, j.getString("endpoint"));
+      assertEquals(tags, j.getString("tags"));
+      assertEquals(metrics[i], j.getString("metric"));
+      assertEquals("GAUGE", j.getString("counterType"));
+      assertEquals(20, j.getInt("step"));
+      assertEquals(host, j.getString("endpoint"));
     }
   }
 
@@ -77,18 +78,18 @@ public class MetricsPoolTest {
     pool.genJsonsFromHistogram("TestHist", h, builder);
 
     JSONArray array = new JSONArray("[" + builder.toString() + "]");
-    Assert.assertEquals(2, array.length());
+    assertEquals(2, array.length());
 
     String[] metrics = {"TestHist.p99", "TestHist.p999"};
 
     for (int i = 0; i < array.length(); ++i) {
       JSONObject j = array.getJSONObject(i);
 
-      Assert.assertEquals(tags, j.getString("tags"));
-      Assert.assertEquals(metrics[i], j.getString("metric"));
-      Assert.assertEquals("GAUGE", j.getString("counterType"));
-      Assert.assertEquals(20, j.getInt("step"));
-      Assert.assertEquals(host, j.getString("endpoint"));
+      assertEquals(tags, j.getString("tags"));
+      assertEquals(metrics[i], j.getString("metric"));
+      assertEquals("GAUGE", j.getString("counterType"));
+      assertEquals(20, j.getInt("step"));
+      assertEquals(host, j.getString("endpoint"));
     }
   }
 
@@ -107,25 +108,25 @@ public class MetricsPoolTest {
     MetricsPool.oneMetricToJson(metric, builder);
 
     JSONObject obj = new JSONObject(builder.toString());
-    Assert.assertEquals(metric.endpoint, obj.getString("endpoint"));
-    Assert.assertEquals(metric.metric, obj.getString("metric"));
-    Assert.assertEquals(metric.timestamp, obj.getLong("timestamp"));
-    Assert.assertEquals(metric.step, obj.getInt("step"));
-    Assert.assertEquals(metric.value, obj.getDouble("value"));
-    Assert.assertEquals(metric.counterType, obj.getString("counterType"));
-    Assert.assertEquals(metric.tags, obj.getString("tags"));
+    assertEquals(metric.endpoint, obj.getString("endpoint"));
+    assertEquals(metric.metric, obj.getString("metric"));
+    assertEquals(metric.timestamp, obj.getLong("timestamp"));
+    assertEquals(metric.step, obj.getInt("step"));
+    assertEquals(metric.value, obj.getDouble("value"));
+    assertEquals(metric.counterType, obj.getString("counterType"));
+    assertEquals(metric.tags, obj.getString("tags"));
 
     builder.setLength(0);
     metric.tags = "";
     MetricsPool.oneMetricToJson(metric, builder);
     obj = new JSONObject(builder.toString());
-    Assert.assertEquals(metric.endpoint, obj.getString("endpoint"));
-    Assert.assertEquals(metric.metric, obj.getString("metric"));
-    Assert.assertEquals(metric.timestamp, obj.getLong("timestamp"));
-    Assert.assertEquals(metric.step, obj.getInt("step"));
-    Assert.assertEquals(metric.value, obj.getDouble("value"));
-    Assert.assertEquals(metric.counterType, obj.getString("counterType"));
-    Assert.assertEquals(metric.tags, obj.getString("tags"));
+    assertEquals(metric.endpoint, obj.getString("endpoint"));
+    assertEquals(metric.metric, obj.getString("metric"));
+    assertEquals(metric.timestamp, obj.getLong("timestamp"));
+    assertEquals(metric.step, obj.getInt("step"));
+    assertEquals(metric.value, obj.getDouble("value"));
+    assertEquals(metric.counterType, obj.getString("counterType"));
+    assertEquals(metric.tags, obj.getString("tags"));
   }
 
   @Test
@@ -143,18 +144,18 @@ public class MetricsPoolTest {
     }
 
     JSONArray array = new JSONArray(pool.metricsToJson());
-    Assert.assertEquals(6, array.length());
+    assertEquals(6, array.length());
     for (int i = 0; i < array.length(); ++i) {
       JSONObject j = array.getJSONObject(i);
 
       if (j.getString("metric").contains("@")) {
-        Assert.assertEquals(tags + ",table=temp", j.getString("tags"));
+        assertEquals(tags + ",table=temp", j.getString("tags"));
       } else {
-        Assert.assertEquals(tags, j.getString("tags"));
+        assertEquals(tags, j.getString("tags"));
       }
-      Assert.assertEquals("GAUGE", j.getString("counterType"));
-      Assert.assertEquals(20, j.getInt("step"));
-      Assert.assertEquals(host, j.getString("endpoint"));
+      assertEquals("GAUGE", j.getString("counterType"));
+      assertEquals(20, j.getInt("step"));
+      assertEquals(host, j.getString("endpoint"));
     }
   }
 

--- a/java-client/src/test/java/org/apache/pegasus/operator/ClientOperatorTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/operator/ClientOperatorTest.java
@@ -19,13 +19,15 @@
 
 package org.apache.pegasus.operator;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.pegasus.apps.check_and_mutate_request;
 import org.apache.pegasus.apps.multi_get_request;
 import org.apache.pegasus.apps.update_request;
 import org.apache.pegasus.base.blob;
 import org.apache.pegasus.base.gpid;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ClientOperatorTest {
 
@@ -33,20 +35,20 @@ public class ClientOperatorTest {
   public void testSupportBackupRequest() {
     client_operator op =
         new rrdb_multi_get_operator(new gpid(1, 1), "test", new multi_get_request(), 0);
-    Assert.assertTrue(op.supportBackupRequest());
+    assertTrue(op.supportBackupRequest());
 
     op = new rrdb_get_operator(new gpid(1, 1), "test", new blob(), 0);
-    Assert.assertTrue(op.supportBackupRequest());
+    assertTrue(op.supportBackupRequest());
 
     op = new rrdb_ttl_operator(new gpid(1, 1), "test", new blob(), 0);
-    Assert.assertTrue(op.supportBackupRequest());
+    assertTrue(op.supportBackupRequest());
 
     op = new rrdb_put_operator(new gpid(1, 1), "test", new update_request(), 0);
-    Assert.assertFalse(op.supportBackupRequest());
+    assertFalse(op.supportBackupRequest());
 
     op =
         new rrdb_check_and_mutate_operator(
             new gpid(1, 1), "test", new check_and_mutate_request(), 0);
-    Assert.assertFalse(op.supportBackupRequest());
+    assertFalse(op.supportBackupRequest());
   }
 }

--- a/java-client/src/test/java/org/apache/pegasus/rpc/async/ClusterManagerTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/rpc/async/ClusterManagerTest.java
@@ -18,21 +18,25 @@
  */
 package org.apache.pegasus.rpc.async;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.apache.pegasus.base.error_code;
 import org.apache.pegasus.base.rpc_address;
 import org.apache.pegasus.client.ClientOptions;
 import org.apache.pegasus.rpc.InternalTableOptions;
 import org.apache.pegasus.rpc.ReplicationException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ClusterManagerTest {
-  @Before
+  @BeforeEach
   public void before() throws Exception {}
 
-  @After
+  @AfterEach
   public void after() throws Exception {}
 
   /** Method: getReplicaSession(rpc_address address) */
@@ -46,7 +50,7 @@ public class ClusterManagerTest {
     // input an invalid rpc address
     rpc_address address = new rpc_address();
     ReplicaSession session = testManager.getReplicaSession(address);
-    Assert.assertNull(session);
+    assertNull(session);
   }
 
   /** Method: openTable(String name, KeyHasher h) */
@@ -61,9 +65,9 @@ public class ClusterManagerTest {
     try {
       result = testManager.openTable("testName", InternalTableOptions.forTest());
     } catch (ReplicationException e) {
-      Assert.assertEquals(error_code.error_types.ERR_SESSION_RESET, e.getErrorType());
+      assertEquals(error_code.error_types.ERR_SESSION_RESET, e.getErrorType());
     } finally {
-      Assert.assertNull(result);
+      assertNull(result);
     }
     testManager.close();
 
@@ -73,20 +77,20 @@ public class ClusterManagerTest {
     try {
       result = testManager.openTable("hehe", InternalTableOptions.forTest());
     } catch (ReplicationException e) {
-      Assert.assertEquals(error_code.error_types.ERR_OBJECT_NOT_FOUND, e.getErrorType());
+      assertEquals(error_code.error_types.ERR_OBJECT_NOT_FOUND, e.getErrorType());
     } finally {
-      Assert.assertNull(result);
+      assertNull(result);
     }
 
     // test open an valid table
     try {
       result = testManager.openTable("temp", InternalTableOptions.forTest());
     } catch (ReplicationException e) {
-      Assert.fail();
+      fail();
     } finally {
-      Assert.assertNotNull(result);
+      assertNotNull(result);
       // in onebox, we create a table named temp with 8 partitions in default.
-      Assert.assertEquals(8, result.getPartitionCount());
+      assertEquals(8, result.getPartitionCount());
     }
     testManager.close();
   }

--- a/java-client/src/test/java/org/apache/pegasus/rpc/async/InterceptorTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/rpc/async/InterceptorTest.java
@@ -18,13 +18,16 @@
  */
 package org.apache.pegasus.rpc.async;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import org.apache.pegasus.client.ClientOptions;
 import org.apache.pegasus.client.PException;
 import org.apache.pegasus.client.PegasusClientFactory;
 import org.apache.pegasus.client.PegasusTableInterface;
 import org.apache.pegasus.client.TableOptions;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class InterceptorTest {
   @Test
@@ -42,20 +45,18 @@ public class InterceptorTest {
 
     // if origin value was not compressed, both commonTable and compressTable can read origin value
     commonTable.set(hashKey, sortKey, commonValue, 10000);
-    Assertions.assertEquals(
-        new String(commonTable.get(hashKey, sortKey, 10000)), new String(commonValue));
-    Assertions.assertEquals(
-        new String(compressTable.get(hashKey, sortKey, 10000)), new String(commonValue));
+    assertEquals(new String(commonTable.get(hashKey, sortKey, 10000)), new String(commonValue));
+    assertEquals(new String(compressTable.get(hashKey, sortKey, 10000)), new String(commonValue));
 
     // if origin value was compressed, only compressTable can read successfully
     compressTable.set(hashKey, sortKey, compressionValue, 10000);
-    Assertions.assertNotEquals(
+    assertNotEquals(
         new String(commonTable.get(hashKey, sortKey, 10000)), new String(compressionValue));
-    Assertions.assertEquals(
+    assertEquals(
         new String(compressTable.get(hashKey, sortKey, 10000)), new String(compressionValue));
 
     // if origin value is null, return null
     byte[] ret = compressTable.get("not-exist".getBytes(), sortKey, 10000);
-    Assertions.assertNull(ret);
+    assertNull(ret);
   }
 }

--- a/java-client/src/test/java/org/apache/pegasus/rpc/async/TimeoutBenchmark.java
+++ b/java-client/src/test/java/org/apache/pegasus/rpc/async/TimeoutBenchmark.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pegasus.rpc.async;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pegasus.apps.update_request;
 import org.apache.pegasus.base.blob;
@@ -27,8 +30,7 @@ import org.apache.pegasus.client.ClientOptions;
 import org.apache.pegasus.rpc.InternalTableOptions;
 import org.apache.pegasus.rpc.ReplicationException;
 import org.apache.pegasus.tools.Toollet;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
 /** Created by weijiesun on 16-11-25. */
@@ -52,12 +54,12 @@ public class TimeoutBenchmark {
     for (int i = 0; i < count; ++i) {
       try {
         handle.operate(op, 0);
-        Assert.fail();
+        fail();
       } catch (ReplicationException e) {
         long t = System.currentTimeMillis();
         result[i] = t - current;
         current = t;
-        Assert.assertEquals(e.getErrorType(), error_code.error_types.ERR_TIMEOUT);
+        assertEquals(e.getErrorType(), error_code.error_types.ERR_TIMEOUT);
       }
     }
     System.out.println("finished");
@@ -85,7 +87,7 @@ public class TimeoutBenchmark {
       handle = manager.openTable("temp", InternalTableOptions.forTest());
     } catch (ReplicationException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
       return;
     }
 

--- a/java-client/src/test/java/org/apache/pegasus/security/NegotiationTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/security/NegotiationTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pegasus.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 
 import java.nio.charset.Charset;
@@ -26,9 +28,8 @@ import org.apache.pegasus.apps.negotiation_response;
 import org.apache.pegasus.apps.negotiation_status;
 import org.apache.pegasus.base.blob;
 import org.apache.pegasus.rpc.async.ReplicaSession;
-import org.junit.Assert;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class NegotiationTest {
@@ -40,16 +41,16 @@ public class NegotiationTest {
 
     Mockito.doNothing().when(mockNegotiation).send(any(), any());
     mockNegotiation.start();
-    Assert.assertEquals(mockNegotiation.getStatus(), negotiation_status.SASL_LIST_MECHANISMS);
+    assertEquals(mockNegotiation.getStatus(), negotiation_status.SASL_LIST_MECHANISMS);
   }
 
   @Test
   public void tetGetMatchMechanism() {
     String matchMechanism = negotiation.getMatchMechanism("GSSAPI,ABC");
-    Assert.assertEquals(matchMechanism, "GSSAPI");
+    assertEquals(matchMechanism, "GSSAPI");
 
     matchMechanism = negotiation.getMatchMechanism("TEST,ABC");
-    Assert.assertEquals(matchMechanism, "");
+    assertEquals(matchMechanism, "");
   }
 
   @Test
@@ -85,8 +86,7 @@ public class NegotiationTest {
                   negotiation_status.SASL_LIST_MECHANISMS_RESP,
                   new blob("GSSAPI".getBytes(Charset.defaultCharset())));
           mockNegotiation.onRecvMechanisms(response);
-          Assert.assertEquals(
-              mockNegotiation.getStatus(), negotiation_status.SASL_SELECT_MECHANISMS);
+          assertEquals(mockNegotiation.getStatus(), negotiation_status.SASL_SELECT_MECHANISMS);
         });
 
     // deal with wrong response.msg
@@ -121,7 +121,7 @@ public class NegotiationTest {
     try {
       Mockito.when(mockNegotiation.saslWrapper.getInitialResponse()).thenReturn(new blob());
     } catch (Exception ex) {
-      Assert.fail();
+      fail();
     }
 
     // normal case
@@ -129,7 +129,7 @@ public class NegotiationTest {
         new negotiation_response(
             negotiation_status.SASL_SELECT_MECHANISMS_RESP, new blob(new byte[0]));
     Assertions.assertDoesNotThrow(() -> mockNegotiation.onMechanismSelected(response));
-    Assert.assertEquals(mockNegotiation.getStatus(), negotiation_status.SASL_INITIATE);
+    assertEquals(mockNegotiation.getStatus(), negotiation_status.SASL_INITIATE);
 
     // deal with wrong response.status
     response.status = negotiation_status.SASL_LIST_MECHANISMS;
@@ -150,7 +150,7 @@ public class NegotiationTest {
     try {
       Mockito.when(mockNegotiation.saslWrapper.evaluateChallenge(any())).thenReturn(new blob());
     } catch (Exception ex) {
-      Assert.fail();
+      fail();
     }
 
     // normal case
@@ -159,11 +159,11 @@ public class NegotiationTest {
           negotiation_response response =
               new negotiation_response(negotiation_status.SASL_CHALLENGE, new blob(new byte[0]));
           mockNegotiation.onChallenge(response);
-          Assert.assertEquals(mockNegotiation.getStatus(), negotiation_status.SASL_CHALLENGE_RESP);
+          assertEquals(mockNegotiation.getStatus(), negotiation_status.SASL_CHALLENGE_RESP);
 
           response = new negotiation_response(negotiation_status.SASL_SUCC, new blob(new byte[0]));
           mockNegotiation.onChallenge(response);
-          Assert.assertEquals(mockNegotiation.getStatus(), negotiation_status.SASL_SUCC);
+          assertEquals(mockNegotiation.getStatus(), negotiation_status.SASL_SUCC);
         });
 
     // deal with wrong response.status

--- a/java-client/src/test/java/org/apache/pegasus/security/NegotiationTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/security/NegotiationTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pegasus.security;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
 import java.nio.charset.Charset;
@@ -28,7 +30,6 @@ import org.apache.pegasus.apps.negotiation_response;
 import org.apache.pegasus.apps.negotiation_status;
 import org.apache.pegasus.base.blob;
 import org.apache.pegasus.rpc.async.ReplicaSession;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -57,10 +58,10 @@ public class NegotiationTest {
   public void testCheckStatus() {
     negotiation_status expectedStatus = negotiation_status.SASL_LIST_MECHANISMS;
 
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> negotiation.checkStatus(negotiation_status.SASL_LIST_MECHANISMS, expectedStatus));
 
-    Assertions.assertThrows(
+    assertThrows(
         Exception.class,
         () ->
             negotiation.checkStatus(negotiation_status.SASL_LIST_MECHANISMS_RESP, expectedStatus));
@@ -73,13 +74,13 @@ public class NegotiationTest {
     mockNegotiation.saslWrapper = mockSaslWrapper;
 
     Mockito.doNothing().when(mockNegotiation).send(any(), any());
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> {
           Mockito.when(mockNegotiation.saslWrapper.init(any())).thenReturn(new byte[0]);
         });
 
     // normal case
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> {
           negotiation_response response =
               new negotiation_response(
@@ -90,7 +91,7 @@ public class NegotiationTest {
         });
 
     // deal with wrong response.msg
-    Assertions.assertThrows(
+    assertThrows(
         Exception.class,
         () -> {
           negotiation_response response =
@@ -101,7 +102,7 @@ public class NegotiationTest {
         });
 
     // deal with wrong response.status
-    Assertions.assertThrows(
+    assertThrows(
         Exception.class,
         () -> {
           negotiation_response response =
@@ -128,12 +129,12 @@ public class NegotiationTest {
     negotiation_response response =
         new negotiation_response(
             negotiation_status.SASL_SELECT_MECHANISMS_RESP, new blob(new byte[0]));
-    Assertions.assertDoesNotThrow(() -> mockNegotiation.onMechanismSelected(response));
+    assertDoesNotThrow(() -> mockNegotiation.onMechanismSelected(response));
     assertEquals(mockNegotiation.getStatus(), negotiation_status.SASL_INITIATE);
 
     // deal with wrong response.status
     response.status = negotiation_status.SASL_LIST_MECHANISMS;
-    Assertions.assertThrows(Exception.class, () -> mockNegotiation.onMechanismSelected(response));
+    assertThrows(Exception.class, () -> mockNegotiation.onMechanismSelected(response));
   }
 
   @Test
@@ -154,7 +155,7 @@ public class NegotiationTest {
     }
 
     // normal case
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> {
           negotiation_response response =
               new negotiation_response(negotiation_status.SASL_CHALLENGE, new blob(new byte[0]));
@@ -167,7 +168,7 @@ public class NegotiationTest {
         });
 
     // deal with wrong response.status
-    Assertions.assertThrows(
+    assertThrows(
         Exception.class,
         () -> {
           negotiation_response response =

--- a/java-client/src/test/java/org/apache/pegasus/security/NegotiationTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/security/NegotiationTest.java
@@ -20,8 +20,8 @@ package org.apache.pegasus.security;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 
 import java.nio.charset.Charset;

--- a/java-client/src/test/java/org/apache/pegasus/tools/TestZstdWrapper.java
+++ b/java-client/src/test/java/org/apache/pegasus/tools/TestZstdWrapper.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pegasus.tools;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.apache.pegasus.client.PException;
 import org.apache.pegasus.client.PegasusClientFactory;
 import org.apache.pegasus.client.PegasusClientInterface;
 import org.apache.pegasus.client.PegasusTableInterface;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestZstdWrapper {
   @Test
@@ -46,31 +49,31 @@ public class TestZstdWrapper {
       byte[] compressedBuf = table.get("h".getBytes(), "s".getBytes(), 1000);
 
       // decompress the value
-      Assert.assertArrayEquals(ZstdWrapper.decompress(compressedBuf), value);
+      assertArrayEquals(ZstdWrapper.decompress(compressedBuf), value);
     }
 
     // ensure empty value won't break the program
     {
       try {
         ZstdWrapper.decompress("".getBytes());
-        Assert.fail("expecting a IllegalArgumentException");
+        fail("expecting a IllegalArgumentException");
       } catch (Exception e) {
-        Assert.assertTrue(e instanceof IllegalArgumentException);
+        assertTrue(e instanceof IllegalArgumentException);
       }
       try {
         ZstdWrapper.decompress(null);
-        Assert.fail("expecting a IllegalArgumentException");
+        fail("expecting a IllegalArgumentException");
       } catch (Exception e) {
-        Assert.assertTrue(e instanceof IllegalArgumentException);
+        assertTrue(e instanceof IllegalArgumentException);
       }
     }
 
     { // decompress invalid data
       try {
         ZstdWrapper.decompress("abc123".getBytes());
-        Assert.fail("expecting a PException");
+        fail("expecting a PException");
       } catch (Exception e) {
-        Assert.assertTrue(e instanceof PException);
+        assertTrue(e instanceof PException);
       }
     }
   }

--- a/java-client/src/test/resources/simplelogger.properties
+++ b/java-client/src/test/resources/simplelogger.properties
@@ -17,6 +17,6 @@
 # under the License.
 #
 
-org.slf4j.simpleLogger.defaultLogLevel=debug
+org.slf4j.simpleLogger.defaultLogLevel=info
 org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.dateTimeFormat=yyyy/MM/dd HH:mm:ss.SSS


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
The test of java client are using junit3 and junit4 in the same time. It should change to use junit5 uniformly.

### What is changed and how does it work?

1. Change the java client test import and usage for uniformly junit5. Such as deprecated 'Assert' from usage of junit3. 
2. upgrader junit version to 5.9.3，use junit.api  and junit.jupiter.engine 
3. introduce org.hamcrest for some test
4. fix slf4j-api dependency prombles

#### Tests <!-- At least one of them must be included. -->

- Unit test 

#### Side effects
only java client unit test

#### Related changes
pom.xml have some jar dependency problems. Exclude slf4j-api from libthrift、zookeeper、metrics-core
