### PR TITLE
fix(hdfs): export LIBHDFS_OPTS=-Xrs to ensure server could exit normally

### DIFF
--- a/scripts/config_hdfs.sh
+++ b/scripts/config_hdfs.sh
@@ -58,6 +58,11 @@ if [ ! -d "$HADOOP_HOME/etc/hadoop" ] || [ ! -d "$HADOOP_HOME/share/hadoop" ]; t
   echo "HADOOP_HOME must be set to the location of your Hadoop jars and core-site.xml."
   return 1
 fi
+
+# Reduces the use of operating system signals by the JVM. See details:
+# https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
+export LIBHDFS_OPTS="-Xrs"
+
 export CLASSPATH=$CLASSPATH:$HADOOP_HOME/etc/hadoop/
 for f in $HADOOP_HOME/share/hadoop/common/lib/*.jar; do
   export CLASSPATH=$CLASSPATH:$f

--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -77,13 +77,7 @@ hdfs_service::hdfs_service()
 
 hdfs_service::~hdfs_service()
 {
-    // We should not call hdfsDisconnect() here if jvm has exited.
-    // And there is no simple, safe way to call hdfsDisconnect()
-    // when process terminates (the proper solution is likely to create a
-    // signal handler to detect when the process is killed, but we would still
-    // leak when pegasus crashes).
-    //
-    // close();
+    close();
 }
 
 error_code hdfs_service::initialize(const std::vector<std::string> &args)

--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -75,10 +75,7 @@ hdfs_service::hdfs_service()
     _write_token_bucket.reset(new folly::DynamicTokenBucket());
 }
 
-hdfs_service::~hdfs_service()
-{
-    close();
-}
+hdfs_service::~hdfs_service() { close(); }
 
 error_code hdfs_service::initialize(const std::vector<std::string> &args)
 {

--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -18,10 +18,13 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <rocksdb/env.h>
+#include <stdlib.h>
 #include <algorithm>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 
+#include "fmt/core.h"
 #include "hdfs/hdfs.h"
 #include "hdfs_service.h"
 #include "rocksdb/slice.h"


### PR DESCRIPTION
Resolve https://github.com/apache/incubator-pegasus/issues/1913.

Reduces the use of operating system signals by the JVM by exporting
LIBHDFS_OPTS="-Xrs" to resolve the issue of unexpected exit order of
JVM threads and Pegasus threads.
See details: https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html