### PR TITLE
refactor(function_test): Generate bulk load files internally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,6 @@ scripts/py_utils/*.pyc
 cmake-build-debug
 packages
 
-src/test/function_test/bulk_load/pegasus-bulk-load-function-test-files/
 config-shell.ini.*
 *.tar.gz
 pegasus-server*

--- a/run.sh
+++ b/run.sh
@@ -444,15 +444,6 @@ function run_test()
     fi
     echo "test_modules=$test_modules"
 
-    # download bulk load test data
-    if [[ "$test_modules" =~ "bulk_load_test" && ! -d "$ROOT/src/test/function_test/bulk_load/pegasus-bulk-load-function-test-files" ]]; then
-        echo "Start to download files used for bulk load function test"
-        wget "https://github.com/XiaoMi/pegasus-common/releases/download/deps/pegasus-bulk-load-function-test-files.zip"
-        unzip "pegasus-bulk-load-function-test-files.zip" -d "$ROOT/src/test/function_test/bulk_load"
-        rm "pegasus-bulk-load-function-test-files.zip"
-        echo "Prepare files used for bulk load function test succeed"
-    fi
-
     for module in `echo $test_modules | sed 's/,/ /g'`; do
         echo "====================== run $module =========================="
         # restart onebox when test pegasus

--- a/src/block_service/local/local_service.h
+++ b/src/block_service/local/local_service.h
@@ -22,6 +22,7 @@
 #include <nlohmann/json_fwd.hpp> // IWYU pragma: keep
 #include <stdint.h>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "block_service/block_service.h"

--- a/src/block_service/local/local_service.h
+++ b/src/block_service/local/local_service.h
@@ -22,7 +22,6 @@
 #include <nlohmann/json_fwd.hpp> // IWYU pragma: keep
 #include <stdint.h>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "block_service/block_service.h"

--- a/src/test/function_test/backup_restore/test_backup_and_restore.cpp
+++ b/src/test/function_test/backup_restore/test_backup_and_restore.cpp
@@ -61,7 +61,7 @@ public:
     {
         NO_FATALS(wait_table_healthy(table_name_));
         NO_FATALS(write_data(s_num_of_rows));
-        NO_FATALS(verify_data(table_name_, s_num_of_rows));
+        NO_FATALS(verify_data(s_num_of_rows));
 
         auto resp =
             ddl_client_->backup_app(table_id_, s_provider_type, user_specified_path).get_value();
@@ -70,7 +70,7 @@ public:
         NO_FATALS(wait_backup_complete(backup_id));
         ASSERT_EQ(ERR_OK,
                   ddl_client_->do_restore(s_provider_type,
-                                          cluster_name_,
+                                          kClusterName,
                                           /* policy_name */ "",
                                           backup_id,
                                           table_name_,

--- a/src/test/function_test/base_api/integration_test.cpp
+++ b/src/test/function_test/base_api/integration_test.cpp
@@ -70,7 +70,7 @@ TEST_F(integration_test, write_corrupt_db)
                 // cause timeout.
                 // Force to fetch the latest route table.
                 client_ =
-                    pegasus_client_factory::get_client(cluster_name_.c_str(), table_name_.c_str());
+                    pegasus_client_factory::get_client(kClusterName.c_str(), table_name_.c_str());
                 ASSERT_TRUE(client_ != nullptr);
             } else {
                 ASSERT_TRUE(false) << ret;
@@ -86,8 +86,7 @@ TEST_F(integration_test, write_corrupt_db)
                 break;
             }
             ASSERT_EQ(PERR_NOT_FOUND, ret);
-            client_ =
-                pegasus_client_factory::get_client(cluster_name_.c_str(), table_name_.c_str());
+            client_ = pegasus_client_factory::get_client(kClusterName.c_str(), table_name_.c_str());
             ASSERT_TRUE(client_ != nullptr);
 
             ret = client_->get(hkey, skey, got_value);
@@ -180,7 +179,7 @@ TEST_F(integration_test, read_corrupt_db)
                 // a new read operation on the primary replica it ever held will cause timeout.
                 // Force to fetch the latest route table.
                 client_ =
-                    pegasus_client_factory::get_client(cluster_name_.c_str(), table_name_.c_str());
+                    pegasus_client_factory::get_client(kClusterName.c_str(), table_name_.c_str());
                 ASSERT_TRUE(client_ != nullptr);
             } else {
                 ASSERT_TRUE(false) << ret;

--- a/src/test/function_test/base_api/test_batch_get.cpp
+++ b/src/test/function_test/base_api/test_batch_get.cpp
@@ -49,7 +49,7 @@ class batch_get : public test_util
 TEST_F(batch_get, set_and_then_batch_get)
 {
     auto rrdb_client =
-        new ::dsn::apps::rrdb_client(cluster_name_.c_str(), meta_list_, table_name_.c_str());
+        new ::dsn::apps::rrdb_client(kClusterName.c_str(), meta_list_, table_name_.c_str());
 
     int test_data_count = 100;
     int test_timeout_milliseconds = 3000;

--- a/src/test/function_test/base_api/test_copy.cpp
+++ b/src/test/function_test/base_api/test_copy.cpp
@@ -94,10 +94,10 @@ public:
                   ddl_client_->create_app(
                       destination_app_name, "pegasus", default_partitions, 3, {}, false));
         source_client_ =
-            pegasus_client_factory::get_client(cluster_name_.c_str(), source_app_name.c_str());
+            pegasus_client_factory::get_client(kClusterName.c_str(), source_app_name.c_str());
         ASSERT_NE(nullptr, source_client_);
         destination_client_ =
-            pegasus_client_factory::get_client(cluster_name_.c_str(), destination_app_name.c_str());
+            pegasus_client_factory::get_client(kClusterName.c_str(), destination_app_name.c_str());
         ASSERT_NE(nullptr, destination_client_);
     }
 

--- a/src/test/function_test/base_api/test_scan.cpp
+++ b/src/test/function_test/base_api/test_scan.cpp
@@ -52,7 +52,7 @@ public:
         test_util::SetUp();
         ASSERT_EQ(dsn::ERR_OK, ddl_client_->drop_app(table_name_, 0));
         ASSERT_EQ(dsn::ERR_OK, ddl_client_->create_app(table_name_, "pegasus", 8, 3, {}, false));
-        client_ = pegasus_client_factory::get_client(cluster_name_.c_str(), table_name_.c_str());
+        client_ = pegasus_client_factory::get_client(kClusterName.c_str(), table_name_.c_str());
         ASSERT_TRUE(client_ != nullptr);
         ASSERT_NO_FATAL_FAILURE(fill_database());
     }

--- a/src/test/function_test/bulk_load/CMakeLists.txt
+++ b/src/test/function_test/bulk_load/CMakeLists.txt
@@ -31,6 +31,7 @@ set(MY_PROJ_LIBS
         dsn_client
         dsn_replication_common
         dsn_utils
+        dsn.block_service.local
         pegasus_client_static
         gtest
         sasl2

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -49,6 +49,7 @@
 #include "utils/errors.h"
 #include "utils/filesystem.h"
 #include "utils/rand.h"
+#include "utils/test_macros.h"
 
 using dsn::partition_configuration;
 using dsn::replication::replica_helper;
@@ -62,7 +63,16 @@ using std::vector;
 namespace pegasus {
 
 test_util::test_util(map<string, string> create_envs)
-    : cluster_name_("onebox"), table_name_("temp"), create_envs_(std::move(create_envs))
+    : kOpNames({{test_util::OperateDataType::kSet, "set"},
+                {test_util::OperateDataType::kGet, "get"},
+                {test_util::OperateDataType::kDelete, "delete"},
+                {test_util::OperateDataType::kCheckNotFound, "check not found"}}),
+      kClusterName("onebox"),
+      kHashkeyPrefix("hashkey_"),
+      kSortkey("sortkey"),
+      kValuePrefix("value_"),
+      kCreateEnvs(std::move(create_envs)),
+      table_name_("temp")
 {
 }
 
@@ -73,7 +83,7 @@ void test_util::SetUpTestCase() { ASSERT_TRUE(pegasus_client_factory::initialize
 void test_util::SetUp()
 {
     ASSERT_TRUE(replica_helper::load_meta_servers(
-        meta_list_, PEGASUS_CLUSTER_SECTION_NAME.c_str(), cluster_name_.c_str()));
+        meta_list_, PEGASUS_CLUSTER_SECTION_NAME.c_str(), kClusterName.c_str()));
     ASSERT_FALSE(meta_list_.empty());
 
     ddl_client_ = std::make_shared<replication_ddl_client>(meta_list_);
@@ -81,16 +91,16 @@ void test_util::SetUp()
     ddl_client_->set_max_wait_app_ready_secs(120);
 
     dsn::error_code ret =
-        ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, create_envs_, false);
+        ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, kCreateEnvs, false);
     if (ret == dsn::ERR_INVALID_PARAMETERS) {
         ASSERT_EQ(dsn::ERR_OK, ddl_client_->drop_app(table_name_, 0));
         ASSERT_EQ(dsn::ERR_OK,
                   ddl_client_->create_app(
-                      table_name_, "pegasus", partition_count_, 3, create_envs_, false));
+                      table_name_, "pegasus", partition_count_, 3, kCreateEnvs, false));
     } else {
         ASSERT_EQ(dsn::ERR_OK, ret);
     }
-    client_ = pegasus_client_factory::get_client(cluster_name_.c_str(), table_name_.c_str());
+    client_ = pegasus_client_factory::get_client(kClusterName.c_str(), table_name_.c_str());
     ASSERT_TRUE(client_ != nullptr);
 
     int32_t partition_count;
@@ -168,35 +178,100 @@ void test_util::wait_table_healthy(const std::string &table_name) const
         180);
 }
 
+void test_util::operate_data(OperateDataType type,
+                             const std::string &table_name,
+                             const std::string &hashkey_prefix,
+                             const std::optional<std::string> &value_prefix,
+                             int count) const
+{
+    fmt::print(stdout, "start to {} {} key-value pairs...\n", kOpNames.at(type), count);
+    auto *client = pegasus_client_factory::get_client(kClusterName.c_str(), table_name.c_str());
+    ASSERT_NE(client, nullptr);
+    int64_t start = dsn_now_ms();
+    ASSERT_GT(count, 0);
+    ASSERT_LE(count, 10000);
+    for (int i = 0; i < count; i++) {
+        auto hashkey = fmt::format("{}{:04}", hashkey_prefix, i);
+        std::string value;
+        if (value_prefix) {
+            value = fmt::format("{}{}", *value_prefix, i);
+        }
+        switch (type) {
+        case OperateDataType::kSet:
+            ASSERT_FALSE(value.empty());
+            ASSERT_EQ(PERR_OK, client->set(hashkey, kSortkey, value));
+            break;
+        case OperateDataType::kGet: {
+            std::string value_new;
+            ASSERT_EQ(PERR_OK, client->get(hashkey, kSortkey, value_new));
+            ASSERT_FALSE(value.empty());
+            ASSERT_EQ(value, value_new);
+            break;
+        }
+        case OperateDataType::kDelete:
+            ASSERT_EQ(PERR_OK, client->del(hashkey, kSortkey));
+            break;
+        case OperateDataType::kCheckNotFound: {
+            std::string value_new;
+            ASSERT_EQ(PERR_NOT_FOUND, client->get(hashkey, kSortkey, value_new));
+            ASSERT_TRUE(value_new.empty());
+            break;
+        }
+        default:
+            ASSERT_FALSE(true);
+        }
+    }
+    fmt::print(stdout,
+               "{} data complete, total time = {}s\n",
+               kOpNames.at(type),
+               (dsn_now_ms() - start) / 1000);
+}
+
+void test_util::write_data(const std::string &hashkey_prefix,
+                           const std::string &value_prefix,
+                           int count) const
+{
+    NO_FATALS(
+        operate_data(OperateDataType::kSet, table_name_, hashkey_prefix, value_prefix, count));
+}
+
 void test_util::write_data(int count) const
 {
-    fmt::print(stdout, "start to write {} key-value pairs...\n", count);
-    ASSERT_NE(client_, nullptr);
-    int64_t start = dsn_now_ms();
-    for (int i = 0; i < count; i++) {
-        ASSERT_EQ(PERR_OK,
-                  client_->set(fmt::format("hash_key_{}", i),
-                               fmt::format("sort_key_{}", i),
-                               fmt::format("value_{}", i)));
-    }
-    fmt::print(stdout, "write data complete, total time = {}s", (dsn_now_ms() - start) / 1000);
+    NO_FATALS(write_data(kHashkeyPrefix, kValuePrefix, count));
+}
+
+void test_util::verify_data(const std::string &table_name,
+                            const std::string &hashkey_prefix,
+                            const std::string &value_prefix,
+                            int count) const
+{
+    NO_FATALS(operate_data(OperateDataType::kGet, table_name, hashkey_prefix, value_prefix, count));
 }
 
 void test_util::verify_data(const std::string &table_name, int count) const
 {
-    fmt::print(stdout, "start to get {} key-value pairs...\n", count);
-    auto *client = pegasus_client_factory::get_client(cluster_name_.c_str(), table_name.c_str());
-    ASSERT_NE(client, nullptr);
-    int64_t start = dsn_now_ms();
-    for (int i = 0; i < count; i++) {
-        std::string value_new;
-        ASSERT_EQ(
-            PERR_OK,
-            client->get(fmt::format("hash_key_{}", i), fmt::format("sort_key_{}", i), value_new));
-        ASSERT_EQ(fmt::format("value_{}", i), value_new);
-    }
-    int64_t end = dsn_now_ms();
-    fmt::print(stdout, "verify data complete, total time = {}s", (dsn_now_ms() - start) / 1000);
+    NO_FATALS(verify_data(table_name, kHashkeyPrefix, kValuePrefix, count));
+}
+
+void test_util::verify_data(int count) const
+{
+    NO_FATALS(verify_data(table_name_, kHashkeyPrefix, kValuePrefix, count));
+}
+
+void test_util::delete_data(const std::string &table_name,
+                            const std::string &hashkey_prefix,
+                            int count) const
+{
+    NO_FATALS(
+        operate_data(OperateDataType::kDelete, table_name, hashkey_prefix, std::nullopt, count));
+}
+
+void test_util::check_not_found(const std::string &table_name,
+                                const std::string &hashkey_prefix,
+                                int count) const
+{
+    NO_FATALS(operate_data(
+        OperateDataType::kCheckNotFound, table_name, hashkey_prefix, std::nullopt, count));
 }
 
 void test_util::update_table_env(const std::vector<std::string> &keys,
@@ -209,4 +284,5 @@ void test_util::update_table_env(const std::vector<std::string> &keys,
     fmt::print(stdout, "sleep 31s to wait app_envs update\n");
     std::this_thread::sleep_for(std::chrono::seconds(31));
 }
+
 } // namespace pegasus

--- a/src/test/function_test/utils/test_util.h
+++ b/src/test/function_test/utils/test_util.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -65,16 +66,52 @@ public:
 
     void wait_table_healthy(const std::string &table_name) const;
 
+    // Write some data to table 'table_name_' according to the parameters.
+    void
+    write_data(const std::string &hashkey_prefix, const std::string &value_prefix, int count) const;
     void write_data(int count) const;
+
+    // Verify the data can be read from the table according to the parameters.
+    void verify_data(const std::string &table_name,
+                     const std::string &hashkey_prefix,
+                     const std::string &value_prefix,
+                     int count) const;
+    void verify_data(int count) const;
     void verify_data(const std::string &table_name, int count) const;
+
+    // Delete some data from the table according to the parameters.
+    void
+    delete_data(const std::string &table_name, const std::string &hashkey_prefix, int count) const;
+
+    // Verify the data can NOT be read from the table according to the parameters.
+    void check_not_found(const std::string &table_name,
+                         const std::string &hashkey_prefix,
+                         int count) const;
 
     void update_table_env(const std::vector<std::string> &keys,
                           const std::vector<std::string> &values) const;
 
 protected:
-    const std::string cluster_name_;
+    enum class OperateDataType
+    {
+        kSet,
+        kGet,
+        kDelete,
+        kCheckNotFound
+    };
+    std::map<test_util::OperateDataType, std::string> kOpNames;
+    void operate_data(OperateDataType type,
+                      const std::string &table_name,
+                      const std::string &hashkey_prefix,
+                      const std::optional<std::string> &value_prefix,
+                      int count) const;
+
+    const std::string kClusterName;
+    const std::string kHashkeyPrefix;
+    const std::string kSortkey;
+    const std::string kValuePrefix;
+    const std::map<std::string, std::string> kCreateEnvs;
     std::string table_name_;
-    const std::map<std::string, std::string> create_envs_;
     int32_t table_id_;
     int32_t partition_count_ = 8;
     std::vector<dsn::partition_configuration> partitions_;


### PR DESCRIPTION
Before this patch, the Pegasus function test `bulk_load_test` will download
files from external site, it may break some ASF policies.
This patch make the test to generate bulk load test files internally, it make
the procedure transparent to developers, know what key-values are generated and
bulk loaded.