### PR TITLE
refactor(fmt): Use operator<< instead of explict to_string() (2nd)

### DIFF
--- a/src/meta/duplication/duplication_info.h
+++ b/src/meta/duplication/duplication_info.h
@@ -188,9 +188,6 @@ public:
     // Test util
     bool equals_to(const duplication_info &rhs) const { return to_string() == rhs.to_string(); }
 
-    // To json encoded string.
-    std::string to_string() const;
-
     friend std::ostream &operator<<(std::ostream &os, const duplication_info &di)
     {
         return os << di.to_string();
@@ -199,6 +196,9 @@ public:
     const char *log_prefix() const { return prefix_for_log.c_str(); }
 
 private:
+    // To json encoded string.
+    std::string to_string() const;
+
     friend class duplication_info_test;
     friend class meta_duplication_service_test;
 

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -647,7 +647,7 @@ void meta_duplication_service::do_restore_duplication(dupid_t dup_id,
             auto dup = duplication_info::decode_from_blob(
                 dup_id, app->app_id, app->app_name, app->partition_count, store_path, json);
             if (nullptr == dup) {
-                LOG_ERROR("failed to decode json \"{}\" on path {}", json.to_string(), store_path);
+                LOG_ERROR("failed to decode json \"{}\" on path {}", json, store_path);
                 return; // fail fast
             }
             if (!dup->is_invalid_status()) {

--- a/src/replica/duplication/replica_duplicator.h
+++ b/src/replica/duplication/replica_duplicator.h
@@ -126,8 +126,6 @@ public:
     // won't be effected when this duplication is removed.
     dsn::task_tracker *tracker() { return &_tracker; }
 
-    std::string to_string() const;
-
     // To ensure mutation logs after start_decree is available
     // for duplication. If not, it means the eventual consistency
     // of duplication is no longer guaranteed due to the missing logs.
@@ -150,6 +148,8 @@ private:
 
     friend class load_mutation;
     friend class ship_mutation;
+
+    std::string to_string() const;
 
     const dupid_t _id;
     const std::string _remote_cluster_name;

--- a/src/replica/duplication/replica_follower.h
+++ b/src/replica/duplication/replica_follower.h
@@ -79,10 +79,8 @@ private:
     {
         std::string app_info = fmt::format("{}.{}", _master_cluster_name, _master_app_name);
         if (_master_replica_config.primary != rpc_address::s_invalid_address) {
-            return fmt::format("{}({}|{})",
-                               app_info,
-                               _master_replica_config.primary,
-                               _master_replica_config.pid.to_string());
+            return fmt::format(
+                "{}({}|{})", app_info, _master_replica_config.primary, _master_replica_config.pid);
         }
         return app_info;
     }

--- a/src/replica/duplication/replica_follower.h
+++ b/src/replica/duplication/replica_follower.h
@@ -81,7 +81,7 @@ private:
         if (_master_replica_config.primary != rpc_address::s_invalid_address) {
             return fmt::format("{}({}|{})",
                                app_info,
-                               _master_replica_config.primary.to_string(),
+                               _master_replica_config.primary,
                                _master_replica_config.pid.to_string());
         }
         return app_info;

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -71,7 +71,7 @@ namespace replication {
 const std::string replica_init_info::kInitInfo = ".init-info";
 const std::string kms_info::kKmsInfo = ".kms-info";
 
-std::string replica_init_info::to_string()
+std::string replica_init_info::to_string() const
 {
     return fmt::format(
         "init_ballot = {}, init_durable_decree = {}, init_offset_in_private_log = {}",

--- a/src/replica/replication_app_base.h
+++ b/src/replica/replication_app_base.h
@@ -70,8 +70,8 @@ public:
 
     static const std::string kInitInfo;
 
-public:
-    std::string to_string();
+private:
+    std::string to_string() const;
 };
 
 class replica_app_info

--- a/src/replica/storage/simple_kv/simple_kv.app.example.h
+++ b/src/replica/storage/simple_kv/simple_kv.app.example.h
@@ -74,7 +74,7 @@ public:
             error_code err;
             std::string resp;
             std::tie(err, resp) = _simple_kv_client->read_sync(req);
-            std::cout << "call RPC_SIMPLE_KV_SIMPLE_KV_READ end, return " << err.to_string();
+            std::cout << "call RPC_SIMPLE_KV_SIMPLE_KV_READ end, return " << err;
             if (ERR_OK == err)
                 std::cout << ", read result: " << resp;
             std::cout << std::endl;
@@ -89,8 +89,7 @@ public:
             error_code err;
             int32_t resp;
             std::tie(err, resp) = _simple_kv_client->write_sync(req);
-            std::cout << "call RPC_SIMPLE_KV_SIMPLE_KV_WRITE end, return " << err.to_string()
-                      << std::endl;
+            std::cout << "call RPC_SIMPLE_KV_SIMPLE_KV_WRITE end, return " << err << std::endl;
             // async:
             //_simple_kv_client->write(req, empty_rpc_handler);
         }
@@ -102,8 +101,7 @@ public:
             error_code err;
             int32_t resp;
             std::tie(err, resp) = _simple_kv_client->append_sync(req);
-            std::cout << "call RPC_SIMPLE_KV_SIMPLE_KV_APPEND end, return " << err.to_string()
-                      << std::endl;
+            std::cout << "call RPC_SIMPLE_KV_SIMPLE_KV_APPEND end, return " << err << std::endl;
 
             // async:
             //_simple_kv_client->append(req, empty_rpc_handler);

--- a/src/replica/storage/simple_kv/test/case.cpp
+++ b/src/replica/storage/simple_kv/test/case.cpp
@@ -1106,7 +1106,7 @@ void test_case::print(case_line *cl, const std::string &other, bool is_skip)
     {
         char buf[100];
         sprintf(buf, "%5d  ", cl->line_no());
-        std::cout << buf << cl->to_string() << std::endl;
+        std::cout << buf << *cl << std::endl;
         if (!other.empty()) {
             std::cout << " <==>  " << other << std::endl;
         }

--- a/src/replica/storage/simple_kv/test/case.h
+++ b/src/replica/storage/simple_kv/test/case.h
@@ -89,12 +89,13 @@ public:
     static const char *NAME() { return "set"; }
     virtual ~set_case_line() {}
     virtual std::string name() const { return NAME(); }
-    virtual std::string to_string() const;
     virtual bool parse(const std::string &params);
 
     void apply_set() const;
 
 private:
+    std::string to_string() const override;
+
     bool _null_loop_set;
     int _null_loop;
     bool _lb_for_test;
@@ -122,14 +123,16 @@ public:
     static const char *NAME() { return "skip"; }
     virtual ~skip_case_line() {}
     virtual std::string name() const { return NAME(); }
-    virtual std::string to_string() const;
     virtual bool parse(const std::string &params);
 
     int count() const { return _count; }
     int skipped() const { return _skipped; }
     void skip_one() { _skipped++; }
     bool is_skip_done() const { return _skipped >= _count; }
+
 private:
+    std::string to_string() const override;
+
     int _count;
     int _skipped;
 };
@@ -141,8 +144,10 @@ public:
     static const char *NAME() { return "exit"; }
     virtual ~exit_case_line() {}
     virtual std::string name() const { return NAME(); }
-    virtual std::string to_string() const;
     virtual bool parse(const std::string &params);
+
+private:
+    std::string to_string() const override;
 };
 
 class state_case_line : public case_line
@@ -151,7 +156,6 @@ public:
     static const char *NAME() { return "state"; }
     virtual ~state_case_line() {}
     virtual std::string name() const { return NAME(); }
-    virtual std::string to_string() const;
     virtual bool parse(const std::string &params);
 
     // return false if check failed
@@ -159,6 +163,8 @@ public:
     bool check_state(const state_snapshot &cur_state, bool &forward);
 
 private:
+    std::string to_string() const override;
+
     state_snapshot _state;
 };
 
@@ -168,7 +174,6 @@ public:
     static const char *NAME() { return "config"; }
     virtual ~config_case_line() {}
     virtual std::string name() const { return NAME(); }
-    virtual std::string to_string() const;
     virtual bool parse(const std::string &params);
 
     // return false if check failed
@@ -176,6 +181,8 @@ public:
     bool check_config(const parti_config &cur_config, bool &forward);
 
 private:
+    std::string to_string() const override;
+
     parti_config _config;
 };
 
@@ -208,13 +215,15 @@ public:
     // return true if 'ev' satisfy 'this' condition
     virtual bool check_satisfied(const event *ev) const = 0;
 
-    std::string to_string() const;
     friend std::ostream &operator<<(std::ostream &os, const event &evt)
     {
         return os << evt.to_string();
     }
 
     static event *parse(int line_no, const std::string &params);
+
+private:
+    std::string to_string() const;
 };
 
 class event_on_task : public event
@@ -349,19 +358,19 @@ public:
 class event_case_line : public case_line
 {
 public:
-public:
     virtual ~event_case_line()
     {
         if (_event_cond)
             delete _event_cond;
     }
-    virtual std::string to_string() const;
     virtual bool parse(const std::string &params);
 
     bool check_satisfied(const event *ev) const;
 
-public:
     event *_event_cond;
+
+protected:
+    std::string to_string() const override;
 };
 
 class wait_case_line : public event_case_line
@@ -383,12 +392,13 @@ class modify_case_line : public event_case_line
 {
 public:
     static const char *NAME() { return "modify"; }
-    virtual std::string name() const { return NAME(); }
-    virtual std::string to_string() const;
+    virtual std::string name() const { return NAME(); };
     virtual bool parse(const std::string &params);
     virtual void modify(const event *ev);
 
-public:
+private:
+    std::string to_string() const override;
+
     std::string _modify_delay;
 };
 
@@ -407,7 +417,6 @@ public:
 public:
     static const char *NAME() { return "client"; }
     virtual std::string name() const { return NAME(); }
-    virtual std::string to_string() const;
     virtual bool parse(const std::string &params);
 
     client_type type() const { return _type; }
@@ -425,6 +434,8 @@ public:
     std::string config_command_to_string(dsn::replication::config_type::type cfg_command) const;
 
 private:
+    std::string to_string() const override;
+
     client_type _type;
     int _id;
     std::string _key;

--- a/src/replica/storage/simple_kv/test/common.cpp
+++ b/src/replica/storage/simple_kv/test/common.cpp
@@ -102,13 +102,6 @@ rpc_address node_to_address(const std::string &name)
     return test_checker::instance().node_name_to_address(name);
 }
 
-std::string gpid_to_string(gpid gpid)
-{
-    std::stringstream oss;
-    oss << gpid.get_app_id() << "." << gpid.get_partition_index();
-    return oss.str();
-}
-
 bool gpid_from_string(const std::string &str, gpid &gpid)
 {
     size_t pos = str.find('.');
@@ -123,7 +116,7 @@ std::string replica_id::to_string() const
 {
     std::stringstream oss;
 #ifdef ENABLE_GPID
-    oss << gpid_to_string(gpid) << "@" << node;
+    oss << gpid << "@" << node;
 #else
     oss << node;
 #endif
@@ -271,7 +264,7 @@ std::string parti_config::to_string() const
     std::stringstream oss;
     oss << "{"
 #ifdef ENABLE_GPID
-        << gpid_to_string(gpid) << ","
+        << gpid << ","
 #endif
         << ballot << "," << primary << ",[";
     for (size_t i = 0; i < secondaries.size(); ++i) {

--- a/src/replica/storage/simple_kv/test/common.h
+++ b/src/replica/storage/simple_kv/test/common.h
@@ -62,7 +62,6 @@ std::string address_to_node(rpc_address addr);
 // return invalid addr if not found
 rpc_address node_to_address(const std::string &name);
 
-std::string gpid_to_string(gpid gpid);
 bool gpid_from_string(const std::string &str, gpid &gpid);
 
 struct replica_id

--- a/src/runtime/task/task_engine.cpp
+++ b/src/runtime/task/task_engine.cpp
@@ -110,7 +110,7 @@ void task_worker_pool::start()
         "{}, partitioned = {}, ...",
         _node->full_name(),
         _spec.name,
-        _spec.pool_code.to_string(),
+        _spec.pool_code,
         _spec.worker_count,
         _spec.worker_share_core ? "true" : "false",
         _spec.partitioned ? "true" : "false");
@@ -301,8 +301,7 @@ void task_engine::get_queue_info(/*out*/ std::stringstream &ss)
                 first_flag = 1;
             else
                 ss << ",";
-            ss << "\t{\"pool_name\":\"" << p->spec().pool_code.to_string()
-               << "\",\n\t\"pool_queue\":\n";
+            ss << "\t{\"pool_name\":\"" << p->spec().pool_code << "\",\n\t\"pool_queue\":\n";
             p->get_queue_info(ss);
             ss << "}\n";
         }

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -2784,8 +2784,8 @@ bool calculate_hash_value(command_executor *e, shell_context *sc, arguments args
         ::dsn::error_code err =
             sc->ddl_client->list_app(sc->current_app_name, app_id, partition_count, partitions);
         if (err != ::dsn::ERR_OK) {
-            std::cout << "list app [" << sc->current_app_name
-                      << "] failed, error=" << err.to_string() << std::endl;
+            std::cout << "list app [" << sc->current_app_name << "] failed, error=" << err
+                      << std::endl;
             return true;
         }
         uint64_t partition_index = key_hash % (uint64_t)partition_count;
@@ -2801,7 +2801,7 @@ bool calculate_hash_value(command_executor *e, shell_context *sc, arguments args
             for (int i = 0; i < pc.secondaries.size(); ++i) {
                 if (i != 0)
                     oss << ",";
-                oss << pc.secondaries[i].to_string();
+                oss << pc.secondaries[i];
             }
             tp.add_row_name_and_data("secondaries", oss.str());
         }

--- a/src/shell/commands/debugger.cpp
+++ b/src/shell/commands/debugger.cpp
@@ -227,8 +227,8 @@ bool mlog_dump(command_executor *e, shell_context *sc, arguments args)
                               update.set_expire_ts_seconds);
                 } else {
                     os << INDENT << "ERROR: unsupported code "
-                       << ::dsn::task_code(msg->local_rpc_code).to_string() << "("
-                       << msg->local_rpc_code << ")" << std::endl;
+                       << ::dsn::task_code(msg->local_rpc_code) << "(" << msg->local_rpc_code << ")"
+                       << std::endl;
                 }
             }
         };

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -88,7 +88,7 @@ bool query_cluster_info(command_executor *e, shell_context *sc, arguments args)
 
     ::dsn::error_code err = sc->ddl_client->cluster_info(out_file, resolve_ip, json);
     if (err != ::dsn::ERR_OK) {
-        std::cout << "get cluster info failed, error=" << err.to_string() << std::endl;
+        std::cout << "get cluster info failed, error=" << err << std::endl;
     }
     return true;
 }
@@ -293,7 +293,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
     std::map<dsn::rpc_address, dsn::replication::node_status::type> nodes;
     auto r = sc->ddl_client->list_nodes(s, nodes);
     if (r != dsn::ERR_OK) {
-        std::cout << "list nodes failed, error=" << r.to_string() << std::endl;
+        std::cout << "list nodes failed, error=" << r << std::endl;
         return true;
     }
 
@@ -316,7 +316,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
         std::vector<::dsn::app_info> apps;
         r = sc->ddl_client->list_apps(dsn::app_status::AS_AVAILABLE, apps);
         if (r != dsn::ERR_OK) {
-            std::cout << "list apps failed, error=" << r.to_string() << std::endl;
+            std::cout << "list apps failed, error=" << r << std::endl;
             return true;
         }
 
@@ -326,8 +326,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             std::vector<dsn::partition_configuration> partitions;
             r = sc->ddl_client->list_app(app.app_name, app_id, partition_count, partitions);
             if (r != dsn::ERR_OK) {
-                std::cout << "list app " << app.app_name << " failed, error=" << r.to_string()
-                          << std::endl;
+                std::cout << "list app " << app.app_name << " failed, error=" << r << std::endl;
                 return true;
             }
 
@@ -396,19 +395,19 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             if (tmp_it == tmp_map.end())
                 continue;
             if (!results[i].first) {
-                std::cout << "query perf counter info from node " << node_addr.to_string()
-                          << " failed" << std::endl;
+                std::cout << "query perf counter info from node " << node_addr << " failed"
+                          << std::endl;
                 return true;
             }
             dsn::perf_counter_info info;
             dsn::blob bb(results[i].second.data(), 0, results[i].second.size());
             if (!dsn::json::json_forwarder<dsn::perf_counter_info>::decode(bb, info)) {
-                std::cout << "decode perf counter info from node " << node_addr.to_string()
+                std::cout << "decode perf counter info from node " << node_addr
                           << " failed, result = " << results[i].second << std::endl;
                 return true;
             }
             if (info.result != "OK") {
-                std::cout << "query perf counter info from node " << node_addr.to_string()
+                std::cout << "query perf counter info from node " << node_addr
                           << " returns error, error = " << info.result << std::endl;
                 return true;
             }

--- a/src/shell/commands/rebalance.cpp
+++ b/src/shell/commands/rebalance.cpp
@@ -58,7 +58,7 @@ bool set_meta_level(command_executor *e, shell_context *sc, arguments args)
         std::cout << "control meta level ok, the old level is "
                   << _meta_function_level_VALUES_TO_NAMES.find(resp.old_level)->second << std::endl;
     } else {
-        std::cout << "control meta level got error " << resp.err.to_string() << std::endl;
+        std::cout << "control meta level got error " << resp.err << std::endl;
     }
     return true;
 }
@@ -71,7 +71,7 @@ bool get_meta_level(command_executor *e, shell_context *sc, arguments args)
         std::cout << "current meta level is "
                   << _meta_function_level_VALUES_TO_NAMES.find(resp.old_level)->second << std::endl;
     } else {
-        std::cout << "get meta level got error " << resp.err.to_string() << std::endl;
+        std::cout << "get meta level got error " << resp.err << std::endl;
     }
     return true;
 }
@@ -133,7 +133,7 @@ bool propose(command_executor *e, shell_context *sc, arguments args)
         tp != config_type::CT_INVALID, "parse %s as config_type failed.\n", proposal_type.c_str());
     request.action_list = {new_proposal_action(target, node, tp)};
     dsn::error_code err = sc->ddl_client->send_balancer_proposal(request);
-    std::cout << "send proposal response: " << err.to_string() << std::endl;
+    std::cout << "send proposal response: " << err << std::endl;
     return true;
 }
 
@@ -223,6 +223,6 @@ bool balance(command_executor *e, shell_context *sc, arguments args)
         return false;
     }
     dsn::error_code ec = sc->ddl_client->send_balancer_proposal(request);
-    std::cout << "send balance proposal result: " << ec.to_string() << std::endl;
+    std::cout << "send balance proposal result: " << ec << std::endl;
     return true;
 }

--- a/src/shell/commands/recovery.cpp
+++ b/src/shell/commands/recovery.cpp
@@ -158,7 +158,7 @@ bool recover(command_executor *e, shell_context *sc, arguments args)
     dsn::error_code ec = sc->ddl_client->do_recovery(
         node_list, wait_seconds, skip_bad_nodes, skip_lost_partitions, output_file);
     if (!output_file.empty()) {
-        std::cout << "recover complete with err = " << ec.to_string() << std::endl;
+        std::cout << "recover complete with err = " << ec << std::endl;
     }
     return true;
 }
@@ -283,7 +283,7 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
     int proposed_count = 0;
     int i = 0;
     for (const ddd_partition_info &pinfo : ddd_partitions) {
-        out << "(" << ++i << ") " << pinfo.config.pid.to_string() << std::endl;
+        out << "(" << ++i << ") " << pinfo.config.pid << std::endl;
         out << "    config: ballot(" << pinfo.config.ballot << "), "
             << "last_committed(" << pinfo.config.last_committed_decree << ")" << std::endl;
         out << "    ----" << std::endl;
@@ -297,7 +297,7 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
             char time_buf[30] = {0};
             ::dsn::utils::time_ms_to_string(n.drop_time_ms, time_buf);
             out << "    dropped[" << j++ << "]: "
-                << "node(" << n.node.to_string() << "), "
+                << "node(" << n.node << "), "
                 << "drop_time(" << time_buf << "), "
                 << "alive(" << (n.is_alive ? "true" : "false") << "), "
                 << "collected(" << (n.is_collected ? "true" : "false") << "), "
@@ -314,7 +314,7 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
         j = 0;
         for (const ::dsn::rpc_address &r : pinfo.config.last_drops) {
             out << "    last_drops[" << j++ << "]: "
-                << "node(" << r.to_string() << ")";
+                << "node(" << r << ")";
             if (j == (int)pinfo.config.last_drops.size() - 1)
                 out << "  <== the secondary latest";
             else if (j == (int)pinfo.config.last_drops.size())
@@ -376,10 +376,9 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
                     new_proposal_action(primary, primary, config_type::CT_ASSIGN_PRIMARY)};
                 request.force = false;
                 dsn::error_code err = sc->ddl_client->send_balancer_proposal(request);
-                out << "    propose_request: propose -g " << request.gpid.to_string()
-                    << " -p ASSIGN_PRIMARY -t " << primary.to_string() << " -n "
-                    << primary.to_string() << std::endl;
-                out << "    propose_response: " << err.to_string() << std::endl;
+                out << "    propose_request: propose -g " << request.gpid
+                    << " -p ASSIGN_PRIMARY -t " << primary << " -n " << primary << std::endl;
+                out << "    propose_response: " << err << std::endl;
                 proposed_count++;
             } else {
                 out << "    propose_request: none" << std::endl;

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -112,7 +112,7 @@ bool ls_apps(command_executor *e, shell_context *sc, arguments args)
     }
     ::dsn::error_code err = sc->ddl_client->list_apps(s, show_all, detailed, json, output_file);
     if (err != ::dsn::ERR_OK)
-        std::cout << "list apps failed, error=" << err.to_string() << std::endl;
+        std::cout << "list apps failed, error=" << err << std::endl;
     return true;
 }
 
@@ -166,7 +166,7 @@ bool query_app(command_executor *e, shell_context *sc, arguments args)
     ::dsn::error_code err =
         sc->ddl_client->list_app(app_name, detailed, json, out_file, resolve_ip);
     if (err != ::dsn::ERR_OK) {
-        std::cout << "query app " << app_name << " failed, error=" << err.to_string() << std::endl;
+        std::cout << "query app " << app_name << " failed, error=" << err << std::endl;
     }
     return true;
 }
@@ -297,8 +297,7 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
 
     dsn::error_code err = sc->ddl_client->list_app(app_name, app_id, partition_count, partitions);
     if (err != ::dsn::ERR_OK) {
-        std::cout << "ERROR: list app " << app_name << " failed, error=" << err.to_string()
-                  << std::endl;
+        std::cout << "ERROR: list app " << app_name << " failed, error=" << err << std::endl;
         return true;
     }
     if (!partitions.empty()) {
@@ -390,7 +389,7 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
             if (resolve_ip && dsn::utils::hostname_from_ip_port(ip.c_str(), &hostname)) {
                 oss << hostname << "(";
             } else {
-                oss << p.primary.to_string() << "(";
+                oss << p.primary << "(";
             };
             if (disk_found)
                 oss << disk_value;
@@ -441,7 +440,7 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
                 if (resolve_ip && dsn::utils::hostname_from_ip_port(ip.c_str(), &hostname)) {
                     oss << hostname << "(";
                 } else {
-                    oss << p.secondaries[j].to_string() << "(";
+                    oss << p.secondaries[j] << "(";
                 };
                 if (found)
                     oss << value;
@@ -740,7 +739,7 @@ bool create_app(command_executor *e, shell_context *sc, arguments args)
                   << std::endl;
     else
         std::cout << "create app \"" << pegasus::utils::c_escape_string(app_name)
-                  << "\" failed, error = " << err.to_string() << std::endl;
+                  << "\" failed, error = " << err << std::endl;
     return true;
 }
 
@@ -779,7 +778,7 @@ bool drop_app(command_executor *e, shell_context *sc, arguments args)
     if (err == ::dsn::ERR_OK)
         std::cout << "drop app " << app_name << " succeed" << std::endl;
     else
-        std::cout << "drop app " << app_name << " failed, error=" << err.to_string() << std::endl;
+        std::cout << "drop app " << app_name << " failed, error=" << err << std::endl;
     return true;
 }
 
@@ -839,7 +838,7 @@ bool recall_app(command_executor *e, shell_context *sc, arguments args)
     if (dsn::ERR_OK == err)
         std::cout << "recall app " << id << " succeed" << std::endl;
     else
-        std::cout << "recall app " << id << " failed, error=" << err.to_string() << std::endl;
+        std::cout << "recall app " << id << " failed, error=" << err << std::endl;
     return true;
 }
 

--- a/src/utils/latency_tracer.cpp
+++ b/src/utils/latency_tracer.cpp
@@ -320,7 +320,7 @@ void latency_tracer::dump_trace_points(/*out*/ std::string &traces)
         traces.append(fmt::format("\t{}[TRACE:[{}.{}]{}]{}\n",
                                   header_format,
                                   _description,
-                                  dsn::task_code(_task_code).to_string(),
+                                  dsn::task_code(_task_code),
                                   _name,
                                   header_format));
         uint64_t previous_point_ts = _points.begin()->first;


### PR DESCRIPTION
There is no functional changes, but only refactor to simplify the code.