### PR TITLE
feat(dns_resolver): Add metrics for dns_resolver

### DIFF
--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -19,12 +19,16 @@
 
 #include <algorithm>
 #include <memory>
+#include <set>
 #include <utility>
 
+#include "absl/strings/string_view.h"
+#include "fmt/core.h"
 #include "fmt/format.h"
 #include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/group_address.h"
 #include "runtime/rpc/group_host_port.h"
+#include "utils/autoref_ptr.h"
 #include "utils/fmt_logging.h"
 
 METRIC_DEFINE_gauge_int64(server,

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -49,6 +49,11 @@ dns_resolver::dns_resolver()
       METRIC_VAR_INIT_server(dns_resolver_resolve_duration_ns),
       METRIC_VAR_INIT_server(dns_resolver_resolve_by_dns_duration_ns)
 {
+#ifndef MOCK_TEST
+    static int only_one_instance = 0;
+    only_one_instance++;
+    CHECK_EQ_MSG(1, only_one_instance, "dns_resolver should only created once!");
+#endif
 }
 
 bool dns_resolver::get_cached_addresses(const host_port &hp, std::vector<rpc_address> &addresses)

--- a/src/runtime/rpc/dns_resolver.cpp
+++ b/src/runtime/rpc/dns_resolver.cpp
@@ -27,19 +27,35 @@
 #include "runtime/rpc/group_host_port.h"
 #include "utils/fmt_logging.h"
 
+METRIC_DEFINE_gauge_int64(server,
+                          dns_resolver_cache_size,
+                          dsn::metric_unit::kKeys,
+                          "The size of the host_port to rpc_address resolve results cache");
+
+METRIC_DEFINE_percentile_int64(
+    server,
+    dns_resolver_resolve_duration_ns,
+    dsn::metric_unit::kNanoSeconds,
+    "The duration of resolving a host port, may either get from cache or resolve by DNS lookup");
+
+METRIC_DEFINE_percentile_int64(server,
+                               dns_resolver_resolve_by_dns_duration_ns,
+                               dsn::metric_unit::kNanoSeconds,
+                               "The duration of resolving a host port by DNS lookup");
 namespace dsn {
 
-void dns_resolver::add_item(const host_port &hp, const rpc_address &addr)
+dns_resolver::dns_resolver()
+    : METRIC_VAR_INIT_server(dns_resolver_cache_size),
+      METRIC_VAR_INIT_server(dns_resolver_resolve_duration_ns),
+      METRIC_VAR_INIT_server(dns_resolver_resolve_by_dns_duration_ns)
 {
-    utils::auto_write_lock l(_lock);
-    _dsn_cache.insert(std::make_pair(hp, addr));
 }
 
 bool dns_resolver::get_cached_addresses(const host_port &hp, std::vector<rpc_address> &addresses)
 {
     utils::auto_read_lock l(_lock);
-    const auto &found = _dsn_cache.find(hp);
-    if (found == _dsn_cache.end()) {
+    const auto &found = _dns_cache.find(hp);
+    if (found == _dns_cache.end()) {
         return false;
     }
 
@@ -55,19 +71,26 @@ error_s dns_resolver::resolve_addresses(const host_port &hp, std::vector<rpc_add
     }
 
     std::vector<rpc_address> resolved_addresses;
-    RETURN_NOT_OK(hp.resolve_addresses(resolved_addresses));
+    {
+        METRIC_VAR_AUTO_LATENCY(dns_resolver_resolve_by_dns_duration_ns);
+        RETURN_NOT_OK(hp.resolve_addresses(resolved_addresses));
+    }
 
     {
-        utils::auto_write_lock l(_lock);
         if (resolved_addresses.size() > 1) {
-            LOG_DEBUG(
-                "host_port '{}' resolves to {} different addresses {}, using the first one {}.",
-                hp,
-                resolved_addresses.size(),
-                fmt::join(resolved_addresses, ","),
-                resolved_addresses[0]);
+            LOG_DEBUG("host_port '{}' resolves to {} different addresses {}, only the first one {} "
+                      "will be cached.",
+                      hp,
+                      resolved_addresses.size(),
+                      fmt::join(resolved_addresses, ","),
+                      resolved_addresses[0]);
         }
-        _dsn_cache.insert(std::make_pair(hp, resolved_addresses[0]));
+
+        utils::auto_write_lock l(_lock);
+        const auto it = _dns_cache.insert(std::make_pair(hp, resolved_addresses[0]));
+        if (it.second) {
+            METRIC_VAR_INCREMENT(dns_resolver_cache_size);
+        }
     }
 
     addresses = std::move(resolved_addresses);
@@ -76,18 +99,19 @@ error_s dns_resolver::resolve_addresses(const host_port &hp, std::vector<rpc_add
 
 rpc_address dns_resolver::resolve_address(const host_port &hp)
 {
+    METRIC_VAR_AUTO_LATENCY(dns_resolver_resolve_duration_ns);
     switch (hp.type()) {
     case HOST_TYPE_GROUP: {
         rpc_address addr;
-        auto group_address = hp.group_host_port();
-        addr.assign_group(group_address->name());
+        auto hp_group = hp.group_host_port();
+        addr.assign_group(hp_group->name());
 
-        for (const auto &hp : group_address->members()) {
+        for (const auto &hp : hp_group->members()) {
             CHECK_TRUE(addr.group_address()->add(resolve_address(hp)));
         }
         addr.group_address()->set_update_leader_automatically(
-            group_address->is_update_leader_automatically());
-        addr.group_address()->set_leader(resolve_address(group_address->leader()));
+            hp_group->is_update_leader_automatically());
+        addr.group_address()->set_leader(resolve_address(hp_group->leader()));
         return addr;
     }
     case HOST_TYPE_IPV4: {
@@ -104,7 +128,7 @@ rpc_address dns_resolver::resolve_address(const host_port &hp)
         return addresses[0];
     }
     default:
-        return rpc_address();
+        return {};
     }
 }
 

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -180,6 +180,9 @@ error_s host_port::resolve_addresses(std::vector<rpc_address> &addresses) const
         return error_s::make(dsn::ERR_INVALID_STATE, "invalid host_port type: HOST_TYPE_GROUP");
     case HOST_TYPE_IPV4:
         break;
+    default:
+        CHECK(false, "");
+        __builtin_unreachable();
     }
 
     rpc_address rpc_addr;


### PR DESCRIPTION
The DNS resolve function maybe slow, and the memory size of dns_resolver is
not limited currently, this patch adds 3 useful metrics to improve observability:
- dns_resolver_cache_size
- dns_resolver_resolve_duration_ns
- dns_resolver_resolve_by_dns_duration_ns