### PR TITLE
feat(new_metrics): add some basic fields to the response to metrics query

### DIFF
--- a/src/runtime/task/task.h
+++ b/src/runtime/task/task.h
@@ -243,6 +243,7 @@ public:
     static int get_current_worker_index();
     static const char *get_current_node_name();
     static rpc_engine *get_current_rpc();
+    static rpc_engine *get_current_rpc2();
     static env_provider *get_current_env();
 
     static void set_tls_dsn_context(
@@ -592,6 +593,11 @@ __inline /*static*/ rpc_engine *task::get_current_rpc()
 {
     check_tls_dsn();
     return tls_dsn.rpc;
+}
+
+__inline /*static*/ rpc_engine *task::get_current_rpc2()
+{
+    return tls_dsn.magic == 0xdeadbeef ? tls_dsn.rpc : nullptr;
 }
 
 __inline /*static*/ env_provider *task::get_current_env()

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -46,6 +46,7 @@ if (APPLE)
     target_link_libraries(${MY_PROJ_NAME} PRIVATE dsn_http)
 else()
     dsn_add_shared_library()
+    target_link_libraries(${MY_PROJ_NAME} PRIVATE dsn_replication_common)
 endif()
 
 add_subdirectory(long_adder_bench)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -43,7 +43,7 @@ set(MY_BINPLACES "")
 
 if (APPLE)
     dsn_add_static_library()
-    target_link_libraries(${MY_PROJ_NAME} PRIVATE dsn_http)
+    target_link_libraries(${MY_PROJ_NAME} PRIVATE dsn_http dsn_replication_common)
 else()
     dsn_add_shared_library()
     target_link_libraries(${MY_PROJ_NAME} PRIVATE dsn_replication_common)

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -22,14 +22,15 @@
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 #include <boost/system/error_code.hpp>
 #include <fmt/core.h>
-#include <new>
 #include <unistd.h>
+#include <new>
 
-#include "common/common.h"
 #include "http/http_method.h"
 #include "http/http_status_code.h"
 #include "runtime/api_layer1.h"
+#include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_engine.h"
+#include "runtime/service_app.h"
 #include "runtime/service_engine.h"
 #include "runtime/task/task.h"
 #include "utils/flags.h"

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -478,18 +478,19 @@ void encode_port(dsn::metric_json_writer &writer)
 
 } // anonymous namespace
 
-void metric_registry::encode_entities(metric_json_writer &writer, const metric_filters &filters) const
+void metric_registry::encode_entities(metric_json_writer &writer,
+                                      const metric_filters &filters) const
 {
     writer.Key(dsn::kMetricEntitiesField.c_str());
 
     writer.StartArray();
 
-    { 
-    utils::auto_read_lock l(_lock);
+    {
+        utils::auto_read_lock l(_lock);
 
-    for (const auto &entity : _entities) {
-        entity.second->take_snapshot(writer, filters);
-    }
+        for (const auto &entity : _entities) {
+            entity.second->take_snapshot(writer, filters);
+        }
     }
 
     writer.EndArray();

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -347,11 +347,12 @@ const std::string kMetricEntityTypeField = "type";
 const std::string kMetricEntityIdField = "id";
 const std::string kMetricEntityAttrsField = "attributes";
 const std::string kMetricEntityMetricsField = "metrics";
-const std::string kMetricEntitiesField = "entities";
+
 const std::string kMetricClusterField = "cluster";
 const std::string kMetricRoleField = "role";
 const std::string kMetricHostField = "host";
 const std::string kMetricPortField = "port";
+const std::string kMetricEntitiesField = "entities";
 
 class metric_entity : public ref_counter
 {

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -692,6 +692,8 @@ private:
                                             const std::string &id,
                                             const metric_entity::attr_map &attrs);
 
+    void encode_entities(metric_json_writer &writer, const metric_filters &filters) const;
+
     // These functions are used to retire stale entities.
     //
     // Since retirement is infrequent, there tend to be no entity that should be retired.

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -347,6 +347,11 @@ const std::string kMetricEntityTypeField = "type";
 const std::string kMetricEntityIdField = "id";
 const std::string kMetricEntityAttrsField = "attributes";
 const std::string kMetricEntityMetricsField = "metrics";
+const std::string kMetricEntitiesField = "entities";
+const std::string kMetricClusterField = "cluster";
+const std::string kMetricRoleField = "role";
+const std::string kMetricHostField = "host";
+const std::string kMetricPortField = "port";
 
 class metric_entity : public ref_counter
 {

--- a/src/utils/test/metrics_test.cpp
+++ b/src/utils/test/metrics_test.cpp
@@ -2267,22 +2267,35 @@ TEST(metrics_test, take_snapshot_entity)
     }
 }
 
+const std::unordered_set<std::string> kAllMetricQueryFields = {kMetricClusterField,
+                                                               kMetricRoleField,
+                                                               kMetricHostField,
+                                                               kMetricPortField,
+                                                               kMetricEntitiesField};
+
 void check_entity_ids_from_json_string(const std::string &json_string,
                                        const std::unordered_set<std::string> &expected_entity_ids)
 {
-    // Even if there is not any entity selected, `json_string` should be "[]".
+    // Even if there is not any entity selected, `json_string` should not be empty.
     ASSERT_FALSE(json_string.empty());
 
     rapidjson::Document doc;
     rapidjson::ParseResult result = doc.Parse(json_string.c_str());
     ASSERT_FALSE(result.IsError());
 
+    // The root struct should be an object.
+    ASSERT_TRUE(doc.IsObject());
+    for (const auto &field : kAllMetricQueryFields) {
+        ASSERT_TRUE(doc.HasMember(field.c_str()));
+    }
+
     // Actual entity ids parsed from json string.
     std::unordered_set<std::string> actual_entity_ids;
 
     // The json format for entities should be an array.
-    ASSERT_TRUE(doc.IsArray());
-    for (const auto &entity : doc.GetArray()) {
+    const auto &entities = doc.FindMember(kMetricEntitiesField.c_str())->value;
+    ASSERT_TRUE(entities.IsArray());
+    for (const auto &entity : entities.GetArray()) {
         // The json format for each entity should be an object.
         ASSERT_TRUE(entity.IsObject());
 
@@ -2429,12 +2442,19 @@ void check_entities_from_json_string(const std::string &json_string,
         return;
     }
 
+    // The successful response should be an object.
+    ASSERT_TRUE(doc.IsObject());
+    for (const auto &field : kAllMetricQueryFields) {
+        ASSERT_TRUE(doc.HasMember(field.c_str()));
+    }
+
     // Actual entities parsed from json string.
     entity_container actual_entities;
 
     // The json format for entities should be an array.
-    ASSERT_TRUE(doc.IsArray());
-    for (const auto &entity : doc.GetArray()) {
+    const auto &entities = doc.FindMember(kMetricEntitiesField.c_str())->value;
+    ASSERT_TRUE(entities.IsArray());
+    for (const auto &entity : entities.GetArray()) {
         // The json format for each entity should be an object.
         ASSERT_TRUE(entity.IsObject());
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1820

Labels are needed by metric models like Prometheus Data Model.
Therefore, cluster name, role name, host name and port should be
provided in the response to metrics query as the labels. All of these
fields would be added in the form of name/value pairs of json object.

Original entity array would be the value of a json object with name
"entities".