### PR TITLE
fix(build): fix undefined reference to thrift-generated objects while linking libdsn_client.a

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -40,4 +40,6 @@ set(MY_BINPLACES "")
 
 dsn_add_static_library()
 
+target_link_libraries(${MY_PROJ_NAME} PRIVATE dsn_replication_common)
+
 add_subdirectory(test)


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1846

The module `replication_ddl_client` in `libdsn_client.a` has referenced
thrift-generated objects, which are included in `libdsn_replication_common.a`
Thus, `libdsn_replication_common.a` should be linked privately to
`libdsn_client.a`.