### PR TITLE
feat(new_metrics): build the http query string based on metric filters

### DIFF
--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -83,11 +83,6 @@ std::string build_rel_path(const std::string &root_path, const std::string &sub_
     http_call_registry::instance().remove(full_path);
 }
 
-/* static */ std::string get_full_path(const std::string &root_path, const std::string &sub_path)
-{
-    return '/' + build_rel_path(root_path, sub_path);
-}
-
 std::string http_service::get_rel_path(const std::string &sub_path) const
 {
     return build_rel_path(path(), sub_path);

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -57,6 +57,16 @@ error_s update_config(const http_request &req)
     return update_flag(iter->first, iter->second);
 }
 
+// If sub_path is 'app/duplication', the built path would be '<root_path>/app/duplication'.
+std::string build_rel_path(const std::string &root_path, const std::string &sub_path)
+{
+    std::string rel_path(root_path);
+    if (!rel_path.empty()) {
+        rel_path += '/';
+    }
+    return rel_path += sub_path;
+}
+
 } // anonymous namespace
 
 /*extern*/ http_call &register_http_call(std::string full_path)
@@ -73,18 +83,20 @@ error_s update_config(const http_request &req)
     http_call_registry::instance().remove(full_path);
 }
 
-void http_service::register_handler(std::string sub_path, http_callback cb, std::string help)
+std::string http_service::add_sub_path(const std::string &sub_path) const
 {
-    CHECK(!sub_path.empty(), "");
+    return build_rel_path(path(), sub_path);
+}
+
+void http_service::register_handler(std::string sub_path, http_callback cb, std::string help) const
+{
+    CHECK_FALSE(sub_path.empty());
     if (!FLAGS_enable_http_server) {
         return;
     }
+
     auto call = std::make_unique<http_call>();
-    call->path = this->path();
-    if (!call->path.empty()) {
-        call->path += '/';
-    }
-    call->path += sub_path;
+    call->path = add_sub_path(sub_path);
     call->callback = std::move(cb);
     call->help = std::move(help);
     http_call_registry::instance().add(std::move(call));

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -58,7 +58,7 @@ error_s update_config(const http_request &req)
 }
 
 // If sub_path is 'app/duplication', the built path would be '<root_path>/app/duplication'.
-std::string get_rel_path(const std::string &root_path, const std::string &sub_path)
+std::string build_rel_path(const std::string &root_path, const std::string &sub_path)
 {
     std::string rel_path(root_path);
     if (!rel_path.empty()) {
@@ -85,12 +85,12 @@ std::string get_rel_path(const std::string &root_path, const std::string &sub_pa
 
 /* static */ std::string get_full_path(const std::string &root_path, const std::string &sub_path)
 {
-    return '/' + get_rel_path(root_path, sub_path);
+    return '/' + build_rel_path(root_path, sub_path);
 }
 
 std::string http_service::get_rel_path(const std::string &sub_path) const
 {
-    return get_rel_path(path(), sub_path);
+    return build_rel_path(path(), sub_path);
 }
 
 void http_service::register_handler(std::string sub_path, http_callback cb, std::string help) const

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -58,7 +58,7 @@ error_s update_config(const http_request &req)
 }
 
 // If sub_path is 'app/duplication', the built path would be '<root_path>/app/duplication'.
-std::string build_rel_path(const std::string &root_path, const std::string &sub_path)
+std::string get_rel_path(const std::string &root_path, const std::string &sub_path)
 {
     std::string rel_path(root_path);
     if (!rel_path.empty()) {
@@ -83,9 +83,14 @@ std::string build_rel_path(const std::string &root_path, const std::string &sub_
     http_call_registry::instance().remove(full_path);
 }
 
-std::string http_service::add_sub_path(const std::string &sub_path) const
+/* static */ std::string get_full_path(const std::string &root_path, const std::string &sub_path)
 {
-    return build_rel_path(path(), sub_path);
+    return '/' + get_rel_path(root_path, sub_path);
+}
+
+std::string http_service::get_rel_path(const std::string &sub_path) const
+{
+    return get_rel_path(path(), sub_path);
 }
 
 void http_service::register_handler(std::string sub_path, http_callback cb, std::string help) const
@@ -96,7 +101,7 @@ void http_service::register_handler(std::string sub_path, http_callback cb, std:
     }
 
     auto call = std::make_unique<http_call>();
-    call->path = add_sub_path(sub_path);
+    call->path = get_rel_path(sub_path);
     call->callback = std::move(cb);
     call->help = std::move(help);
     http_call_registry::instance().add(std::move(call));

--- a/src/http/http_server.h
+++ b/src/http/http_server.h
@@ -89,9 +89,6 @@ struct http_call
 class http_service
 {
 public:
-    // If sub_path is 'app/duplication', the built path would be '/<root_path>/app/duplication',
-    static std::string get_full_path(const std::string &root_path, const std::string &sub_path);
-
     http_service() noexcept = default;
     virtual ~http_service() = default;
 

--- a/src/http/http_server.h
+++ b/src/http/http_server.h
@@ -89,6 +89,10 @@ struct http_call
 class http_service
 {
 public:
+    // If sub_path is 'app/duplication', the built path would be '/<root_path>/app/duplication',
+    static std::string get_full_path(const std::string &root_path, const std::string &sub_path);
+
+    http_service() noexcept = default;
     virtual ~http_service() = default;
 
     virtual std::string path() const = 0;
@@ -98,7 +102,7 @@ public:
 private:
     // If sub_path is 'app/duplication', the built path would be '<root_path>/app/duplication',
     // where path() would be called as root_path.
-    std::string add_sub_path(const std::string &sub_path) const;
+    std::string get_rel_path(const std::string &sub_path) const;
 };
 
 class http_server_base : public http_service

--- a/src/http/http_server.h
+++ b/src/http/http_server.h
@@ -93,7 +93,12 @@ public:
 
     virtual std::string path() const = 0;
 
-    void register_handler(std::string sub_path, http_callback cb, std::string help);
+    void register_handler(std::string sub_path, http_callback cb, std::string help) const;
+
+private:
+    // If sub_path is 'app/duplication', the built path would be '<root_path>/app/duplication',
+    // where path() would be called as root_path.
+    std::string add_sub_path(const std::string &sub_path) const;
 };
 
 class http_server_base : public http_service

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -44,7 +44,7 @@ set(MY_BINPLACES "")
 
 if (APPLE)
     dsn_add_static_library()
-    target_link_libraries(${MY_PROJ_NAME} PRIVATE dsn_http dsn_replication_common)
+    target_link_libraries(${MY_PROJ_NAME} PRIVATE dsn_http dsn_replication_common absl::strings)
 else()
     dsn_add_shared_library()
     target_link_libraries(${MY_PROJ_NAME} PRIVATE dsn_replication_common)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -36,7 +36,8 @@ set(MY_PROJ_LIBS
         rocksdb
         lz4
         zstd
-        snappy)
+        snappy
+        absl::strings)
 
 # Extra files that will be installed
 set(MY_BINPLACES "")

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -231,17 +231,6 @@ void metric_filters::extract_entity_metrics(const metric_entity::metric_map &can
     }
 }
 
-namespace {
-
-const std::string kMetricFiltersWithMetricFieldsField = "with_metric_fields";
-const std::string kMetricFiltersTypesField = "types";
-const std::string kMetricFiltersIdsField = "ids";
-const std::string kMetricFiltersAttributesField = "attributes";
-const std::string kMetricFiltersMetricsField = "metrics";
-const std::string kMetricFiltersDetailField = "detail";
-
-} // anonymous namespace
-
 std::string metric_filters::to_query_string() const
 {
 #define COMBINE_FIELD_PAIR(name, container)                                                        \
@@ -281,8 +270,8 @@ metric_entity_prototype::~metric_entity_prototype() {}
 
 const std::string metrics_http_service::kMetricsRootPath("");
 const std::string metrics_http_service::kMetricsQuerySubPath("metrics");
-const std::string metrics_http_service::kMetricsQueryPath(http_service::get_full_path(
-    metrics_http_service::kMetricsRootPath, metrics_http_service::kMetricsQuerySubPath));
+const std::string
+    metrics_http_service::kMetricsQueryPath('/' + metrics_http_service::kMetricsQuerySubPath);
 
 metrics_http_service::metrics_http_service(metric_registry *registry) : _registry(registry)
 {

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -235,6 +235,10 @@ std::string metric_filters::to_query_string() const
 {
 #define COMBINE_FIELD_PAIR(name, container)                                                        \
     do {                                                                                           \
+        if (container.empty()) {                                                                   \
+            break;                                                                                 \
+        }                                                                                          \
+                                                                                                   \
         std::string pair(#name);                                                                   \
         pair += '=';                                                                               \
         pair += boost::join(container, ",");                                                       \

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -245,14 +245,18 @@ metric_entity_prototype::metric_entity_prototype(const char *name) : _name(name)
 
 metric_entity_prototype::~metric_entity_prototype() {}
 
+const std::string metrics_http_service::kMetricsRootPath("");
+const std::string metrics_http_service::kMetricsQuerySubPath("metrics");
+const std::string metrics_http_service::kMetricsQueryPath("/" + metrics_http_service::kMetricsQuerySubPath);
+
 metrics_http_service::metrics_http_service(metric_registry *registry) : _registry(registry)
 {
-    register_handler("metrics",
+    register_handler(kMetricsQuerySubPath,
                      std::bind(&metrics_http_service::get_metrics_handler,
                                this,
                                std::placeholders::_1,
                                std::placeholders::_2),
-                     "ip:port/metrics");
+                     fmt::format("ip:port{}", kMetricsQueryPath));
 }
 
 namespace {

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -244,13 +244,13 @@ const std::string kMetricFiltersDetailField = "detail";
 
 std::string metric_filters::to_query_string() const
 {
-#define COMBINE_FIELD_PAIR(name, value) \
-    do {\
-        std::string pair(#name);\
-        pair+='=';\
-        pair+=boost::join(values, ",");\
-        fields.push_back(std::move(pair));\
-    }while (0)
+#define COMBINE_FIELD_PAIR(name, container)                                                        \
+    do {                                                                                           \
+        std::string pair(#name);                                                                   \
+        pair += '=';                                                                               \
+        pair += boost::join(container, ",");                                                       \
+        fields.push_back(std::move(pair));                                                         \
+    } while (0)
 
     std::vector<std::string> fields;
     COMBINE_FIELD_PAIR(with_metric_fields, with_metric_fields);
@@ -281,7 +281,8 @@ metric_entity_prototype::~metric_entity_prototype() {}
 
 const std::string metrics_http_service::kMetricsRootPath("");
 const std::string metrics_http_service::kMetricsQuerySubPath("metrics");
-const std::string metrics_http_service::kMetricsQueryPath(http_service::get_full_path(metrics_http_service::kMetricsRootPath,metrics_http_service::kMetricsQuerySubPath));
+const std::string metrics_http_service::kMetricsQueryPath(http_service::get_full_path(
+    metrics_http_service::kMetricsRootPath, metrics_http_service::kMetricsQuerySubPath));
 
 metrics_http_service::metrics_http_service(metric_registry *registry) : _registry(registry)
 {

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -509,6 +509,8 @@ struct metric_filters
     void extract_entity_metrics(const metric_entity::metric_map &candidates,
                                 metric_entity::metric_map &target_metrics) const;
 
+    std::string to_query_string() const;
+
     // `with_metric_fields` includes all the metric fields that are wanted by client. If it
     // is empty, there will be no restriction: in other words, all fields owned by the metric
     // will be put in the response.
@@ -563,12 +565,16 @@ class metric_registry; // IWYU pragma: keep
 class metrics_http_service : public http_server_base
 {
 public:
+    static const std::string kMetricsRootPath;
+    static const std::string kMetricsQuerySubPath;
+    static const std::string kMetricsQueryPath;
+
     explicit metrics_http_service(metric_registry *registry);
     ~metrics_http_service() = default;
 
     // There is only one API now whose URI is "/metrics", thus just make
     // this URI as sub path while leaving the root path empty.
-    std::string path() const override { return ""; }
+    std::string path() const override { return kMetricsRootPath; }
 
 private:
     friend void test_get_metrics_handler(const http_request &req, http_response &resp);

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -509,6 +509,9 @@ struct metric_filters
     void extract_entity_metrics(const metric_entity::metric_map &candidates,
                                 metric_entity::metric_map &target_metrics) const;
 
+    // Build the http query string based on metric filters. This is useful when an http request
+    // is performed for metrics query: firstly, set metric filters with what you want; then,
+    // get query string by this function conveniently and put it into the http request.
     std::string to_query_string() const;
 
     // `with_metric_fields` includes all the metric fields that are wanted by client. If it

--- a/src/utils/strings.cpp
+++ b/src/utils/strings.cpp
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <strings.h>
 #include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <sstream> // IWYU pragma: keep
 #include <utility>
@@ -424,5 +425,11 @@ std::string find_string_prefix(const std::string &input, char separator)
     }
     return input.substr(0, current);
 }
+
+bool has_space(const std::string &str)
+{
+    return std::any_of(str.begin(), str.end(), [](unsigned char c) { return std::isspace(c); });
+}
+
 } // namespace utils
 } // namespace dsn

--- a/src/utils/strings.cpp
+++ b/src/utils/strings.cpp
@@ -24,11 +24,11 @@
  * THE SOFTWARE.
  */
 
+#include <absl/strings/ascii.h>
 #include <openssl/md5.h>
 #include <stdio.h>
 #include <strings.h>
 #include <algorithm>
-#include <cctype>
 #include <cstring>
 #include <sstream> // IWYU pragma: keep
 #include <utility>
@@ -428,7 +428,11 @@ std::string find_string_prefix(const std::string &input, char separator)
 
 bool has_space(const std::string &str)
 {
-    return std::any_of(str.begin(), str.end(), [](unsigned char c) { return std::isspace(c); });
+    // Use absl::ascii_isspace() instead of std::isspace(), which could not be used as
+    // the predicate directly, since it might be implemented as a macro, and its parameter
+    // must be declared as unsigned. Thus, to use std::isspace(), we have to wrap it into
+    // a lambda expression.
+    return std::any_of(str.begin(), str.end(), absl::ascii_isspace);
 }
 
 } // namespace utils

--- a/src/utils/strings.h
+++ b/src/utils/strings.h
@@ -122,6 +122,7 @@ std::string string_md5(const char *buffer, unsigned int length);
 // if there is no prefix or the first character is "separator", it will return "".
 std::string find_string_prefix(const std::string &input, char separator);
 
+// Decide if there are some space characters in the given string, such as ' ', '\r', '\n' or '\t'.
 bool has_space(const std::string &str);
 
 } // namespace utils

--- a/src/utils/strings.h
+++ b/src/utils/strings.h
@@ -121,5 +121,8 @@ std::string string_md5(const char *buffer, unsigned int length);
 // splits the "input" string by the only character "separator" to get the string prefix.
 // if there is no prefix or the first character is "separator", it will return "".
 std::string find_string_prefix(const std::string &input, char separator);
+
+bool has_space(const std::string &str);
+
 } // namespace utils
 } // namespace dsn

--- a/src/utils/test/metrics_test.cpp
+++ b/src/utils/test/metrics_test.cpp
@@ -2887,6 +2887,84 @@ TEST(metrics_test, http_get_metrics)
     }
 }
 
+struct metric_filters_query_string_case
+{
+    metric_filters::metric_fields_type with_metric_fields;
+    metric_filters::entity_types_type entity_types;
+    metric_filters::entity_ids_type entity_ids;
+    metric_filters::entity_attrs_type entity_attrs;
+    metric_filters::entity_metrics_type entity_metrics;
+    size_t expected_fields;
+};
+
+class MetricFiltersQueryStringTest : public testing::TestWithParam<metric_filters_query_string_case>
+{
+};
+
+const std::vector<metric_filters_query_string_case> metric_filters_query_string_tests = {
+    {{"name", "value"}, {"replica"}, {}, {}, {"rdb_total_sst_files", "rdb_total_sst_size_mb"}, 3},
+};
+
+TEST_P(MetricFiltersQueryStringTest, BuildQueryString)
+{
+    const auto &query_string_case = GetParam();
+
+    metric_filters filters;
+
+#define COPY_CONTAINER(field) filters.field = query_string_case.field
+
+    COPY_CONTAINER(with_metric_fields);
+    COPY_CONTAINER(entity_types);
+    COPY_CONTAINER(entity_ids);
+    COPY_CONTAINER(entity_attrs);
+    COPY_CONTAINER(entity_metrics);
+
+#undef COPY_CONTAINER
+
+    const auto &query_string = filters.to_query_string();
+    ASSERT_FALSE(utils::has_space(query_string));
+    std::cout << "query string: " << query_string << std::endl;
+
+    std::vector<std::string> fields;
+    utils::split_args(query_string.c_str(), fields, '&');
+    ASSERT_EQ(query_string_case.expected_fields, fields.size());
+
+    size_t i = 0;
+
+#define CHECK_FIELD(name, type, field)                                                             \
+    do {                                                                                           \
+        if (query_string_case.field.empty()) {                                                     \
+            break;                                                                                 \
+        }                                                                                          \
+                                                                                                   \
+        ASSERT_LT(i, query_string_case.expected_fields);                                           \
+                                                                                                   \
+        std::vector<std::string> kvs;                                                              \
+        utils::split_args(fields[i].c_str(), kvs, '=');                                            \
+        ASSERT_EQ(2, kvs.size());                                                                  \
+        ASSERT_STREQ(#name, kvs[0].c_str());                                                       \
+                                                                                                   \
+        type actual_field;                                                                         \
+        utils::split_args(kvs[1].c_str(), actual_field, ',');                                      \
+        ASSERT_EQ(query_string_case.field, actual_field);                                          \
+        ++i;                                                                                       \
+    } while (0)
+
+    CHECK_FIELD(with_metric_fields, metric_filters::metric_fields_type, with_metric_fields);
+    CHECK_FIELD(types, metric_filters::entity_types_type, entity_types);
+    CHECK_FIELD(ids, metric_filters::entity_ids_type, entity_ids);
+    CHECK_FIELD(attributes, metric_filters::entity_attrs_type, entity_attrs);
+    CHECK_FIELD(metrics, metric_filters::entity_metrics_type, entity_metrics);
+
+#undef CHECK_FIELD
+
+    ASSERT_EQ(query_string_case.expected_fields, i);
+}
+
+INSTANTIATE_TEST_SUITE_P(MetricsTest,
+                         MetricFiltersQueryStringTest,
+                         testing::ValuesIn(metric_filters_query_string_tests));
+
 using surviving_metrics_case = std::tuple<std::string, bool, bool, bool, bool>;
 
 class MetricsRetirementTest : public testing::TestWithParam<surviving_metrics_case>

--- a/src/utils/test/metrics_test.cpp
+++ b/src/utils/test/metrics_test.cpp
@@ -2923,6 +2923,7 @@ TEST_P(MetricFiltersQueryStringTest, BuildQueryString)
 
 #define COPY_CONTAINER(field) filters.field = query_string_case.field
 
+    // Copy the data of the case to the tested metric filters.
     COPY_CONTAINER(with_metric_fields);
     COPY_CONTAINER(entity_types);
     COPY_CONTAINER(entity_ids);
@@ -2931,10 +2932,15 @@ TEST_P(MetricFiltersQueryStringTest, BuildQueryString)
 
 #undef COPY_CONTAINER
 
+    // Build the http query string based on the tested metric filters.
     const auto &query_string = filters.to_query_string();
-    ASSERT_FALSE(utils::has_space(query_string));
     std::cout << "query string: " << query_string << std::endl;
 
+    // There should not be any space character in the query string.
+    ASSERT_FALSE(utils::has_space(query_string));
+
+    // Extract each field name/value pair from the query string and check the number of
+    // the fields.
     std::vector<std::string> fields;
     utils::split_args(query_string.c_str(), fields, '&');
     ASSERT_EQ(query_string_case.expected_fields, fields.size());
@@ -2960,6 +2966,8 @@ TEST_P(MetricFiltersQueryStringTest, BuildQueryString)
         ++i;                                                                                       \
     } while (0)
 
+    // Check each field name/value extracted from the query string is exactly equal to the
+    // original metric filters.
     CHECK_FIELD(with_metric_fields, metric_filters::metric_fields_type, with_metric_fields);
     CHECK_FIELD(types, metric_filters::entity_types_type, entity_types);
     CHECK_FIELD(ids, metric_filters::entity_ids_type, entity_ids);
@@ -2968,6 +2976,7 @@ TEST_P(MetricFiltersQueryStringTest, BuildQueryString)
 
 #undef CHECK_FIELD
 
+    // All of the fields should have been checked.
     ASSERT_EQ(query_string_case.expected_fields, i);
 }
 

--- a/src/utils/test/metrics_test.cpp
+++ b/src/utils/test/metrics_test.cpp
@@ -2902,7 +2902,17 @@ class MetricFiltersQueryStringTest : public testing::TestWithParam<metric_filter
 };
 
 const std::vector<metric_filters_query_string_case> metric_filters_query_string_tests = {
+    // Empty query string.
+    {{}, {}, {}, {}, {}, 0},
+    // Some fields were missing in the query string.
     {{"name", "value"}, {"replica"}, {}, {}, {"rdb_total_sst_files", "rdb_total_sst_size_mb"}, 3},
+    // All fields were present.
+    {{"name", "value"},
+     {"replica"},
+     {"replica5.2"},
+     {"table_id", "partition_id"},
+     {"rdb_total_sst_files", "rdb_total_sst_size_mb"},
+     5},
 };
 
 TEST_P(MetricFiltersQueryStringTest, BuildQueryString)

--- a/src/utils/test/utils.cpp
+++ b/src/utils/test/utils.cpp
@@ -45,8 +45,8 @@
 #include "utils/strings.h"
 #include "utils/utils.h"
 
-using namespace ::dsn;
-using namespace ::dsn::utils;
+namespace dsn {
+namespace utils {
 
 TEST(core, get_last_component)
 {
@@ -568,3 +568,37 @@ TEST(core, get_intersection)
     ASSERT_EQ(intersection.size(), 1);
     ASSERT_EQ(*intersection.begin(), 3);
 }
+
+struct has_space_case
+{
+    std::string str;
+    bool expected_has_space;
+};
+
+class HasSpaceTest : public testing::TestWithParam<has_space_case>
+{
+};
+
+TEST_P(HasSpaceTest, HasSpace)
+{
+    const auto &space_case = GetParam();
+    EXPECT_EQ(space_case.expected_has_space, has_space(space_case.str));
+}
+
+const std::vector<has_space_case> has_space_tests = {
+    {"abc xyz", true},
+    {" abcxyz", true},
+    {"abcxyz ", true},
+    {"abc  xyz", true},
+    {"abc\r\nxyz", true},
+    {"abc\r\nxyz", true},
+    {"abc\txyz", true},
+    {"abc\txyz", true},
+    {"abcxyz", false},
+    {"abc_xyz", false},
+};
+
+INSTANTIATE_TEST_SUITE_P(StringTest, HasSpaceTest, testing::ValuesIn(has_space_tests));
+
+} // namespace utils
+} // namespace dsn


### PR DESCRIPTION
Pegasus shell needs to fetch metrics by http client. However, building query
string is not simple. You have to write each field name yourself, and assemble
all field names/values into a valid query string.

To simplify this operation, we could allow metric filters to support exporting
the query string. Users could just set conditions they need to metric filters,
then get the query string just by a function conveniently.