### PR TITLE
refactor(test): replace deprecated INSTANTIATE_TEST_CASE_P with INSTANTIATE_TEST_SUITE_P

### DIFF
--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -78,7 +78,7 @@ public:
     const std::string kTestFileName = "aio_test.txt";
 };
 
-INSTANTIATE_TEST_CASE_P(, aio_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, aio_test, ::testing::Values(false, true));
 
 TEST_P(aio_test, basic)
 {

--- a/src/block_service/test/block_service_manager_test.cpp
+++ b/src/block_service/test/block_service_manager_test.cpp
@@ -70,7 +70,7 @@ public:
     std::string FILE_NAME = "test_file";
 };
 
-INSTANTIATE_TEST_CASE_P(, block_service_manager_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, block_service_manager_test, ::testing::Values(false, true));
 
 TEST_P(block_service_manager_test, remote_file_not_exist)
 {

--- a/src/block_service/test/hdfs_service_test.cpp
+++ b/src/block_service/test/hdfs_service_test.cpp
@@ -124,7 +124,7 @@ void HDFSClientTest::write_test_files_async(const std::string &local_test_path,
     }
 }
 
-INSTANTIATE_TEST_CASE_P(, HDFSClientTest, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, HDFSClientTest, ::testing::Values(false, true));
 
 TEST_P(HDFSClientTest, test_hdfs_read_write)
 {

--- a/src/block_service/test/local_service_test.cpp
+++ b/src/block_service/test/local_service_test.cpp
@@ -43,7 +43,7 @@ class local_service_test : public pegasus::encrypt_data_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, local_service_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, local_service_test, ::testing::Values(false, true));
 
 TEST_P(local_service_test, file_metadata)
 {

--- a/src/common/test/fs_manager_test.cpp
+++ b/src/common/test/fs_manager_test.cpp
@@ -49,7 +49,7 @@ class fs_manager_test : public pegasus::encrypt_data_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, fs_manager_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, fs_manager_test, ::testing::Values(false, true));
 
 TEST_P(fs_manager_test, initialize)
 {

--- a/src/http/test/http_client_test.cpp
+++ b/src/http/test/http_client_test.cpp
@@ -193,7 +193,7 @@ const std::vector<http_scheme_case> http_scheme_tests = {
      ""},
 };
 
-INSTANTIATE_TEST_CASE_P(HttpClientTest, HttpSchemeTest, testing::ValuesIn(http_scheme_tests));
+INSTANTIATE_TEST_SUITE_P(HttpClientTest, HttpSchemeTest, testing::ValuesIn(http_scheme_tests));
 
 TEST(HttpUrlTest, Clear)
 {
@@ -303,7 +303,7 @@ const std::vector<http_url_build_case> http_url_tests = {
      "http://10.10.1.2:34801/api/multi/level/path?key1=abc&key2=123456"},
 };
 
-INSTANTIATE_TEST_CASE_P(HttpUrlTest, HttpUrlBuildTest, testing::ValuesIn(http_url_tests));
+INSTANTIATE_TEST_SUITE_P(HttpUrlTest, HttpUrlBuildTest, testing::ValuesIn(http_url_tests));
 
 TEST(HttpClientTest, Connect)
 {
@@ -525,8 +525,8 @@ const std::vector<http_client_method_case> http_client_method_tests = {
      "please use POST method"},
 };
 
-INSTANTIATE_TEST_CASE_P(HttpClientTest,
-                        HttpClientMethodTest,
-                        testing::ValuesIn(http_client_method_tests));
+INSTANTIATE_TEST_SUITE_P(HttpClientTest,
+                         HttpClientMethodTest,
+                         testing::ValuesIn(http_client_method_tests));
 
 } // namespace dsn

--- a/src/http/test/http_status_code_test.cpp
+++ b/src/http/test/http_status_code_test.cpp
@@ -61,8 +61,8 @@ const std::vector<http_status_message_case> http_status_message_tests = {
     {http_status_code::kInvalidCode, kInvalidHttpStatus},
 };
 
-INSTANTIATE_TEST_CASE_P(HttpStatusCodeTest,
-                        HttpStatusMessageTest,
-                        testing::ValuesIn(http_status_message_tests));
+INSTANTIATE_TEST_SUITE_P(HttpStatusCodeTest,
+                         HttpStatusMessageTest,
+                         testing::ValuesIn(http_status_message_tests));
 
 } // namespace dsn

--- a/src/meta/test/meta_state/meta_state_service.cpp
+++ b/src/meta/test/meta_state/meta_state_service.cpp
@@ -289,7 +289,7 @@ class meta_state_service_test : public pegasus::encrypt_data_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, meta_state_service_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, meta_state_service_test, ::testing::Values(false, true));
 
 TEST_P(meta_state_service_test, simple)
 {

--- a/src/nfs/test/main.cpp
+++ b/src/nfs/test/main.cpp
@@ -64,7 +64,7 @@ class nfs_test : public pegasus::encrypt_data_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, nfs_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, nfs_test, ::testing::Values(false, true));
 
 TEST_P(nfs_test, basic)
 {

--- a/src/replica/backup/test/replica_backup_manager_test.cpp
+++ b/src/replica/backup/test/replica_backup_manager_test.cpp
@@ -37,7 +37,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_backup_manager_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_backup_manager_test, ::testing::Values(false, true));
 
 TEST_P(replica_backup_manager_test, clear_cold_backup)
 {

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -419,7 +419,7 @@ public:
     std::string FILE_NAME = "test_sst_file";
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_bulk_loader_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_bulk_loader_test, ::testing::Values(false, true));
 
 // on_bulk_load unit tests
 TEST_P(replica_bulk_loader_test, on_bulk_load_not_primary)

--- a/src/replica/duplication/test/dup_replica_http_service_test.cpp
+++ b/src/replica/duplication/test/dup_replica_http_service_test.cpp
@@ -38,7 +38,7 @@ class dup_replica_http_service_test : public duplication_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, dup_replica_http_service_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, dup_replica_http_service_test, ::testing::Values(false, true));
 
 TEST_P(dup_replica_http_service_test, query_duplication_handler)
 {

--- a/src/replica/duplication/test/duplication_sync_timer_test.cpp
+++ b/src/replica/duplication/test/duplication_sync_timer_test.cpp
@@ -373,7 +373,7 @@ protected:
     std::unique_ptr<duplication_sync_timer> dup_sync;
 };
 
-INSTANTIATE_TEST_CASE_P(, duplication_sync_timer_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, duplication_sync_timer_test, ::testing::Values(false, true));
 
 TEST_P(duplication_sync_timer_test, duplication_sync) { test_duplication_sync(); }
 

--- a/src/replica/duplication/test/load_from_private_log_test.cpp
+++ b/src/replica/duplication/test/load_from_private_log_test.cpp
@@ -272,7 +272,7 @@ public:
     std::unique_ptr<replica_duplicator> duplicator;
 };
 
-INSTANTIATE_TEST_CASE_P(, load_from_private_log_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, load_from_private_log_test, ::testing::Values(false, true));
 
 TEST_P(load_from_private_log_test, find_log_file_to_start) { test_find_log_file_to_start(); }
 
@@ -421,7 +421,7 @@ public:
     std::unique_ptr<end_stage_t> end_stage;
 };
 
-INSTANTIATE_TEST_CASE_P(, load_fail_mode_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, load_fail_mode_test, ::testing::Values(false, true));
 
 TEST_P(load_fail_mode_test, fail_skip)
 {

--- a/src/replica/duplication/test/mutation_batch_test.cpp
+++ b/src/replica/duplication/test/mutation_batch_test.cpp
@@ -54,7 +54,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, mutation_batch_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, mutation_batch_test, ::testing::Values(false, true));
 
 TEST_P(mutation_batch_test, add_mutation_if_valid)
 {

--- a/src/replica/duplication/test/replica_duplicator_manager_test.cpp
+++ b/src/replica/duplication/test/replica_duplicator_manager_test.cpp
@@ -182,7 +182,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_duplicator_manager_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_duplicator_manager_test, ::testing::Values(false, true));
 
 TEST_P(replica_duplicator_manager_test, get_duplication_confirms)
 {

--- a/src/replica/duplication/test/replica_duplicator_test.cpp
+++ b/src/replica/duplication/test/replica_duplicator_test.cpp
@@ -136,7 +136,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_duplicator_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_duplicator_test, ::testing::Values(false, true));
 
 TEST_P(replica_duplicator_test, new_duplicator) { test_new_duplicator(); }
 

--- a/src/replica/duplication/test/replica_follower_test.cpp
+++ b/src/replica/duplication/test/replica_follower_test.cpp
@@ -113,7 +113,7 @@ public:
     mock_replica_ptr _mock_replica;
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_follower_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_follower_test, ::testing::Values(false, true));
 
 TEST_P(replica_follower_test, test_init_master_info)
 {

--- a/src/replica/duplication/test/ship_mutation_test.cpp
+++ b/src/replica/duplication/test/ship_mutation_test.cpp
@@ -103,7 +103,7 @@ public:
     std::unique_ptr<replica_duplicator> duplicator;
 };
 
-INSTANTIATE_TEST_CASE_P(, ship_mutation_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, ship_mutation_test, ::testing::Values(false, true));
 
 TEST_P(ship_mutation_test, ship_mutation_tuple_set) { test_ship_mutation_tuple_set(); }
 

--- a/src/replica/split/test/replica_split_test.cpp
+++ b/src/replica/split/test/replica_split_test.cpp
@@ -547,7 +547,7 @@ public:
     learn_state _mock_learn_state;
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_split_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_split_test, ::testing::Values(false, true));
 
 // parent_start_split tests
 TEST_P(replica_split_test, parent_start_split_tests)

--- a/src/replica/test/log_block_test.cpp
+++ b/src/replica/test/log_block_test.cpp
@@ -37,7 +37,7 @@ class log_block_test : public replica_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, log_block_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, log_block_test, ::testing::Values(false, true));
 
 TEST_P(log_block_test, constructor)
 {
@@ -60,7 +60,7 @@ class log_appender_test : public replica_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, log_appender_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, log_appender_test, ::testing::Values(false, true));
 
 TEST_P(log_appender_test, constructor)
 {

--- a/src/replica/test/log_file_test.cpp
+++ b/src/replica/test/log_file_test.cpp
@@ -54,7 +54,7 @@ protected:
     size_t _start_offset{10};
 };
 
-INSTANTIATE_TEST_CASE_P(, log_file_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, log_file_test, ::testing::Values(false, true));
 
 TEST_P(log_file_test, commit_log_blocks)
 {

--- a/src/replica/test/main.cpp
+++ b/src/replica/test/main.cpp
@@ -35,7 +35,7 @@ class cold_backup_context_test : public pegasus::encrypt_data_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, cold_backup_context_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, cold_backup_context_test, ::testing::Values(false, true));
 
 TEST_P(cold_backup_context_test, check_backup_on_remote) { app->check_backup_on_remote_test(); }
 

--- a/src/replica/test/mutation_log_learn_test.cpp
+++ b/src/replica/test/mutation_log_learn_test.cpp
@@ -57,7 +57,7 @@ class mutation_log_learn_test : public replica_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, mutation_log_learn_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, mutation_log_learn_test, ::testing::Values(false, true));
 
 TEST_P(mutation_log_learn_test, learn)
 {

--- a/src/replica/test/mutation_log_test.cpp
+++ b/src/replica/test/mutation_log_test.cpp
@@ -80,7 +80,7 @@ class replication_test : public pegasus::encrypt_data_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, replication_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replication_test, ::testing::Values(false, true));
 
 TEST_P(replication_test, log_file)
 {
@@ -441,7 +441,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, mutation_log_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, mutation_log_test, ::testing::Values(false, true));
 
 TEST_P(mutation_log_test, replay_single_file_1000) { test_replay_single_file(1000); }
 

--- a/src/replica/test/open_replica_test.cpp
+++ b/src/replica/test/open_replica_test.cpp
@@ -43,7 +43,7 @@ public:
     ~open_replica_test() { dsn::utils::filesystem::remove_path("./tmp_dir"); }
 };
 
-INSTANTIATE_TEST_CASE_P(, open_replica_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, open_replica_test, ::testing::Values(false, true));
 
 TEST_P(open_replica_test, open_replica_add_decree_and_ballot_check)
 {

--- a/src/replica/test/replica_disk_migrate_test.cpp
+++ b/src/replica/test/replica_disk_migrate_test.cpp
@@ -147,7 +147,7 @@ private:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_disk_migrate_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_disk_migrate_test, ::testing::Values(false, true));
 
 TEST_P(replica_disk_migrate_test, on_migrate_replica)
 {

--- a/src/replica/test/replica_disk_test.cpp
+++ b/src/replica/test/replica_disk_test.cpp
@@ -86,7 +86,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_disk_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_disk_test, ::testing::Values(false, true));
 
 TEST_P(replica_disk_test, on_query_disk_info_all_app)
 {

--- a/src/replica/test/replica_http_service_test.cpp
+++ b/src/replica/test/replica_http_service_test.cpp
@@ -95,7 +95,7 @@ private:
     std::unique_ptr<replica_http_service> _http_svc;
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_http_service_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_http_service_test, ::testing::Values(false, true));
 
 TEST_P(replica_http_service_test, update_config_handler)
 {

--- a/src/replica/test/replica_learn_test.cpp
+++ b/src/replica/test/replica_learn_test.cpp
@@ -177,7 +177,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_learn_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_learn_test, ::testing::Values(false, true));
 
 TEST_P(replica_learn_test, get_learn_start_decree) { test_get_learn_start_decree(); }
 

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -259,7 +259,7 @@ private:
     const std::string _policy_name;
 };
 
-INSTANTIATE_TEST_CASE_P(, replica_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, replica_test, ::testing::Values(false, true));
 
 TEST_P(replica_test, write_size_limited)
 {

--- a/src/server/test/capacity_unit_calculator_test.cpp
+++ b/src/server/test/capacity_unit_calculator_test.cpp
@@ -154,7 +154,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, capacity_unit_calculator_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, capacity_unit_calculator_test, ::testing::Values(false, true));
 
 TEST_P(capacity_unit_calculator_test, init) { test_init(); }
 

--- a/src/server/test/hotkey_collector_test.cpp
+++ b/src/server/test/hotkey_collector_test.cpp
@@ -122,7 +122,7 @@ public:
     dsn::task_tracker _tracker;
 };
 
-INSTANTIATE_TEST_CASE_P(, coarse_collector_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, coarse_collector_test, ::testing::Values(false, true));
 
 TEST_P(coarse_collector_test, coarse_collector)
 {
@@ -179,7 +179,7 @@ public:
     dsn::task_tracker _tracker;
 };
 
-INSTANTIATE_TEST_CASE_P(, fine_collector_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, fine_collector_test, ::testing::Values(false, true));
 
 TEST_P(fine_collector_test, fine_collector)
 {
@@ -289,7 +289,7 @@ public:
     dsn::task_tracker _tracker;
 };
 
-INSTANTIATE_TEST_CASE_P(, hotkey_collector_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, hotkey_collector_test, ::testing::Values(false, true));
 
 TEST_P(hotkey_collector_test, hotkey_type)
 {

--- a/src/server/test/hotspot_partition_test.cpp
+++ b/src/server/test/hotspot_partition_test.cpp
@@ -119,7 +119,7 @@ public:
     void clear_calculator_histories() { calculator._partitions_stat_histories.clear(); }
 };
 
-INSTANTIATE_TEST_CASE_P(, hotspot_partition_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, hotspot_partition_test, ::testing::Values(false, true));
 
 TEST_P(hotspot_partition_test, hotspot_partition_policy)
 {

--- a/src/server/test/manual_compact_service_test.cpp
+++ b/src/server/test/manual_compact_service_test.cpp
@@ -108,7 +108,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, manual_compact_service_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, manual_compact_service_test, ::testing::Values(false, true));
 
 TEST_P(manual_compact_service_test, check_compact_disabled)
 {

--- a/src/server/test/pegasus_compression_options_test.cpp
+++ b/src/server/test/pegasus_compression_options_test.cpp
@@ -98,7 +98,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, pegasus_compression_options_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, pegasus_compression_options_test, ::testing::Values(false, true));
 
 TEST_P(pegasus_compression_options_test, compression_type_convert_ok)
 {

--- a/src/server/test/pegasus_mutation_duplicator_test.cpp
+++ b/src/server/test/pegasus_mutation_duplicator_test.cpp
@@ -289,7 +289,7 @@ private:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, pegasus_mutation_duplicator_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, pegasus_mutation_duplicator_test, ::testing::Values(false, true));
 
 TEST_P(pegasus_mutation_duplicator_test, get_hash_from_request)
 {

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -140,7 +140,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, pegasus_server_impl_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, pegasus_server_impl_test, ::testing::Values(false, true));
 
 TEST_P(pegasus_server_impl_test, test_table_level_slow_query)
 {

--- a/src/server/test/pegasus_server_write_test.cpp
+++ b/src/server/test/pegasus_server_write_test.cpp
@@ -137,7 +137,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, pegasus_server_write_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, pegasus_server_write_test, ::testing::Values(false, true));
 
 TEST_P(pegasus_server_write_test, batch_writes) { test_batch_writes(); }
 

--- a/src/server/test/pegasus_write_service_impl_test.cpp
+++ b/src/server/test/pegasus_write_service_impl_test.cpp
@@ -86,7 +86,7 @@ public:
     dsn::apps::incr_response resp;
 };
 
-INSTANTIATE_TEST_CASE_P(, incr_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, incr_test, ::testing::Values(false, true));
 
 TEST_P(incr_test, incr_on_absent_record)
 {

--- a/src/server/test/pegasus_write_service_test.cpp
+++ b/src/server/test/pegasus_write_service_test.cpp
@@ -221,7 +221,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, pegasus_write_service_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, pegasus_write_service_test, ::testing::Values(false, true));
 
 TEST_P(pegasus_write_service_test, multi_put) { test_multi_put(); }
 

--- a/src/server/test/rocksdb_wrapper_test.cpp
+++ b/src/server/test/rocksdb_wrapper_test.cpp
@@ -101,7 +101,7 @@ public:
     }
 };
 
-INSTANTIATE_TEST_CASE_P(, rocksdb_wrapper_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, rocksdb_wrapper_test, ::testing::Values(false, true));
 
 TEST_P(rocksdb_wrapper_test, get)
 {

--- a/src/utils/test/TokenBucketTest.cpp
+++ b/src/utils/test/TokenBucketTest.cpp
@@ -75,7 +75,7 @@ static std::vector<std::pair<double, double>> rateToConsumeSize = {
     {100, 1}, {1000, 1}, {10000, 1}, {10000, 5},
 };
 
-INSTANTIATE_TEST_CASE_P(TokenBucket, TokenBucketTest, ::testing::ValuesIn(rateToConsumeSize));
+INSTANTIATE_TEST_SUITE_P(TokenBucket, TokenBucketTest, ::testing::ValuesIn(rateToConsumeSize));
 
 TEST(TokenBucket, drainOnFail)
 {

--- a/src/utils/test/enum_helper_test.cpp
+++ b/src/utils/test/enum_helper_test.cpp
@@ -79,9 +79,9 @@ const std::vector<command_type_enum_from_string_case> command_type_enum_from_str
     {"UNDEFINE_TYPE", command_type::INVALID_TYPE},
 };
 
-INSTANTIATE_TEST_CASE_P(EnumHelperTest,
-                        CommandTypeEnumFromStringTest,
-                        testing::ValuesIn(command_type_enum_from_string_tests));
+INSTANTIATE_TEST_SUITE_P(EnumHelperTest,
+                         CommandTypeEnumFromStringTest,
+                         testing::ValuesIn(command_type_enum_from_string_tests));
 
 using command_type_enum_to_string_case = std::tuple<command_type, std::string>;
 
@@ -107,9 +107,9 @@ const std::vector<command_type_enum_to_string_case> command_type_enum_to_string_
     {command_type::INVALID_TYPE, "Unknown"},
 };
 
-INSTANTIATE_TEST_CASE_P(EnumHelperTest,
-                        CommandTypeEnumToStringTest,
-                        testing::ValuesIn(command_type_enum_to_string_tests));
+INSTANTIATE_TEST_SUITE_P(EnumHelperTest,
+                         CommandTypeEnumToStringTest,
+                         testing::ValuesIn(command_type_enum_to_string_tests));
 
 #define ENUM_FOREACH_STATUS_CODE(DEF)                                                              \
     DEF(Ok, 100, status_code)                                                                      \
@@ -178,9 +178,9 @@ const std::vector<status_code_enum_from_string_case> status_code_enum_from_strin
     {"UndefinedCode", status_code::kInvalidCode},
 };
 
-INSTANTIATE_TEST_CASE_P(EnumHelperTest,
-                        StatusCodeEnumFromStringTest,
-                        testing::ValuesIn(status_code_enum_from_string_tests));
+INSTANTIATE_TEST_SUITE_P(EnumHelperTest,
+                         StatusCodeEnumFromStringTest,
+                         testing::ValuesIn(status_code_enum_from_string_tests));
 
 using status_code_enum_to_string_case = std::tuple<status_code, std::string>;
 
@@ -207,9 +207,9 @@ const std::vector<status_code_enum_to_string_case> status_code_enum_to_string_te
     {status_code::kInvalidCode, "Unknown"},
 };
 
-INSTANTIATE_TEST_CASE_P(EnumHelperTest,
-                        StatusCodeEnumToStringTest,
-                        testing::ValuesIn(status_code_enum_to_string_tests));
+INSTANTIATE_TEST_SUITE_P(EnumHelperTest,
+                         StatusCodeEnumToStringTest,
+                         testing::ValuesIn(status_code_enum_to_string_tests));
 
 using status_code_enum_from_long_case = std::tuple<long, status_code>;
 
@@ -240,9 +240,9 @@ const std::vector<status_code_enum_from_long_case> status_code_enum_from_long_te
     {10000, status_code::kInvalidCode},
 };
 
-INSTANTIATE_TEST_CASE_P(EnumHelperTest,
-                        StatusCodeEnumFromLongTest,
-                        testing::ValuesIn(status_code_enum_from_long_tests));
+INSTANTIATE_TEST_SUITE_P(EnumHelperTest,
+                         StatusCodeEnumFromLongTest,
+                         testing::ValuesIn(status_code_enum_from_long_tests));
 
 using status_code_enum_to_long_case = std::tuple<status_code, long>;
 
@@ -271,8 +271,8 @@ const std::vector<status_code_enum_to_long_case> status_code_enum_to_long_tests 
     {status_code::kInvalidCode, kInvalidStatus},
 };
 
-INSTANTIATE_TEST_CASE_P(EnumHelperTest,
-                        StatusCodeEnumToLongTest,
-                        testing::ValuesIn(status_code_enum_to_long_tests));
+INSTANTIATE_TEST_SUITE_P(EnumHelperTest,
+                         StatusCodeEnumToLongTest,
+                         testing::ValuesIn(status_code_enum_to_long_tests));
 
 } // namespace dsn

--- a/src/utils/test/env.cpp
+++ b/src/utils/test/env.cpp
@@ -76,7 +76,7 @@ class env_file_test : public pegasus::encrypt_data_test_base
 {
 };
 
-INSTANTIATE_TEST_CASE_P(, env_file_test, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, env_file_test, ::testing::Values(false, true));
 
 TEST_P(env_file_test, encrypt_file_2_files)
 {

--- a/src/utils/test/file_utils.cpp
+++ b/src/utils/test/file_utils.cpp
@@ -339,7 +339,7 @@ public:
     void file_utils_test_cleanup() {}
 };
 
-INSTANTIATE_TEST_CASE_P(, file_utils, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, file_utils, ::testing::Values(false, true));
 
 TEST_P(file_utils, basic)
 {

--- a/src/utils/test/load_dump_object_test.cpp
+++ b/src/utils/test/load_dump_object_test.cpp
@@ -52,9 +52,9 @@ protected:
     FileDataType type_;
 };
 
-INSTANTIATE_TEST_CASE_P(,
-                        load_dump_object,
-                        ::testing::Values(FileDataType::kNonSensitive, FileDataType::kSensitive));
+INSTANTIATE_TEST_SUITE_P(,
+                         load_dump_object,
+                         ::testing::Values(FileDataType::kNonSensitive, FileDataType::kSensitive));
 
 TEST_P(load_dump_object, nlohmann_json_struct_normal_test)
 {

--- a/src/utils/test/metrics_test.cpp
+++ b/src/utils/test/metrics_test.cpp
@@ -3095,9 +3095,9 @@ const std::vector<surviving_metrics_case> metrics_retirement_tests = {
     {std::string("server_121"), false, false, false, false},
 };
 
-INSTANTIATE_TEST_CASE_P(MetricsTest,
-                        MetricsRetirementTest,
-                        testing::ValuesIn(metrics_retirement_tests));
+INSTANTIATE_TEST_SUITE_P(MetricsTest,
+                         MetricsRetirementTest,
+                         testing::ValuesIn(metrics_retirement_tests));
 
 class MetricVarTest : public testing::Test
 {

--- a/src/utils/test/utils.cpp
+++ b/src/utils/test/utils.cpp
@@ -159,9 +159,9 @@ const std::vector<c_string_equality> c_string_equality_tests = {
     {"Abc", "a", false, false},
 };
 
-INSTANTIATE_TEST_CASE_P(StringTest,
-                        CStringEqualityTest,
-                        testing::ValuesIn(c_string_equality_tests));
+INSTANTIATE_TEST_SUITE_P(StringTest,
+                         CStringEqualityTest,
+                         testing::ValuesIn(c_string_equality_tests));
 
 using c_string_n_bytes_equality = std::tuple<const char *, const char *, size_t, bool, bool, bool>;
 
@@ -243,9 +243,9 @@ const std::vector<c_string_n_bytes_equality> c_string_n_bytes_equality_tests = {
     {"abc\0xyz", "abc\0xyz", 7, true, true, true},
 };
 
-INSTANTIATE_TEST_CASE_P(StringTest,
-                        CStringNBytesEqualityTest,
-                        testing::ValuesIn(c_string_n_bytes_equality_tests));
+INSTANTIATE_TEST_SUITE_P(StringTest,
+                         CStringNBytesEqualityTest,
+                         testing::ValuesIn(c_string_n_bytes_equality_tests));
 
 // For containers such as std::unordered_set, the expected result will be deduplicated
 // at initialization. Therefore, it can be used to compare with actual result safely.


### PR DESCRIPTION
INSTANTIATE_TEST_CASE_P is a legacy API, used to instantiates the
value-parameterized test suite. INSTANTIATE_TEST_SUITE_P can be
substituted for it.