### PR TITLE
refactor(test): use semicolon instead of comma to separate each option in TEST_OPTS

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -46,7 +46,7 @@ on:
 env:
   # Update the options to reduce the consumption of the disk space
   ONEBOX_OPTS: disk_min_available_space_ratio=5
-  TEST_OPTS: disk_min_available_space_ratio=5,throttle_test_medium_value_kb=10,throttle_test_large_value_kb=25
+  TEST_OPTS: disk_min_available_space_ratio=5;throttle_test_medium_value_kb=10;throttle_test_large_value_kb=25
 
 jobs:
   cpp_clang_format_linter:

--- a/run.sh
+++ b/run.sh
@@ -484,16 +484,16 @@ function run_test()
             # Update options if needed, this should be done before starting onebox to make new options take effect.
             if [ "${module}" == "recovery_test" ]; then
                 master_count=1
-                opts="meta_state_service_type=meta_state_service_simple,distributed_lock_service_type=distributed_lock_service_simple"
+                opts="meta_state_service_type=meta_state_service_simple;distributed_lock_service_type=distributed_lock_service_simple"
             fi
             if [ "${module}" == "backup_restore_test" ]; then
-                opts="cold_backup_disabled=false,cold_backup_checkpoint_reserve_minutes=0,cold_backup_root=onebox"
+                opts="cold_backup_disabled=false;cold_backup_checkpoint_reserve_minutes=0;cold_backup_root=onebox"
             fi
             if [ "${module}" == "restore_test" ]; then
-                opts="cold_backup_disabled=false,cold_backup_checkpoint_reserve_minutes=0,cold_backup_root=onebox"
+                opts="cold_backup_disabled=false;cold_backup_checkpoint_reserve_minutes=0;cold_backup_root=onebox"
             fi
             # Append onebox_opts if needed.
-            [ -z ${onebox_opts} ] || opts="${opts},${onebox_opts}"
+            [ -z ${onebox_opts} ] || opts="${opts};${onebox_opts}"
             # Start onebox.
             if ! run_start_onebox -m ${master_count} -w -c --opts ${opts}; then
                 echo "ERROR: unable to continue on testing because starting onebox failed"
@@ -844,7 +844,7 @@ function run_start_onebox()
     fi
 
     OPTS=`echo $OPTS | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })

--- a/src/common/test/run.sh
+++ b/src/common/test/run.sh
@@ -38,7 +38,7 @@ if [ -n ${TEST_OPTS} ]; then
     fi
 
     OPTS=`echo ${TEST_OPTS} | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })

--- a/src/meta/test/run.sh
+++ b/src/meta/test/run.sh
@@ -35,7 +35,7 @@ if [ -n ${TEST_OPTS} ]; then
     fi
 
     OPTS=`echo ${TEST_OPTS} | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })

--- a/src/replica/backup/test/run.sh
+++ b/src/replica/backup/test/run.sh
@@ -30,7 +30,7 @@ if [ -n ${TEST_OPTS} ]; then
     fi
 
     OPTS=`echo ${TEST_OPTS} | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })

--- a/src/replica/bulk_load/test/run.sh
+++ b/src/replica/bulk_load/test/run.sh
@@ -30,7 +30,7 @@ if [ -n ${TEST_OPTS} ]; then
     fi
 
     OPTS=`echo ${TEST_OPTS} | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })

--- a/src/replica/duplication/test/run.sh
+++ b/src/replica/duplication/test/run.sh
@@ -30,7 +30,7 @@ if [ -n ${TEST_OPTS} ]; then
     fi
 
     OPTS=`echo ${TEST_OPTS} | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })

--- a/src/replica/split/test/run.sh
+++ b/src/replica/split/test/run.sh
@@ -30,7 +30,7 @@ if [ -n ${TEST_OPTS} ]; then
     fi
 
     OPTS=`echo ${TEST_OPTS} | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })

--- a/src/replica/storage/simple_kv/run.sh
+++ b/src/replica/storage/simple_kv/run.sh
@@ -36,7 +36,7 @@ if [ -n ${TEST_OPTS} ]; then
     fi
 
     OPTS=`echo ${TEST_OPTS} | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })

--- a/src/replica/storage/simple_kv/test/run.sh
+++ b/src/replica/storage/simple_kv/test/run.sh
@@ -112,7 +112,7 @@ else
 fi
 
 if [ ! -z "${cases}" ]; then
-    OLD_TEST_OPTS=${TEST_OPTS//;/ }
+    OLD_TEST_OPTS=${TEST_OPTS}
     TEST_OPTS="${OLD_TEST_OPTS};encrypt_data_at_rest=false"
     for id in ${cases}; do
         run_case ${id}

--- a/src/replica/storage/simple_kv/test/run.sh
+++ b/src/replica/storage/simple_kv/test/run.sh
@@ -37,7 +37,7 @@ function run_single()
         fi
 
         OPTS=`echo ${TEST_OPTS} | xargs`
-        config_kvs=(${OPTS//,/ })
+        config_kvs=(${OPTS//;/ })
         for config_kv in ${config_kvs[@]}; do
             config_kv=`echo $config_kv | xargs`
             kv=(${config_kv//=/ })
@@ -112,13 +112,13 @@ else
 fi
 
 if [ ! -z "${cases}" ]; then
-    OLD_TEST_OPTS=${TEST_OPTS}
-    TEST_OPTS=${OLD_TEST_OPTS},encrypt_data_at_rest=false
+    OLD_TEST_OPTS=${TEST_OPTS//,/;}
+    TEST_OPTS="${OLD_TEST_OPTS};encrypt_data_at_rest=false"
     for id in ${cases}; do
         run_case ${id}
         echo
     done
-    TEST_OPTS=${OLD_TEST_OPTS},encrypt_data_at_rest=true
+    TEST_OPTS="${OLD_TEST_OPTS};encrypt_data_at_rest=true"
     for id in ${cases}; do
         run_case ${id}
         echo

--- a/src/replica/storage/simple_kv/test/run.sh
+++ b/src/replica/storage/simple_kv/test/run.sh
@@ -112,7 +112,7 @@ else
 fi
 
 if [ ! -z "${cases}" ]; then
-    OLD_TEST_OPTS=${TEST_OPTS//,/;}
+    OLD_TEST_OPTS=${TEST_OPTS//;/ }
     TEST_OPTS="${OLD_TEST_OPTS};encrypt_data_at_rest=false"
     for id in ${cases}; do
         run_case ${id}

--- a/src/replica/test/run.sh
+++ b/src/replica/test/run.sh
@@ -35,7 +35,7 @@ if [ -n ${TEST_OPTS} ]; then
     fi
 
     OPTS=`echo ${TEST_OPTS} | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })

--- a/src/server/test/run.sh
+++ b/src/server/test/run.sh
@@ -30,7 +30,7 @@ if [ -n ${TEST_OPTS} ]; then
     fi
 
     OPTS=`echo ${TEST_OPTS} | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })

--- a/src/test/function_test/run.sh
+++ b/src/test/function_test/run.sh
@@ -31,7 +31,7 @@ if [ -n ${TEST_OPTS} ]; then
     fi
 
     OPTS=`echo ${TEST_OPTS} | xargs`
-    config_kvs=(${OPTS//,/ })
+    config_kvs=(${OPTS//;/ })
     for config_kv in ${config_kvs[@]}; do
         config_kv=`echo $config_kv | xargs`
         kv=(${config_kv//=/ })


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
 
Now options in TEST_OPTS  are separated by comma. However, some
options contains commas itself. We could use semicolon instead of
comma. 

##### Code changes

- Change comma in opts of some unit tests to colon.
- Change TEST_OPTS replacement method.
