### PR TITLE
fix(rocksdb): force librocksdb.so* to be output into the directory 'lib'

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -39,6 +39,8 @@ on:
       - 'docker/thirdparties-bin/**'
       - 'CMakeLists.txt'
       - 'run.sh'
+      - 'scripts/pack_server.sh'
+      - 'scripts/pack_tools.sh'
       - 'cmake_modules/**'
       - 'src/**'
       - 'thirdparty/**'

--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -124,7 +124,7 @@ fi
 
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/bin
 copy_file ./thirdparty/output/lib/libhdfs* ${pack}/bin
-copy_file ./thirdparty/output/lib64/librocksdb.so.8 ${pack}/bin
+copy_file ./thirdparty/output/lib/librocksdb.so.8 ${pack}/bin
 copy_file ./scripts/sendmail.sh ${pack}/bin
 copy_file ./src/server/config.ini ${pack}/bin
 copy_file ./src/server/config.min.ini ${pack}/bin

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -454,6 +454,7 @@ set(ROCKSDB_OPTIONS
         -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
         -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
+        -DCMAKE_INSTALL_LIBDIR=lib
         -DPORTABLE=${ROCKSDB_PORTABLE})
 # Link error on MacOS, disable building encfs plugin.
 # See https://github.com/pegasus-kv/encfs/issues/4


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1805

After building was finished, sometimes librocksdb.so* would be output into
the directory `lib64` rather than `lib`, which would lead to an error that
librocksdb.so* could not be found while packing server.

To solve this problem, just specify the output dir for librocksdb.so*.