### PR TITLE
feat(http_client): add http_url class to help build URLs for http client

### DIFF
--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -58,6 +58,9 @@ dsn::error_s http_url::init()
         return dsn::error_s::make(dsn::ERR_CURL_FAILED, "fail to initialize curl url");
     }
 
+    // Set "http" as the default scheme.
+    set_scheme("http");
+
     return dsn::error_s::ok();
 }
 

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -312,10 +312,13 @@ size_t http_client::on_response_data(const void *data, size_t length)
 
 dsn::error_s http_client::set_url(const std::string &new_url)
 {
-    // DO NOT call curl_easy_setopt() on CURLOPT_URL, since The CURLOPT_URL string is ignored
+    // DO NOT call curl_easy_setopt() on CURLOPT_URL, since the CURLOPT_URL string is ignored
     // if CURLOPT_CURLU is set. See following docs for details:
     // * https://curl.se/libcurl/c/CURLOPT_CURLU.html
     // * https://curl.se/libcurl/c/CURLOPT_URL.html
+    //
+    // Use a temporary object for the reason that once the error occurred, `_url` would not
+    // be dirty.
     http_url tmp;
     RETURN_NOT_OK(tmp.init());
     RETURN_NOT_OK(tmp.set_url(new_url.c_str()));
@@ -325,6 +328,7 @@ dsn::error_s http_client::set_url(const std::string &new_url)
 
 dsn::error_s http_client::set_url(const http_url &new_url)
 {
+    // Extract the URL string from new_url and attach it to the client.
     std::string str;
     RETURN_NOT_OK(new_url.to_string(str));
 

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -50,11 +50,14 @@ DSN_DEFINE_uint32(http,
             #expr == #ok, code == (ok), "{}: {}", fmt::format(__VA_ARGS__), to_error_msg(code));   \
     } while (0)
 
-#define CHECK_IF_CURL_URL_SET_OK(url, part, content, ...)                                          \
+#define CHECK_IF_CURL_URL_OK(url, expr, ...)                                                       \
     do {                                                                                           \
         CHECK_NOTNULL(url, "CURLU object has not been allocated");                                 \
-        CHECK_IF_CURL_OK(curl_url_set(url, CURLUPART_##part, content, 0), CURLUE_OK, __VA_ARGS__); \
+        CHECK_IF_CURL_OK(expr, CURLUE_OK, __VA_ARGS__);                                            \
     } while (0)
+
+#define CHECK_IF_CURL_URL_SET_OK(url, part, content, ...)                                          \
+    CHECK_IF_CURL_URL_OK(url, curl_url_set(url, CURLUPART_##part, content, 0), __VA_ARGS__)
 
 #define CHECK_IF_CURL_URL_SET_NULL_OK(url, part, ...)                                              \
     CHECK_IF_CURL_URL_SET_OK(url,                                                                  \
@@ -183,6 +186,8 @@ DEF_HTTP_URL_SET_FUNC(query, QUERY)
 
 dsn::error_s http_url::to_string(std::string &url) const
 {
+    CHECK_NOTNULL(_url, "CURLU object has not been allocated");
+
     char *content;
     RETURN_IF_CURL_URL_GET_NOT_OK(CURLUPART_URL, &content, 0);
 
@@ -248,15 +253,6 @@ inline dsn::error_code to_error_code(CURLcode code)
     RETURN_IF_CURL_EASY_NOT_OK(curl_easy_setopt(_curl, CURLOPT_##opt, input),                      \
                                "failed to set " #opt " with " #input)
 
-#define CHECK_IF_CURL_EASY_SETOPT_OK(opt, input, ...)                                              \
-    do {                                                                                           \
-        CHECK_NOTNULL(_curl, "CURL object has not been allocated");                                \
-        CHECK_IF_CURL_OK(curl_easy_setopt(_curl, CURLOPT_##opt, input),                            \
-                         CURLE_OK,                                                                 \
-                         "failed to set " #opt " with " #input ": {}",                             \
-                         fmt::format(__VA_ARGS__));                                                \
-    } while (0)
-
 #define RETURN_IF_CURL_EASY_GETINFO_NOT_OK(info, output)                                           \
     RETURN_IF_CURL_EASY_NOT_OK(curl_easy_getinfo(_curl, CURLINFO_##info, output),                  \
                                "failed to get from " #info)
@@ -265,7 +261,21 @@ inline dsn::error_code to_error_code(CURLcode code)
     RETURN_IF_CURL_EASY_NOT_OK(curl_easy_perform(_curl),                                           \
                                "failed to perform http request(method={}, url={})",                \
                                enum_to_string(_method),                                            \
-                               _url);
+                               _url)
+
+#define CHECK_IF_CURL_EASY_OK(expr, ...)                                                           \
+    do {                                                                                           \
+        CHECK_NOTNULL(_curl, "CURL object has not been allocated");                                \
+        CHECK_IF_CURL_OK(expr, CURLE_OK, __VA_ARGS__);                                             \
+    } while (0)
+
+#define CHECK_IF_CURL_EASY_SETOPT_OK(opt, input, ...)                                              \
+    do {                                                                                           \
+        CHECK_NOTNULL(_curl, "CURL object has not been allocated");                                \
+        CHECK_IF_CURL_EASY_OK(curl_easy_setopt(_curl, CURLOPT_##opt, input),                       \
+                              "failed to set " #opt " with " #input ": {}",                        \
+                              fmt::format(__VA_ARGS__));                                           \
+    } while (0)
 
 dsn::error_s http_client::init()
 {

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -66,6 +66,13 @@ DSN_DEFINE_uint32(http,
                              "curl_url_set(part = " #part                                          \
                              ", content = nullptr) should always return CURLUE_OK")
 
+// Set "http" as the default scheme.
+#define SET_DEFAULT_HTTP_SCHEME(url)                                                               \
+    CHECK_IF_CURL_URL_SET_OK(url,                                                                  \
+                             SCHEME,                                                               \
+                             enum_to_val(http_scheme::kHttp, std::string()).c_str(),               \
+                             "failed to set CURLUPART_SCHEME with 'http'")
+
 namespace {
 
 inline dsn::error_code to_error_code(CURLUcode code)
@@ -88,8 +95,7 @@ CURLU *new_curlu()
     CURLU *url = curl_url();
     CHECK_NOTNULL(url, "fail to allocate a CURLU object due to out of memory");
 
-    // Set "http" as the default scheme.
-    CHECK_IF_CURL_URL_SET_OK(url, SCHEME, "http", "failed to set CURLUPART_SCHEME with 'http'");
+    SET_DEFAULT_HTTP_SCHEME(url);
 
     return url;
 }
@@ -148,6 +154,8 @@ void http_url::clear()
     // Setting the url with nullptr would lead to the release of memory for each part of the url,
     // thus clearing the url.
     CHECK_IF_CURL_URL_SET_NULL_OK(_url.get(), URL);
+
+    SET_DEFAULT_HTTP_SCHEME(_url.get());
 }
 
 #define RETURN_IF_CURL_URL_NOT_OK(expr, ...) RETURN_IF_CURL_NOT_OK(expr, CURLUE_OK, __VA_ARGS__)
@@ -171,6 +179,11 @@ void http_url::clear()
 DEF_HTTP_URL_SET_FUNC(url, URL)
 
 DEF_HTTP_URL_SET_FUNC(scheme, SCHEME)
+
+dsn::error_s http_url::set_scheme(http_scheme scheme)
+{
+    return set_scheme(enum_to_val(scheme, std::string()).c_str());
+}
 
 DEF_HTTP_URL_SET_FUNC(host, HOST)
 

--- a/src/http/http_client.h
+++ b/src/http/http_client.h
@@ -83,6 +83,7 @@ public:
 
 private:
     friend class http_client;
+    friend void test_after_move(http_url &, http_url &);
 
     // Only used by `http_client` to get the underlying CURLU object.
     CURLU *curlu() const { return _url.get(); }
@@ -170,7 +171,7 @@ public:
     dsn::error_s set_timeout(long timeout_ms);
 
     // Specify the http auth type which include NONE BASIC DIGEST SPNEGO
-    dsn::error_s set_auth(http_auth_type authType);
+    dsn::error_s set_auth(http_auth_type auth_type);
 
     // Operations for the header fields.
     void clear_header_fields();

--- a/src/http/http_client.h
+++ b/src/http/http_client.h
@@ -35,7 +35,6 @@
 #include "utils/ports.h"
 
 USER_DEFINED_ENUM_FORMATTER(CURLUcode)
-
 USER_DEFINED_ENUM_FORMATTER(CURLcode)
 
 namespace dsn {
@@ -62,7 +61,7 @@ ENUM_CONST_DEF_TO_VAL_FUNC(std::string, http_scheme, ENUM_FOREACH_HTTP_SCHEME)
 class http_url
 {
 public:
-    // `http` is the default scheme for the URL.
+    // The scheme is set to `http` as default for the URL.
     http_url() noexcept;
 
     ~http_url() = default;
@@ -73,7 +72,7 @@ public:
     http_url(http_url &&) noexcept;
     http_url &operator=(http_url &&) noexcept;
 
-    // Clear the URL.
+    // Clear the URL. And the scheme is reset to `http`.
     void clear();
 
     // Operations that update the components of a URL.
@@ -89,6 +88,7 @@ public:
     // Extract the URL string.
     dsn::error_s to_string(std::string &url) const;
 
+    // Formatter for fmt::format.
     friend std::ostream &operator<<(std::ostream &os, const http_url &url)
     {
         std::string str;

--- a/src/http/http_client.h
+++ b/src/http/http_client.h
@@ -31,6 +31,28 @@
 
 namespace dsn {
 
+class http_url
+{
+public:
+    http_url();
+    ~http_url();
+
+    dsn::error_s init();
+    dsn::error_s set_scheme(const char *scheme);
+    dsn::error_s set_host(const char *host);
+    dsn::error_s set_port(const char *port);
+    dsn::error_s set_port(uint16_t port);
+    dsn::error_s set_path(const char *path);
+    dsn::error_s set_query(const char *query);
+
+    dsn::error_s to_string(std::string &url) const;
+
+private:
+    friend class http_client;
+
+    CURLU *_url;
+};
+
 // A library for http client that provides convenient APIs to access http services, implemented
 // based on libcurl (https://curl.se/libcurl/c/).
 //
@@ -84,6 +106,9 @@ public:
 
     // Specify the target url that the request would be sent for.
     dsn::error_s set_url(const std::string &url);
+
+    // Specify the target url by `http_url` class.
+    dsn::error_s set_url(const http_url &url);
 
     // Using post method, with `data` as the payload for post body.
     dsn::error_s with_post_method(const std::string &data);

--- a/src/http/http_client.h
+++ b/src/http/http_client.h
@@ -112,7 +112,7 @@ private:
 // url_err = url.set_host(host);
 // url_err = url.set_port(port);
 // url_err = url.set_path(path);
-// client.set_url(std::move(url)); // Or client.set_url(url);
+// err = client.set_url(std::move(url)); // Or err = client.set_url(url);
 //
 // If you would use GET method, call `with_get_method`:
 // err = client.with_get_method();

--- a/src/http/http_client.h
+++ b/src/http/http_client.h
@@ -29,6 +29,7 @@
 #include "absl/strings/string_view.h"
 #include "http/http_method.h"
 #include "http/http_status_code.h"
+#include "utils/enum_helper.h"
 #include "utils/errors.h"
 #include "utils/fmt_utils.h"
 #include "utils/ports.h"
@@ -38,6 +39,22 @@ USER_DEFINED_ENUM_FORMATTER(CURLUcode)
 USER_DEFINED_ENUM_FORMATTER(CURLcode)
 
 namespace dsn {
+
+// Now https and ftp have not been supported. To support them, build curl by
+// "./configure --with-ssl=... --enable-ftp ...".
+#define ENUM_FOREACH_HTTP_SCHEME(DEF)                                                              \
+    DEF(Http, "http", http_scheme)                                                                 \
+    DEF(Https, "https", http_scheme)                                                               \
+    DEF(Ftp, "ftp", http_scheme)
+
+enum class http_scheme : size_t
+{
+    ENUM_FOREACH_HTTP_SCHEME(ENUM_CONST_DEF) kCount,
+    kInvalidScheme,
+};
+
+ENUM_CONST_DEF_FROM_VAL_FUNC(std::string, http_scheme, ENUM_FOREACH_HTTP_SCHEME)
+ENUM_CONST_DEF_TO_VAL_FUNC(std::string, http_scheme, ENUM_FOREACH_HTTP_SCHEME)
 
 // A class that helps http client build URLs, based on CURLU object of libcurl.
 // About CURLU object, please see: https://curl.se/libcurl/c/libcurl-url.html.
@@ -62,6 +79,7 @@ public:
     // Operations that update the components of a URL.
     dsn::error_s set_url(const char *url);
     dsn::error_s set_scheme(const char *scheme);
+    dsn::error_s set_scheme(http_scheme scheme);
     dsn::error_s set_host(const char *host);
     dsn::error_s set_port(const char *port);
     dsn::error_s set_port(uint16_t port);

--- a/src/http/http_client.h
+++ b/src/http/http_client.h
@@ -19,15 +19,16 @@
 
 #include <curl/curl.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <functional>
 #include <string>
 #include <unordered_map>
 
+#include "absl/strings/string_view.h"
 #include "http/http_method.h"
 #include "http/http_status_code.h"
 #include "utils/errors.h"
 #include "utils/ports.h"
-#include "absl/strings/string_view.h"
 
 namespace dsn {
 

--- a/src/http/http_client.h
+++ b/src/http/http_client.h
@@ -50,6 +50,12 @@ public:
 private:
     friend class http_client;
 
+    void free_curlu_object();
+
+    CURLU *get_curlu_object() const;
+
+    std::string to_error_msg(CURLUcode code) const;
+
     CURLU *_url;
 };
 

--- a/src/http/http_client.h
+++ b/src/http/http_client.h
@@ -116,7 +116,7 @@ private:
 // url_err = url.set_host(host);
 // url_err = url.set_port(port);
 // url_err = url.set_path(path);
-// err = client.set_url(url); Or err = client.set_url(std::move(url));
+// err = client.set_url(url); // Or err = client.set_url(std::move(url));
 //
 // If you would use GET method, call `with_get_method`:
 // err = client.with_get_method();

--- a/src/http/test/http_client_test.cpp
+++ b/src/http/test/http_client_test.cpp
@@ -44,8 +44,6 @@ using http_url_case =
 class HttpUrlTest : public testing::TestWithParam<http_url_case>
 {
 public:
-    void SetUp() override { ASSERT_TRUE(_url.init()); }
-
     void test_build_url(const char *scheme,
                         const char *host,
                         uint16_t port,
@@ -258,14 +256,15 @@ public:
     }
 
     template <typename TUrl>
-    void test_mothod(const TUrl &url,
+    void test_mothod(TUrl &&url,
                      const http_method method,
                      const std::string &post_data,
                      const http_status_code expected_http_status,
                      const std::string &expected_response)
     {
         ASSERT_TRUE(_client.init());
-        ASSERT_TRUE(_client.set_url(url));
+        // ASSERT_TRUE(_client.set_url(url));
+        _client.set_url(url);
 
         switch (method) {
         case http_method::GET:
@@ -307,7 +306,6 @@ TEST_P(HttpClientMethodTest, ExecMethod)
     {
         // Test with url class.
         http_url url;
-        ASSERT_TRUE(url.init());
         ASSERT_TRUE(url.set_host(host));
         ASSERT_TRUE(url.set_port(port));
         ASSERT_TRUE(url.set_path(path));

--- a/src/http/test/http_client_test.cpp
+++ b/src/http/test/http_client_test.cpp
@@ -88,33 +88,13 @@ const std::vector<http_url_case> http_url_tests = {
     // Test default scheme, specified ip, empty path and query.
     {nullptr, "10.10.1.2", 34801, "", "", "http://10.10.1.2:34801/"},
     // Test default scheme, specified host, empty path and query.
-    {nullptr,
-     "www.example.com",
-     8080,
-     "",
-     "",
-     "http://www.example.com:8080/"},
+    {nullptr, "www.example.com", 8080, "", "", "http://www.example.com:8080/"},
     // Test default scheme, specified ip and path, empty query.
-    {nullptr,
-     "10.10.1.2",
-     34801,
-     "/api",
-     "",
-     "http://10.10.1.2:34801/api"},
+    {nullptr, "10.10.1.2", 34801, "/api", "", "http://10.10.1.2:34801/api"},
     // Test default scheme, specified host and path, empty query.
-    {nullptr,
-     "www.example.com",
-     8080,
-     "/api",
-     "",
-     "http://www.example.com:8080/api"},
+    {nullptr, "www.example.com", 8080, "/api", "", "http://www.example.com:8080/api"},
     // Test default scheme, specified ip, path and query.
-    {nullptr,
-     "10.10.1.2",
-     34801,
-     "/api",
-     "foo=bar",
-     "http://10.10.1.2:34801/api?foo=bar"},
+    {nullptr, "10.10.1.2", 34801, "/api", "foo=bar", "http://10.10.1.2:34801/api?foo=bar"},
     // Test default scheme, specified ip, path and query.
     {nullptr,
      "www.example.com",

--- a/src/http/test/http_client_test.cpp
+++ b/src/http/test/http_client_test.cpp
@@ -23,7 +23,6 @@
 #include <cstring>
 #include <iostream>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -203,6 +202,9 @@ TEST(HttpUrlTest, Clear)
     ASSERT_EQ(kTestUrlA, str);
 
     url.clear();
+
+    // After cleared, at least it should be set with some host; otherwise, extracting the URL
+    // string would lead to error.
     const auto &err = url.to_string(str);
     ASSERT_FALSE(err);
     const std::string expected_description_prefix(

--- a/src/http/test/http_client_test.cpp
+++ b/src/http/test/http_client_test.cpp
@@ -54,8 +54,8 @@ public:
         ASSERT_TRUE(_url.set_scheme(scheme));
         ASSERT_TRUE(_url.set_host(host));
         ASSERT_TRUE(_url.set_port(port));
-        ASSERT_TRUE(_url.set_port(path));
-        ASSERT_TRUE(_url.set_port(query));
+        ASSERT_TRUE(_url.set_path(path));
+        ASSERT_TRUE(_url.set_query(query));
 
         std::string actual_url;
         ASSERT_TRUE(_url.to_string(actual_url));
@@ -85,7 +85,7 @@ const std::vector<http_url_case> http_url_tests = {
      34801,
      "/api",
      "key1=abc&key2=123456",
-     "http://10.10.1.2:34801/api?key1=abc&key2=-123456"},
+     "http://10.10.1.2:34801/api?key1=abc&key2=123456"},
 };
 
 INSTANTIATE_TEST_CASE_P(HttpClientTest, HttpUrlTest, testing::ValuesIn(http_url_tests));

--- a/src/http/test/http_client_test.cpp
+++ b/src/http/test/http_client_test.cpp
@@ -24,8 +24,10 @@
 #include <iostream>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "http/http_client.h"
 #include "http/http_method.h"

--- a/src/http/test/http_client_test.cpp
+++ b/src/http/test/http_client_test.cpp
@@ -37,10 +37,10 @@
 #include "utils/strings.h"
 #include "utils/test_macros.h"
 
+// IWYU pragma: no_forward_declare dsn::HttpClientMethodTest_ExecMethodByCopyUrlClass_Test
+// IWYU pragma: no_forward_declare dsn::HttpClientMethodTest_ExecMethodByMoveUrlClass_Test
+// IWYU pragma: no_forward_declare dsn::HttpClientMethodTest_ExecMethodByUrlString_Test
 namespace dsn {
-// IWYU pragma: no_forward_declare HttpClientMethodTest_ExecMethodByCopyUrlClass_Test
-// IWYU pragma: no_forward_declare HttpClientMethodTest_ExecMethodByMoveUrlClass_Test
-// IWYU pragma: no_forward_declare HttpClientMethodTest_ExecMethodByUrlString_Test
 
 void check_expected_description_prefix(const std::string &expected_description_prefix,
                                        const dsn::error_s &err)

--- a/src/http/test/http_client_test.cpp
+++ b/src/http/test/http_client_test.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <fmt/core.h>
+#include <stdint.h>
 // IWYU pragma: no_include <gtest/gtest-message.h>
 // IWYU pragma: no_include <gtest/gtest-param-test.h>
 // IWYU pragma: no_include <gtest/gtest-test-part.h>

--- a/src/http/test/http_client_test.cpp
+++ b/src/http/test/http_client_test.cpp
@@ -127,39 +127,7 @@ TEST(HttpUrlTest, CallMoveAssignmentOperator)
     test_after_move(url_1, url_2);
 }
 
-using http_url_build_case =
-    std::tuple<const char *, const char *, uint16_t, const char *, const char *, const char *>;
-
-class HttpUrlBuildTest : public testing::TestWithParam<http_url_build_case>
-{
-public:
-    void test_build_url(const char *scheme,
-                        const char *host,
-                        uint16_t port,
-                        const char *path,
-                        const char *query,
-                        const char *expected_url)
-    {
-        if (!utils::is_empty(scheme)) {
-            // Empty scheme will lead to error.
-            ASSERT_TRUE(_url.set_scheme(scheme));
-        }
-
-        ASSERT_TRUE(_url.set_host(host));
-        ASSERT_TRUE(_url.set_port(port));
-        ASSERT_TRUE(_url.set_path(path));
-        ASSERT_TRUE(_url.set_query(query));
-
-        std::string actual_url;
-        ASSERT_TRUE(_url.to_string(actual_url));
-        EXPECT_STREQ(expected_url, actual_url.c_str());
-    }
-
-private:
-    http_url _url;
-};
-
-TEST_P(HttpUrlBuildTest, BuildUrl)
+struct http_url_build_case
 {
     const char *scheme;
     const char *host;
@@ -167,10 +135,33 @@ TEST_P(HttpUrlBuildTest, BuildUrl)
     const char *path;
     const char *query;
     const char *expected_url;
-    std::tie(scheme, host, port, path, query, expected_url) = GetParam();
+};
 
-    test_build_url(scheme, host, port, path, query, expected_url);
-}
+class HttpUrlBuildTest : public testing::TestWithParam<http_url_build_case>
+{
+public:
+    void test_build_url(const http_url_build_case &build_case)
+    {
+        if (!utils::is_empty(build_case.scheme)) {
+            // Empty scheme will lead to error.
+            ASSERT_TRUE(_url.set_scheme(build_case.scheme));
+        }
+
+        ASSERT_TRUE(_url.set_host(build_case.host));
+        ASSERT_TRUE(_url.set_port(build_case.port));
+        ASSERT_TRUE(_url.set_path(build_case.path));
+        ASSERT_TRUE(_url.set_query(build_case.query));
+
+        std::string actual_url;
+        ASSERT_TRUE(_url.to_string(actual_url));
+        EXPECT_STREQ(build_case.expected_url, actual_url.c_str());
+    }
+
+private:
+    http_url _url;
+};
+
+TEST_P(HttpUrlBuildTest, BuildUrl) { test_build_url(GetParam()); }
 
 const std::vector<http_url_build_case> http_url_tests = {
     // Test default scheme, specified ip, empty path and query.

--- a/src/http/test/http_client_test.cpp
+++ b/src/http/test/http_client_test.cpp
@@ -38,6 +38,9 @@
 #include "utils/test_macros.h"
 
 namespace dsn {
+// IWYU pragma: no_forward_declare HttpClientMethodTest_ExecMethodByCopyUrlClass_Test
+// IWYU pragma: no_forward_declare HttpClientMethodTest_ExecMethodByMoveUrlClass_Test
+// IWYU pragma: no_forward_declare HttpClientMethodTest_ExecMethodByUrlString_Test
 
 void check_expected_description_prefix(const std::string &expected_description_prefix,
                                        const dsn::error_s &err)

--- a/src/utils/enum_helper.h
+++ b/src/utils/enum_helper.h
@@ -179,7 +179,8 @@ class enum_helper_xxx;
     helper->register_enum(#str, enum_class::ENUM_CONST(str));
 
 #define ENUM_CONST_DEF_MAPPER(direction, from_type, to_type, enum_foreach, enum_def)               \
-    inline to_type enum_##direction##_val(from_type from_val, to_type invalid_to_val)              \
+    inline to_type enum_##direction##_val(const from_type &from_val,                               \
+                                          const to_type &invalid_to_val)                           \
     {                                                                                              \
         static const std::unordered_map<from_type, to_type> kMap = {enum_foreach(enum_def)};       \
                                                                                                    \


### PR DESCRIPTION
There are multiple components for a URL used to issue http requests,
such as scheme, host, port, path and query. However, to build each
URL by such components, we could assemble them into a string only
by fmt::format or concatenating them together with some separators.

This PR is to provide a class named http_url that help build URLs on
demand. Just specify each component we need to http_url, then
extract the URL string. We could set the extracted the URL string,
or just set http_url object itself to http client to tell what is the URL
for the http requests.