### PR TITLE
feat(run.sh): make it possible to build partial objects

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -605,10 +605,10 @@ jobs:
           rm -rf hadoop-bin/share/doc
           rm -rf zookeeper-bin/docs
       - name: Compilation
+        # TODO(yingchun): Append "-m dsn_utils_tests" to the command if not needed to pack server or tools, for example, the dependencies are static linked.
         run: |
           ccache -p
           ccache -z
-          // TODO(yingchun): Append "-m dsn_utils_tests" to the command if not needed to pack server or tools, for example, the dependencies are static linked.
           ./run.sh build --test --skip_thirdparty -j $(nproc) -t release --use_jemalloc
           ccache -s
       - name: Clear Build Files

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -608,7 +608,8 @@ jobs:
         run: |
           ccache -p
           ccache -z
-          ./run.sh build --test --skip_thirdparty -j $(nproc) -t release --use_jemalloc -m dsn_utils_tests
+          // TODO(yingchun): Append "-m dsn_utils_tests" to the command if not needed to pack server or tools, for example, the dependencies are static linked.
+          ./run.sh build --test --skip_thirdparty -j $(nproc) -t release --use_jemalloc
           ccache -s
       - name: Clear Build Files
         run: |

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -608,7 +608,7 @@ jobs:
         run: |
           ccache -p
           ccache -z
-          ./run.sh build --test --skip_thirdparty -j $(nproc) -t release --use_jemalloc
+          ./run.sh build --test --skip_thirdparty -j $(nproc) -t release --use_jemalloc -m dsn_utils_tests
           ccache -s
       - name: Clear Build Files
         run: |


### PR DESCRIPTION
Now it's possible to build partial objects by specifying "-m obj1,obj2" parameter to `./run.sh build`.