### PR TITLE
refactor(json_file): Refactor the load and dump functions of JSON objects

### DIFF
--- a/src/block_service/local/local_service.h
+++ b/src/block_service/local/local_service.h
@@ -41,14 +41,8 @@ struct file_metadata
     std::string md5;
 
     file_metadata(int64_t s = 0, const std::string &m = "") : size(s), md5(m) {}
-
-    // Dump the object to a file in JSON format.
-    error_code dump_to_file(const std::string &file_path) const;
-
-    // Load the object from a file in JSON format.
-    error_code load_from_file(const std::string &file_path);
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(file_metadata, size, md5)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(file_metadata, size, md5);
 
 class local_service : public block_filesystem
 {

--- a/src/block_service/test/local_service_test.cpp
+++ b/src/block_service/test/local_service_test.cpp
@@ -32,6 +32,7 @@
 #include "test_util/test_util.h"
 #include "utils/env.h"
 #include "utils/error_code.h"
+#include "utils/load_dump_object.h"
 
 namespace dsn {
 namespace dist {
@@ -49,11 +50,11 @@ TEST_P(local_service_test, file_metadata)
     const int64_t kSize = 12345;
     const std::string kMD5 = "0123456789abcdef0123456789abcdef";
     auto meta_file_path = local_service::get_metafile("a.txt");
-    ASSERT_EQ(ERR_OK, file_metadata(kSize, kMD5).dump_to_file(meta_file_path));
+    ASSERT_EQ(ERR_OK, dsn::utils::dump_njobj_to_file(file_metadata(kSize, kMD5), meta_file_path));
     ASSERT_TRUE(boost::filesystem::exists(meta_file_path));
 
     file_metadata fm;
-    fm.load_from_file(meta_file_path);
+    ASSERT_EQ(ERR_OK, dsn::utils::load_njobj_from_file(meta_file_path, &fm));
     ASSERT_EQ(kSize, fm.size);
     ASSERT_EQ(kMD5, fm.md5);
 }
@@ -64,7 +65,8 @@ TEST_P(local_service_test, load_metadata)
     auto meta_file_path = local_service::get_metafile(file.file_name());
 
     {
-        ASSERT_EQ(ERR_OK, file_metadata(5, "abcde").dump_to_file(meta_file_path));
+        ASSERT_EQ(ERR_OK,
+                  dsn::utils::dump_njobj_to_file(file_metadata(5, "abcde"), meta_file_path));
         ASSERT_EQ(ERR_OK, file.load_metadata());
         ASSERT_EQ("abcde", file.get_md5sum());
         ASSERT_EQ(5, file.get_size());

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -92,7 +92,8 @@ private:
                            int32_t file_index,
                            dist::block_service::block_filesystem *fs);
 
-    // \return ERR_FILE_OPERATION_FAILED: file not exist, get size failed, open file failed
+    // \return ERR_PATH_NOT_FOUND: file not exist
+    // \return ERR_FILE_OPERATION_FAILED: get size failed, open file failed
     // \return ERR_CORRUPTION: parse failed
     // need to acquire write lock while calling it
     error_code parse_bulk_load_metadata(const std::string &fname);

--- a/src/replica/replica_disk_migrator.cpp
+++ b/src/replica/replica_disk_migrator.cpp
@@ -36,6 +36,7 @@
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
 #include "utils/thread_access_checker.h"
+#include "utils/load_dump_object.h"
 
 namespace dsn {
 namespace replication {
@@ -251,7 +252,9 @@ bool replica_disk_migrator::migrate_replica_app_info(const replica_disk_migrate_
         return false;
     });
     replica_init_info init_info = _replica->get_app()->init_info();
-    const auto &store_init_info_err = init_info.store(_target_replica_dir);
+    const auto &store_init_info_err = utils::dump_rjobj_to_file(
+        init_info,
+        utils::filesystem::path_combine(_target_replica_dir, replica_init_info::kInitInfo));
     if (store_init_info_err != ERR_OK) {
         LOG_ERROR_PREFIX("disk migration(origin={}, target={}) stores app init info failed({})",
                          req.origin_disk,

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -17,8 +17,6 @@
 
 #include <boost/cstdint.hpp>
 #include <boost/lexical_cast.hpp>
-#include <rocksdb/env.h>
-#include <rocksdb/status.h>
 #include <stdint.h>
 #include <atomic>
 #include <fstream>
@@ -34,7 +32,6 @@
 #include "block_service/block_service_manager.h"
 #include "common/backup_common.h"
 #include "common/gpid.h"
-#include "common/json_helper.h"
 #include "common/replication.codes.h"
 #include "dsn.layer2_types.h"
 #include "failure_detector/failure_detector_multimaster.h"
@@ -55,6 +52,7 @@
 #include "utils/error_code.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
+#include "utils/load_dump_object.h"
 
 using namespace dsn::dist::block_service;
 
@@ -91,31 +89,6 @@ bool replica::remove_useless_file_under_chkpt(const std::string &chkpt_dir,
             return false;
         }
         LOG_INFO_PREFIX("remove useless file({}) succeed", pair.second);
-    }
-    return true;
-}
-
-bool replica::read_cold_backup_metadata(const std::string &fname,
-                                        cold_backup_metadata &backup_metadata)
-{
-    if (!::dsn::utils::filesystem::file_exists(fname)) {
-        LOG_ERROR_PREFIX(
-            "checkpoint on remote storage media is damaged, coz file({}) doesn't exist", fname);
-        return false;
-    }
-
-    std::string data;
-    auto s = rocksdb::ReadFileToString(
-        dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive), fname, &data);
-    if (!s.ok()) {
-        LOG_ERROR_PREFIX("read file '{}' failed, err = {}", fname, s.ToString());
-        return false;
-    }
-
-    if (!::dsn::json::json_forwarder<cold_backup_metadata>::decode(
-            blob::create_from_bytes(std::move(data)), backup_metadata)) {
-        LOG_ERROR_PREFIX("file({}) under checkpoint is damaged", fname);
-        return false;
     }
     return true;
 }
@@ -206,13 +179,14 @@ error_code replica::get_backup_metadata(block_filesystem *fs,
         return err;
     }
 
-    // parse cold_backup_meta from metadata file
+    // Load cold_backup_metadata from metadata file.
     const std::string local_backup_metada_file =
         utils::filesystem::path_combine(local_chkpt_dir, cold_backup_constant::BACKUP_METADATA);
-    if (!read_cold_backup_metadata(local_backup_metada_file, backup_metadata)) {
-        LOG_ERROR_PREFIX("read cold_backup_metadata from file({}) failed",
+    auto ec = dsn::utils::load_rjobj_from_file(local_backup_metada_file, &backup_metadata);
+    if (ec != ERR_OK) {
+        LOG_ERROR_PREFIX("load cold_backup_metadata from file({}) failed",
                          local_backup_metada_file);
-        return ERR_FILE_OPERATION_FAILED;
+        return ec;
     }
 
     _chkpt_total_size = backup_metadata.checkpoint_total_size;

--- a/src/test/function_test/bulk_load/CMakeLists.txt
+++ b/src/test/function_test/bulk_load/CMakeLists.txt
@@ -39,6 +39,7 @@ set(MY_PROJ_LIBS
         krb5
         function_test_utils
         test_utils
+        dsn_utils
         rocksdb
         lz4
         zstd

--- a/src/utils/filesystem.cpp
+++ b/src/utils/filesystem.cpp
@@ -41,6 +41,7 @@
 #include <unistd.h>
 #include <memory>
 
+#include "absl/strings/string_view.h"
 #include "utils/defer.h"
 #include "utils/env.h"
 #include "utils/fail_point.h"
@@ -48,7 +49,6 @@
 #include "utils/fmt_logging.h"
 #include "utils/ports.h"
 #include "utils/safe_strerror_posix.h"
-#include "absl/strings/string_view.h"
 
 #define getcwd_ getcwd
 #define rmdir_ rmdir

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -275,13 +275,23 @@ inline const char *null_str_printer(const char *s) { return s == nullptr ? "(nul
         LOG_AND_RETURN_NOT_TRUE(level, _err == ::dsn::ERR_OK, _err, __VA_ARGS__);                  \
     } while (0)
 
-// Return the given rocksdb::Status 's' if it is not OK.
-#define LOG_AND_RETURN_NOT_RDB_OK(level, s, ...)                                                   \
+// Return the given rocksdb::Status of 'exp' if it is not OK.
+#define LOG_AND_RETURN_NOT_RDB_OK(level, exp, ...)                                                 \
     do {                                                                                           \
-        const auto &_s = (s);                                                                      \
+        const auto &_s = (exp);                                                                    \
         if (dsn_unlikely(!_s.ok())) {                                                              \
             LOG_##level("{}: {}", _s.ToString(), fmt::format(__VA_ARGS__));                        \
             return _s;                                                                             \
+        }                                                                                          \
+    } while (0)
+
+// Return the given 'err' code if 'exp' is not OK.
+#define LOG_AND_RETURN_CODE_NOT_RDB_OK(level, exp, err, ...)                                       \
+    do {                                                                                           \
+        const auto _s = (exp);                                                                     \
+        if (dsn_unlikely(!_s.ok())) {                                                              \
+            LOG_##level("{}: {}", _s.ToString(), fmt::format(__VA_ARGS__));                        \
+            return err;                                                                            \
         }                                                                                          \
     } while (0)
 

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -288,7 +288,7 @@ inline const char *null_str_printer(const char *s) { return s == nullptr ? "(nul
 // Return the given 'err' code if 'exp' is not OK.
 #define LOG_AND_RETURN_CODE_NOT_RDB_OK(level, exp, err, ...)                                       \
     do {                                                                                           \
-        const auto _s = (exp);                                                                     \
+        const auto &_s = (exp);                                                                    \
         if (dsn_unlikely(!_s.ok())) {                                                              \
             LOG_##level("{}: {}", _s.ToString(), fmt::format(__VA_ARGS__));                        \
             return err;                                                                            \

--- a/src/utils/load_dump_object.h
+++ b/src/utils/load_dump_object.h
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <fmt/core.h>
+#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
+#include <rocksdb/env.h>
+#include <rocksdb/slice.h>
+#include <initializer_list>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/json_helper.h"
+#include "utils/blob.h"
+#include "utils/defer.h"
+#include "utils/env.h"
+#include "utils/error_code.h"
+#include "utils/filesystem.h"
+#include "utils/fmt_logging.h"
+
+namespace dsn {
+namespace utils {
+
+// Write 'data' to path 'file_path', while 'type' decide whether to encrypt the data.
+template <class T>
+error_code write_data_to_file(const std::string &file_path, const T &data, const FileDataType &type)
+{
+    const std::string tmp_file_path = fmt::format("{}.tmp", file_path);
+    auto cleanup = defer([tmp_file_path]() { filesystem::remove_path(tmp_file_path); });
+    LOG_AND_RETURN_CODE_NOT_RDB_OK(
+        ERROR,
+        rocksdb::WriteStringToFile(PegasusEnv(type),
+                                   rocksdb::Slice(data.data(), data.length()),
+                                   tmp_file_path,
+                                   /* should_sync */ true),
+        ERR_FILE_OPERATION_FAILED,
+        "write file '{}' failed",
+        tmp_file_path);
+    LOG_AND_RETURN_NOT_TRUE(ERROR,
+                            filesystem::rename_path(tmp_file_path, file_path),
+                            ERR_FILE_OPERATION_FAILED,
+                            "move file from '{}' to '{}' failed",
+                            tmp_file_path,
+                            file_path);
+    return ERR_OK;
+}
+
+// Load a object from the file in 'file_path' to 'obj', the file content must be in JSON format.
+// The object T must use the marco DEFINE_JSON_SERIALIZATION(...) when defining, which implement
+// the RapidJson APIs.
+template <class T>
+error_code load_rjobj_from_file(const std::string &file_path, T *obj)
+{
+    LOG_AND_RETURN_NOT_TRUE(ERROR,
+                            filesystem::path_exists(file_path),
+                            ERR_PATH_NOT_FOUND,
+                            "file '{}' not exist",
+                            file_path);
+    std::string data;
+    LOG_AND_RETURN_CODE_NOT_RDB_OK(
+        ERROR,
+        rocksdb::ReadFileToString(PegasusEnv(FileDataType::kSensitive), file_path, &data),
+        ERR_FILE_OPERATION_FAILED,
+        "read file '{}' failed",
+        file_path);
+    LOG_AND_RETURN_NOT_TRUE(
+        ERROR,
+        json::json_forwarder<T>::decode(blob::create_from_bytes(std::move(data)), *obj),
+        ERR_CORRUPTION,
+        "decode JSON from file '{}' failed",
+        file_path);
+    return ERR_OK;
+}
+
+// Dump the object to the file in 'file_path' according to 'obj', the file content will be in JSON
+// format.
+// The object T must use the marco DEFINE_JSON_SERIALIZATION(...) when defining, which implement
+// the RapidJson APIs.
+template <class T>
+error_code dump_rjobj_to_file(const T &obj, const std::string &file_path)
+{
+    const auto data = json::json_forwarder<T>::encode(obj);
+    LOG_AND_RETURN_NOT_OK(ERROR,
+                          write_data_to_file(file_path, data, FileDataType::kSensitive),
+                          "dump content to '{}' failed",
+                          file_path);
+    return ERR_OK;
+}
+
+// Similar to load_rjobj_from_file, but the object T must use the
+// marco NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(...) when defining,
+// which implement the NlohmannJson APIs.
+template <class T>
+error_code load_njobj_from_file(const std::string &file_path, T *obj)
+{
+    LOG_AND_RETURN_NOT_TRUE(ERROR,
+                            filesystem::path_exists(file_path),
+                            ERR_PATH_NOT_FOUND,
+                            "file '{}' not exist",
+                            file_path);
+    std::string data;
+    LOG_AND_RETURN_CODE_NOT_RDB_OK(
+        ERROR,
+        rocksdb::ReadFileToString(PegasusEnv(FileDataType::kSensitive), file_path, &data),
+        ERR_FILE_OPERATION_FAILED,
+        "read file '{}' failed",
+        file_path);
+    try {
+        nlohmann::json::parse(data).get_to(*obj);
+    } catch (nlohmann::json::exception &exp) {
+        LOG_WARNING("decode JSON from file '{}' failed, exception = {}, data = [{}]",
+                    file_path,
+                    exp.what(),
+                    data);
+        return ERR_CORRUPTION;
+    }
+    return ERR_OK;
+}
+
+// Similar to dump_rjobj_to_file, but the object T must use the
+// marco NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(...) when defining,
+// which implement the NlohmannJson APIs.
+template <class T>
+error_code dump_njobj_to_file(const T &obj, const std::string &file_path)
+{
+    const auto data = nlohmann::json(obj).dump();
+    LOG_AND_RETURN_NOT_OK(ERROR,
+                          write_data_to_file(file_path, data, FileDataType::kSensitive),
+                          "dump content to '{}' failed",
+                          file_path);
+    return ERR_OK;
+}
+
+} // namespace utils
+} // namespace dsn

--- a/src/utils/test/load_dump_object_test.cpp
+++ b/src/utils/test/load_dump_object_test.cpp
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "utils/load_dump_object.h"
+
+#include <nlohmann/detail/macro_scope.hpp>
+#include <rocksdb/status.h>
+#include <algorithm>
+#include <cstdint>
+
+#include "gtest/gtest.h"
+
+namespace dsn {
+namespace utils {
+struct nlohmann_json_struct;
+struct rapid_json_struct;
+
+#define STRUCT_CONTENT(T)                                                                          \
+    int64_t a;                                                                                     \
+    std::string b;                                                                                 \
+    std::vector<int64_t> c;                                                                        \
+    bool operator==(const T &other) const { return a == other.a && b == other.b && c == other.c; }
+
+struct nlohmann_json_struct
+{
+    STRUCT_CONTENT(nlohmann_json_struct);
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(nlohmann_json_struct, a, b, c);
+
+TEST(load_dump_object, nlohmann_json_struct_normal_test)
+{
+    const std::string path("nlohmann_json_struct_test");
+    nlohmann_json_struct obj;
+    obj.a = 123;
+    obj.b = "hello world";
+    obj.c = std::vector<int64_t>({1, 3, 5, 2, 4});
+    ASSERT_EQ(ERR_OK, dump_njobj_to_file(obj, path));
+    nlohmann_json_struct obj2;
+    ASSERT_EQ(ERR_OK, load_njobj_from_file(path, &obj2));
+    ASSERT_EQ(obj, obj2);
+}
+
+TEST(load_dump_object, nlohmann_json_struct_load_failed_test)
+{
+    const std::string path("nlohmann_json_struct_test_bad");
+    ASSERT_TRUE(filesystem::remove_path(path));
+
+    nlohmann_json_struct obj;
+    ASSERT_EQ(ERR_PATH_NOT_FOUND, load_njobj_from_file(path, &obj));
+
+    auto s =
+        rocksdb::WriteStringToFile(dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive),
+                                   rocksdb::Slice("invalid data"),
+                                   path,
+                                   /* should_sync */ true);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+
+    ASSERT_EQ(ERR_CORRUPTION, load_njobj_from_file(path, &obj));
+}
+
+struct rapid_json_struct
+{
+    STRUCT_CONTENT(rapid_json_struct);
+    DEFINE_JSON_SERIALIZATION(a, b, c);
+};
+
+TEST(load_dump_object, rapid_json_struct_test)
+{
+    const std::string path("rapid_json_struct_test");
+    rapid_json_struct obj;
+    obj.a = 123;
+    obj.b = "hello world";
+    obj.c = std::vector<int64_t>({1, 3, 5, 2, 4});
+    ASSERT_EQ(ERR_OK, dump_rjobj_to_file(obj, path));
+    rapid_json_struct obj2;
+    ASSERT_EQ(ERR_OK, load_rjobj_from_file(path, &obj2));
+    ASSERT_EQ(obj, obj2);
+}
+
+TEST(load_dump_object, rapid_json_struct_load_failed_test)
+{
+    const std::string path("rapid_json_struct_test_bad");
+    ASSERT_TRUE(filesystem::remove_path(path));
+
+    rapid_json_struct obj;
+    ASSERT_EQ(ERR_PATH_NOT_FOUND, load_rjobj_from_file(path, &obj));
+
+    auto s =
+        rocksdb::WriteStringToFile(dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive),
+                                   rocksdb::Slice("invalid data"),
+                                   path,
+                                   /* should_sync */ true);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+
+    ASSERT_EQ(ERR_CORRUPTION, load_rjobj_from_file(path, &obj));
+}
+
+} // namespace utils
+} // namespace dsn


### PR DESCRIPTION
This patch mainly refactoring the objects load and dump functions.
There are 2 types of objects, one is using DEFINE_JSON_SERIALIZATION macro to make the object
can be converted to/from JSON string which corresponding to RapidJson, the other is using
NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE macro which corresponding to NlohmannJson. So there are 2
types of functions (i.e. load_rjobj_from_file/dump_rjobj_to_file and
load_njobj_from_file/dump_njobj_to_file).

This patch refactor the code to use the newly added functions to do the operations, and also
add some unit tests.