### PR TITLE
fix(logger): logs fail to be printed to stdout and the process is not terminated for fatal errors before logging is initialized

### DIFF
--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
@@ -37,12 +37,12 @@
 
 #include "aio/aio_task.h"
 #include "aio/file_io.h"
+#include "common/replication.codes.h"
 #include "consensus_types.h"
 #include "rocksdb/env.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "runtime/serverlet.h"
-#include "runtime/task/task_code.h"
 #include "simple_kv_types.h"
 #include "utils/autoref_ptr.h"
 #include "utils/binary_reader.h"
@@ -50,7 +50,6 @@
 #include "utils/env.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
-#include "utils/threadpool_code.h"
 #include "utils/utils.h"
 
 // TODO(yingchun): most of the code are the same as

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
@@ -68,8 +68,6 @@ namespace dsn {
 namespace replication {
 namespace test {
 
-DEFINE_TASK_CODE(LPC_AIO_IMMEDIATE_CALLBACK, TASK_PRIORITY_COMMON, dsn::THREAD_POOL_DEFAULT)
-
 bool simple_kv_service_impl::s_simple_kv_open_fail = false;
 bool simple_kv_service_impl::s_simple_kv_close_fail = false;
 bool simple_kv_service_impl::s_simple_kv_get_checkpoint_fail = false;

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -138,6 +138,31 @@ void screen_logger::dsn_logv(const char *file,
     vprintf(fmt, args);
     printf("\n");
 
+    if (log_level >= LOG_LEVEL_ERROR) {
+        ::fflush(stdout);
+    }
+
+    process_fatal_log(log_level);
+}
+
+void screen_logger::dsn_log(const char *file,
+                            const char *function,
+                            const int line,
+                            dsn_log_level_t log_level,
+                            const char *str)
+{
+    utils::auto_lock<::dsn::utils::ex_lock_nr> l(_lock);
+
+    print_header(stdout, log_level);
+    if (!_short_header) {
+        printf("%s:%d:%s(): ", file, line, function);
+    }
+    printf("%s\n", str);
+
+    if (log_level >= LOG_LEVEL_ERROR) {
+        ::fflush(stdout);
+    }
+
     process_fatal_log(log_level);
 }
 

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -57,9 +57,7 @@ public:
                  const char *function,
                  const int line,
                  dsn_log_level_t log_level,
-                 const char *str) override
-    {
-    }
+                 const char *str) override;
 
     virtual void flush();
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1807

Implement `dsn_log` interface for `screen_logger` in case that there is
not any logging message being printed and the process is not terminated,
while invalid values for the options loaded from configuration file are found,
or some other errors occur that would make assertions fail.