### PR TITLE
fix: specify ambiguous meta_server_list on recovery_test

### DIFF
--- a/src/test/function_test/recovery/test_recovery.cpp
+++ b/src/test/function_test/recovery/test_recovery.cpp
@@ -65,6 +65,11 @@ protected:
     }
 
 public:
+    // For easier configuration modifications,
+    // select "single_master_cluster" cluster
+    // which onebox just start one master.
+    recovery_test() : test_util(std::map<std::string, std::string>(), "single_master_cluster") {}
+
     std::vector<dsn::rpc_address> get_rpc_address_list(const std::vector<int> ports)
     {
         std::vector<dsn::rpc_address> result;

--- a/src/test/function_test/recovery/test_recovery.cpp
+++ b/src/test/function_test/recovery/test_recovery.cpp
@@ -66,9 +66,8 @@ protected:
     }
 
 public:
-    // For easier configuration modifications,
-    // select "single_master_cluster" cluster
-    // which onebox just start one master.
+    // The cluster name "single_master_cluster" (see src/test/function_test/config.ini) means the
+    // cluster has only one meta server, while "onebox" means the cluster has 3 meta servers.
     recovery_test() : test_util(std::map<std::string, std::string>(), "single_master_cluster") {}
 
     std::vector<dsn::rpc_address> get_rpc_address_list(const std::vector<int> ports)

--- a/src/test/function_test/recovery/test_recovery.cpp
+++ b/src/test/function_test/recovery/test_recovery.cpp
@@ -20,6 +20,7 @@
 #include <fmt/core.h>
 #include <chrono>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <string>
 #include <thread>

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -62,12 +62,12 @@ using std::vector;
 
 namespace pegasus {
 
-test_util::test_util(map<string, string> create_envs)
+test_util::test_util(map<string, string> create_envs, std::string cluster_name)
     : kOpNames({{test_util::OperateDataType::kSet, "set"},
                 {test_util::OperateDataType::kGet, "get"},
                 {test_util::OperateDataType::kDelete, "delete"},
                 {test_util::OperateDataType::kCheckNotFound, "check not found"}}),
-      kClusterName("onebox"),
+      kClusterName(cluster_name),
       kHashkeyPrefix("hashkey_"),
       kSortkey("sortkey"),
       kValuePrefix("value_"),

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -62,7 +62,7 @@ using std::vector;
 
 namespace pegasus {
 
-test_util::test_util(map<string, string> create_envs, std::string cluster_name)
+test_util::test_util(map<string, string> create_envs, const std::string &cluster_name)
     : kOpNames({{test_util::OperateDataType::kSet, "set"},
                 {test_util::OperateDataType::kGet, "get"},
                 {test_util::OperateDataType::kDelete, "delete"},

--- a/src/test/function_test/utils/test_util.h
+++ b/src/test/function_test/utils/test_util.h
@@ -50,7 +50,7 @@ class test_util : public ::testing::Test
 {
 public:
     test_util(std::map<std::string, std::string> create_envs = {},
-              std::string cluster_name = "onebox");
+              const std::string &cluster_name = "onebox");
     virtual ~test_util();
 
     static void SetUpTestCase();

--- a/src/test/function_test/utils/test_util.h
+++ b/src/test/function_test/utils/test_util.h
@@ -49,7 +49,8 @@ class pegasus_client;
 class test_util : public ::testing::Test
 {
 public:
-    test_util(std::map<std::string, std::string> create_envs = {}, std::string cluster_name = "onebox");
+    test_util(std::map<std::string, std::string> create_envs = {},
+              std::string cluster_name = "onebox");
     virtual ~test_util();
 
     static void SetUpTestCase();

--- a/src/test/function_test/utils/test_util.h
+++ b/src/test/function_test/utils/test_util.h
@@ -49,7 +49,7 @@ class pegasus_client;
 class test_util : public ::testing::Test
 {
 public:
-    test_util(std::map<std::string, std::string> create_envs = {});
+    test_util(std::map<std::string, std::string> create_envs = {}, std::string cluster_name = "onebox");
     virtual ~test_util();
 
     static void SetUpTestCase();


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Issue: https://github.com/apache/incubator-pegasus/issues/1838

match the behavior of A and B in meta_server_list
