### PR TITLE
fix(shell): add missing librocksdb.so.8 while packing tools and fix errors while launching shell

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -20,12 +20,12 @@ set -e
 
 LOCAL_HOSTNAME=`hostname -f`
 PID=$$
-ROOT=`pwd`
+ROOT="$(cd "$(dirname "$0")" && pwd)"
 export BUILD_ROOT_DIR=${ROOT}/build
 export BUILD_LATEST_DIR=${BUILD_ROOT_DIR}/latest
 export REPORT_DIR="$ROOT/test_report"
 export THIRDPARTY_ROOT=$ROOT/thirdparty
-export LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/amd64/server:${BUILD_LATEST_DIR}/output/lib:${THIRDPARTY_ROOT}/output/lib:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/amd64/server:${ROOT}/lib:${BUILD_LATEST_DIR}/output/lib:${THIRDPARTY_ROOT}/output/lib:${LD_LIBRARY_PATH}
 # Disable AddressSanitizerOneDefinitionRuleViolation, see https://github.com/google/sanitizers/issues/1017 for details.
 export ASAN_OPTIONS=detect_odr_violation=0
 # See https://github.com/gperftools/gperftools/wiki/gperftools'-stacktrace-capturing-methods-and-their-issues.
@@ -1720,7 +1720,7 @@ function run_shell()
     fi
 
     cd ${ROOT}
-    ln -s -f ${BUILD_LATEST_DIR}/output/bin/pegasus_shell/pegasus_shell
+    ln -s -f ${ROOT}/bin/pegasus_shell/pegasus_shell
     ./pegasus_shell ${CONFIG} $CLUSTER_NAME
     # because pegasus shell will catch 'Ctrl-C' signal, so the following commands will be executed
     # even user inputs 'Ctrl-C', so that the temporary config file will be cleared when exit shell.

--- a/run.sh
+++ b/run.sh
@@ -1720,7 +1720,16 @@ function run_shell()
     fi
 
     cd ${ROOT}
-    ln -s -f ${ROOT}/bin/pegasus_shell/pegasus_shell
+    if [ -f ${ROOT}/bin/pegasus_shell/pegasus_shell ]; then
+        # The pegasus_shell was packaged by pack_tools, to be used on production environment.
+        ln -s -f ${ROOT}/bin/pegasus_shell/pegasus_shell
+    elif [ -f ${BUILD_LATEST_DIR}/output/bin/pegasus_shell/pegasus_shell ]; then
+        # The pegasus_shell was built locally, to be used for test on development environment.
+        ln -s -f ${BUILD_LATEST_DIR}/output/bin/pegasus_shell/pegasus_shell
+    else
+        echo "ERROR: pegasus_shell could not be found"
+        exit 1
+    fi
     ./pegasus_shell ${CONFIG} $CLUSTER_NAME
     # because pegasus shell will catch 'Ctrl-C' signal, so the following commands will be executed
     # even user inputs 'Ctrl-C', so that the temporary config file will be cleared when exit shell.

--- a/scripts/pack_tools.sh
+++ b/scripts/pack_tools.sh
@@ -132,7 +132,8 @@ else
 fi
 
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/lib/
-copy_file ./thirdparty/output/lib/libhdfs* ${pack}/lib
+copy_file ./thirdparty/output/lib/libhdfs* ${pack}/lib/
+copy_file ./thirdparty/output/lib/librocksdb.so.8 ${pack}/lib/
 copy_file `get_stdcpp_lib $custom_gcc` ${pack}/lib/
 
 pack_tools_lib() {


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1886

Fix some problems while launching shell by `/path/to/tools/run.sh shell ...`
on production environment:

- `src/shell/config.ini` could not be found since `run.sh` was executed with
absolute path rather than relative path
- `pegasus_shell` binary could not be found for the packaged directory by
`pack_tools` which tends to used on production environment
- packaged libraries such as `libdsn_replica_server.so` could not be found
since the directory of libraries are missing in `LD_LIBRARY_PATH`
- while loading shared libraries `librocksdb.so.8` was not found which has
not be packaged into tools