### PR TITLE
fix(java-client): Fix the failed java-client test

### DIFF
--- a/.github/workflows/lint_and_test_java-client.yml
+++ b/.github/workflows/lint_and_test_java-client.yml
@@ -94,8 +94,7 @@ jobs:
       - name: Start Pegasus cluster
         run: |
           apt-get update
-          apt-get -y install tree
-          tree ${JAVA_HOME}
+          apt-get install net-tools -y
           export LD_LIBRARY_PATH=$(pwd)/thirdparty/output/lib:${JAVA_HOME}/jre/lib/amd64/server
           ulimit -s unlimited
           ./run.sh start_onebox

--- a/java-client/README.md
+++ b/java-client/README.md
@@ -19,43 +19,54 @@ under the License.
 
 # Pegasus Java Client
 
-## Build
+## Development
+
+### 1. Prepare
 
 ```
-cd scripts && sh recompile_thrift.sh && cd -
+cd scripts && bash recompile_thrift.sh
+```
+
+### 2. Format the code
+
+```
 mvn spotless:apply
+```
+
+### 3. Build
+
+```
 mvn clean package -DskipTests
 ```
 
-## Install
+### 4. Test
+
+To run test, you should prepare the test environment:
+1. Start [Pegasus onebox](https://pegasus.apache.org/overview/onebox/)
+2. Install some necessary tools, such as `net-tools`
 
 ```
-cd scripts && sh recompile_thrift.sh && cd -
-mvn spotless:apply
-mvn clean install -DskipTests
-```
-
-## Test
-
-To run test, you should start pegasus onebox firstly, and run test as:
-
-```
-cd scripts && sh recompile_thrift.sh && cd -
-mvn spotless:apply
 mvn clean package
 ```
 
-or specify one test:
+Or specify one test:
 
 ```
-cd scripts && sh recompile_thrift.sh && cd -
-mvn spotless:apply
 mvn clean package -Dtest=TestPing
 ```
 
-## Configuration
+## Using Pegasus Java client
 
-Configure client by "pegasus.properties", for example:
+### Install
+
+```
+cd scripts && bash recompile_thrift.sh && cd -
+mvn clean install -DskipTests
+```
+
+### Configuration
+
+Configure client by `pegasus.properties` file, for example:
 
 ```
 meta_servers = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
@@ -66,14 +77,14 @@ perf_counter_tags = k1=v1,k2=v2,k3=v3
 push_counter_interval_secs = 10
 ```
 
-You can provide a parameter of 'configPath' when creating a client instance.
+You can provide a parameter of `configPath` when creating a client instance.
 
-The format of 'configPath' should be one of these:
+The format of `configPath` should be one of these:
 * zk path: zk://host1:port1,host2:port2,host3:port3/path/to/config
 * local file path: file:///path/to/config
 * resource path: resource:///path/to/config
 
-## PerfCounter(Metrics)
+### PerfCounter (Metrics)
 
 Pegasus Java Client supports QPS and latency statistics of requests.
 
@@ -93,7 +104,7 @@ For each type of request(get, set, multiset, etc.), we collect 8 metrics:
 5. latency-p50: the moving median of request's queries
 6. latency-p99: the moving p99 of request's queries
 7. lantecy-p999: the moving p999 of request's queries
-8: latency-max: the moving max of request's queries
+8. latency-max: the moving max of request's queries
 
 We use io.dropwizard.metrics library to calculate the request count.
 

--- a/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
@@ -2817,14 +2817,17 @@ public class TestBasic {
   }
 
   @Test
-  public void testRequestDetail() throws PException {
+  public void testOperationTimeout() throws PException {
+    String tableName = "temp";
+
+    // Create a PegasusClientInterface object 'client' which causes exceptions throw out.
     Duration caseTimeout = Duration.ofMillis(1);
     ClientOptions client_opt = ClientOptions.builder().operationTimeout(caseTimeout).build();
-
-    PegasusClientFactory.createClient(client_opt);
     PegasusClientInterface client = PegasusClientFactory.createClient(client_opt);
-    String tableName = "temp";
-    PegasusTableInterface tb = client.openTable(tableName);
+
+    // Create a PegasusTableInterface object 'tb' which doesn't cause exceptions throw out.
+    PegasusClientInterface client2 = PegasusClientFactory.createClient(ClientOptions.create());
+    PegasusTableInterface tb = client2.openTable(tableName);
 
     String HashPrefix = "TestHash";
     String SortPrefix = "TestSort";

--- a/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
@@ -2640,7 +2640,7 @@ public class TestBasic {
   @Test // test for making sure return "maxFetchCount" if has "maxFetchCount" valid record
   public void testScanRangeWithValueExpired() throws PException, InterruptedException {
     String tableName = "temp";
-    String hashKey = "hashKey";
+    String hashKey = "hashKey_testScanRangeWithValueExpired";
     // generate records: sortKeys=[expired_0....expired_999,persistent_0...persistent_9]
     generateRecordsWithExpired(tableName, hashKey, 1000, 10);
 
@@ -2649,73 +2649,119 @@ public class TestBasic {
     // case A: scan all record
     // case A1: scan all record: if persistent record count >= maxFetchCount, it must return
     // maxFetchCount records
+    int maxFetchCount = 5;
     PegasusTable.ScanRangeResult caseA1 =
-        table.scanRange(hashKey.getBytes(), null, null, new ScanOptions(), 5, 0);
-    assertScanResult(0, 4, false, caseA1);
+        table.scanRange(hashKey.getBytes(), null, null, new ScanOptions(), maxFetchCount, 0);
+    assertScanResult(hashKey, 0, 4, false, caseA1);
     // case A2: scan all record: if persistent record count < maxFetchCount, it only return
     // persistent count records
+    maxFetchCount = 100;
     PegasusTable.ScanRangeResult caseA2 =
-        table.scanRange(hashKey.getBytes(), null, null, new ScanOptions(), 100, 0);
-    assertScanResult(0, 9, true, caseA2);
+        table.scanRange(hashKey.getBytes(), null, null, new ScanOptions(), maxFetchCount, 0);
+    assertScanResult(hashKey, 0, 9, true, caseA2);
 
     // case B: scan limit record by "startSortKey" and "":
     // case B1: scan limit record by "expired_0" and "", if persistent record count >=
     // maxFetchCount, it must return maxFetchCount records
+    maxFetchCount = 5;
     PegasusTable.ScanRangeResult caseB1 =
         table.scanRange(
-            hashKey.getBytes(), "expired_0".getBytes(), "".getBytes(), new ScanOptions(), 5, 0);
-    assertScanResult(0, 4, false, caseB1);
+            hashKey.getBytes(),
+            "expired_0".getBytes(),
+            "".getBytes(),
+            new ScanOptions(),
+            maxFetchCount,
+            0);
+    assertScanResult(hashKey, 0, 4, false, caseB1);
     // case B2: scan limit record by "expired_0" and "", if persistent record count < maxFetchCount,
     // it only return valid records
+    maxFetchCount = 50;
     PegasusTable.ScanRangeResult caseB2 =
         table.scanRange(
-            hashKey.getBytes(), "expired_0".getBytes(), "".getBytes(), new ScanOptions(), 50, 0);
-    assertScanResult(0, 9, true, caseB2);
+            hashKey.getBytes(),
+            "expired_0".getBytes(),
+            "".getBytes(),
+            new ScanOptions(),
+            maxFetchCount,
+            0);
+    assertScanResult(hashKey, 0, 9, true, caseB2);
     // case B3: scan limit record by "persistent_5" and "", if following persistent record count <
     // maxFetchCount, it only return valid records
+    maxFetchCount = 50;
     PegasusTable.ScanRangeResult caseB3 =
         table.scanRange(
-            hashKey.getBytes(), "persistent_5".getBytes(), "".getBytes(), new ScanOptions(), 50, 0);
-    assertScanResult(5, 9, true, caseB3);
+            hashKey.getBytes(),
+            "persistent_5".getBytes(),
+            "".getBytes(),
+            new ScanOptions(),
+            maxFetchCount,
+            0);
+    assertScanResult(hashKey, 5, 9, true, caseB3);
     // case B4: scan limit record by "persistent_5" and "", if following persistent record count >
     // maxFetchCount, it only return valid records
+    maxFetchCount = 3;
     PegasusTable.ScanRangeResult caseB4 =
         table.scanRange(
-            hashKey.getBytes(), "persistent_5".getBytes(), "".getBytes(), new ScanOptions(), 3, 0);
-    assertScanResult(5, 7, false, caseB4);
+            hashKey.getBytes(),
+            "persistent_5".getBytes(),
+            "".getBytes(),
+            new ScanOptions(),
+            maxFetchCount,
+            0);
+    assertScanResult(hashKey, 5, 7, false, caseB4);
 
     // case C: scan limit record by "" and "stopSortKey":
     // case C1: scan limit record by "" and "expired_7", if will return 0 record
+    maxFetchCount = 3;
     PegasusTable.ScanRangeResult caseC1 =
         table.scanRange(
-            hashKey.getBytes(), "".getBytes(), "expired_7".getBytes(), new ScanOptions(), 3, 0);
+            hashKey.getBytes(),
+            "".getBytes(),
+            "expired_7".getBytes(),
+            new ScanOptions(),
+            maxFetchCount,
+            0);
     assertTrue(caseC1.allFetched);
     assertEquals(0, caseC1.results.size()); // among "" and "expired_7" has 0 valid record
     // case C2: scan limit record by "" and "persistent_7", if valid record count < maxFetchCount,
     // it only return valid record
+    maxFetchCount = 10;
     PegasusTable.ScanRangeResult caseC2 =
         table.scanRange(
-            hashKey.getBytes(), "".getBytes(), "persistent_7".getBytes(), new ScanOptions(), 10, 0);
-    assertScanResult(0, 6, true, caseC2);
+            hashKey.getBytes(),
+            "".getBytes(),
+            "persistent_7".getBytes(),
+            new ScanOptions(),
+            maxFetchCount,
+            0);
+    assertScanResult(hashKey, 0, 6, true, caseC2);
     // case C3: scan limit record by "" and "persistent_7", if valid record count > maxFetchCount,
     // it only return valid record
+    maxFetchCount = 2;
     PegasusTable.ScanRangeResult caseC3 =
         table.scanRange(
-            hashKey.getBytes(), "".getBytes(), "persistent_7".getBytes(), new ScanOptions(), 2, 0);
-    assertScanResult(0, 1, false, caseC3);
+            hashKey.getBytes(),
+            "".getBytes(),
+            "persistent_7".getBytes(),
+            new ScanOptions(),
+            maxFetchCount,
+            0);
+    assertScanResult(hashKey, 0, 1, false, caseC3);
 
     // case D: use multiGetSortKeys, which actually equal with case A but no value
     // case D1: maxFetchCount > 0, return maxFetchCount valid record
+    maxFetchCount = -1;
     PegasusTableInterface.MultiGetSortKeysResult caseD1 =
-        table.multiGetSortKeys(hashKey.getBytes(), 5, -1, 0);
+        table.multiGetSortKeys(hashKey.getBytes(), 5, maxFetchCount, 0);
     assertFalse(caseD1.allFetched);
     assertEquals(5, caseD1.keys.size());
     for (int i = 0; i <= 4; i++) {
       assertEquals("persistent_" + i, new String(caseD1.keys.get(i)));
     }
     // case D1: maxFetchCount < 0, return all valid record
+    maxFetchCount = -1;
     PegasusTableInterface.MultiGetSortKeysResult caseD2 =
-        table.multiGetSortKeys(hashKey.getBytes(), 10, -1, 0);
+        table.multiGetSortKeys(hashKey.getBytes(), 10, maxFetchCount, 0);
     assertTrue(caseD2.allFetched);
     assertEquals(10, caseD2.keys.size());
     for (int i = 0; i <= 9; i++) {
@@ -2727,7 +2773,8 @@ public class TestBasic {
       String tableName, String hashKey, int expiredCount, int persistentCount)
       throws PException, InterruptedException {
     PegasusClientInterface client = PegasusClientFactory.getSingletonClient();
-    // assign prefix to make sure the expire record is stored front of persistent
+    // Specify the prefixes to make sure the expired records are stored in front of the persistent
+    // ones.
     String expiredSortKeyPrefix = "expired_";
     String persistentSortKeyPrefix = "persistent_";
     while (expiredCount-- > 0) {
@@ -2738,7 +2785,7 @@ public class TestBasic {
           (expiredSortKeyPrefix + expiredCount + "_value").getBytes(),
           1);
     }
-    // sleep to make sure the record is expired
+    // Sleep a while to make sure the records are expired.
     Thread.sleep(1000);
     while (persistentCount-- > 0) {
       client.set(
@@ -2751,6 +2798,7 @@ public class TestBasic {
   }
 
   private void assertScanResult(
+      String hashKey,
       int startIndex,
       int stopIndex,
       boolean expectAllFetched,
@@ -2758,8 +2806,7 @@ public class TestBasic {
     assertEquals(expectAllFetched, actuallyRes.allFetched);
     assertEquals(stopIndex - startIndex + 1, actuallyRes.results.size());
     for (int i = startIndex; i <= stopIndex; i++) {
-      assertEquals(
-          "hashKey", new String(actuallyRes.results.get(i - startIndex).getLeft().getKey()));
+      assertEquals(hashKey, new String(actuallyRes.results.get(i - startIndex).getLeft().getKey()));
       assertEquals(
           "persistent_" + i,
           new String(actuallyRes.results.get(i - startIndex).getLeft().getValue()));

--- a/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestBasic.java
@@ -2888,21 +2888,21 @@ public class TestBasic {
       logger.info("Test multiDel PException request");
       {
         List<byte[]> sortKeys = new ArrayList<byte[]>();
-        sortKeys.add("basic_test_sort_key_0".getBytes());
-        sortKeys.add("basic_test_sort_key_1".getBytes());
-        sortKeys.add("basic_test_sort_key_2".getBytes());
-
         List<Pair<byte[], byte[]>> values = new ArrayList<Pair<byte[], byte[]>>();
-        values.add(Pair.of("basic_test_sort_key_0".getBytes(), "basic_test_value_0".getBytes()));
-        values.add(Pair.of("basic_test_sort_key_1".getBytes(), "basic_test_value_1".getBytes()));
-        values.add(Pair.of("basic_test_sort_key_2".getBytes(), "basic_test_value_2".getBytes()));
+        int count = 500;
+        while (count-- > 0) {
+          String tempSortKey = "basic_test_sort_key_0";
+          sortKeys.add(tempSortKey.getBytes());
+          values.add(Pair.of(tempSortKey.getBytes(), "basic_test_value_0".getBytes()));
+        }
 
-        tb.multiSet(hashKey.getBytes(), values, 5000);
+        // Expect multiSet with a higher timeout will not throw exception.
         assertDoesNotThrow(
             () -> {
               tb.multiSet(hashKey.getBytes(), values, 5000);
             });
 
+        // Expect multiSet with a lower timeout will throw exception.
         Throwable exception =
             assertThrows(
                 PException.class,
@@ -2913,7 +2913,7 @@ public class TestBasic {
             exception
                 .getMessage()
                 .contains(
-                    "request=[hashKey[:32]=\"TestHash_0\",sortKey[:32]=\"\",sortKeyCount=3,valueLength=-1]"));
+                    "request=[hashKey[:32]=\"TestHash_0\",sortKey[:32]=\"\",sortKeyCount=500,valueLength=-1]"));
       }
     } catch (Throwable e) {
       e.printStackTrace();

--- a/java-client/src/test/java/org/apache/pegasus/tools/Toollet.java
+++ b/java-client/src/test/java/org/apache/pegasus/tools/Toollet.java
@@ -82,7 +82,7 @@ public class Toollet {
       Process process = Runtime.getRuntime().exec(new String[] {"bash", "-c", command});
       int result = process.waitFor();
       if (0 != result) {
-        logger.warn("exec command {} failed, error code {}", command, result);
+        logger.warn("exec command '{}' failed, error code {}", command, result);
         return false;
       }
       return true;


### PR DESCRIPTION
Fix the failed java-client tests, and improve some the code style, including:
- Install `net-tools` which is needed by test tool Toollet.java, it use `netstat`
to find some processes.
- Improve the flaky test testOperationTimeout.
- Use an independent hashkey for testScanRangeWithValueExpired to avoid
conflicts.
- Improve some code style.
- Update the README.md.