### PR TITLE
refactor(host_port): Make some functions as static

### DIFF
--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -437,7 +437,7 @@ inline bool json_decode(const dsn::json::JsonObject &in, dsn::host_port &hp)
         return true;
     }
     hp = host_port::from_string(host_port_string);
-    return hp.is_invalid();
+    return !hp.is_invalid();
 }
 
 inline void json_encode(JsonWriter &out, const dsn::partition_configuration &config);

--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -436,7 +436,8 @@ inline bool json_decode(const dsn::json::JsonObject &in, dsn::host_port &hp)
     if (host_port_string == "invalid host_port") {
         return true;
     }
-    return hp.from_string(host_port_string);
+    hp = host_port::from_string(host_port_string);
+    return hp.is_invalid();
 }
 
 inline void json_encode(JsonWriter &out, const dsn::partition_configuration &config);

--- a/src/runtime/rpc/group_host_port.h
+++ b/src/runtime/rpc/group_host_port.h
@@ -128,10 +128,10 @@ inline rpc_group_host_port::rpc_group_host_port(const rpc_group_address *g_addr)
 {
     _name = g_addr->name();
     for (const auto &addr : g_addr->members()) {
-        CHECK_TRUE(add(host_port(addr)));
+        CHECK_TRUE(add(host_port::from_address(addr)));
     }
     _update_leader_automatically = g_addr->is_update_leader_automatically();
-    set_leader(host_port(g_addr->leader()));
+    set_leader(host_port::from_address(g_addr->leader()));
 }
 
 inline rpc_group_host_port &rpc_group_host_port::operator=(const rpc_group_host_port &other)

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -64,6 +64,8 @@ host_port host_port::from_address(rpc_address addr)
     default:
         break;
     }
+
+    // Now is_invalid() return false.
     hp._type = addr.type();
     return hp;
 }
@@ -88,7 +90,7 @@ host_port host_port::from_string(const std::string &host_port_str)
         return hp;
     }
 
-    // Now is_invalid() return true.
+    // Now is_invalid() return false.
     hp._type = HOST_TYPE_IPV4;
     return hp;
 }

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -28,6 +28,7 @@
 #include "fmt/core.h"
 #include "runtime/rpc/group_host_port.h"
 #include "runtime/rpc/rpc_host_port.h"
+#include "utils/api_utilities.h"
 #include "utils/error_code.h"
 #include "utils/ports.h"
 #include "utils/string_conv.h"

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -52,7 +52,6 @@ public:
     static const host_port s_invalid_host_port;
     explicit host_port() = default;
     explicit host_port(std::string host, uint16_t port);
-    explicit host_port(rpc_address addr);
 
     host_port(const host_port &other) { *this = other; }
     host_port &operator=(const host_port &other);
@@ -64,7 +63,7 @@ public:
     const std::string &host() const { return _host; }
     uint16_t port() const { return _port; }
 
-    bool is_invalid() const { return _type == HOST_TYPE_INVALID; }
+    [[nodiscard]] bool is_invalid() const { return _type == HOST_TYPE_INVALID; }
 
     std::string to_string() const;
 
@@ -83,8 +82,15 @@ public:
     // Resolve host_port to rpc_addresses.
     // Trere may be multiple rpc_addresses for one host_port.
     error_s resolve_addresses(std::vector<rpc_address> &addresses) const;
-    // This function is used for validating the format of string like "localhost:8888".
-    bool from_string(const std::string &s);
+
+    // Construct a host_port object from 'addr'
+    static host_port from_address(rpc_address addr);
+
+    // Construct a host_port object from 'host_port_str', the latter is in the format of
+    // "localhost:8888".
+    // NOTE: The constructed host_port object maybe invalid, remember to check it by is_invalid()
+    // before using it.
+    static host_port from_string(const std::string &host_port_str);
 
     // for serialization in thrift format
     uint32_t read(::apache::thrift::protocol::TProtocol *iprot);

--- a/src/runtime/test/host_port_test.cpp
+++ b/src/runtime/test/host_port_test.cpp
@@ -92,7 +92,6 @@ TEST(host_port_test, operators)
     host_port hp3;
     ASSERT_TRUE(hp3.is_invalid());
     hp3 = host_port::from_string(hp_str);
-    ASSERT_TRUE(hp3.is_invalid());
     ASSERT_EQ(hp, hp3);
     ASSERT_FALSE(hp3.is_invalid());
 
@@ -100,7 +99,6 @@ TEST(host_port_test, operators)
     ASSERT_TRUE(hp4.is_invalid());
     std::string hp_str2 = "pegasus:8080";
     hp4 = host_port::from_string(hp_str2);
-    ASSERT_FALSE(hp4.is_invalid());
     ASSERT_TRUE(hp4.is_invalid());
 
     host_port hp5("localhost", 8081);

--- a/src/runtime/test/host_port_test.cpp
+++ b/src/runtime/test/host_port_test.cpp
@@ -63,7 +63,7 @@ TEST(host_port_test, host_port_build)
 
     {
         rpc_address addr = rpc_address("localhost", 8080);
-        host_port hp1(addr);
+        host_port hp1 = host_port::from_address(addr);
         ASSERT_EQ(hp, hp1);
     }
 }
@@ -91,14 +91,16 @@ TEST(host_port_test, operators)
     std::string hp_str = "localhost:8080";
     host_port hp3;
     ASSERT_TRUE(hp3.is_invalid());
-    ASSERT_TRUE(hp3.from_string(hp_str));
+    hp3 = host_port::from_string(hp_str);
+    ASSERT_TRUE(hp3.is_invalid());
     ASSERT_EQ(hp, hp3);
     ASSERT_FALSE(hp3.is_invalid());
 
     host_port hp4;
     ASSERT_TRUE(hp4.is_invalid());
     std::string hp_str2 = "pegasus:8080";
-    ASSERT_FALSE(hp4.from_string(hp_str2));
+    hp4 = host_port::from_string(hp_str2);
+    ASSERT_FALSE(hp4.is_invalid());
     ASSERT_TRUE(hp4.is_invalid());
 
     host_port hp5("localhost", 8081);
@@ -196,7 +198,7 @@ TEST(host_port_test, rpc_group_host_port)
     ASSERT_EQ(2, g_addr->count());
 
     host_port hp_grp2;
-    hp_grp2 = host_port(addr_grp);
+    hp_grp2 = host_port::from_address(addr_grp);
     ASSERT_EQ(HOST_TYPE_GROUP, hp_grp2.type());
 
     auto g_hp = hp_grp2.group_host_port();
@@ -254,7 +256,7 @@ TEST(host_port_test, dns_resolver)
         ASSERT_EQ(g_addr->is_update_leader_automatically(), g_hp->is_update_leader_automatically());
         ASSERT_STREQ(g_addr->name(), g_hp->name());
         ASSERT_EQ(g_addr->count(), g_hp->count());
-        ASSERT_EQ(host_port(g_addr->leader()), g_hp->leader());
+        ASSERT_EQ(host_port::from_address(g_addr->leader()), g_hp->leader());
     }
 }
 

--- a/src/utils/test/json_helper_test.cpp
+++ b/src/utils/test/json_helper_test.cpp
@@ -511,7 +511,7 @@ TEST(json_helper, host_port_encode_decode)
     dsn::host_port hp("localhost", 8888);
     dsn::blob bb = dsn::json::json_forwarder<decltype(hp)>::encode(hp);
     dsn::host_port hp2;
-    dsn::json::json_forwarder<dsn::host_port>::decode(bb, hp2);
+    ASSERT_TRUE(dsn::json::json_forwarder<dsn::host_port>::decode(bb, hp2));
 
     ASSERT_EQ(hp, hp2);
 }


### PR DESCRIPTION
This patch mainly has cchanges:
- Change the constructor `host_port(rpc_address addr)` to a static function
  `host_port from_address(rpc_address addr)`. It's a good practice to keep
  constructors light and fast, this function contains a reverse DNS lookup,
  it may be slow.

- Change `bool from_string(const std::string &s)` to a static function
  `host_port from_string(const std::string &host_port_str)` in host_port.
  It seems there isn't a scenario to modify an exist host_port object by
  calling obj.from_string(s), so make it as static to clarify this.

This patch also adds SCOPED_LOG_SLOW_EXECUTION to log slow operations if it
exceed 100 milliseconds.