### PR TITLE
fix(scripts): drop unnecessary dependencies for pack_server.sh

### DIFF
--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -135,11 +135,8 @@ pack_server_lib() {
     pack_system_lib "${pack}/bin" server "$1"
 }
 
-pack_server_lib snappy
 pack_server_lib crypto
 pack_server_lib ssl
-pack_server_lib zstd
-pack_server_lib lz4
 
 # Pack hadoop-related files.
 # If you want to use hdfs service to backup/restore/bulkload pegasus tables,


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1792

Now that snappy/zstd/lz4 has not been the direct dependencies
of Pegasus(actually all of them is the dependency of rocksdb),
just remove them from pack_server.sh.