### PR TITLE
refactor(configs): Update some default configs and remove some useless configs

### DIFF
--- a/docker/pegasus-docker-compose/config.min.ini
+++ b/docker/pegasus-docker-compose/config.min.ini
@@ -137,7 +137,6 @@
   partition_count = 4
 
 [pegasus.server]
-  perf_counter_enable_logging = false
   # Where the metrics are collected. If no value is given, no sink is used.
   # Options:
   #   - falcon

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -72,17 +72,6 @@ DSN_DEFINE_int32(replication,
                  fd_grace_seconds,
                  10,
                  "The grace in seconds assigned to remote FD slaves");
-DSN_DEFINE_group_validator(fd_lease_and_grace_seconds, [](std::string &message) -> bool {
-    if (FLAGS_fd_grace_seconds <= FLAGS_fd_lease_seconds) {
-        message = fmt::format(
-            "replication.fd_grace_seconds({}) should be > replication.fd_lease_seconds({})",
-            FLAGS_fd_grace_seconds,
-            FLAGS_fd_lease_seconds);
-        return false;
-    }
-    return true;
-});
-
 DSN_DEFINE_int32(replication,
                  cold_backup_checkpoint_reserve_minutes,
                  10,

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -49,26 +49,39 @@ DSN_DEFINE_bool(replication, duplication_enabled, true, "is duplication enabled"
 DSN_DEFINE_int32(replication,
                  mutation_2pc_min_replica_count,
                  2,
-                 "minimum number of alive replicas under which write is allowed. it's valid if "
-                 "larger than 0, otherwise, the final value is based on app_max_replica_count");
-DSN_DEFINE_int32(
-    replication,
-    gc_interval_ms,
-    30 * 1000,
-    "every what period (ms) we do replica stat. The name contains 'gc' is for legacy reason.");
+                 "The minimum number of ALIVE replicas under which write is allowed. It's valid if "
+                 "larger than 0, otherwise, the final value is based on 'app_max_replica_count'");
+DSN_DEFINE_int32(replication,
+                 gc_interval_ms,
+                 30 * 1000,
+                 "The interval milliseconds to do replica statistics. The name contains 'gc' is "
+                 "for legacy reason");
 DSN_DEFINE_int32(replication,
                  fd_check_interval_seconds,
                  2,
-                 "every this period(seconds) the FD will check healthness of remote peers");
+                 "The interval seconds of failure detector to check healthness of remote peers");
 DSN_DEFINE_int32(replication,
                  fd_beacon_interval_seconds,
                  3,
-                 "every this period(seconds) the FD sends beacon message to remote peers");
-DSN_DEFINE_int32(replication, fd_lease_seconds, 9, "lease (seconds) get from remote FD master");
+                 "The interval seconds of failure detector to send beacon message to remote peers");
+DSN_DEFINE_int32(replication,
+                 fd_lease_seconds,
+                 9,
+                 "The lease in seconds get from remote FD master");
 DSN_DEFINE_int32(replication,
                  fd_grace_seconds,
                  10,
-                 "grace (seconds) assigned to remote FD slaves (grace > lease)");
+                 "The grace in seconds assigned to remote FD slaves");
+DSN_DEFINE_group_validator(fd_lease_and_grace_seconds, [](std::string &message) -> bool {
+    if (FLAGS_fd_grace_seconds <= FLAGS_fd_lease_seconds) {
+        message = fmt::format(
+            "replication.fd_grace_seconds({}) should be > replication.fd_lease_seconds({})",
+            FLAGS_fd_grace_seconds,
+            FLAGS_fd_lease_seconds);
+        return false;
+    }
+    return true;
+});
 
 DSN_DEFINE_int32(replication,
                  cold_backup_checkpoint_reserve_minutes,
@@ -82,20 +95,25 @@ DSN_DEFINE_int32(replication,
 DSN_DEFINE_bool(replication,
                 empty_write_disabled,
                 false,
-                "whether to disable empty write, default is false");
+                "Whether to disable the function of primary replicas periodically "
+                "generating empty write operations to check the group status");
 DSN_TAG_VARIABLE(empty_write_disabled, FT_MUTABLE);
 
 DSN_DEFINE_string(replication,
                   slog_dir,
                   "",
-                  "The shared log directory. Deprecated since Pegasus "
-                  "2.6.0, but leave it and do not modify the value if "
-                  "upgrading from older versions.");
-DSN_DEFINE_string(replication, data_dirs, "", "replica directory list");
+                  "The shared log directory. Deprecated since Pegasus 2.6.0, but "
+                  "leave it and do not modify the value if upgrading from older versions.");
+DSN_DEFINE_string(replication,
+                  data_dirs,
+                  "",
+                  "A list of directories for replica data storage, it is recommended to "
+                  "configure one item per disk. 'tag' is the tag name of the directory");
 DSN_DEFINE_string(replication,
                   data_dirs_black_list_file,
                   "/home/work/.pegasus_data_dirs_black_list",
-                  "replica directory black list file");
+                  "Blacklist file, where each line is a path that needs to be ignored, mainly used "
+                  "to filter out bad drives");
 DSN_DEFINE_string(replication,
                   cold_backup_root,
                   "",

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -66,11 +66,11 @@ DSN_DEFINE_int32(replication,
                  "The interval seconds of failure detector to send beacon message to remote peers");
 DSN_DEFINE_int32(replication,
                  fd_lease_seconds,
-                 9,
+                 20,
                  "The lease in seconds get from remote FD master");
 DSN_DEFINE_int32(replication,
                  fd_grace_seconds,
-                 10,
+                 22,
                  "The grace in seconds assigned to remote FD slaves");
 DSN_DEFINE_int32(replication,
                  cold_backup_checkpoint_reserve_minutes,

--- a/src/meta/meta_options.cpp
+++ b/src/meta/meta_options.cpp
@@ -38,15 +38,16 @@
 DSN_DEFINE_string(meta_server,
                   meta_state_service_parameters,
                   "",
-                  "meta_state_service provider parameters");
+                  "Initialization parameters for metadata storage services");
 DSN_DEFINE_string(meta_server,
                   meta_function_level_on_start,
                   "steady",
-                  "meta function level on start");
+                  "The default function_level state when MetaServer starts. "
+                  "The 'steady' represents a stable state without load balancing");
 DSN_DEFINE_string(meta_server,
                   distributed_lock_service_parameters,
                   "",
-                  "distributed_lock_service provider parameters");
+                  "Initialization parameters for distributed lock services");
 DSN_DEFINE_string(meta_server,
                   replica_white_list,
                   "",

--- a/src/meta/meta_server_failure_detector.cpp
+++ b/src/meta/meta_server_failure_detector.cpp
@@ -49,16 +49,21 @@
 DSN_DEFINE_int32(meta_server,
                  max_succssive_unstable_restart,
                  5,
-                 "meta server will treat a rs unstable so as to reject it is beacons if "
-                 "its successively restarting count exceeds this value.");
+                 "The maximum number of times a ReplicaServer can be disconnected. If the number "
+                 "of a ReplicaServer disconnects exceeds this threshold, MetaServer will add it to "
+                 "the blacklist to avoid instability caused by frequent reconnection");
 DSN_DEFINE_uint64(meta_server,
                   stable_rs_min_running_seconds,
                   600,
-                  "The minimal running seconds for a stable replica server");
+                  "The time threshold for determining whether a ReplicaServer is running stably");
 DSN_DEFINE_string(meta_server,
                   distributed_lock_service_type,
+#ifdef MOCK_TEST
                   "distributed_lock_service_simple",
-                  "dist lock provider");
+#else
+                  "distributed_lock_service_zookeeper",
+#endif
+                  "The implementation class of distributed lock service");
 
 namespace dsn {
 namespace replication {

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -73,7 +73,8 @@ DSN_DECLARE_string(hosts_list);
 DSN_DEFINE_bool(meta_server,
                 recover_from_replica_server,
                 false,
-                "whether to recover from replica server when no apps in remote storage");
+                "Whether to recover tables from replica servers when there is no "
+                "data of the tables in remote storage");
 DSN_DEFINE_bool(meta_server, cold_backup_disabled, true, "whether to disable cold backup");
 DSN_DEFINE_bool(meta_server,
                 enable_white_list,
@@ -82,7 +83,8 @@ DSN_DEFINE_bool(meta_server,
 DSN_DEFINE_uint64(meta_server,
                   min_live_node_count_for_unfreeze,
                   3,
-                  "minimum live node count without which the state is freezed");
+                  "If the number of ALIVE nodes is less than this threshold, MetaServer will "
+                  "also enter the 'freezed' protection state");
 DSN_TAG_VARIABLE(min_live_node_count_for_unfreeze, FT_MUTABLE);
 DSN_DEFINE_validator(min_live_node_count_for_unfreeze,
                      [](uint64_t min_live_node_count) -> bool { return min_live_node_count > 0; });
@@ -90,26 +92,33 @@ DSN_DEFINE_validator(min_live_node_count_for_unfreeze,
 DSN_DEFINE_int32(replication,
                  lb_interval_ms,
                  10000,
-                 "every this period(ms) the meta server will do load balance");
+                 "The interval milliseconds of meta server to execute load balance");
 DSN_DEFINE_int32(meta_server,
                  node_live_percentage_threshold_for_update,
                  65,
-                 "If live_node_count * 100 < total_node_count * "
-                 "node_live_percentage_threshold_for_update, then freeze the cluster.");
+                 "If the proportion of ALIVE nodes is less than this threshold, MetaServer will "
+                 "enter the 'freezed' protection state");
 DSN_DEFINE_validator(node_live_percentage_threshold_for_update,
                      [](int32_t value) -> bool { return value >= 0 && value <= 100; });
 DSN_DEFINE_string(meta_server,
                   meta_state_service_type,
+#ifdef MOCK_TEST
                   "meta_state_service_simple",
-                  "meta_state_service provider type");
+#else
+                  "meta_state_service_zookeeper",
+#endif
+                  "The implementation class of metadata storage service");
 DSN_DEFINE_string(meta_server,
                   cluster_root,
                   "/",
-                  "The root of the cluster meta state service to be stored on remote storage");
+                  "The root of the cluster meta state service to be stored on remote storage. "
+                  "Different meta servers in the same cluster need to be configured with the "
+                  "same value, while different clusters using different values if they share "
+                  "the same remote storage");
 DSN_DEFINE_string(meta_server,
                   server_load_balancer_type,
                   "greedy_load_balancer",
-                  "server load balancer provider");
+                  "The implementation class of load balancer");
 DSN_DEFINE_string(meta_server,
                   partition_guardian_type,
                   "partition_guardian",

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -396,6 +396,7 @@ error_code meta_service::start()
         _failure_detector->set_allow_list(_meta_opts.replica_white_list);
     _failure_detector->register_ctrl_commands();
 
+    CHECK_GT_MSG(FLAGS_fd_grace_seconds, FLAGS_fd_lease_seconds, "");
     err = _failure_detector->start(FLAGS_fd_check_interval_seconds,
                                    FLAGS_fd_beacon_interval_seconds,
                                    FLAGS_fd_lease_seconds,

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -38,11 +38,18 @@
 #include "utils/strings.h"
 #include "utils/time_utils.h"
 
-DSN_DEFINE_int32(meta_server, max_replicas_in_group, 4, "max replicas(alive & dead) in a group");
+DSN_DEFINE_int32(
+    meta_server,
+    max_replicas_in_group,
+    4,
+    "The maximum number of replicas retained in a replica group (alive + dead replicas)");
 DSN_DEFINE_int64(meta_server,
                  replica_assign_delay_ms_for_dropouts,
                  300000,
-                 "The delay milliseconds to dropout replicas assign");
+                 "The maximum time threshold for waiting for a secondary replica to re-join the "
+                 "cluster after it has been removed. If the secondary replica has not yet "
+                 "recovered beyond this time threshold, an attempt will be made to add new "
+                 "secondary replicas on other nodes");
 
 namespace dsn {
 namespace replication {

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -45,7 +45,7 @@ DSN_DEFINE_int32(
     "The maximum number of replicas retained in a replica group (alive + dead replicas)");
 DSN_DEFINE_int64(meta_server,
                  replica_assign_delay_ms_for_dropouts,
-                 300000,
+                 600000,
                  "The maximum time threshold for waiting for a secondary replica to re-join the "
                  "cluster after it has been removed. If the secondary replica has not yet "
                  "recovered beyond this time threshold, an attempt will be made to add new "

--- a/src/redis_protocol/proxy/config.ini
+++ b/src/redis_protocol/proxy/config.ini
@@ -127,16 +127,6 @@ is_profile = true
 [task.RPC_RRDB_RRDB_CLEAR_SCANNER_ACK]
 is_profile = true
 
-[pegasus.server]
-perf_counter_cluster_name = onebox
-perf_counter_update_interval_seconds = 10
-perf_counter_enable_logging = true
-perf_counter_enable_falcon = false
-
-falcon_host = 127.0.0.1
-falcon_port = 1988
-falcon_path = /v1/push
-
 [pegasus.clusters]
 onebox = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
 

--- a/src/replica/disk_cleaner.cpp
+++ b/src/replica/disk_cleaner.cpp
@@ -41,7 +41,7 @@
 DSN_DEFINE_uint64(replication,
                   gc_disk_error_replica_interval_seconds,
                   7 * 24 * 3600 /*7day*/,
-                  "The interval milliseconds to GC error replicas, which are in directories "
+                  "The interval in seconds to GC error replicas, which are in directories "
                   "suffixed with '.err'");
 DSN_TAG_VARIABLE(gc_disk_error_replica_interval_seconds, FT_MUTABLE);
 

--- a/src/replica/disk_cleaner.cpp
+++ b/src/replica/disk_cleaner.cpp
@@ -38,11 +38,11 @@
 #include "utils/string_conv.h"
 #include "absl/strings/string_view.h"
 
-DSN_DEFINE_uint64(
-    replication,
-    gc_disk_error_replica_interval_seconds,
-    7 * 24 * 3600 /*7day*/,
-    "Duration of error replica being removed, which is in a directory with '.err' suffixed");
+DSN_DEFINE_uint64(replication,
+                  gc_disk_error_replica_interval_seconds,
+                  7 * 24 * 3600 /*7day*/,
+                  "The interval milliseconds to GC error replicas, which are in directories "
+                  "suffixed with '.err'");
 DSN_TAG_VARIABLE(gc_disk_error_replica_interval_seconds, FT_MUTABLE);
 
 DSN_DEFINE_uint64(

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -63,15 +63,15 @@
 DSN_DEFINE_bool(replication,
                 batch_write_disabled,
                 false,
-                "whether to disable auto-batch of replicated write requests");
+                "Whether to disable auto-batch of replicated write requests");
 DSN_DEFINE_int32(replication,
                  staleness_for_commit,
                  10,
-                 "how many concurrent two phase commit rounds are allowed");
+                 "The maximum number of two-phase commit rounds are allowed");
 DSN_DEFINE_int32(replication,
                  max_mutation_count_in_prepare_list,
                  110,
-                 "maximum number of mutations in prepare list");
+                 "The maximum number of mutations allowed in prepare list");
 DSN_DEFINE_group_validator(max_mutation_count_in_prepare_list, [](std::string &message) -> bool {
     if (FLAGS_max_mutation_count_in_prepare_list < FLAGS_staleness_for_commit) {
         message = fmt::format("replication.max_mutation_count_in_prepare_list({}) should be >= "

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -66,7 +66,7 @@ DSN_DEFINE_bool(replication,
                 "Whether to disable auto-batch of replicated write requests");
 DSN_DEFINE_int32(replication,
                  staleness_for_commit,
-                 10,
+                 20,
                  "The maximum number of two-phase commit rounds are allowed");
 DSN_DEFINE_int32(replication,
                  max_mutation_count_in_prepare_list,

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -85,12 +85,12 @@ DSN_TAG_VARIABLE(reject_write_when_disk_insufficient, FT_MUTABLE);
 
 DSN_DEFINE_int32(replication,
                  prepare_timeout_ms_for_secondaries,
-                 1000,
+                 3000,
                  "The timeout in millisecond for the primary replicas to send prepare requests to "
                  "the secondaries in two phase commit");
 DSN_DEFINE_int32(replication,
                  prepare_timeout_ms_for_potential_secondaries,
-                 3000,
+                 5000,
                  "The timeout in millisecond for the primary replicas to send prepare requests to "
                  "the learners in two phase commit");
 DSN_DEFINE_int32(replication,

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -86,11 +86,13 @@ DSN_TAG_VARIABLE(reject_write_when_disk_insufficient, FT_MUTABLE);
 DSN_DEFINE_int32(replication,
                  prepare_timeout_ms_for_secondaries,
                  1000,
-                 "timeout (ms) for prepare message to secondaries in two phase commit");
+                 "The timeout in millisecond for the primary replicas to send prepare requests to "
+                 "the secondaries in two phase commit");
 DSN_DEFINE_int32(replication,
                  prepare_timeout_ms_for_potential_secondaries,
                  3000,
-                 "timeout (ms) for prepare message to potential secondaries in two phase commit");
+                 "The timeout in millisecond for the primary replicas to send prepare requests to "
+                 "the learners in two phase commit");
 DSN_DEFINE_int32(replication,
                  prepare_decree_gap_for_debug_logging,
                  10000,

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -62,11 +62,16 @@
 
 /// The replica membership state periodical checking part of replica.
 
-DSN_DEFINE_bool(replication, group_check_disabled, false, "whether group check is disabled");
-DSN_DEFINE_int32(replication,
-                 group_check_interval_ms,
-                 10000,
-                 "every what period (ms) we check the replica healthness");
+DSN_DEFINE_bool(replication,
+                group_check_disabled,
+                false,
+                "Whether to disable the primary replicas to send group-check requests to "
+                "other replicas periodically");
+DSN_DEFINE_int32(
+    replication,
+    group_check_interval_ms,
+    10000,
+    "The interval in milliseconds for the primary replicas to send group-check requests");
 
 DSN_DECLARE_bool(empty_write_disabled);
 

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -70,7 +70,7 @@ DSN_DEFINE_bool(replication,
 DSN_DEFINE_int32(
     replication,
     group_check_interval_ms,
-    10000,
+    100000,
     "The interval in milliseconds for the primary replicas to send group-check requests");
 
 DSN_DECLARE_bool(empty_write_disabled);

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -76,7 +76,7 @@ DSN_DEFINE_int32(replication,
                  "both satisfied, the useless logs can be reserved");
 DSN_DEFINE_int32(replication,
                  log_private_reserve_max_time_seconds,
-                 3600,
+                 36000,
                  "The maximum time in seconds of useless private log to be reserved. NOTE: only "
                  "when 'log_private_reserve_max_size_mb' and "
                  "'log_private_reserve_max_time_seconds' are both satisfied, the useless logs can "

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -67,21 +67,20 @@
 DSN_DEFINE_int32(replication,
                  checkpoint_max_interval_hours,
                  2,
-                 "maximum time interval (hours) where a new checkpoint must be created");
+                 "The maximum time interval in hours of replica checkpoints must be generated");
 DSN_DEFINE_int32(replication,
                  log_private_reserve_max_size_mb,
-                 0,
-                 "max size of useless private log to be reserved. NOTE: only when "
-                 "FLAGS_log_private_reserve_max_size_mb and "
-                 "FLAGS_log_private_reserve_max_time_seconds are both satisfied, the useless logs "
-                 "can be reserved.");
+                 1000,
+                 "The maximum size of useless private log to be reserved. NOTE: only when "
+                 "'log_private_reserve_max_size_mb' and 'log_private_reserve_max_time_seconds' are "
+                 "both satisfied, the useless logs can be reserved");
 DSN_DEFINE_int32(replication,
                  log_private_reserve_max_time_seconds,
-                 0,
-                 "max time in seconds of useless private log to be reserved. NOTE: only when "
-                 "FLAGS_log_private_reserve_max_size_mb and "
-                 "FLAGS_log_private_reserve_max_time_seconds are both satisfied, the useless logs "
-                 "can be reserved.");
+                 3600,
+                 "The maximum time in seconds of useless private log to be reserved. NOTE: only "
+                 "when 'log_private_reserve_max_size_mb' and "
+                 "'log_private_reserve_max_time_seconds' are both satisfied, the useless logs can "
+                 "be reserved");
 
 namespace dsn {
 namespace replication {

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -59,7 +59,7 @@ DSN_DEFINE_bool(replication,
 
 DSN_DEFINE_int32(replication,
                  checkpoint_interval_seconds,
-                 300,
+                 100,
                  "The interval in seconds to generate replica checkpoints. Note that "
                  "the checkpoint may not be generated when attempt");
 

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -52,16 +52,21 @@
 #include "utils/fmt_logging.h"
 #include "utils/uniq_timestamp_us.h"
 
-DSN_DEFINE_bool(replication, checkpoint_disabled, false, "whether checkpoint is disabled");
+DSN_DEFINE_bool(replication,
+                checkpoint_disabled,
+                false,
+                "Whether to disable to generate replica checkpoints periodically");
+
 DSN_DEFINE_int32(replication,
                  checkpoint_interval_seconds,
                  100,
-                 "every what period (seconds) we do checkpoints for replicated apps");
+                 "The interval in seconds to generate replica checkpoints. Note that "
+                 "the checkpoint may not be generated when attempt");
 
 DSN_DEFINE_int32(replication,
                  log_private_file_size_mb,
                  32,
-                 "private log maximum segment file size (MB)");
+                 "The maximum size (MB) of private log segment file");
 
 namespace dsn {
 namespace replication {

--- a/src/replica/replica_init.cpp
+++ b/src/replica/replica_init.cpp
@@ -59,7 +59,7 @@ DSN_DEFINE_bool(replication,
 
 DSN_DEFINE_int32(replication,
                  checkpoint_interval_seconds,
-                 100,
+                 300,
                  "The interval in seconds to generate replica checkpoints. Note that "
                  "the checkpoint may not be generated when attempt");
 

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -241,7 +241,7 @@ DSN_DECLARE_string(server_key);
 DSN_DEFINE_bool(replication,
                 deny_client_on_start,
                 false,
-                "whether to deny client read and write requests when starting the server");
+                "Whether to deny client read and write requests when starting the server");
 DSN_DEFINE_bool(replication,
                 verbose_client_log_on_start,
                 false,
@@ -251,10 +251,11 @@ DSN_DEFINE_bool(replication,
                 mem_release_enabled,
                 true,
                 "whether to enable periodic memory release");
-DSN_DEFINE_bool(replication,
-                gc_disabled,
-                false,
-                "whether to disable replica stat. The name contains 'gc' is for legacy reason.");
+DSN_DEFINE_bool(
+    replication,
+    gc_disabled,
+    false,
+    "Whether to disable replica statistics. The name contains 'gc' is for legacy reason");
 DSN_DEFINE_bool(replication, disk_stat_disabled, false, "whether to disable disk stat");
 DSN_DEFINE_bool(replication,
                 delay_for_fd_timeout_on_start,
@@ -264,8 +265,9 @@ DSN_DEFINE_bool(replication,
 DSN_DEFINE_bool(replication,
                 config_sync_disabled,
                 false,
-                "whether to disable replica configuration periodical sync with the meta server");
-DSN_DEFINE_bool(replication, fd_disabled, false, "whether to disable failure detection");
+                "The interval milliseconds of replica server to send replica config-sync "
+                "requests to meta server");
+DSN_DEFINE_bool(replication, fd_disabled, false, "Whether to disable failure detection");
 DSN_DEFINE_bool(replication,
                 verbose_commit_log_on_start,
                 false,
@@ -291,8 +293,12 @@ DSN_DEFINE_int32(replication,
 DSN_DEFINE_int32(replication,
                  gc_memory_replica_interval_ms,
                  10 * 60 * 1000,
-                 "after closing a healthy replica (due to LB), the replica will remain in memory "
-                 "for this long (ms) for quick recover");
+                 "The milliseconds of a replica remain in memory for quick recover aim after it's "
+                 "closed in healthy state (due to LB)");
+DSN_DEFINE_int32(replication,
+                 log_shared_file_size_mb,
+                 32,
+                 "shared log maximum segment file size (MB)");
 DSN_DEFINE_int32(
     replication,
     mem_release_check_interval_ms,

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -265,8 +265,8 @@ DSN_DEFINE_bool(replication,
 DSN_DEFINE_bool(replication,
                 config_sync_disabled,
                 false,
-                "The interval milliseconds of replica server to send replica config-sync "
-                "requests to meta server");
+                "Whether to disable replica server to send replica config-sync "
+                "requests to meta server periodically");
 DSN_DEFINE_bool(replication, fd_disabled, false, "Whether to disable failure detection");
 DSN_DEFINE_bool(replication,
                 verbose_commit_log_on_start,

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -295,10 +295,6 @@ DSN_DEFINE_int32(replication,
                  10 * 60 * 1000,
                  "The milliseconds of a replica remain in memory for quick recover aim after it's "
                  "closed in healthy state (due to LB)");
-DSN_DEFINE_int32(replication,
-                 log_shared_file_size_mb,
-                 32,
-                 "shared log maximum segment file size (MB)");
 DSN_DEFINE_int32(
     replication,
     mem_release_check_interval_ms,

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -689,6 +689,7 @@ void replica_stub::initialize_start()
             [this]() { this->on_meta_server_disconnected(); },
             [this]() { this->on_meta_server_connected(); });
 
+        CHECK_GT_MSG(FLAGS_fd_grace_seconds, FLAGS_fd_lease_seconds, "");
         CHECK_EQ_MSG(_failure_detector->start(FLAGS_fd_check_interval_seconds,
                                               FLAGS_fd_beacon_interval_seconds,
                                               FLAGS_fd_lease_seconds,

--- a/src/replica/storage/simple_kv/test/case-202-0.ini
+++ b/src/replica/storage/simple_kv/test/case-202-0.ini
@@ -195,7 +195,6 @@ log_buffer_size_mb = 1
 log_pending_max_ms = 100
 log_file_size_mb = 32
 log_batch_write = false
-log_private_batch_buffer_kb = 4
 
 log_buffer_size_mb_private = 1
 log_pending_max_ms_private = 100

--- a/src/replica/storage/simple_kv/test/case-202-1.ini
+++ b/src/replica/storage/simple_kv/test/case-202-1.ini
@@ -195,7 +195,6 @@ log_buffer_size_mb = 1
 log_pending_max_ms = 100
 log_file_size_mb = 32
 log_batch_write = false
-log_private_batch_buffer_kb = 4
 
 log_buffer_size_mb_private = 1
 log_pending_max_ms_private = 100

--- a/src/replica/storage/simple_kv/test/case-203-0.ini
+++ b/src/replica/storage/simple_kv/test/case-203-0.ini
@@ -195,7 +195,6 @@ log_buffer_size_mb = 1
 log_pending_max_ms = 100
 log_file_size_mb = 32
 log_batch_write = false
-log_private_batch_buffer_kb = 0
 
 log_buffer_size_mb_private = 1
 log_pending_max_ms_private = 100

--- a/src/replica/storage/simple_kv/test/case-204.ini
+++ b/src/replica/storage/simple_kv/test/case-204.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-204.ini
+++ b/src/replica/storage/simple_kv/test/case-204.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-205.ini
+++ b/src/replica/storage/simple_kv/test/case-205.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-205.ini
+++ b/src/replica/storage/simple_kv/test/case-205.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-206.ini
+++ b/src/replica/storage/simple_kv/test/case-206.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-206.ini
+++ b/src/replica/storage/simple_kv/test/case-206.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-207.ini
+++ b/src/replica/storage/simple_kv/test/case-207.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-207.ini
+++ b/src/replica/storage/simple_kv/test/case-207.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-208.ini
+++ b/src/replica/storage/simple_kv/test/case-208.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-208.ini
+++ b/src/replica/storage/simple_kv/test/case-208.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-209.ini
+++ b/src/replica/storage/simple_kv/test/case-209.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-209.ini
+++ b/src/replica/storage/simple_kv/test/case-209.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-210.ini
+++ b/src/replica/storage/simple_kv/test/case-210.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-210.ini
+++ b/src/replica/storage/simple_kv/test/case-210.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-211.ini
+++ b/src/replica/storage/simple_kv/test/case-211.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-211.ini
+++ b/src/replica/storage/simple_kv/test/case-211.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-212.act
+++ b/src/replica/storage/simple_kv/test/case-212.act
@@ -85,7 +85,6 @@ state:{{r1,pri,2,20,5},{r2,sec,2,20,5}}
 #                    (1)
 #   learn        :    |-->
 #
-#   private_log is in memory because log_private_batch_buffer_kb=4
 client:replica_config:receiver=r1,type=add_secondary,node=r3
 config:{3,r1,[r2,r3]}
 state:{{r1,pri,3,20},{r2,sec,3,20},{r3,sec,3,20}}

--- a/src/replica/storage/simple_kv/test/case-212.ini
+++ b/src/replica/storage/simple_kv/test/case-212.ini
@@ -192,7 +192,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-212.ini
+++ b/src/replica/storage/simple_kv/test/case-212.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-213.act
+++ b/src/replica/storage/simple_kv/test/case-213.act
@@ -85,7 +85,6 @@ state:{{r1,pri,2,20,5},{r2,sec,2,20,5}}
 #                    (1)
 #   learn        :    |-->
 #
-#   private_log is in file because log_private_batch_buffer_kb=0
 client:replica_config:receiver=r1,type=add_secondary,node=r3
 config:{3,r1,[r2,r3]}
 state:{{r1,pri,3,20},{r2,sec,3,20},{r3,sec,3,20}}

--- a/src/replica/storage/simple_kv/test/case-213.ini
+++ b/src/replica/storage/simple_kv/test/case-213.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-213.ini
+++ b/src/replica/storage/simple_kv/test/case-213.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-214.ini
+++ b/src/replica/storage/simple_kv/test/case-214.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-214.ini
+++ b/src/replica/storage/simple_kv/test/case-214.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-215.ini
+++ b/src/replica/storage/simple_kv/test/case-215.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-215.ini
+++ b/src/replica/storage/simple_kv/test/case-215.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-216.ini
+++ b/src/replica/storage/simple_kv/test/case-216.ini
@@ -194,7 +194,6 @@ fd_grace_seconds = 15
 log_private_disabled = false
 log_file_size_mb = 32
 log_shared_batch_buffer_kb = 0
-log_private_batch_buffer_kb = 4
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-216.ini
+++ b/src/replica/storage/simple_kv/test/case-216.ini
@@ -193,7 +193,6 @@ fd_grace_seconds = 15
 
 log_private_disabled = false
 log_file_size_mb = 32
-log_shared_batch_buffer_kb = 0
 
 config_sync_disabled = false
 config_sync_interval_ms = 30000

--- a/src/replica/storage/simple_kv/test/case-603.act
+++ b/src/replica/storage/simple_kv/test/case-603.act
@@ -27,7 +27,7 @@
 #   new primary will not accept old primary as a learner until it's commit decree reach A
 #
 # NOTICE: 
-#   run this case, should disable group check through set replication.group_check_disable = true
+#   run this case, should disable group check through set replication.group_check_disabled = true
 
 set:load_balance_for_test=1,not_exit_on_log_failure=1
 

--- a/src/runtime/global_config.h
+++ b/src/runtime/global_config.h
@@ -177,7 +177,9 @@ struct service_spec
 CONFIG_BEGIN(service_spec)
 CONFIG_FLD_STRING(tool, "", "use what tool to run this process, e.g., native or simulator")
 CONFIG_FLD_STRING_LIST(toollets, "use what toollets, e.g., tracer, profiler, fault_injector")
-CONFIG_FLD_STRING(data_dir, "./data", "where to put the all the data/log/coredump, etc..")
+CONFIG_FLD_STRING(data_dir,
+                  "./data",
+                  "The default directory to place the all the data/log/coredump, etc..")
 CONFIG_FLD(
     bool,
     bool,

--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -83,8 +83,8 @@
 
 DSN_DEFINE_uint32(network,
                   io_service_worker_count,
-                  1,
-                  "thread number for io service (timer and boost network)");
+                  4,
+                  "The thread number of IO service (timer and boost network)");
 
 namespace dsn {
 class rpc_engine;

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -61,7 +61,7 @@ METRIC_DEFINE_gauge_int64(server,
 DSN_DEFINE_uint32(network,
                   conn_threshold_per_ip,
                   0,
-                  "max connection count to each server per ip, 0 means no limit");
+                  "The maximum connection count to each server per ip, 0 means no limit");
 DSN_DEFINE_string(network, unknown_message_header_format, "", "format for unknown message headers");
 DSN_DEFINE_string(network,
                   explicit_host_address,

--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -78,10 +78,11 @@
 #include "utils/sys_exit_hook.h"
 #include "utils/threadpool_spec.h"
 
-DSN_DEFINE_bool(core,
-                pause_on_start,
-                false,
-                "whether to pause at startup time for easier debugging");
+DSN_DEFINE_bool(
+    core,
+    pause_on_start,
+    false,
+    "Whether to pause during startup to wait for interactive input, often for debugging perpose");
 #ifdef DSN_ENABLE_GPERF
 DSN_DEFINE_double(core,
                   tcmalloc_release_rate,

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -272,13 +272,6 @@ stateful = true
   log_private_reserve_max_time_seconds = 3600
   plog_force_flush = false
 
-  log_shared_file_size_mb = 128
-  log_shared_gc_flush_replicas_limit = 64
-  log_shared_batch_buffer_kb = 0
-  log_shared_force_flush = false
-  log_shared_pending_size_throttling_threshold_kb = 0
-  log_shared_pending_size_throttling_delay_ms = 0
-
   config_sync_disabled = false
   config_sync_interval_ms = 30000
 

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -72,10 +72,10 @@
   logging_flush_on_exit = true
 
 [tools.simple_logger]
-  short_header = false
+  short_header = true
   fast_flush = false
-  max_number_of_log_files_on_disk = 500
-  stderr_start_level = LOG_LEVEL_ERROR
+  max_number_of_log_files_on_disk = 20
+  stderr_start_level = LOG_LEVEL_WARNING
 
 [nfs]
   nfs_copy_block_bytes = 4194304
@@ -206,7 +206,7 @@
   # partition guardian is used to keep partitions healthy. 
   # e.g. if max_replicas_in_group = 3, one primary and two secondaries must be kept for each partition 
   partition_guardian_type = partition_guardian
-  replica_assign_delay_ms_for_dropouts = 600000
+  replica_assign_delay_ms_for_dropouts = 300000
   max_replicas_in_group = 3
   max_reserved_dropped_replicas = 0
   balancer_in_turn = false
@@ -236,20 +236,20 @@ stateful = true
   delay_for_fd_timeout_on_start = false
   empty_write_disabled = false
 
-  prepare_timeout_ms_for_secondaries = 3000
-  prepare_timeout_ms_for_potential_secondaries = 5000
+  prepare_timeout_ms_for_secondaries = 1000
+  prepare_timeout_ms_for_potential_secondaries = 3000
   prepare_decree_gap_for_debug_logging = 10000
 
   batch_write_disabled = false
-  staleness_for_commit = 20
+  staleness_for_commit = 10
   max_mutation_count_in_prepare_list = 110
   mutation_2pc_min_replica_count = 2
 
   group_check_disabled = false
-  group_check_interval_ms = 100000
+  group_check_interval_ms = 10000
 
   checkpoint_disabled = false
-  checkpoint_interval_seconds = 300
+  checkpoint_interval_seconds = 100
   checkpoint_max_interval_hours = 2
 
   gc_disabled = false
@@ -264,12 +264,12 @@ stateful = true
   fd_disabled = false
   fd_check_interval_seconds = 2
   fd_beacon_interval_seconds = 3
-  fd_lease_seconds = 20
-  fd_grace_seconds = 22
+  fd_lease_seconds = 9
+  fd_grace_seconds = 10
 
   log_private_file_size_mb = 32
   log_private_reserve_max_size_mb = 1000
-  log_private_reserve_max_time_seconds = 36000
+  log_private_reserve_max_time_seconds = 3600
   plog_force_flush = false
 
   log_shared_file_size_mb = 128
@@ -387,8 +387,6 @@ stateful = true
 
   manual_compact_min_interval_seconds = 600
 
-  perf_counter_update_interval_seconds = 10
-  perf_counter_enable_logging = false
   # Where the metrics are collected. If no value is given, no sink is used.
   # Options:
   #   - falcon
@@ -396,10 +394,6 @@ stateful = true
   perf_counter_sink =
   perf_counter_read_capacity_unit_size = 4096
   perf_counter_write_capacity_unit_size = 4096
-
-  falcon_host = 127.0.0.1
-  falcon_port = 1988
-  falcon_path = /v1/push
 
   # The HTTP port exposed to Prometheus for pulling metrics from pegasus server.
   prometheus_port = 9091

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -72,7 +72,7 @@
   logging_flush_on_exit = true
 
 [tools.simple_logger]
-  short_header = true
+  short_header = false
   fast_flush = false
   max_number_of_log_files_on_disk = 20
   stderr_start_level = LOG_LEVEL_WARNING

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -206,7 +206,7 @@
   # partition guardian is used to keep partitions healthy. 
   # e.g. if max_replicas_in_group = 3, one primary and two secondaries must be kept for each partition 
   partition_guardian_type = partition_guardian
-  replica_assign_delay_ms_for_dropouts = 300000
+  replica_assign_delay_ms_for_dropouts = 600000
   max_replicas_in_group = 3
   max_reserved_dropped_replicas = 0
   balancer_in_turn = false
@@ -236,20 +236,20 @@ stateful = true
   delay_for_fd_timeout_on_start = false
   empty_write_disabled = false
 
-  prepare_timeout_ms_for_secondaries = 1000
-  prepare_timeout_ms_for_potential_secondaries = 3000
+  prepare_timeout_ms_for_secondaries = 3000
+  prepare_timeout_ms_for_potential_secondaries = 5000
   prepare_decree_gap_for_debug_logging = 10000
 
   batch_write_disabled = false
-  staleness_for_commit = 10
+  staleness_for_commit = 20
   max_mutation_count_in_prepare_list = 110
   mutation_2pc_min_replica_count = 2
 
   group_check_disabled = false
-  group_check_interval_ms = 10000
+  group_check_interval_ms = 100000
 
   checkpoint_disabled = false
-  checkpoint_interval_seconds = 100
+  checkpoint_interval_seconds = 300
   checkpoint_max_interval_hours = 2
 
   gc_disabled = false
@@ -264,12 +264,12 @@ stateful = true
   fd_disabled = false
   fd_check_interval_seconds = 2
   fd_beacon_interval_seconds = 3
-  fd_lease_seconds = 9
-  fd_grace_seconds = 10
+  fd_lease_seconds = 20
+  fd_grace_seconds = 22
 
   log_private_file_size_mb = 32
   log_private_reserve_max_size_mb = 1000
-  log_private_reserve_max_time_seconds = 3600
+  log_private_reserve_max_time_seconds = 36000
   plog_force_flush = false
 
   config_sync_disabled = false

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -146,7 +146,6 @@
   partition_count = 4
 
 [pegasus.server]
-  perf_counter_enable_logging = false
   # Where the metrics are collected. If no value is given, no sink is used.
   # Options:
   #   - falcon

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -89,7 +89,7 @@
 DSN_DEFINE_bool(pegasus.server,
                 rocksdb_verbose_log,
                 false,
-                "whether to print verbose log for debugging");
+                "Whether to print RocksDB related verbose log for debugging");
 DSN_DEFINE_int32(pegasus.server,
                  hotkey_analyse_time_interval_s,
                  10,

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -252,39 +252,42 @@ DSN_DEFINE_int64(
 DSN_DEFINE_int32(pegasus.server,
                  rocksdb_max_background_flushes,
                  4,
-                 "rocksdb options.max_background_flushes, flush threads are shared among all "
-                 "rocksdb instances in one process");
+                 "Corresponding to RocksDB's options.max_background_flushes, the flush threads are "
+                 "shared among all RocksDB's instances in the process");
 DSN_DEFINE_int32(pegasus.server,
                  rocksdb_max_background_compactions,
                  12,
-                 "rocksdb options.max_background_compactions, compaction threads are shared among "
-                 "all rocksdb instances in one process");
+                 "Corresponding to RocksDB's options.max_background_compactions, compaction "
+                 "threads are shared among all rocksdb instances in the process");
 DSN_DEFINE_int32(pegasus.server,
                  rocksdb_max_write_buffer_number,
                  3,
-                 "rocksdb options.max_write_buffer_number");
-DSN_DEFINE_int32(pegasus.server, rocksdb_num_levels, 6, "rocksdb options.num_levels");
+                 "Corresponding to RocksDB's options.max_write_buffer_number");
+DSN_DEFINE_int32(pegasus.server,
+                 rocksdb_num_levels,
+                 6,
+                 "Corresponding to RocksDB's options.num_levels");
 DSN_DEFINE_int32(pegasus.server,
                  rocksdb_target_file_size_multiplier,
                  1,
-                 "rocksdb options.target_file_size_multiplier");
+                 "Corresponding to RocksDB's options.target_file_size_multiplier");
 DSN_DEFINE_int32(pegasus.server,
                  rocksdb_level0_file_num_compaction_trigger,
                  4,
-                 "rocksdb options.level0_file_num_compaction_trigger");
+                 "Corresponding to RocksDB's options.level0_file_num_compaction_trigger");
 DSN_DEFINE_int32(pegasus.server,
                  rocksdb_level0_slowdown_writes_trigger,
                  30,
-                 "rocksdb options.level0_slowdown_writes_trigger, default 30");
+                 "Corresponding to RocksDB's options.level0_slowdown_writes_trigger");
 DSN_DEFINE_int32(pegasus.server,
                  rocksdb_level0_stop_writes_trigger,
                  60,
-                 "rocksdb options.level0_stop_writes_trigger");
-DSN_DEFINE_int32(
-    pegasus.server,
-    rocksdb_block_cache_num_shard_bits,
-    -1,
-    "block cache will be sharded into 2^num_shard_bits shards, default value is -1(auto)");
+                 "Corresponding to RocksDB's options.level0_stop_writes_trigger");
+DSN_DEFINE_int32(pegasus.server,
+                 rocksdb_block_cache_num_shard_bits,
+                 -1,
+                 "The number of shard bits of the block cache, it means the block cache is sharded "
+                 "into 2^n shards to reduce lock contention. -1 means automatically determined");
 
 // COMPATIBILITY ATTENTION:
 // Although old releases would see the new structure as corrupt filter data and read the
@@ -308,15 +311,15 @@ DSN_DEFINE_bool(pegasus.server,
 DSN_DEFINE_bool(pegasus.server,
                 rocksdb_use_direct_reads,
                 false,
-                "rocksdb options.use_direct_reads");
+                "Corresponding to RocksDB's options.use_direct_reads");
 DSN_DEFINE_bool(pegasus.server,
                 rocksdb_use_direct_io_for_flush_and_compaction,
                 false,
-                "rocksdb options.use_direct_io_for_flush_and_compaction");
+                "Corresponding to RocksDB's options.use_direct_io_for_flush_and_compaction");
 DSN_DEFINE_bool(pegasus.server,
                 rocksdb_disable_table_block_cache,
                 false,
-                "rocksdb _tbl_opts.no_block_cache");
+                "Whether to disable RocksDB's block cache");
 DSN_DEFINE_bool(pegasus.server,
                 rocksdb_enable_write_buffer_manager,
                 false,
@@ -358,7 +361,7 @@ DSN_DEFINE_bool(pegasus.server,
 DSN_DEFINE_bool(pegasus.server,
                 rocksdb_disable_bloom_filter,
                 false,
-                "Whether to disable bloom filter");
+                "Whether to disable RocksDB bloom filter");
 // If used, For every data block we load into memory, we will create a bitmap
 // of size ((block_size / `read_amp_bytes_per_bit`) / 8) bytes. This bitmap
 // will be used to figure out the percentage we actually read of the blocks.
@@ -470,21 +473,21 @@ DSN_DEFINE_uint64(pegasus.server,
                   "get/multi-get operation duration exceed this threshold will be logged");
 DSN_DEFINE_validator(rocksdb_slow_query_threshold_ns,
                      [](uint64_t value) -> bool { return value > 0; });
-DSN_DEFINE_uint64(
-    pegasus.server,
-    rocksdb_abnormal_get_size_threshold,
-    1000000,
-    "get operation value size exceed this threshold will be logged, 0 means no check");
+DSN_DEFINE_uint64(pegasus.server,
+                  rocksdb_abnormal_get_size_threshold,
+                  1000000,
+                  "A warning log will be print if the key-value size of Get operation is larger "
+                  "than this config, 0 means never print");
 DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_abnormal_multi_get_size_threshold,
                   10000000,
-                  "multi-get operation total key-value size exceed this threshold will be logged, "
-                  "0 means no check");
+                  "A warning log will be print if the total key-value size of Multi-Get operation "
+                  "is larger than this config, 0 means never print");
 DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_abnormal_multi_get_iterate_count_threshold,
                   1000,
-                  "multi-get operation iterate count exceed this threshold will be logged, 0 means "
-                  "no check");
+                  "A warning log will be print if the scan iteration count of Multi-Get operation "
+                  "is larger than this config, 0 means never print");
 DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_multi_get_max_iteration_size,
                   30 << 20,
@@ -498,27 +501,28 @@ DSN_DEFINE_uint64(pegasus.server,
 DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_compaction_readahead_size,
                   2 * 1024 * 1024,
-                  "rocksdb options.compaction_readahead_size");
+                  "Corresponding to RocksDB's options.compaction_readahead_size");
 DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_writable_file_max_buffer_size,
                   1024 * 1024,
-                  "rocksdb options.writable_file_max_buffer_size");
+                  "Corresponding to RocksDB's options.writable_file_max_buffer_size");
 DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_write_buffer_size,
                   64 * 1024 * 1024,
-                  "rocksdb options.write_buffer_size");
+                  "Corresponding to RocksDB's options.write_buffer_size");
 DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_target_file_size_base,
                   64 * 1024 * 1024,
-                  "rocksdb options.target_file_size_base");
+                  "Corresponding to RocksDB's options.target_file_size_base");
 DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_max_bytes_for_level_base,
                   10 * 64 * 1024 * 1024,
-                  "rocksdb options.max_bytes_for_level_base");
-DSN_DEFINE_uint64(pegasus.server,
-                  rocksdb_block_cache_capacity,
-                  10 * 1024 * 1024 * 1024ULL,
-                  "block cache capacity for one pegasus server, shared by all rocksdb instances");
+                  "Corresponding to RocksDB's options.max_bytes_for_level_base");
+DSN_DEFINE_uint64(
+    pegasus.server,
+    rocksdb_block_cache_capacity,
+    10 * 1024 * 1024 * 1024ULL,
+    "The Block Cache capacity shared by all RocksDB instances in the process, in bytes");
 DSN_DEFINE_uint64(pegasus.server,
                   rocksdb_total_size_across_write_buffer,
                   0,
@@ -540,7 +544,7 @@ DSN_DEFINE_uint64(pegasus.server,
 DSN_DEFINE_double(pegasus.server,
                   rocksdb_max_bytes_for_level_multiplier,
                   10,
-                  "rocksdb options.rocksdb_max_bytes_for_level_multiplier");
+                  "Corresponding to RocksDB's options.rocksdb_max_bytes_for_level_multiplier");
 DSN_DEFINE_double(pegasus.server,
                   rocksdb_bloom_filter_bits_per_key,
                   10,
@@ -548,8 +552,9 @@ DSN_DEFINE_double(pegasus.server,
 DSN_DEFINE_string(pegasus.server,
                   rocksdb_compression_type,
                   "lz4",
-                  "rocksdb options.compression. Available config: '[none|snappy|zstd|lz4]' for all "
-                  "level 2 and higher levels, and "
+                  "Corresponding to RocksDB's options.compression. Available config: "
+                  "'[none|snappy|zstd|lz4]' for all "
+                  "level 1 and higher levels, and "
                   "'per_level:[none|snappy|zstd|lz4],[none|snappy|zstd|lz4],...' for each level "
                   "0,1,..., the last compression type will be used for levels not specified in the "
                   "list.");

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -142,7 +142,6 @@ cluster_name = onebox
 
 deny_client_on_start = false
 delay_for_fd_timeout_on_start = false
-verbose_log_on_commit = false
 empty_write_disabled = false
 
 prepare_timeout_ms_for_secondaries = 1000
@@ -172,9 +171,6 @@ fd_lease_seconds = 20
 fd_grace_seconds = 22
 
 log_private_file_size_mb = 32
-log_private_batch_buffer_kb = 512
-log_private_batch_buffer_count = 512
-log_private_batch_buffer_flush_interval_ms = 100000
 log_private_reserve_max_size_mb = 0
 log_private_reserve_max_time_seconds = 0
 
@@ -198,15 +194,6 @@ max_concurrent_uploading_file_count = 5
 rocksdb_verbose_log = false
 rocksdb_write_buffer_size = 10485760
 verify_timetag = true
-
-perf_counter_cluster_name = onebox
-perf_counter_update_interval_seconds = 10
-perf_counter_enable_logging = false
-perf_counter_enable_falcon = false
-
-falcon_host = 127.0.0.1
-falcon_port = 1988
-falcon_path = /v1/push
 
 hot_bucket_variance_threshold = 5
 hot_key_variance_threshold = 5

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -174,11 +174,6 @@ log_private_file_size_mb = 32
 log_private_reserve_max_size_mb = 0
 log_private_reserve_max_time_seconds = 0
 
-log_shared_file_size_mb = 32
-log_shared_gc_flush_replicas_limit = 64
-log_shared_batch_buffer_kb = 0
-log_shared_force_flush = false
-
 config_sync_disabled = false
 config_sync_interval_ms = 30000
 

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -42,9 +42,12 @@
 DSN_DEFINE_string(core,
                   logging_start_level,
                   "LOG_LEVEL_INFO",
-                  "logs with level below this will not be logged");
+                  "Logs with level larger than or equal to this level be logged");
 
-DSN_DEFINE_bool(core, logging_flush_on_exit, true, "flush log when exit system");
+DSN_DEFINE_bool(core,
+                logging_flush_on_exit,
+                true,
+                "Whether to flush the logs when the process exits");
 
 log_level_t log_start_level = LOG_LEVEL_INFO;
 

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -50,8 +50,10 @@
 DSN_DEFINE_bool(tools.simple_logger, fast_flush, false, "whether to flush immediately");
 DSN_DEFINE_bool(tools.simple_logger,
                 short_header,
-                true,
-                "whether to use short header (excluding file/function etc.)");
+                false,
+                "Whether to use short header (excluding "
+                "file, file number and function name "
+                "fields in each line)");
 
 DSN_DEFINE_uint64(tools.simple_logger,
                   max_number_of_log_files_on_disk,

--- a/src/utils/threadpool_spec.h
+++ b/src/utils/threadpool_spec.h
@@ -79,8 +79,8 @@ struct threadpool_spec
 };
 
 CONFIG_BEGIN(threadpool_spec)
-CONFIG_FLD_STRING(name, "", "thread pool name")
-CONFIG_FLD(int, uint64, worker_count, 2, "thread/worker count")
+CONFIG_FLD_STRING(name, "", "Thread pool name")
+CONFIG_FLD(int, uint64, worker_count, 4, "The number of threads in the thread pool")
 CONFIG_FLD(int,
            uint64,
            dequeue_batch_size,
@@ -92,7 +92,7 @@ CONFIG_FLD_ENUM(worker_priority_t,
                 THREAD_xPRIORITY_NORMAL,
                 THREAD_xPRIORITY_INVALID,
                 false,
-                "thread priority")
+                "The scheduling priority of threads in OS")
 CONFIG_FLD(bool, bool, worker_share_core, true, "whether the threads share all assigned cores")
 CONFIG_FLD(uint64_t,
            uint64,
@@ -103,9 +103,9 @@ CONFIG_FLD(bool,
            bool,
            partitioned,
            false,
-           "whethe the threads share a single "
-           "queue(partitioned=false) or not; the latter is usually "
-           "for workload hash partitioning for avoiding locking")
+           "Whether each thread has its own task queue, and tasks are assigned to a specific "
+           "thread for execution based on a hash rule to reduce lock contention. Otherwise, "
+           "the threads share a single queue")
 CONFIG_FLD_STRING(queue_factory_name, "", "task queue provider name")
 CONFIG_FLD_STRING(worker_factory_name, "", "task worker provider name")
 CONFIG_FLD_STRING_LIST(queue_aspects, "task queue aspects names, usually for tooling purpose")

--- a/src/zookeeper/zookeeper_session_mgr.cpp
+++ b/src/zookeeper/zookeeper_session_mgr.cpp
@@ -35,7 +35,7 @@
 #include "utils/singleton_store.h"
 #include "zookeeper_session.h"
 
-DSN_DEFINE_string(zookeeper, logfile, "", "The Zookeeper logfile");
+DSN_DEFINE_string(zookeeper, logfile, "zoo.log", "The Zookeeper logfile");
 
 namespace dsn {
 namespace dist {


### PR DESCRIPTION
- Change some default config values in code base to make them more meaningful, including:

  | config name                                  | old default value | new default value |
  |----------------------------------------------|-------------------|-------------------|
  | log_private_reserve_max_size_mb              | 0                 | 1000              |
  | log_private_reserve_max_time_seconds         | 0                 | 36000             |
  | io_service_worker_count                      | 1                 | 4                 |
  | [threadpool..default]worker_count            | 2                 | 4                 |
  | [zookeeper]logfile                           | ""                | zoo.log           |
  | [tools.simple_logger]short_header            | true              | false             |
  | fd_lease_seconds                             | 9                 | 20                |
  | fd_grace_seconds                             | 10                | 22                |
  | replica_assign_delay_ms_for_dropouts         | 300000            | 600000            |
  | staleness_for_commit                         | 10                | 20                |
  | prepare_timeout_ms_for_secondaries           | 1000              | 3000              |
  | prepare_timeout_ms_for_potential_secondaries | 3000              | 5000              |
  | group_check_interval_ms                      | 10000             | 100000            |

- Change some config values in `src/server/config.ini` to keep consistent to code base, including:

  | config name                                          | old default value | new default value |
  |------------------------------------------------------|-------------------|-------------------|
  | [tools.simple_logger]max_number_of_log_files_on_disk | 500               | 20                |
  | [tools.simple_logger]stderr_start_level              | LOG_LEVEL_ERROR   | LOG_LEVEL_WARNING |

- Improve some config descriptions
- Remove some never used configs, including:
   - perf_counter_cluster_name
   - perf_counter_update_interval_seconds
   - perf_counter_enable_logging
   - perf_counter_enable_falcon
   - falcon_host
   - falcon_port
   - falcon_path
   - log_shared_file_size_mb
   - log_shared_gc_flush_replicas_limit
   - log_shared_batch_buffer_kb
   - log_shared_force_flush
   - log_shared_pending_size_throttling_threshold_kb
   - log_shared_pending_size_throttling_delay_ms
   - log_private_batch_buffer_kb
   - log_private_batch_buffer_count
   - log_private_batch_buffer_flush_interval_ms
   - verbose_log_on_commit
- Add a validator to check "fd_grace_seconds > fd_lease_seconds"
- Distinguish test and production environments

  | config name                   | test environment                | production environment             |
  |-------------------------------|---------------------------------|------------------------------------|
  | distributed_lock_service_type | distributed_lock_service_simple | distributed_lock_service_zookeeper |
  | meta_state_service_type       | meta_state_service_simple       | meta_state_service_zookeeper       |