### PR TITLE
refactor(command_manager): Simplify command_manager code

### DIFF
--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -48,10 +48,6 @@ namespace dsn {
 namespace replication {
 
 DSN_DEFINE_bool(replication, duplication_enabled, true, "is duplication enabled");
-DSN_DEFINE_int32(replication,
-                 max_concurrent_bulk_load_downloading_count,
-                 5,
-                 "concurrent bulk load downloading replica count");
 
 DSN_DEFINE_int32(replication,
                  mutation_2pc_min_replica_count,
@@ -143,8 +139,6 @@ void replication_options::initialize()
     }
 
     CHECK(!data_dirs.empty(), "no replica data dir found, maybe not set or excluded by black list");
-
-    max_concurrent_bulk_load_downloading_count = FLAGS_max_concurrent_bulk_load_downloading_count;
 
     CHECK(replica_helper::load_meta_servers(meta_servers), "invalid meta server config");
 }

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -64,8 +64,6 @@ public:
     std::vector<std::string> data_dirs;
     std::vector<std::string> data_dir_tags;
 
-    int32_t max_concurrent_bulk_load_downloading_count;
-
 public:
     replication_options() = default;
     ~replication_options();

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -20,7 +20,6 @@
 #include <iterator>
 #include <map>
 #include <set>
-#include <string>
 
 #include "app_balance_policy.h"
 #include "common/gpid.h"
@@ -50,30 +49,18 @@ app_balance_policy::app_balance_policy(meta_service *svc) : load_balance_policy(
         _only_primary_balancer = false;
         _only_move_primary = false;
     }
-    _cmds.emplace_back(dsn::command_manager::instance().register_command(
-        {"meta.lb.balancer_in_turn"},
-        "meta.lb.balancer_in_turn <true|false>",
-        "control whether do app balancer in turn",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(_balancer_in_turn, "lb.balancer_in_turn", args);
-        }));
+    _cmds.emplace_back(dsn::command_manager::instance().register_bool_command(
+        _balancer_in_turn, "meta.lb.balancer_in_turn", "control whether do app balancer in turn"));
 
-    _cmds.emplace_back(dsn::command_manager::instance().register_command(
-        {"meta.lb.only_primary_balancer"},
-        "meta.lb.only_primary_balancer <true|false>",
-        "control whether do only primary balancer",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(
-                _only_primary_balancer, "lb.only_primary_balancer", args);
-        }));
+    _cmds.emplace_back(dsn::command_manager::instance().register_bool_command(
+        _only_primary_balancer,
+        "meta.lb.only_primary_balancer",
+        "control whether do only primary balancer"));
 
-    _cmds.emplace_back(dsn::command_manager::instance().register_command(
-        {"meta.lb.only_move_primary"},
-        "meta.lb.only_move_primary <true|false>",
-        "control whether only move primary in balancer",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(_only_move_primary, "lb.only_move_primary", args);
-        }));
+    _cmds.emplace_back(dsn::command_manager::instance().register_bool_command(
+        _only_move_primary,
+        "meta.lb.only_move_primary",
+        "control whether only move primary in balancer"));
 }
 
 void app_balance_policy::balance(bool checker, const meta_view *global_view, migration_list *list)

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -338,7 +338,7 @@ private:
 
     replication_options _opts;
     meta_options _meta_opts;
-    uint64_t _node_live_percentage_threshold_for_update;
+    int32_t _node_live_percentage_threshold_for_update;
     std::unique_ptr<command_deregister> _ctrl_node_live_percentage_threshold_for_update;
 
     std::shared_ptr<server_state> _state;

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -21,6 +21,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <algorithm>
+#include <cstdint>
 #include <ostream>
 #include <unordered_map>
 
@@ -34,7 +35,6 @@
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/metrics.h"
-#include "utils/string_conv.h"
 #include "utils/strings.h"
 #include "utils/time_utils.h"
 
@@ -42,10 +42,10 @@ namespace dsn {
 namespace replication {
 
 DSN_DEFINE_int32(meta_server, max_replicas_in_group, 4, "max replicas(alive & dead) in a group");
-DSN_DEFINE_uint64(meta_server,
-                  replica_assign_delay_ms_for_dropouts,
-                  300000,
-                  "The delay milliseconds to dropout replicas assign");
+DSN_DEFINE_int64(meta_server,
+                 replica_assign_delay_ms_for_dropouts,
+                 300000,
+                 "The delay milliseconds to dropout replicas assign");
 
 partition_guardian::partition_guardian(meta_service *svc) : _svc(svc)
 {
@@ -681,12 +681,11 @@ void partition_guardian::finish_cure_proposal(meta_view &view,
 
 void partition_guardian::register_ctrl_commands()
 {
-    // TODO(yingchun): update _replica_assign_delay_ms_for_dropouts by http
-    _cmds.emplace_back(dsn::command_manager::instance().register_command(
-        {"meta.lb.assign_delay_ms"},
-        "lb.assign_delay_ms [num | DEFAULT]",
-        "control the replica_assign_delay_ms_for_dropouts config",
-        [this](const std::vector<std::string> &args) { return ctrl_assign_delay_ms(args); }));
+    _cmds.emplace_back(dsn::command_manager::instance().register_int_command(
+        _replica_assign_delay_ms_for_dropouts,
+        FLAGS_replica_assign_delay_ms_for_dropouts,
+        "meta.lb.assign_delay_ms",
+        "control the replica_assign_delay_ms_for_dropouts config"));
 
     _cmds.emplace_back(dsn::command_manager::instance().register_command(
         {"meta.lb.assign_secondary_black_list"},
@@ -695,26 +694,6 @@ void partition_guardian::register_ctrl_commands()
         [this](const std::vector<std::string> &args) {
             return ctrl_assign_secondary_black_list(args);
         }));
-}
-
-std::string partition_guardian::ctrl_assign_delay_ms(const std::vector<std::string> &args)
-{
-    std::string result("OK");
-    if (args.empty()) {
-        result = std::to_string(_replica_assign_delay_ms_for_dropouts);
-    } else {
-        if (args[0] == "DEFAULT") {
-            _replica_assign_delay_ms_for_dropouts = FLAGS_replica_assign_delay_ms_for_dropouts;
-        } else {
-            int32_t v = 0;
-            if (!dsn::buf2int32(args[0], v) || v <= 0) {
-                result = std::string("ERR: invalid arguments");
-            } else {
-                _replica_assign_delay_ms_for_dropouts = v;
-            }
-        }
-    }
-    return result;
 }
 
 std::string

--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -74,7 +74,6 @@ private:
     void finish_cure_proposal(meta_view &view,
                               const dsn::gpid &gpid,
                               const configuration_proposal_action &action);
-    std::string ctrl_assign_delay_ms(const std::vector<std::string> &args);
     std::string ctrl_assign_secondary_black_list(const std::vector<std::string> &args);
 
     void set_ddd_partition(ddd_partition_info &&partition)
@@ -103,7 +102,7 @@ private:
     // ]
 
     std::vector<std::unique_ptr<command_deregister>> _cmds;
-    uint64_t _replica_assign_delay_ms_for_dropouts;
+    int64_t _replica_assign_delay_ms_for_dropouts;
 
     friend class meta_partition_guardian_test;
 };

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -38,7 +38,7 @@
 #include <sstream> // IWYU pragma: keep
 #include <string>
 #include <thread>
-#include <type_traits>
+// IWYU pragma: no_include <type_traits>
 #include <unordered_map>
 
 #include "app_env_validator.h"

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -163,38 +163,16 @@ void server_state::register_cli_commands()
             return std::string(err.to_string());
         }));
 
-    _cmds.emplace_back(dsn::command_manager::instance().register_command(
-        {"meta.lb.add_secondary_enable_flow_control"},
-        "meta.lb.add_secondary_enable_flow_control <true|false>",
-        "control whether enable add secondary flow control",
-        [this](const std::vector<std::string> &args) {
-            return remote_command_set_bool_flag(
-                _add_secondary_enable_flow_control, "lb.add_secondary_enable_flow_control", args);
-        }));
+    _cmds.emplace_back(dsn::command_manager::instance().register_bool_command(
+        _add_secondary_enable_flow_control,
+        "meta.lb.add_secondary_enable_flow_control",
+        "control whether enable add secondary flow control"));
 
-    _cmds.emplace_back(dsn::command_manager::instance().register_command(
-        {"meta.lb.add_secondary_max_count_for_one_node"},
-        "meta.lb.add_secondary_max_count_for_one_node [num | DEFAULT]",
-        "control the max count to add secondary for one node",
-        [this](const std::vector<std::string> &args) {
-            std::string result("OK");
-            if (args.empty()) {
-                result = std::to_string(_add_secondary_max_count_for_one_node);
-            } else {
-                if (args[0] == "DEFAULT") {
-                    _add_secondary_max_count_for_one_node =
-                        FLAGS_add_secondary_max_count_for_one_node;
-                } else {
-                    int32_t v = 0;
-                    if (!dsn::buf2int32(args[0], v) || v < 0) {
-                        result = std::string("ERR: invalid arguments");
-                    } else {
-                        _add_secondary_max_count_for_one_node = v;
-                    }
-                }
-            }
-            return result;
-        }));
+    _cmds.emplace_back(dsn::command_manager::instance().register_int_command(
+        _add_secondary_max_count_for_one_node,
+        FLAGS_add_secondary_max_count_for_one_node,
+        "meta.lb.add_secondary_max_count_for_one_node",
+        "control the max count to add secondary for one node"));
 }
 
 void server_state::initialize(meta_service *meta_svc, const std::string &apps_root)

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -38,6 +38,7 @@
 #include <sstream> // IWYU pragma: keep
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <unordered_map>
 
 #include "app_env_validator.h"

--- a/src/meta/test/meta_test_base.cpp
+++ b/src/meta/test/meta_test_base.cpp
@@ -116,7 +116,7 @@ void meta_test_base::set_min_live_node_count_for_unfreeze(uint64_t node_count)
     FLAGS_min_live_node_count_for_unfreeze = node_count;
 }
 
-void meta_test_base::set_node_live_percentage_threshold_for_update(uint64_t percentage_threshold)
+void meta_test_base::set_node_live_percentage_threshold_for_update(int32_t percentage_threshold)
 {
     _ms->_node_live_percentage_threshold_for_update = percentage_threshold;
 }

--- a/src/meta/test/meta_test_base.h
+++ b/src/meta/test/meta_test_base.h
@@ -53,7 +53,7 @@ public:
 
     void set_min_live_node_count_for_unfreeze(uint64_t node_count);
 
-    void set_node_live_percentage_threshold_for_update(uint64_t percentage_threshold);
+    void set_node_live_percentage_threshold_for_update(int32_t percentage_threshold);
 
     std::vector<rpc_address> ensure_enough_alive_nodes(int min_node_count);
 

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -70,9 +70,9 @@
 namespace dsn {
 namespace replication {
 
+DSN_DECLARE_int32(node_live_percentage_threshold_for_update);
+DSN_DECLARE_int64(replica_assign_delay_ms_for_dropouts);
 DSN_DECLARE_uint64(min_live_node_count_for_unfreeze);
-DSN_DECLARE_uint64(node_live_percentage_threshold_for_update);
-DSN_DECLARE_uint64(replica_assign_delay_ms_for_dropouts);
 
 class fake_sender_meta_service : public dsn::replication::meta_service
 {

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -588,7 +588,7 @@ void nfs_client_impl::register_cli_commands()
             FLAGS_max_copy_rate_megabytes_per_disk,
             "nfs.max_copy_rate_megabytes_per_disk",
             fmt::format("{}, "
-                        "should be less than 'nfs_copy_block_bytes' which is {}",
+                        "should be greater than 'nfs_copy_block_bytes' which is {}",
                         kMaxCopyRateMegaBytesPerDiskDesc,
                         FLAGS_nfs_copy_block_bytes),
             &check_max_copy_rate_megabytes_per_disk);

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -61,10 +61,10 @@ class disk_file;
 
 namespace service {
 
-static const char *max_send_rate_megabytes_per_disk_desc =
+static const char *kMaxSendRateMegaBytesPerDiskDesc =
     "The maximum bandwidth (MB/s) of reading data per local disk "
     "when transferring data to remote node, 0 means no limit";
-DSN_DEFINE_int64(nfs, max_send_rate_megabytes_per_disk, 0, max_send_rate_megabytes_per_disk_desc);
+DSN_DEFINE_int64(nfs, max_send_rate_megabytes_per_disk, 0, kMaxSendRateMegaBytesPerDiskDesc);
 DSN_TAG_VARIABLE(max_send_rate_megabytes_per_disk, FT_MUTABLE);
 
 DSN_DECLARE_int32(file_close_timer_interval_ms_on_server);
@@ -263,7 +263,7 @@ void nfs_service_impl::register_cli_commands()
             FLAGS_max_send_rate_megabytes_per_disk,
             FLAGS_max_send_rate_megabytes_per_disk,
             "nfs.max_send_rate_megabytes_per_disk",
-            max_send_rate_megabytes_per_disk_desc);
+            kMaxSendRateMegaBytesPerDiskDesc);
     });
 }
 

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -42,7 +42,6 @@
 #include "utils/env.h"
 #include "utils/filesystem.h"
 #include "utils/flags.h"
-#include "utils/string_conv.h"
 #include "utils/utils.h"
 
 METRIC_DEFINE_counter(
@@ -62,11 +61,10 @@ class disk_file;
 
 namespace service {
 
-DSN_DEFINE_uint32(
-    nfs,
-    max_send_rate_megabytes_per_disk,
-    0,
-    "max rate per disk of send to remote node(MB/s)，zero means disable rate limiter");
+static const char *max_send_rate_megabytes_per_disk_desc =
+    "The maximum bandwidth (MB/s) of reading data per local disk "
+    "when transferring data to remote node, 0 means no limit";
+DSN_DEFINE_int64(nfs, max_send_rate_megabytes_per_disk, 0, max_send_rate_megabytes_per_disk_desc);
 DSN_TAG_VARIABLE(max_send_rate_megabytes_per_disk, FT_MUTABLE);
 
 DSN_DECLARE_int32(file_close_timer_interval_ms_on_server);
@@ -261,26 +259,11 @@ void nfs_service_impl::register_cli_commands()
 {
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-        _nfs_max_send_rate_megabytes_cmd = dsn::command_manager::instance().register_command(
-            {"nfs.max_send_rate_megabytes_per_disk"},
-            "nfs.max_send_rate_megabytes_per_disk [num]",
-            "control the max rate(MB/s) for one disk to send file to remote node",
-            [](const std::vector<std::string> &args) {
-                std::string result("OK");
-
-                if (args.empty()) {
-                    return std::to_string(FLAGS_max_send_rate_megabytes_per_disk);
-                }
-
-                int32_t max_send_rate_megabytes = 0;
-                if (!dsn::buf2int32(args[0], max_send_rate_megabytes) ||
-                    max_send_rate_megabytes <= 0) {
-                    return std::string("ERR: invalid arguments");
-                }
-
-                FLAGS_max_send_rate_megabytes_per_disk = max_send_rate_megabytes;
-                return result;
-            });
+        _nfs_max_send_rate_megabytes_cmd = dsn::command_manager::instance().register_int_command(
+            FLAGS_max_send_rate_megabytes_per_disk,
+            FLAGS_max_send_rate_megabytes_per_disk,
+            "nfs.max_send_rate_megabytes_per_disk",
+            max_send_rate_megabytes_per_disk_desc);
     });
 }
 

--- a/src/replica/backup/cold_backup_context.cpp
+++ b/src/replica/backup/cold_backup_context.cpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <type_traits>
 
 #include "common/backup_common.h"
 #include "common/replication.codes.h"

--- a/src/replica/backup/cold_backup_context.cpp
+++ b/src/replica/backup/cold_backup_context.cpp
@@ -20,7 +20,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include <type_traits>
+// IWYU pragma: no_include <type_traits>
 
 #include "common/backup_common.h"
 #include "common/replication.codes.h"

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -44,6 +44,7 @@
 #include "utils/env.h"
 #include "utils/fail_point.h"
 #include "utils/filesystem.h"
+#include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/load_dump_object.h"
 #include "utils/thread_access_checker.h"
@@ -82,6 +83,8 @@ METRIC_DEFINE_counter(replica,
                       bulk_load_download_file_bytes,
                       dsn::metric_unit::kBytes,
                       "The size of files that have been downloaded successfully for bulk loads");
+
+DSN_DECLARE_int32(max_concurrent_bulk_load_downloading_count);
 
 namespace dsn {
 namespace dist {
@@ -425,7 +428,7 @@ error_code replica_bulk_loader::start_download(const std::string &remote_dir,
                                                const std::string &provider_name)
 {
     if (_stub->_bulk_load_downloading_count.load() >=
-        _stub->_max_concurrent_bulk_load_downloading_count) {
+        FLAGS_max_concurrent_bulk_load_downloading_count) {
         LOG_WARNING_PREFIX("node[{}] already has {} replica downloading, wait for next round",
                            _stub->_primary_address_str,
                            _stub->_bulk_load_downloading_count.load());

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -89,12 +89,12 @@
 #include "remote_cmd/remote_command.h"
 #include "utils/fail_point.h"
 
-static const char *max_concurrent_bulk_load_downloading_count_desc =
+static const char *kMaxConcurrentBulkLoadDownloadingCountDesc =
     "The maximum concurrent bulk load downloading replica count";
 DSN_DEFINE_int32(replication,
                  max_concurrent_bulk_load_downloading_count,
                  5,
-                 max_concurrent_bulk_load_downloading_count_desc);
+                 kMaxConcurrentBulkLoadDownloadingCountDesc);
 
 METRIC_DEFINE_gauge_int64(server,
                           total_replicas,
@@ -2272,7 +2272,7 @@ void replica_stub::register_ctrl_command()
             FLAGS_max_concurrent_bulk_load_downloading_count,
             FLAGS_max_concurrent_bulk_load_downloading_count,
             "replica.max-concurrent-bulk-load-downloading-count",
-            max_concurrent_bulk_load_downloading_count_desc));
+            kMaxConcurrentBulkLoadDownloadingCountDesc));
     });
 }
 

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -78,7 +78,6 @@
 #include "utils/ports.h"
 #include "utils/process_utils.h"
 #include "utils/rand.h"
-#include "utils/string_conv.h"
 #include "utils/strings.h"
 #include "utils/synchronize.h"
 #ifdef DSN_ENABLE_GPERF
@@ -89,6 +88,13 @@
 #include "nfs/nfs_code_definition.h"
 #include "remote_cmd/remote_command.h"
 #include "utils/fail_point.h"
+
+static const char *max_concurrent_bulk_load_downloading_count_desc =
+    "The maximum concurrent bulk load downloading replica count";
+DSN_DEFINE_int32(replication,
+                 max_concurrent_bulk_load_downloading_count,
+                 5,
+                 max_concurrent_bulk_load_downloading_count_desc);
 
 METRIC_DEFINE_gauge_int64(server,
                           total_replicas,
@@ -339,7 +345,6 @@ replica_stub::replica_stub(replica_state_subscriber subscriber /*= nullptr*/,
       _verbose_commit_log(false),
       _release_tcmalloc_memory(false),
       _mem_release_max_reserved_mem_percentage(10),
-      _max_concurrent_bulk_load_downloading_count(5),
       _learn_app_concurrent_count(0),
       _bulk_load_downloading_count(0),
       _manual_emergency_checkpointing_count(0),
@@ -406,8 +411,6 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     _verbose_commit_log = FLAGS_verbose_commit_log_on_start;
     _release_tcmalloc_memory = FLAGS_mem_release_enabled;
     _mem_release_max_reserved_mem_percentage = FLAGS_mem_release_max_reserved_mem_percentage;
-    _max_concurrent_bulk_load_downloading_count =
-        _options.max_concurrent_bulk_load_downloading_count;
 
     // clear dirs if need
     if (clear) {
@@ -2181,32 +2184,18 @@ void replica_stub::register_ctrl_command()
                 return std::string(e.to_string());
             }));
 
-        _cmds.emplace_back(::dsn::command_manager::instance().register_command(
-            {"replica.deny-client"},
-            "replica.deny-client <true|false>",
-            "replica.deny-client - control if deny client read & write request",
-            [this](const std::vector<std::string> &args) {
-                return remote_command_set_bool_flag(_deny_client, "deny-client", args);
-            }));
+        _cmds.emplace_back(::dsn::command_manager::instance().register_bool_command(
+            _deny_client, "replica.deny-client", "control if deny client read & write request"));
 
-        _cmds.emplace_back(::dsn::command_manager::instance().register_command(
-            {"replica.verbose-client-log"},
-            "replica.verbose-client-log <true|false>",
-            "replica.verbose-client-log - control if print verbose error log when reply read & "
-            "write request",
-            [this](const std::vector<std::string> &args) {
-                return remote_command_set_bool_flag(
-                    _verbose_client_log, "verbose-client-log", args);
-            }));
+        _cmds.emplace_back(::dsn::command_manager::instance().register_bool_command(
+            _verbose_client_log,
+            "replica.verbose-client-log",
+            "control if print verbose error log when reply read & write request"));
 
-        _cmds.emplace_back(::dsn::command_manager::instance().register_command(
-            {"replica.verbose-commit-log"},
-            "replica.verbose-commit-log <true|false>",
-            "replica.verbose-commit-log - control if print verbose log when commit mutation",
-            [this](const std::vector<std::string> &args) {
-                return remote_command_set_bool_flag(
-                    _verbose_commit_log, "verbose-commit-log", args);
-            }));
+        _cmds.emplace_back(::dsn::command_manager::instance().register_bool_command(
+            _verbose_commit_log,
+            "replica.verbose-commit-log",
+            "control if print verbose log when commit mutation"));
 
         _cmds.emplace_back(::dsn::command_manager::instance().register_command(
             {"replica.trigger-checkpoint"},
@@ -2246,14 +2235,10 @@ void replica_stub::register_ctrl_command()
             }));
 
 #ifdef DSN_ENABLE_GPERF
-        _cmds.emplace_back(::dsn::command_manager::instance().register_command(
-            {"replica.release-tcmalloc-memory"},
-            "replica.release-tcmalloc-memory <true|false>",
-            "replica.release-tcmalloc-memory - control if try to release tcmalloc memory",
-            [this](const std::vector<std::string> &args) {
-                return remote_command_set_bool_flag(
-                    _release_tcmalloc_memory, "release-tcmalloc-memory", args);
-            }));
+        _cmds.emplace_back(::dsn::command_manager::instance().register_bool_command(
+            _release_tcmalloc_memory,
+            "replica.release-tcmalloc-memory",
+            "control if try to release tcmalloc memory"));
 
         _cmds.emplace_back(::dsn::command_manager::instance().register_command(
             {"replica.get-tcmalloc-status"},
@@ -2265,32 +2250,12 @@ void replica_stub::register_ctrl_command()
                 return std::string(buf);
             }));
 
-        _cmds.emplace_back(::dsn::command_manager::instance().register_command(
-            {"replica.mem-release-max-reserved-percentage"},
-            "replica.mem-release-max-reserved-percentage [num | DEFAULT]",
+        _cmds.emplace_back(::dsn::command_manager::instance().register_int_command(
+            _mem_release_max_reserved_mem_percentage,
+            FLAGS_mem_release_max_reserved_mem_percentage,
+            "replica.mem-release-max-reserved-percentage",
             "control tcmalloc max reserved but not-used memory percentage",
-            [this](const std::vector<std::string> &args) {
-                std::string result("OK");
-                if (args.empty()) {
-                    // show current value
-                    result = "mem-release-max-reserved-percentage = " +
-                             std::to_string(_mem_release_max_reserved_mem_percentage);
-                    return result;
-                }
-                if (args[0] == "DEFAULT") {
-                    // set to default value
-                    _mem_release_max_reserved_mem_percentage =
-                        FLAGS_mem_release_max_reserved_mem_percentage;
-                    return result;
-                }
-                int32_t percentage = 0;
-                if (!dsn::buf2int32(args[0], percentage) || percentage <= 0 || percentage > 100) {
-                    result = std::string("ERR: invalid arguments");
-                } else {
-                    _mem_release_max_reserved_mem_percentage = percentage;
-                }
-                return result;
-            }));
+            [](int32_t new_value) -> bool { return new_value > 0 && new_value <= 100; }));
 
         _cmds.emplace_back(::dsn::command_manager::instance().register_command(
             {"replica.release-all-reserved-memory"},
@@ -2303,33 +2268,11 @@ void replica_stub::register_ctrl_command()
 #elif defined(DSN_USE_JEMALLOC)
         register_jemalloc_ctrl_command();
 #endif
-        // TODO(yingchun): use http
-        _cmds.emplace_back(::dsn::command_manager::instance().register_command(
-            {"replica.max-concurrent-bulk-load-downloading-count"},
-            "replica.max-concurrent-bulk-load-downloading-count [num | DEFAULT]",
-            "control stub max_concurrent_bulk_load_downloading_count",
-            [this](const std::vector<std::string> &args) {
-                std::string result("OK");
-                if (args.empty()) {
-                    result = "max_concurrent_bulk_load_downloading_count=" +
-                             std::to_string(_max_concurrent_bulk_load_downloading_count);
-                    return result;
-                }
-
-                if (args[0] == "DEFAULT") {
-                    _max_concurrent_bulk_load_downloading_count =
-                        _options.max_concurrent_bulk_load_downloading_count;
-                    return result;
-                }
-
-                int32_t count = 0;
-                if (!dsn::buf2int32(args[0], count) || count <= 0) {
-                    result = std::string("ERR: invalid arguments");
-                } else {
-                    _max_concurrent_bulk_load_downloading_count = count;
-                }
-                return result;
-            }));
+        _cmds.emplace_back(::dsn::command_manager::instance().register_int_command(
+            FLAGS_max_concurrent_bulk_load_downloading_count,
+            FLAGS_max_concurrent_bulk_load_downloading_count,
+            "replica.max-concurrent-bulk-load-downloading-count",
+            max_concurrent_bulk_load_downloading_count_desc));
     });
 }
 

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -472,7 +472,6 @@ private:
     bool _verbose_commit_log;
     bool _release_tcmalloc_memory;
     int32_t _mem_release_max_reserved_mem_percentage;
-    int32_t _max_concurrent_bulk_load_downloading_count;
 
     // we limit LT_APP max concurrent count, because nfs service implementation is
     // too simple, it do not support priority.

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -52,9 +52,7 @@ command_manager::register_command(const std::vector<std::string> &commands,
     utils::auto_write_lock l(_lock);
     for (const auto &cmd : commands) {
         CHECK(!cmd.empty(), "should not register empty command");
-        CHECK(_handlers.insert(std::make_pair(cmd, c)).second,
-              "command '{}' already registered",
-              cmd);
+        CHECK(_handlers.emplace(cmd, c).second, "command '{}' already registered", cmd);
     }
 
     return std::make_unique<command_deregister>(reinterpret_cast<uintptr_t>(c));

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -32,6 +32,7 @@
 #include <limits>
 #include <sstream> // IWYU pragma: keep
 #include <thread>
+#include <utility>
 
 namespace dsn {
 

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -32,8 +32,6 @@
 #include <limits>
 #include <sstream> // IWYU pragma: keep
 #include <thread>
-#include <type_traits>
-#include <utility>
 
 namespace dsn {
 

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -26,14 +26,14 @@
 
 #include "utils/command_manager.h"
 
+// IWYU pragma: no_include <ext/alloc_traits.h>
 #include <stdlib.h>
 #include <chrono>
 #include <limits>
 #include <sstream> // IWYU pragma: keep
 #include <thread>
+#include <type_traits>
 #include <utility>
-
-#include "utils/fmt_logging.h"
 
 namespace dsn {
 
@@ -43,29 +43,32 @@ command_manager::register_command(const std::vector<std::string> &commands,
                                   const std::string &help_long,
                                   command_handler handler)
 {
-    utils::auto_write_lock l(_lock);
-    bool is_valid_cmd = false;
-    for (const std::string &cmd : commands) {
-        if (!cmd.empty()) {
-            is_valid_cmd = true;
-            CHECK(_handlers.find(cmd) == _handlers.end(), "command '{}' already regisered", cmd);
-        }
-    }
-    CHECK(is_valid_cmd, "should not register empty command");
-
-    command_instance *c = new command_instance();
+    auto *c = new command_instance();
     c->commands = commands;
     c->help_short = help_one_line;
     c->help_long = help_long;
-    c->handler = handler;
+    c->handler = std::move(handler);
 
-    for (const std::string &cmd : commands) {
-        if (!cmd.empty()) {
-            _handlers[cmd] = c;
-        }
+    utils::auto_write_lock l(_lock);
+    for (const auto &cmd : commands) {
+        CHECK(!cmd.empty(), "should not register empty command");
+        CHECK(_handlers.insert(std::make_pair(cmd, c)).second,
+              "command '{}' already registered",
+              cmd);
     }
 
     return std::make_unique<command_deregister>(reinterpret_cast<uintptr_t>(c));
+}
+
+std::unique_ptr<command_deregister> command_manager::register_bool_command(
+    bool &value, const std::string &command, const std::string &help)
+{
+    return register_command({command},
+                            fmt::format("{} <true|false>", command),
+                            help,
+                            [&value, command](const std::vector<std::string> &args) {
+                                return set_bool(value, command, args);
+                            });
 }
 
 void command_manager::deregister_command(uintptr_t handle)
@@ -97,6 +100,33 @@ bool command_manager::run_command(const std::string &cmd,
         output = h->handler(args);
         return true;
     }
+}
+
+std::string command_manager::set_bool(bool &value,
+                                      const std::string &name,
+                                      const std::vector<std::string> &args)
+{
+    // Query.
+    if (args.empty()) {
+        return value ? "true" : "false";
+    }
+
+    // Invalid arguments size.
+    if (args.size() > 1) {
+        return fmt::format("ERR: invalid arguments, only one boolean argument is acceptable");
+    }
+
+    // Invalid argument.
+    bool new_value;
+    if (!dsn::buf2bool(args[0], new_value, /* ignore_case */ true)) {
+        return fmt::format("ERR: invalid arguments, '{}' is not a boolean", args[0]);
+    }
+
+    // Set to a new value.
+    value = new_value;
+    LOG_INFO("set {} to {} by remote command", name, new_value);
+
+    return "OK";
 }
 
 command_manager::command_manager()


### PR DESCRIPTION
- Simplify the registration of boolean remote command, now it can be registered
  by `ommand_manager::register_bool_command(bool &value, const std::string &command, const std::string &help)`
- Change the type of `node_live_percentage_threshold_for_update` from
  uint64 to int32, there is no impact bacause it's a percentage which
  is range in [0, 100].
- Change the type of `replica_assign_delay_ms_for_dropouts` from uint64
  to int64, there is less impact bacause int64 is big enough to set a
  milliseconds time interval (maximum to 106751991167 days).
- Change the type of `max_copy_rate_megabytes_per_disk`,
  `max_send_rate_megabytes_per_disk` to int64, there is no impact
  bacause its range is enlarged.
- Use FLAGS_max_concurrent_bulk_load_downloading_count directly and remove
  it from replication_options structure and replica_stub class.