### PR TITLE
feat(new_metrics): show table stats by shell `app_stat` command based on new metrics (part 1)

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -646,6 +646,7 @@ inline bool fill_nodes(shell_context *sc, const std::string &type, std::vector<n
     return true;
 }
 
+// Fetch the metrics according to `query_string` for each target node.
 inline std::vector<dsn::http_result> get_metrics(const std::vector<node_desc> &nodes,
                                                  const std::string &query_string)
 {
@@ -709,6 +710,12 @@ inline std::vector<dsn::http_result> get_metrics(const std::vector<node_desc> &n
 
 using stat_var_map = std::unordered_map<std::string, double *>;
 
+// Abstract class used to aggregate the stats based on the custom filters while iterating over
+// the fetched metrics.
+//
+// Given the type and attributes of an entity, derived classes need to implement a custom filter
+// to return the selected `stat_var_map`, if any. Calculations including addition and subtraction
+// are also provided for aggregating the stats.
 class aggregate_stats
 {
 public:
@@ -1616,6 +1623,7 @@ inline bool get_app_stat(shell_context *sc,
         }
     }
 
+    // TODO(wangdan): would be removed after migrating to new metrics completely.
     std::vector<std::string> arguments;
     char tmp[256];
     if (app_name.empty()) {
@@ -1662,6 +1670,8 @@ inline bool get_app_stat(shell_context *sc,
                 "row data requests");
         }
     } else {
+        // TODO(wangdan): use partition_aggregate_stats to implement partition-level stats
+        // for a specific table.
         rows.resize(app_info->partition_count);
         for (int i = 0; i < app_info->partition_count; i++)
             rows[i].row_name = std::to_string(i);

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -799,7 +799,7 @@ public:
 
         const std::array deltas_list = {&_increases, &_rates};
         for (const auto stats : deltas_list) {
-            if (*stats) {
+            if (!(*stats)) {
                 continue;
             }
 

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -714,7 +714,7 @@ class aggregate_stats
 public:
     aggregate_stats() = default;
 
-    ~aggregate_stats() = default;
+    virtual ~aggregate_stats() = default;
 
 #define CALC_STAT_VARS(entities, op)                                                               \
     for (const auto &entity : entities) {                                                          \
@@ -886,7 +886,7 @@ public:
     {
     }
 
-    ~table_aggregate_stats() = default;
+    ~table_aggregate_stats() override = default;
 
 protected:
     dsn::error_s get_stat_vars(const std::string &entity_type,
@@ -899,6 +899,8 @@ protected:
         RETURN_NULL_STAT_VARS_IF_NOT_OK(
             dsn::parse_metric_partition_id(entity_attrs, metric_table_id));
 
+        // Empty `_my_partitions` means there is no restriction; otherwise, the partition id
+        // should be found in `_my_partitions`.
         if (!_my_partitions.empty()) {
             int32_t metric_partition_id;
             RETURN_NULL_STAT_VARS_IF_NOT_OK(
@@ -942,7 +944,7 @@ public:
     {
     }
 
-    ~partition_aggregate_stats() = default;
+    ~partition_aggregate_stats() override = default;
 
 protected:
     dsn::error_s get_stat_vars(const std::string &entity_type,

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -896,8 +896,7 @@ protected:
         RETURN_NULL_STAT_VARS_IF(entity_type != _my_entity_type);
 
         int32_t metric_table_id;
-        RETURN_NULL_STAT_VARS_IF_NOT_OK(
-            dsn::parse_metric_partition_id(entity_attrs, metric_table_id));
+        RETURN_NULL_STAT_VARS_IF_NOT_OK(dsn::parse_metric_table_id(entity_attrs, metric_table_id));
 
         // Empty `_my_partitions` means there is no restriction; otherwise, the partition id
         // should be found in `_my_partitions`.
@@ -954,8 +953,7 @@ protected:
         RETURN_NULL_STAT_VARS_IF(entity_type != _my_entity_type);
 
         int32_t metric_table_id;
-        RETURN_NULL_STAT_VARS_IF_NOT_OK(
-            dsn::parse_metric_partition_id(entity_attrs, metric_table_id));
+        RETURN_NULL_STAT_VARS_IF_NOT_OK(dsn::parse_metric_table_id(entity_attrs, metric_table_id));
 
         int32_t metric_partition_id;
         RETURN_NULL_STAT_VARS_IF_NOT_OK(
@@ -1292,6 +1290,8 @@ inline stat_var_map create_rates(row_data &row)
     });
 }
 
+#undef BIND_ROW
+
 inline std::unique_ptr<aggregate_stats_calcs> create_table_aggregate_stats_calcs(
     const std::map<int32_t, std::vector<dsn::partition_configuration>> &table_partitions,
     const std::map<int32_t, size_t> &table_rows,
@@ -1312,7 +1312,7 @@ inline std::unique_ptr<aggregate_stats_calcs> create_table_aggregate_stats_calcs
         CHECK_LT(table_row->second, rows.size());
 
         auto &row = rows[table_row->second];
-        std::vector<std::pair<table_stat_map *, std::function<stat_var_map(row_data &)>>>
+        const std::vector<std::pair<table_stat_map *, std::function<stat_var_map(row_data &)>>>
             processors = {
                 {&sums, create_sums}, {&increases, create_increases}, {&rates, create_rates},
             };
@@ -1335,8 +1335,6 @@ inline std::unique_ptr<aggregate_stats_calcs> create_table_aggregate_stats_calcs
     calcs->create_rates<table_aggregate_stats>(entity_type, std::move(rates), partitions);
     return calcs;
 }
-
-#undef BIND_ROW
 
 inline bool
 update_app_pegasus_perf_counter(row_data &row, const std::string &counter_name, double value)

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -2355,10 +2355,11 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
         // get estimate key number
         std::vector<row_data> rows;
         std::string app_name = sc->pg_client->get_app_name();
-        if (!get_app_stat(sc, app_name, rows)) {
-            fprintf(stderr, "ERROR: query app stat from server failed");
-            return true;
-        }
+        // TODO(wangdan): no need to use get_app_stat since only rdb_estimate_num_keys is needed.
+        // if (!get_app_stat(sc, app_name, rows)) {
+        //    fprintf(stderr, "ERROR: query app stat from server failed");
+        //    return true;
+        // }
 
         rows.resize(rows.size() + 1);
         row_data &sum = rows.back();

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -2356,6 +2356,7 @@ bool count_data(command_executor *e, shell_context *sc, arguments args)
         std::vector<row_data> rows;
         std::string app_name = sc->pg_client->get_app_name();
         // TODO(wangdan): no need to use get_app_stat since only rdb_estimate_num_keys is needed.
+        // Would be refactored later.
         // if (!get_app_stat(sc, app_name, rows)) {
         //    fprintf(stderr, "ERROR: query app stat from server failed");
         //    return true;

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -404,19 +404,18 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             RETURN_SHELL_IF_GET_METRICS_FAILED(results_end[i], nodes[i], "ending rw requests");
 
             list_nodes_helper &stat = tmp_it->second;
-            total_aggregate_stats increases(
-                "replica",
-                {{"read_capacity_units", &stat.read_cu}, {"write_capacity_units", &stat.write_cu}});
-            total_aggregate_stats rates("replica",
-                                        {{"get_requests", &stat.get_qps},
-                                         {"multi_get_requests", &stat.multi_get_qps},
-                                         {"batch_get_requests", &stat.batch_get_qps},
-                                         {"put_requests", &stat.put_qps},
-                                         {"multi_put_requests", &stat.multi_put_qps}});
-
             aggregate_stats_calcs calcs;
-            calcs.increases = &increases;
-            calcs.rates = &rates;
+            calcs.create_increases<total_aggregate_stats>(
+                "replica",
+                stat_var_map({{"read_capacity_units", &stat.read_cu},
+                              {"write_capacity_units", &stat.write_cu}}));
+            calcs.create_rates<total_aggregate_stats>(
+                "replica",
+                stat_var_map({{"get_requests", &stat.get_qps},
+                              {"multi_get_requests", &stat.multi_get_qps},
+                              {"batch_get_requests", &stat.batch_get_qps},
+                              {"put_requests", &stat.put_qps},
+                              {"multi_put_requests", &stat.multi_put_qps}}));
 
             RETURN_SHELL_IF_PARSE_METRICS_FAILED(
                 calcs.aggregate_metrics(results_start[i].body(), results_end[i].body()),

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -404,16 +404,19 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             RETURN_SHELL_IF_GET_METRICS_FAILED(results_end[i], nodes[i], "ending rw requests");
 
             list_nodes_helper &stat = tmp_it->second;
-            stat_var_map increases = {{"read_capacity_units", &stat.read_cu},
-                                      {"write_capacity_units", &stat.write_cu}};
-            stat_var_map rates = {{"get_requests", &stat.get_qps},
-                                  {"multi_get_requests", &stat.multi_get_qps},
-                                  {"batch_get_requests", &stat.batch_get_qps},
-                                  {"put_requests", &stat.put_qps},
-                                  {"multi_put_requests", &stat.multi_put_qps}};
+            total_aggregate_stats values("replica", {});
+            total_aggregate_stats increases(
+                "replica",
+                {{"read_capacity_units", &stat.read_cu}, {"write_capacity_units", &stat.write_cu}});
+            total_aggregate_stats rates("replica",
+                                        {{"get_requests", &stat.get_qps},
+                                         {"multi_get_requests", &stat.multi_get_qps},
+                                         {"batch_get_requests", &stat.batch_get_qps},
+                                         {"put_requests", &stat.put_qps},
+                                         {"multi_put_requests", &stat.multi_put_qps}});
             RETURN_SHELL_IF_PARSE_METRICS_FAILED(
                 aggregate_metrics(
-                    results_start[i].body(), results_end[i].body(), "replica", increases, rates),
+                    results_start[i].body(), results_end[i].body(), values, increases, rates),
                 nodes[i],
                 "rw requests");
         }

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -404,7 +404,6 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             RETURN_SHELL_IF_GET_METRICS_FAILED(results_end[i], nodes[i], "ending rw requests");
 
             list_nodes_helper &stat = tmp_it->second;
-            total_aggregate_stats values("replica", {});
             total_aggregate_stats increases(
                 "replica",
                 {{"read_capacity_units", &stat.read_cu}, {"write_capacity_units", &stat.write_cu}});
@@ -414,9 +413,13 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
                                          {"batch_get_requests", &stat.batch_get_qps},
                                          {"put_requests", &stat.put_qps},
                                          {"multi_put_requests", &stat.multi_put_qps}});
+
+            aggregate_stats_calcs calcs;
+            calcs.increases = &increases;
+            calcs.rates = &rates;
+
             RETURN_SHELL_IF_PARSE_METRICS_FAILED(
-                aggregate_metrics(
-                    results_start[i].body(), results_end[i].body(), values, increases, rates),
+                calcs.aggregate_metrics(results_start[i].body(), results_end[i].body()),
                 nodes[i],
                 "rw requests");
         }

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -53,6 +53,8 @@
 #include "utils/strings.h"
 #include "utils/utils.h"
 
+DSN_DEFINE_uint32(shell, tables_sample_interval_ms, 1000, "The interval between sampling metrics.");
+
 double convert_to_ratio(double hit, double total)
 {
     return std::abs(total) < 1e-6 ? 0 : hit / total;
@@ -527,7 +529,7 @@ bool app_stat(command_executor *e, shell_context *sc, arguments args)
     }
 
     std::vector<row_data> rows;
-    if (!get_app_stat(sc, app_name, rows)) {
+    if (!get_app_stat(sc, app_name, FLAGS_tables_sample_interval_ms, rows)) {
         std::cout << "ERROR: query app stat from server failed" << std::endl;
         return true;
     }

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -196,14 +196,10 @@ dsn::error_s parse_sst_stat(const std::string &json_string,
                            entity.type);
         }
 
-        const auto &partition = entity.attributes.find("partition_id");
-        if (dsn_unlikely(partition == entity.attributes.end())) {
-            return FMT_ERR(dsn::ERR_INVALID_DATA, "partition_id field was not found");
-        }
-
         int32_t partition_id;
-        if (dsn_unlikely(!dsn::buf2int32(partition->second, partition_id))) {
-            return FMT_ERR(dsn::ERR_INVALID_DATA, "invalid partition_id: {}", partition->second);
+        const auto err = dsn::parse_metric_partition_id(entity.attributes, partition_id);
+        if (!err) {
+            return err;
         }
 
         for (const auto &m : entity.metrics) {

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -46,6 +46,7 @@
 #include "shell/sds/sds.h"
 #include "utils/error_code.h"
 #include "utils/errors.h"
+#include "utils/flags.h"
 #include "utils/metrics.h"
 #include "utils/output_utils.h"
 #include "utils/ports.h"

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -199,10 +199,7 @@ dsn::error_s parse_sst_stat(const std::string &json_string,
         }
 
         int32_t partition_id;
-        const auto err = dsn::parse_metric_partition_id(entity.attributes, partition_id);
-        if (!err) {
-            return err;
-        }
+        RETURN_NOT_OK(dsn::parse_metric_partition_id(entity.attributes, partition_id));
 
         for (const auto &m : entity.metrics) {
             if (m.name == "rdb_total_sst_files") {

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -30,7 +30,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/src/utils/metrics.cpp
+++ b/src/utils/metrics.cpp
@@ -37,7 +37,6 @@
 #include "utils/flags.h"
 #include "utils/rand.h"
 #include "utils/shared_io_service.h"
-#include "utils/string_conv.h"
 #include "utils/strings.h"
 
 DSN_DEFINE_uint64(metrics,

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -1727,6 +1727,8 @@ DEF_ALL_METRIC_BRIEF_SNAPSHOTS(p99);
         }                                                                                          \
     } while (0)
 
+// Find the duration between the 2 timestamps, generally used for calculate the rates over the
+// metrics, such as QPS.
 inline double calc_metric_sample_duration_s(uint64_t timestamp_ns_start, uint64_t timestamp_ns_end)
 {
     CHECK_LT(timestamp_ns_start, timestamp_ns_end);
@@ -1737,6 +1739,7 @@ inline double calc_metric_sample_duration_s(uint64_t timestamp_ns_start, uint64_
     return duration_s.count();
 }
 
+// Parse the attributes as their original types.
 template <typename TAttrValue,
           typename = typename std::enable_if<std::is_arithmetic<TAttrValue>::value>::type>
 inline error_s parse_metric_attribute(const metric_entity::attr_map &attrs,

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -1724,6 +1724,16 @@ DEF_ALL_METRIC_BRIEF_SNAPSHOTS(p99);
         }                                                                                          \
     } while (0)
 
+inline double calc_metric_sample_duration_s(uint64_t timestamp_ns_start, uint64_t timestamp_ns_end)
+{
+    CHECK_LT(timestamp_ns_start, timestamp_ns_end);
+
+    const std::chrono::duration<double, std::nano> duration_ns(
+        static_cast<double>(timestamp_ns_end - timestamp_ns_start));
+    const std::chrono::duration<double> duration_s = duration_ns;
+    return duration_s.count();
+}
+
 template <typename TAttrValue,
           typename = typename std::enable_if<std::is_arithmetic<TAttrValue>::value>::type>
 inline error_s parse_metric_attribute(const metric_entity::attr_map &attrs,

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -25,10 +25,12 @@
 #include <algorithm>
 #include <atomic>
 #include <bitset>
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <new>
+#include <ratio>
 #include <set>
 #include <sstream>
 #include <string>
@@ -45,6 +47,7 @@
 #include "utils/autoref_ptr.h"
 #include "utils/casts.h"
 #include "utils/enum_helper.h"
+#include "utils/error_code.h"
 #include "utils/errors.h"
 #include "utils/fmt_logging.h"
 #include "utils/long_adder.h"

--- a/src/utils/string_conv.h
+++ b/src/utils/string_conv.h
@@ -173,4 +173,17 @@ inline bool buf2double(absl::string_view buf, double &result)
     result = v;
     return true;
 }
+
+inline bool buf2numeric(absl::string_view buf, int32_t &result) { return buf2int32(buf, result); }
+
+inline bool buf2numeric(absl::string_view buf, int64_t &result) { return buf2int64(buf, result); }
+
+inline bool buf2numeric(absl::string_view buf, uint16_t &result) { return buf2uint16(buf, result); }
+
+inline bool buf2numeric(absl::string_view buf, uint32_t &result) { return buf2uint32(buf, result); }
+
+inline bool buf2numeric(absl::string_view buf, uint64_t &result) { return buf2uint64(buf, result); }
+
+inline bool buf2numeric(absl::string_view buf, double &result) { return buf2double(buf, result); }
+
 } // namespace dsn

--- a/src/utils/string_conv.h
+++ b/src/utils/string_conv.h
@@ -174,16 +174,28 @@ inline bool buf2double(absl::string_view buf, double &result)
     return true;
 }
 
-inline bool buf2numeric(absl::string_view buf, int32_t &result) { return buf2int32(buf, result); }
+#define DEF_BUF2NUMERIC_FUNC(type, postfix)                                                        \
+    inline bool buf2numeric(absl::string_view buf, type &result)                                   \
+    {                                                                                              \
+        return buf2##postfix(buf, result);                                                         \
+    }
 
-inline bool buf2numeric(absl::string_view buf, int64_t &result) { return buf2int64(buf, result); }
+#define DEF_BUF2INT_FUNC(type) DEF_BUF2NUMERIC_FUNC(type##_t, type)
 
-inline bool buf2numeric(absl::string_view buf, uint16_t &result) { return buf2uint16(buf, result); }
+DEF_BUF2INT_FUNC(int32)
+DEF_BUF2INT_FUNC(int64)
+DEF_BUF2INT_FUNC(uint16)
+DEF_BUF2INT_FUNC(uint32)
+DEF_BUF2INT_FUNC(uint64)
 
-inline bool buf2numeric(absl::string_view buf, uint32_t &result) { return buf2uint32(buf, result); }
+#undef DEF_BUF2INT_FUNC
 
-inline bool buf2numeric(absl::string_view buf, uint64_t &result) { return buf2uint64(buf, result); }
+#define DEF_BUF2FLOAT_FUNC(type) DEF_BUF2NUMERIC_FUNC(type, type)
 
-inline bool buf2numeric(absl::string_view buf, double &result) { return buf2double(buf, result); }
+DEF_BUF2FLOAT_FUNC(double)
+
+#undef DEF_BUF2FLOAT_FUNC
+
+#undef DEF_BUF2NUMERIC_FUNC
 
 } // namespace dsn


### PR DESCRIPTION
This is the 1st part of migrating metrics for `app_stat` to new framework,
since there are many (59) metrics to be migrated and both table-level and
partition-level should be supported.
 
Since `app_stat` command has more dimensions for stats, i.e. table id and
partition id, an abstract class `aggregate_stats` is introduced to allow users
to perform their self-defined aggregations on fetched metrics.