### PR TITLE
fix(tcmalloc): add the version number as the missing postfix for libtcmalloc_and_profiler.so.* otherwise it would never be linked

### DIFF
--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -119,7 +119,7 @@ if [ "$use_jemalloc" == "on" ]; then
     copy_file ./thirdparty/output/lib/libjemalloc.so.2 ${pack}/bin
     copy_file ./thirdparty/output/lib/libprofiler.so.0 ${pack}/bin
 else
-    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so ${pack}/bin
+    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so.4 ${pack}/bin
 fi
 
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/bin

--- a/scripts/pack_tools.sh
+++ b/scripts/pack_tools.sh
@@ -128,7 +128,7 @@ if [ "$use_jemalloc" == "on" ]; then
     copy_file ./thirdparty/output/lib/libjemalloc.so.2 ${pack}/lib/
     copy_file ./thirdparty/output/lib/libprofiler.so.0 ${pack}/lib/
 else
-    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so ${pack}/lib/
+    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so.4 ${pack}/lib/
 fi
 
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/lib/


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1848

Copy `libtcmalloc_and_profiler.so.4` instead of `libtcmalloc_and_profiler.so`
while packaging binaries and libraries, otherwise tcmalloc library in package
would never be linked while running Pegasus.