### PR TITLE
chore(CI): use actions/labeler@v4 to keep compatiblity (cherry-pick #1711)

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Assign GitHub labels
-        uses: actions/labeler@main
+        uses: actions/labeler@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/workflows/module_labeler_conf.yml


### PR DESCRIPTION
https://github.com/actions/labeler/releases/tag/v5.0.0 has an imcompatible
changes of the config file, this patch use the v4 to keep compatiblity.

This PR is to cherry-pick #1711 into v2.5.