### PR TITLE
fix: fix centos image build (cherry-pick #1356)

### DIFF
--- a/.github/workflows/standardization_lint.yaml
+++ b/.github/workflows/standardization_lint.yaml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: hadolint/hadolint-action@v2.1.0
+      - uses: hadolint/hadolint-action@v3.1.0
         with:
           recursive: true
           ignore: 'DL3033,DL3013,DL3059,SC2086,DL3003,SC2164,DL3008,DL3007,DL3006,DL4001'

--- a/docker/pegasus-build-env/centos6/Dockerfile
+++ b/docker/pegasus-build-env/centos6/Dockerfile
@@ -76,7 +76,7 @@ ENV MAVEN_HOME=/opt/rh/rh-maven33/root/usr/
 ENV PATH=$MAVEN_HOME/bin:$JAVA_HOME/bin:$GCC_HOME/bin:$PYTHON2_HOME/bin/:$PATH
 ENV LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/amd64/server:$PYTHON2_HOME/lib64/:$LD_LIBRARY_PATH
 
-RUN pip install --no-cache-dir cmake
+RUN python -m pip install --user --upgrade pip==20.3.4 && python -m pip install --no-cache-dir cmake -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 RUN wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/0.11.0.tar.gz -P /opt/thrift && \
     cd /opt/thrift && tar xzf 0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -54,7 +54,9 @@ RUN yum -y install centos-release-scl \
                    yum clean all; \
                    rm -rf /var/cache/yum;
 
-RUN pip3 install --no-cache-dir cmake
+ENV PATH="/opt/rh/devtoolset-7/root/bin/:${PATH}"
+
+RUN pip3 install --upgrade pip --no-cache-dir && pip3 install --no-cache-dir cmake -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 RUN wget --progress=dot:giga https://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /opt/maven \
     && cd /opt/maven \
@@ -68,7 +70,6 @@ RUN wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/
     rm -rf thrift-0.11.0 0.11.0.tar.gz
 
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
-ENV PATH="/opt/rh/devtoolset-7/root/bin/:${PATH}"
 ENV PATH="/opt/maven/apache-maven-3.8.3/bin:${PATH}"
 
 WORKDIR /root/apache


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1347

Fix error "ImportError: No module named skbuild" while building CentOS 6 and 7.

This PR is to cherry-pick #1356 to solve #1347.

The reported error is:
```
#15 [11/13] RUN pip install --no-cache-dir cmake
#15 1.602 Collecting cmake
#15 2.225   Downloading https://files.pythonhosted.org/packages/3e/6b/76ca411a4317bdc0012de597c245a59c824aef1f71dd83e8de0b5ec9bc32/cmake-3.27.9.tar.gz (42kB)
#15 2.325     Complete output from command python setup.py egg_info:
#15 2.325     Traceback (most recent call last):
#15 2.325       File "<string>", line 1, in <module>
#15 2.325       File "/tmp/pip-build-56Lgw_/cmake/setup.py", line 8, in <module>
#15 2.325         from skbuild import setup
#15 2.325     ImportError: No module named skbuild
#15 2.325     
#15 2.325     ----------------------------------------
#15 2.332 Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-56Lgw_/cmake/
#15 2.528 You are using pip version 8.1.2, however version 23.3.1 is available.
#15 2.528 You should consider upgrading via the 'pip install --upgrade pip' command.
#15 ERROR: process "/bin/sh -c pip install --no-cache-dir cmake" did not complete successfully: exit code: 1
------
 > [11/13] RUN pip install --no-cache-dir cmake:
2.325     Traceback (most recent call last):
2.325       File "<string>", line 1, in <module>
2.325       File "/tmp/pip-build-56Lgw_/cmake/setup.py", line 8, in <module>
2.325         from skbuild import setup
2.325     ImportError: No module named skbuild
2.325     
2.325     ----------------------------------------
2.332 Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-56Lgw_/cmake/
2.528 You are using pip version 8.1.2, however version 23.3.1 is available.
2.528 You should consider upgrading via the 'pip install --upgrade pip' command.
------
Dockerfile:79
--------------------
  77 |     ENV LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/amd64/server:$PYTHON2_HOME/lib64/:$LD_LIBRARY_PATH
  78 |     
  79 | >>> RUN pip install --no-cache-dir cmake
  80 |     
  81 |     RUN wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/0.11.0.tar.gz -P /opt/thrift && \
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install --no-cache-dir cmake" did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c pip install --no-cache-dir cmake" did not complete successfully: exit code: 1
```