### PR TITLE
fix(scripts): drop unnecessary dependencies for pack_tools.sh

### DIFF
--- a/scripts/pack_tools.sh
+++ b/scripts/pack_tools.sh
@@ -140,11 +140,8 @@ pack_tools_lib() {
     pack_system_lib "${pack}/lib" shell "$1"
 }
 
-pack_tools_lib snappy
 pack_tools_lib crypto
 pack_tools_lib ssl
-pack_tools_lib zstd
-pack_tools_lib lz4
 
 chmod -x ${pack}/lib/*
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1900

Now that snappy/zstd/lz4 has not been the direct dependencies
of Pegasus(actually all of them is the dependency of rocksdb),
just remove them from pack_tools.sh.