### PR TITLE
fix(scripts): fix that librocksdb.so.8 was not found for the executable binary generated by pack_server.sh

### DIFF
--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -124,6 +124,7 @@ fi
 
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/bin
 copy_file ./thirdparty/output/lib/libhdfs* ${pack}/bin
+copy_file ./thirdparty/output/lib64/librocksdb.so.8 ${pack}/bin
 copy_file ./scripts/sendmail.sh ${pack}/bin
 copy_file ./src/server/config.ini ${pack}/bin
 copy_file ./src/server/config.min.ini ${pack}/bin


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1795

Add dynamic library of rocksdb as the dependency of the executable binary.