### PR TITLE
fix(logging): remove too verbose log when key not found (#1829)

### DIFF
--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -298,7 +298,10 @@ void replica::on_client_read(dsn::message_ex *request, bool ignore_throttling)
     uint64_t start_time_ns = dsn_now_ns();
     CHECK(_app, "");
     auto storage_error = _app->on_request(request);
-    if (dsn_unlikely(storage_error != ERR_OK)) {
+    // kNotFound is normal, it indicates that the key is not found (including expired)
+    // in the storage engine, so just ignore it.
+    if (dsn_unlikely(storage_error != rocksdb::Status::kOk &&
+                     storage_error != rocksdb::Status::kNotFound)) {
         switch (storage_error) {
         // TODO(yingchun): Now only kCorruption and kIOError are dealt, consider to deal with
         //  more storage engine errors.


### PR DESCRIPTION
Don't log "client read encountered an unhandled error: 1" when the key is not found.