### PR TITLE
refactor(logging): drop the unnecessary interface, use `log` instead of `dsn_log` and improve the tests

### DIFF
--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -245,7 +245,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
     const auto request_count = mu->client_requests.size();
     mu->data.header.last_committed_decree = last_committed_decree();
 
-    dsn_log_level_t level = LOG_LEVEL_DEBUG;
+    log_level_t level = LOG_LEVEL_DEBUG;
     if (mu->data.header.decree == invalid_decree) {
         mu->set_id(get_ballot(), _prepare_list->max_decree() + 1);
         // print a debug log if necessary
@@ -258,7 +258,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
     }
 
     mu->_tracer->set_name(fmt::format("mutation[{}]", mu->name()));
-    dlog_f(level, "{}: mutation {} init_prepare, mutation_tid={}", name(), mu->name(), mu->tid());
+    LOG(level, "{}: mutation {} init_prepare, mutation_tid={}", name(), mu->name(), mu->tid());
 
     // child should prepare mutation synchronously
     mu->set_is_sync_to_child(_primary_states.sync_send_write_request);

--- a/src/runtime/security/sasl_init.cpp
+++ b/src/runtime/security/sasl_init.cpp
@@ -32,7 +32,7 @@ namespace dsn {
 namespace security {
 DSN_DEFINE_string(security, sasl_plugin_path, "/usr/lib/sasl2", "path to search sasl plugins");
 
-dsn_log_level_t get_dsn_log_level(int level)
+log_level_t get_log_level(int level)
 {
     switch (level) {
     case SASL_LOG_ERR:
@@ -53,7 +53,7 @@ int sasl_simple_logger(void *context, int level, const char *msg)
         return SASL_OK;
     }
 
-    dlog_f(get_dsn_log_level(level), "sasl log info: {}", msg);
+    LOG(get_log_level(level), "sasl log info: {}", msg);
     return SASL_OK;
 }
 

--- a/src/runtime/task/task_spec.h
+++ b/src/runtime/task/task_spec.h
@@ -43,13 +43,13 @@
 #include "utils/join_point.h"
 #include "utils/threadpool_code.h"
 
-ENUM_BEGIN(dsn_log_level_t, LOG_LEVEL_INVALID)
+ENUM_BEGIN(log_level_t, LOG_LEVEL_INVALID)
 ENUM_REG(LOG_LEVEL_DEBUG)
 ENUM_REG(LOG_LEVEL_INFO)
 ENUM_REG(LOG_LEVEL_WARNING)
 ENUM_REG(LOG_LEVEL_ERROR)
 ENUM_REG(LOG_LEVEL_FATAL)
-ENUM_END(dsn_log_level_t)
+ENUM_END(log_level_t)
 
 namespace dsn {
 

--- a/src/runtime/task/task_spec.h
+++ b/src/runtime/task/task_spec.h
@@ -32,7 +32,6 @@
 #include <vector>
 
 #include "runtime/task/task_code.h"
-#include "utils/api_utilities.h"
 #include "utils/config_api.h"
 #include "utils/config_helper.h"
 #include "utils/customizable_id.h"

--- a/src/runtime/task/task_spec.h
+++ b/src/runtime/task/task_spec.h
@@ -43,14 +43,6 @@
 #include "utils/join_point.h"
 #include "utils/threadpool_code.h"
 
-ENUM_BEGIN(log_level_t, LOG_LEVEL_INVALID)
-ENUM_REG(LOG_LEVEL_DEBUG)
-ENUM_REG(LOG_LEVEL_INFO)
-ENUM_REG(LOG_LEVEL_WARNING)
-ENUM_REG(LOG_LEVEL_ERROR)
-ENUM_REG(LOG_LEVEL_FATAL)
-ENUM_END(log_level_t)
-
 namespace dsn {
 
 enum task_state

--- a/src/utils/api_utilities.h
+++ b/src/utils/api_utilities.h
@@ -31,10 +31,9 @@
 
 #pragma once
 
-#include <stdarg.h>
-
-#include "ports.h"
+#include "utils/enum_helper.h"
 #include "utils/fmt_utils.h"
+#include "utils/ports.h"
 
 /*!
 @defgroup logging Logging Service
@@ -58,6 +57,14 @@ enum log_level_t
     LOG_LEVEL_COUNT,
     LOG_LEVEL_INVALID
 };
+
+ENUM_BEGIN(log_level_t, LOG_LEVEL_INVALID)
+ENUM_REG(LOG_LEVEL_DEBUG)
+ENUM_REG(LOG_LEVEL_INFO)
+ENUM_REG(LOG_LEVEL_WARNING)
+ENUM_REG(LOG_LEVEL_ERROR)
+ENUM_REG(LOG_LEVEL_FATAL)
+ENUM_END(log_level_t)
 
 USER_DEFINED_ENUM_FORMATTER(log_level_t)
 

--- a/src/utils/api_utilities.h
+++ b/src/utils/api_utilities.h
@@ -48,7 +48,7 @@
 @{
 */
 
-typedef enum dsn_log_level_t {
+enum log_level_t {
     LOG_LEVEL_DEBUG,
     LOG_LEVEL_INFO,
     LOG_LEVEL_WARNING,
@@ -56,39 +56,20 @@ typedef enum dsn_log_level_t {
     LOG_LEVEL_FATAL,
     LOG_LEVEL_COUNT,
     LOG_LEVEL_INVALID
-} dsn_log_level_t;
+};
 
-USER_DEFINED_ENUM_FORMATTER(dsn_log_level_t)
+USER_DEFINED_ENUM_FORMATTER(log_level_t)
 
 // logs with level smaller than this start_level will not be logged
-extern dsn_log_level_t dsn_log_start_level;
-extern dsn_log_level_t dsn_log_get_start_level();
-extern void dsn_log_set_start_level(dsn_log_level_t level);
-extern void dsn_logv(const char *file,
-                     const char *function,
-                     const int line,
-                     dsn_log_level_t log_level,
-                     const char *fmt,
-                     va_list args);
-extern void dsn_logf(const char *file,
-                     const char *function,
-                     const int line,
-                     dsn_log_level_t log_level,
-                     const char *fmt,
-                     ...);
-extern void dsn_log(const char *file,
+extern log_level_t log_start_level;
+extern log_level_t get_log_start_level();
+extern void set_log_start_level(log_level_t level);
+extern void global_log(const char *file,
                     const char *function,
                     const int line,
-                    dsn_log_level_t log_level,
+                    log_level_t log_level,
                     const char *str);
 extern void dsn_coredump();
-
-// __FILENAME__ macro comes from the cmake, in which we calculate a filename without path.
-#define dlog(level, ...)                                                                           \
-    do {                                                                                           \
-        if (level >= dsn_log_start_level)                                                          \
-            dsn_logf(__FILENAME__, __FUNCTION__, __LINE__, level, __VA_ARGS__);                    \
-    } while (false)
 
 #define dreturn_not_ok_logged(err, ...)                                                            \
     do {                                                                                           \
@@ -124,7 +105,7 @@ extern void dsn_coredump();
 #define dverify_logged(exp, level, ...)                                                            \
     do {                                                                                           \
         if (dsn_unlikely(!(exp))) {                                                                \
-            dlog(level, __VA_ARGS__);                                                              \
+            LOG(level, __VA_ARGS__);                                                              \
             return false;                                                                          \
         }                                                                                          \
     } while (0)
@@ -135,7 +116,7 @@ extern void dsn_coredump();
 #define dstop_on_false_logged(exp, level, ...)                                                     \
     do {                                                                                           \
         if (dsn_unlikely(!(exp))) {                                                                \
-            dlog(level, __VA_ARGS__);                                                              \
+            LOG(level, __VA_ARGS__);                                                              \
             return;                                                                                \
         }                                                                                          \
     } while (0)

--- a/src/utils/api_utilities.h
+++ b/src/utils/api_utilities.h
@@ -48,7 +48,8 @@
 @{
 */
 
-enum log_level_t {
+enum log_level_t
+{
     LOG_LEVEL_DEBUG,
     LOG_LEVEL_INFO,
     LOG_LEVEL_WARNING,
@@ -64,11 +65,8 @@ USER_DEFINED_ENUM_FORMATTER(log_level_t)
 extern log_level_t log_start_level;
 extern log_level_t get_log_start_level();
 extern void set_log_start_level(log_level_t level);
-extern void global_log(const char *file,
-                    const char *function,
-                    const int line,
-                    log_level_t log_level,
-                    const char *str);
+extern void global_log(
+    const char *file, const char *function, const int line, log_level_t log_level, const char *str);
 extern void dsn_coredump();
 
 #define dreturn_not_ok_logged(err, ...)                                                            \
@@ -105,7 +103,7 @@ extern void dsn_coredump();
 #define dverify_logged(exp, level, ...)                                                            \
     do {                                                                                           \
         if (dsn_unlikely(!(exp))) {                                                                \
-            LOG(level, __VA_ARGS__);                                                              \
+            LOG(level, __VA_ARGS__);                                                               \
             return false;                                                                          \
         }                                                                                          \
     } while (0)
@@ -116,7 +114,7 @@ extern void dsn_coredump();
 #define dstop_on_false_logged(exp, level, ...)                                                     \
     do {                                                                                           \
         if (dsn_unlikely(!(exp))) {                                                                \
-            LOG(level, __VA_ARGS__);                                                              \
+            LOG(level, __VA_ARGS__);                                                               \
             return;                                                                                \
         }                                                                                          \
     } while (0)

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -29,10 +29,10 @@
 // TODO(wutao1): prevent construction of std::string for each log.
 
 // __FILENAME__ macro comes from the cmake, in which we calculate a filename without path.
-#define LOG(level, ...)                                                                         \
+#define LOG(level, ...)                                                                            \
     do {                                                                                           \
-        if (level >= log_start_level)                                                          \
-            global_log(                                                                               \
+        if (level >= log_start_level)                                                              \
+            global_log(                                                                            \
                 __FILENAME__, __FUNCTION__, __LINE__, level, fmt::format(__VA_ARGS__).c_str());    \
     } while (false)
 

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -28,18 +28,19 @@
 // instead we use fmt::format.
 // TODO(wutao1): prevent construction of std::string for each log.
 
-#define dlog_f(level, ...)                                                                         \
+// __FILENAME__ macro comes from the cmake, in which we calculate a filename without path.
+#define LOG(level, ...)                                                                         \
     do {                                                                                           \
-        if (level >= dsn_log_start_level)                                                          \
-            dsn_log(                                                                               \
+        if (level >= log_start_level)                                                          \
+            global_log(                                                                               \
                 __FILENAME__, __FUNCTION__, __LINE__, level, fmt::format(__VA_ARGS__).c_str());    \
     } while (false)
 
-#define LOG_DEBUG(...) dlog_f(LOG_LEVEL_DEBUG, __VA_ARGS__)
-#define LOG_INFO(...) dlog_f(LOG_LEVEL_INFO, __VA_ARGS__)
-#define LOG_WARNING(...) dlog_f(LOG_LEVEL_WARNING, __VA_ARGS__)
-#define LOG_ERROR(...) dlog_f(LOG_LEVEL_ERROR, __VA_ARGS__)
-#define LOG_FATAL(...) dlog_f(LOG_LEVEL_FATAL, __VA_ARGS__)
+#define LOG_DEBUG(...) LOG(LOG_LEVEL_DEBUG, __VA_ARGS__)
+#define LOG_INFO(...) LOG(LOG_LEVEL_INFO, __VA_ARGS__)
+#define LOG_WARNING(...) LOG(LOG_LEVEL_WARNING, __VA_ARGS__)
+#define LOG_ERROR(...) LOG(LOG_LEVEL_ERROR, __VA_ARGS__)
+#define LOG_FATAL(...) LOG(LOG_LEVEL_FATAL, __VA_ARGS__)
 
 #define LOG_WARNING_IF(x, ...)                                                                     \
     do {                                                                                           \

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -40,7 +40,7 @@
 #include "utils/logging_provider.h"
 #include "utils/sys_exit_hook.h"
 
-log_level_t log_start_level = log_level_t::LOG_LEVEL_INFO;
+log_level_t log_start_level = LOG_LEVEL_INFO;
 DSN_DEFINE_string(core,
                   logging_start_level,
                   "LOG_LEVEL_INFO",
@@ -72,11 +72,10 @@ void dsn_log_init(const std::string &logging_factory_name,
                   const std::string &dir_log,
                   std::function<std::string()> dsn_log_prefixed_message_func)
 {
-    log_start_level = enum_from_string(FLAGS_logging_start_level, log_level_t::LOG_LEVEL_INVALID);
+    log_start_level = enum_from_string(FLAGS_logging_start_level, LOG_LEVEL_INVALID);
 
-    CHECK_NE_MSG(log_start_level,
-                 log_level_t::LOG_LEVEL_INVALID,
-                 "invalid [core] logging_start_level specified");
+    CHECK_NE_MSG(
+        log_start_level, LOG_LEVEL_INVALID, "invalid [core] logging_start_level specified");
 
     // register log flush on exit
     if (FLAGS_logging_flush_on_exit) {

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -73,8 +73,7 @@ void dsn_log_init(const std::string &logging_factory_name,
                   const std::string &dir_log,
                   std::function<std::string()> dsn_log_prefixed_message_func)
 {
-    log_start_level =
-        enum_from_string(FLAGS_logging_start_level, log_level_t::LOG_LEVEL_INVALID);
+    log_start_level = enum_from_string(FLAGS_logging_start_level, log_level_t::LOG_LEVEL_INVALID);
 
     CHECK_NE_MSG(log_start_level,
                  log_level_t::LOG_LEVEL_INVALID,
@@ -98,11 +97,8 @@ log_level_t get_log_start_level() { return log_start_level; }
 
 void set_log_start_level(log_level_t level) { log_start_level = level; }
 
-void global_log(const char *file,
-             const char *function,
-             const int line,
-             log_level_t log_level,
-             const char *str)
+void global_log(
+    const char *file, const char *function, const int line, log_level_t log_level, const char *str)
 {
     dsn::logging_provider *logger = dsn::logging_provider::instance();
     logger->log(file, function, line, log_level, str);

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -24,7 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdarg.h>
 #include <algorithm>
 #include <functional>
 #include <memory>

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -41,7 +41,7 @@
 #include "utils/logging_provider.h"
 #include "utils/sys_exit_hook.h"
 
-dsn_log_level_t dsn_log_start_level = dsn_log_level_t::LOG_LEVEL_INFO;
+log_level_t log_start_level = log_level_t::LOG_LEVEL_INFO;
 DSN_DEFINE_string(core,
                   logging_start_level,
                   "LOG_LEVEL_INFO",
@@ -73,11 +73,11 @@ void dsn_log_init(const std::string &logging_factory_name,
                   const std::string &dir_log,
                   std::function<std::string()> dsn_log_prefixed_message_func)
 {
-    dsn_log_start_level =
-        enum_from_string(FLAGS_logging_start_level, dsn_log_level_t::LOG_LEVEL_INVALID);
+    log_start_level =
+        enum_from_string(FLAGS_logging_start_level, log_level_t::LOG_LEVEL_INVALID);
 
-    CHECK_NE_MSG(dsn_log_start_level,
-                 dsn_log_level_t::LOG_LEVEL_INVALID,
+    CHECK_NE_MSG(log_start_level,
+                 log_level_t::LOG_LEVEL_INVALID,
                  "invalid [core] logging_start_level specified");
 
     // register log flush on exit
@@ -94,42 +94,18 @@ void dsn_log_init(const std::string &logging_factory_name,
     }
 }
 
-dsn_log_level_t dsn_log_get_start_level() { return dsn_log_start_level; }
+log_level_t get_log_start_level() { return log_start_level; }
 
-void dsn_log_set_start_level(dsn_log_level_t level) { dsn_log_start_level = level; }
+void set_log_start_level(log_level_t level) { log_start_level = level; }
 
-void dsn_logv(const char *file,
-              const char *function,
-              const int line,
-              dsn_log_level_t log_level,
-              const char *fmt,
-              va_list args)
-{
-    dsn::logging_provider *logger = dsn::logging_provider::instance();
-    logger->dsn_logv(file, function, line, log_level, fmt, args);
-}
-
-void dsn_logf(const char *file,
-              const char *function,
-              const int line,
-              dsn_log_level_t log_level,
-              const char *fmt,
-              ...)
-{
-    va_list ap;
-    va_start(ap, fmt);
-    dsn_logv(file, function, line, log_level, fmt, ap);
-    va_end(ap);
-}
-
-void dsn_log(const char *file,
+void global_log(const char *file,
              const char *function,
              const int line,
-             dsn_log_level_t log_level,
+             log_level_t log_level,
              const char *str)
 {
     dsn::logging_provider *logger = dsn::logging_provider::instance();
-    logger->dsn_log(file, function, line, log_level, str);
+    logger->log(file, function, line, log_level, str);
 }
 
 namespace dsn {

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -29,7 +29,6 @@
 #include <memory>
 #include <string>
 
-#include "runtime/task/task_spec.h"
 #include "runtime/tool_api.h"
 #include "simple_logger.h"
 #include "utils/api_utilities.h"

--- a/src/utils/logging_provider.h
+++ b/src/utils/logging_provider.h
@@ -59,10 +59,10 @@ public:
     static void set_logger(logging_provider *logger);
 
     virtual void log(const char *file,
-                         const char *function,
-                         const int line,
-                         log_level_t log_level,
-                         const char *str) = 0;
+                     const char *function,
+                     const int line,
+                     log_level_t log_level,
+                     const char *str) = 0;
 
     virtual void flush() = 0;
 

--- a/src/utils/logging_provider.h
+++ b/src/utils/logging_provider.h
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#include <stdarg.h>
-
 #include "utils/api_utilities.h"
 #include "utils/command_manager.h"
 #include "utils/factory_store.h"

--- a/src/utils/logging_provider.h
+++ b/src/utils/logging_provider.h
@@ -58,17 +58,10 @@ public:
     // not thread-safe
     static void set_logger(logging_provider *logger);
 
-    virtual void dsn_logv(const char *file,
-                          const char *function,
-                          const int line,
-                          dsn_log_level_t log_level,
-                          const char *fmt,
-                          va_list args) = 0;
-
-    virtual void dsn_log(const char *file,
+    virtual void log(const char *file,
                          const char *function,
                          const int line,
-                         dsn_log_level_t log_level,
+                         log_level_t log_level,
                          const char *str) = 0;
 
     virtual void flush() = 0;

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -122,11 +122,8 @@ screen_logger::screen_logger(bool short_header) { _short_header = short_header; 
 
 screen_logger::~screen_logger(void) {}
 
-void screen_logger::log(const char *file,
-                            const char *function,
-                            const int line,
-                            log_level_t log_level,
-                            const char *str)
+void screen_logger::log(
+    const char *file, const char *function, const int line, log_level_t log_level, const char *str)
 {
     utils::auto_lock<::dsn::utils::ex_lock_nr> l(_lock);
 
@@ -208,8 +205,7 @@ simple_logger::simple_logger(const char *log_dir)
                     enum_from_string(FLAGS_logging_start_level, log_level_t::LOG_LEVEL_INVALID);
             } else {
                 std::string level_str = "LOG_LEVEL_" + args[0];
-                start_level =
-                    enum_from_string(level_str.c_str(), log_level_t::LOG_LEVEL_INVALID);
+                start_level = enum_from_string(level_str.c_str(), log_level_t::LOG_LEVEL_INVALID);
                 if (start_level == log_level_t::LOG_LEVEL_INVALID) {
                     return "ERROR: invalid level '" + args[0] + "'";
                 }
@@ -257,11 +253,8 @@ void simple_logger::flush()
     ::fflush(stdout);
 }
 
-void simple_logger::log(const char *file,
-                            const char *function,
-                            const int line,
-                            log_level_t log_level,
-                            const char *str)
+void simple_logger::log(
+    const char *file, const char *function, const int line, log_level_t log_level, const char *str)
 {
     utils::auto_lock<::dsn::utils::ex_lock> l(_lock);
 

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -34,8 +34,8 @@
 #include <sstream>
 #include <vector>
 
+#include "absl/strings/string_view.h"
 #include "runtime/api_layer1.h"
-#include "runtime/task/task_spec.h"
 #include "utils/command_manager.h"
 #include "utils/fail_point.h"
 #include "utils/filesystem.h"
@@ -44,7 +44,6 @@
 #include "utils/ports.h"
 #include "utils/process_utils.h"
 #include "utils/string_conv.h"
-#include "absl/strings/string_view.h"
 #include "utils/strings.h"
 #include "utils/time_utils.h"
 

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -47,10 +47,10 @@ public:
     ~screen_logger() override;
 
     void log(const char *file,
-                 const char *function,
-                 const int line,
-                 log_level_t log_level,
-                 const char *str) override;
+             const char *function,
+             const int line,
+             log_level_t log_level,
+             const char *str) override;
 
     virtual void flush();
 
@@ -70,10 +70,10 @@ public:
     ~simple_logger() override;
 
     void log(const char *file,
-                 const char *function,
-                 const int line,
-                 log_level_t log_level,
-                 const char *str) override;
+             const char *function,
+             const int line,
+             log_level_t log_level,
+             const char *str) override;
 
     void flush() override;
 

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -46,17 +46,10 @@ public:
     explicit screen_logger(bool short_header);
     ~screen_logger() override;
 
-    void dsn_logv(const char *file,
-                  const char *function,
-                  const int line,
-                  dsn_log_level_t log_level,
-                  const char *fmt,
-                  va_list args) override;
-
-    void dsn_log(const char *file,
+    void log(const char *file,
                  const char *function,
                  const int line,
-                 dsn_log_level_t log_level,
+                 log_level_t log_level,
                  const char *str) override;
 
     virtual void flush();
@@ -76,17 +69,10 @@ public:
     simple_logger(const char *log_dir);
     ~simple_logger() override;
 
-    void dsn_logv(const char *file,
-                  const char *function,
-                  const int line,
-                  dsn_log_level_t log_level,
-                  const char *fmt,
-                  va_list args) override;
-
-    void dsn_log(const char *file,
+    void log(const char *file,
                  const char *function,
                  const int line,
-                 dsn_log_level_t log_level,
+                 log_level_t log_level,
                  const char *str) override;
 
     void flush() override;
@@ -102,7 +88,7 @@ private:
     int _start_index;
     int _index;
     int _lines;
-    dsn_log_level_t _stderr_start_level;
+    log_level_t _stderr_start_level;
 };
 } // namespace tools
 } // namespace dsn

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <stdarg.h>
 #include <cstdio>
 #include <string>
 

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -55,7 +55,7 @@ public:
 
 private:
     ::dsn::utils::ex_lock_nr _lock;
-    bool _short_header;
+    const bool _short_header;
 };
 
 /*
@@ -80,9 +80,9 @@ private:
     void create_log_file();
 
 private:
-    std::string _log_dir;
     ::dsn::utils::ex_lock _lock; // use recursive lock to avoid dead lock when flush() is called
                                  // in signal handler if cored for bad logging format reason.
+    const std::string _log_dir;
     FILE *_log;
     int _start_index;
     int _index;

--- a/src/utils/test/endian_test.cpp
+++ b/src/utils/test/endian_test.cpp
@@ -21,6 +21,7 @@
 
 #include "gtest/gtest.h"
 #include "utils/endians.h"
+#include "utils/enum_helper.h"
 
 using namespace dsn;
 

--- a/src/utils/test/logger.cpp
+++ b/src/utils/test/logger.cpp
@@ -25,7 +25,7 @@
  */
 
 #include <errno.h>
-#include <stdarg.h>
+#include <fmt/core.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <algorithm>

--- a/src/utils/test/logger.cpp
+++ b/src/utils/test/logger.cpp
@@ -40,7 +40,6 @@
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/logging_provider.h"
-#include "utils/ports.h"
 #include "utils/safe_strerror_posix.h"
 #include "utils/simple_logger.h"
 

--- a/src/utils/test/logger.cpp
+++ b/src/utils/test/logger.cpp
@@ -92,8 +92,9 @@ static void finish_test_dir()
     ASSERT_TRUE(utils::filesystem::remove_path(dir)) << "remove_directory " << dir << " failed";
 }
 
-#define LOG_PRINT(logger, ...) \
-    (logger)->log(__FILE__, __FUNCTION__, __LINE__, LOG_LEVEL_DEBUG, fmt::format(__VA_ARGS__).c_str())
+#define LOG_PRINT(logger, ...)                                                                     \
+    (logger)->log(                                                                                 \
+        __FILE__, __FUNCTION__, __LINE__, LOG_LEVEL_DEBUG, fmt::format(__VA_ARGS__).c_str())
 
 TEST(tools_common, simple_logger)
 {

--- a/src/utils/test/logger.cpp
+++ b/src/utils/test/logger.cpp
@@ -92,13 +92,8 @@ static void finish_test_dir()
     ASSERT_TRUE(utils::filesystem::remove_path(dir)) << "remove_directory " << dir << " failed";
 }
 
-void log_print(logging_provider *logger, const char *fmt, ...)
-{
-    va_list vl;
-    va_start(vl, fmt);
-    logger->dsn_logv(__FILE__, __FUNCTION__, __LINE__, LOG_LEVEL_DEBUG, fmt, vl);
-    va_end(vl);
-}
+#define LOG_PRINT(logger, ...) \
+    (logger)->log(__FILE__, __FUNCTION__, __LINE__, LOG_LEVEL_DEBUG, fmt::format(__VA_ARGS__).c_str())
 
 TEST(tools_common, simple_logger)
 {
@@ -107,8 +102,8 @@ TEST(tools_common, simple_logger)
 
     {
         auto logger = std::make_unique<screen_logger>(true);
-        log_print(logger.get(), "%s", "test_print");
-        std::thread t([](screen_logger *lg) { log_print(lg, "%s", "test_print"); }, logger.get());
+        LOG_PRINT(logger.get(), "{}", "test_print");
+        std::thread t([](screen_logger *lg) { LOG_PRINT(lg, "{}", "test_print"); }, logger.get());
         t.join();
 
         logger->flush();
@@ -119,7 +114,7 @@ TEST(tools_common, simple_logger)
     for (unsigned int i = 0; i < simple_logger_gc_gap + 10; ++i) {
         auto logger = std::make_unique<simple_logger>("./");
         for (unsigned int i = 0; i != 1000; ++i) {
-            log_print(logger.get(), "%s", "test_print");
+            LOG_PRINT(logger.get(), "{}", "test_print");
         }
         logger->flush();
     }

--- a/src/utils/test/logging.cpp
+++ b/src/utils/test/logging.cpp
@@ -62,7 +62,7 @@ TEST(LoggingTest, LogMacro)
     dsn::fail::cfg("coredump_for_fatal_log", "void(false)");
 
     for (auto test : tests) {
-        // Test logging_provider::log
+        // Test logging_provider::log.
         LOG(test.level, "LOG: sortkey = {}", test.str);
     }
 

--- a/src/utils/test/logging.cpp
+++ b/src/utils/test/logging.cpp
@@ -34,49 +34,40 @@
 
 TEST(core, logging)
 {
-    dsn_log_level_t level = dsn_log_get_start_level();
+    log_level_t level = get_log_start_level();
     std::cout << "logging start level = " << level << std::endl;
-    dsn_logf(__FILENAME__,
-             __FUNCTION__,
-             __LINE__,
-             dsn_log_level_t::LOG_LEVEL_INFO,
-             "in TEST(core, logging)");
-    dsn_log(__FILENAME__, __FUNCTION__, __LINE__, dsn_log_level_t::LOG_LEVEL_INFO, "");
+    global_log(__FILENAME__, __FUNCTION__, __LINE__, log_level_t::LOG_LEVEL_INFO, "in TEST(core, logging)");
 }
 
 TEST(core, logging_big_log)
 {
     std::string big_str(128000, 'x');
-    dsn_logf(__FILENAME__,
+    global_log(__FILENAME__,
              __FUNCTION__,
              __LINE__,
-             dsn_log_level_t::LOG_LEVEL_INFO,
-             "write big str %s",
+             log_level_t::LOG_LEVEL_INFO,
              big_str.c_str());
 }
 
-TEST(core, dlog)
+TEST(core, log)
 {
     struct test_case
     {
-        enum dsn_log_level_t level;
+        enum log_level_t level;
         std::string str;
-    } tests[] = {{dsn_log_level_t::LOG_LEVEL_DEBUG, "This is a test"},
-                 {dsn_log_level_t::LOG_LEVEL_DEBUG, "\\x00%d\\x00\\x01%n/nm"},
-                 {dsn_log_level_t::LOG_LEVEL_INFO, "\\x00%d\\x00\\x01%n/nm"},
-                 {dsn_log_level_t::LOG_LEVEL_WARNING, "\\x00%d\\x00\\x01%n/nm"},
-                 {dsn_log_level_t::LOG_LEVEL_ERROR, "\\x00%d\\x00\\x01%n/nm"},
-                 {dsn_log_level_t::LOG_LEVEL_FATAL, "\\x00%d\\x00\\x01%n/nm"}};
+    } tests[] = {{log_level_t::LOG_LEVEL_DEBUG, "This is a test"},
+                 {log_level_t::LOG_LEVEL_DEBUG, "\\x00%d\\x00\\x01%n/nm"},
+                 {log_level_t::LOG_LEVEL_INFO, "\\x00%d\\x00\\x01%n/nm"},
+                 {log_level_t::LOG_LEVEL_WARNING, "\\x00%d\\x00\\x01%n/nm"},
+                 {log_level_t::LOG_LEVEL_ERROR, "\\x00%d\\x00\\x01%n/nm"},
+                 {log_level_t::LOG_LEVEL_FATAL, "\\x00%d\\x00\\x01%n/nm"}};
 
     dsn::fail::setup();
     dsn::fail::cfg("coredump_for_fatal_log", "void(false)");
 
     for (auto test : tests) {
-        // Test logging_provider::dsn_log
-        dlog_f(test.level, "dlog_f: sortkey = {}", test.str);
-
-        // Test logging_provider::dsn_logv
-        dlog(test.level, "dlog: sortkey = %s", test.str.c_str());
+        // Test logging_provider::log
+        LOG(test.level, "LOG: sortkey = {}", test.str);
     }
 
     dsn::fail::teardown();

--- a/src/utils/test/logging.cpp
+++ b/src/utils/test/logging.cpp
@@ -36,17 +36,17 @@ TEST(core, logging)
 {
     log_level_t level = get_log_start_level();
     std::cout << "logging start level = " << level << std::endl;
-    global_log(__FILENAME__, __FUNCTION__, __LINE__, log_level_t::LOG_LEVEL_INFO, "in TEST(core, logging)");
+    global_log(__FILENAME__,
+               __FUNCTION__,
+               __LINE__,
+               log_level_t::LOG_LEVEL_INFO,
+               "in TEST(core, logging)");
 }
 
 TEST(core, logging_big_log)
 {
     std::string big_str(128000, 'x');
-    global_log(__FILENAME__,
-             __FUNCTION__,
-             __LINE__,
-             log_level_t::LOG_LEVEL_INFO,
-             big_str.c_str());
+    global_log(__FILENAME__, __FUNCTION__, __LINE__, log_level_t::LOG_LEVEL_INFO, big_str.c_str());
 }
 
 TEST(core, log)

--- a/src/utils/test/logging.cpp
+++ b/src/utils/test/logging.cpp
@@ -32,35 +32,31 @@
 #include "utils/fail_point.h"
 #include "utils/fmt_logging.h"
 
-TEST(core, logging)
+TEST(LoggingTest, GlobalLog)
 {
     log_level_t level = get_log_start_level();
-    std::cout << "logging start level = " << level << std::endl;
-    global_log(__FILENAME__,
-               __FUNCTION__,
-               __LINE__,
-               log_level_t::LOG_LEVEL_INFO,
-               "in TEST(core, logging)");
+    std::cout << "logging start level = " << enum_to_string(level) << std::endl;
+    global_log(__FILENAME__, __FUNCTION__, __LINE__, LOG_LEVEL_INFO, "in TEST(core, logging)");
 }
 
-TEST(core, logging_big_log)
+TEST(LoggingTest, GlobalLogBig)
 {
     std::string big_str(128000, 'x');
-    global_log(__FILENAME__, __FUNCTION__, __LINE__, log_level_t::LOG_LEVEL_INFO, big_str.c_str());
+    global_log(__FILENAME__, __FUNCTION__, __LINE__, LOG_LEVEL_INFO, big_str.c_str());
 }
 
-TEST(core, log)
+TEST(LoggingTest, LogMacro)
 {
     struct test_case
     {
-        enum log_level_t level;
+        log_level_t level;
         std::string str;
-    } tests[] = {{log_level_t::LOG_LEVEL_DEBUG, "This is a test"},
-                 {log_level_t::LOG_LEVEL_DEBUG, "\\x00%d\\x00\\x01%n/nm"},
-                 {log_level_t::LOG_LEVEL_INFO, "\\x00%d\\x00\\x01%n/nm"},
-                 {log_level_t::LOG_LEVEL_WARNING, "\\x00%d\\x00\\x01%n/nm"},
-                 {log_level_t::LOG_LEVEL_ERROR, "\\x00%d\\x00\\x01%n/nm"},
-                 {log_level_t::LOG_LEVEL_FATAL, "\\x00%d\\x00\\x01%n/nm"}};
+    } tests[] = {{LOG_LEVEL_DEBUG, "This is a test"},
+                 {LOG_LEVEL_DEBUG, "\\x00%d\\x00\\x01%n/nm"},
+                 {LOG_LEVEL_INFO, "\\x00%d\\x00\\x01%n/nm"},
+                 {LOG_LEVEL_WARNING, "\\x00%d\\x00\\x01%n/nm"},
+                 {LOG_LEVEL_ERROR, "\\x00%d\\x00\\x01%n/nm"},
+                 {LOG_LEVEL_FATAL, "\\x00%d\\x00\\x01%n/nm"}};
 
     dsn::fail::setup();
     dsn::fail::cfg("coredump_for_fatal_log", "void(false)");

--- a/src/utils/test/logging.cpp
+++ b/src/utils/test/logging.cpp
@@ -34,8 +34,7 @@
 
 TEST(LoggingTest, GlobalLog)
 {
-    log_level_t level = get_log_start_level();
-    std::cout << "logging start level = " << enum_to_string(level) << std::endl;
+    std::cout << "logging start level = " << enum_to_string(get_log_start_level()) << std::endl;
     global_log(__FILENAME__, __FUNCTION__, __LINE__, LOG_LEVEL_INFO, "in TEST(core, logging)");
 }
 


### PR DESCRIPTION
Refactor the logging system, including:
- drop the unnecessary interface `logging_provider::dsn_logv()`
- change `dsn_log` or `dlog` to `log` for the naming of logging-related
macros, functions, classes, types and variables
- improve the tests for the logging and fix the bug that the whole
utils test directory is removed after utils tests are finished.