### PR TITLE
fix: fix rocksdb build type (cherry-pick #1340)

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -401,6 +401,7 @@ ExternalProject_Add(rocksdb
         -DWITH_TESTS=OFF
         -DWITH_GFLAGS=OFF
         -DUSE_RTTI=ON
+        -DCMAKE_BUILD_TYPE=Release
         -DWITH_JEMALLOC=${USE_JEMALLOC}
         -DJEMALLOC_ROOT_DIR=${TP_OUTPUT}
         -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1339

RocksDB library is not built in Release version, which may cause terrible performance issues.

This PR is to cherry-pick #1340 into v2.4 to resolve #1339.