### PR TITLE
fix(collector): Change the location of the prometheus.Registerer

### DIFF
--- a/collector/webui/webserver.go
+++ b/collector/webui/webserver.go
@@ -28,8 +28,7 @@ import (
 )
 
 // StartWebServer starts an iris-powered HTTP server.
-func StartWebServer() {
-	registry := prometheus.NewRegistry()
+func StartWebServer(registry prometheus.Registerer) {
 	for _, cV := range metrics.CounterMetricsMap {
 		registry.MustRegister(cV)
 	}


### PR DESCRIPTION


### What problem does this PR solve? <!--add issue link with summary if exists-->

- Change the location of the prometheus.Registerer variable definition.    
- Later, the prometheus.Registerer variable will be passed as a parameter to functions such as NewReplicaServerMetricCollector and NewMetaServerMetricCollector to reduce the coupling of registering metrics into prometheus.Registerer.
