### PR TITLE
refactor: optimize zookeeper client init for sasl

### DIFF
--- a/src/security/negotiation.cpp
+++ b/src/security/negotiation.cpp
@@ -31,6 +31,7 @@ DSN_DEFINE_bool(security,
                 enable_zookeeper_kerberos,
                 false,
                 "whether to enable kerberos for zookeeper client");
+DSN_TAG_VARIABLE(enable_zookeeper_kerberos, FT_MUTABLE);
 DSN_DEFINE_bool(security, mandatory_auth, false, "wheter to do authertication mandatorily");
 DSN_TAG_VARIABLE(mandatory_auth, FT_MUTABLE);
 

--- a/src/security/negotiation.cpp
+++ b/src/security/negotiation.cpp
@@ -31,7 +31,6 @@ DSN_DEFINE_bool(security,
                 enable_zookeeper_kerberos,
                 false,
                 "whether to enable kerberos for zookeeper client");
-DSN_TAG_VARIABLE(enable_zookeeper_kerberos, FT_MUTABLE);
 DSN_DEFINE_bool(security, mandatory_auth, false, "wheter to do authertication mandatorily");
 DSN_TAG_VARIABLE(mandatory_auth, FT_MUTABLE);
 

--- a/src/zookeeper/zookeeper_session.cpp
+++ b/src/zookeeper/zookeeper_session.cpp
@@ -200,9 +200,8 @@ int zookeeper_session::attach(void *callback_owner, const state_callback &cb)
 
         auto param_host = "";
         if (!utils::is_empty(FLAGS_sasl_service_fqdn)) {
-            rpc_address addr;
             CHECK(dsn::rpc_address::from_host_port(FLAGS_sasl_service_fqdn),
-                  "sasl_service_fqdn {} is invalid",
+                  "sasl_service_fqdn '{}' is invalid",
                   FLAGS_sasl_service_fqdn);
             param_host = FLAGS_sasl_service_fqdn;
         }

--- a/src/zookeeper/zookeeper_session.cpp
+++ b/src/zookeeper/zookeeper_session.cpp
@@ -63,7 +63,6 @@ DSN_DEFINE_string(zookeeper,
                   sasl_password_file,
                   "",
                   "File containing the password (recommended for SASL/DIGEST-MD5)");
-DSN_TAG_VARIABLE(sasl_mechanisms_type, FT_MUTABLE);
 DSN_DEFINE_group_validator(enable_zookeeper_kerberos, [](std::string &message) -> bool {
     if (FLAGS_enable_zookeeper_kerberos &&
         !dsn::utils::equals(FLAGS_sasl_mechanisms_type, "GSSAPI")) {
@@ -178,55 +177,58 @@ zookeeper_session::zookeeper_session(const service_app_info &node) : _handle(nul
 int zookeeper_session::attach(void *callback_owner, const state_callback &cb)
 {
     utils::auto_write_lock l(_watcher_lock);
-    if (nullptr == _handle) {
+    do {
+        if (nullptr != _handle) {
+            break;
+        }
         if (utils::is_empty(FLAGS_sasl_mechanisms_type)) {
             _handle = zookeeper_init(
                 FLAGS_hosts_list, global_watcher, FLAGS_timeout_ms, nullptr, this, 0);
-        } else {
-            int err = sasl_client_init(nullptr);
-            CHECK_EQ_MSG(err,
-                         SASL_OK,
-                         "Unable to initialize SASL library {}",
-                         sasl_errstring(err, nullptr, nullptr));
+            break;
+        }
+        int err = sasl_client_init(nullptr);
+        CHECK_EQ_MSG(err,
+                     SASL_OK,
+                     "Unable to initialize SASL library {}",
+                     sasl_errstring(err, nullptr, nullptr));
 
-            if (!utils::is_empty(FLAGS_sasl_password_file)) {
-                CHECK(utils::filesystem::file_exists(FLAGS_sasl_password_file),
-                      "sasl_password_file {} not exist!",
-                      FLAGS_sasl_password_file);
-            }
-
-            auto param_host = "";
-            if (!utils::is_empty(FLAGS_sasl_service_fqdn)) {
-                rpc_address addr;
-                CHECK(dsn::rpc_address::from_host_port(FLAGS_sasl_service_fqdn),
-                      "sasl_service_fqdn {} is invalid",
-                      FLAGS_sasl_service_fqdn);
-                param_host = FLAGS_sasl_service_fqdn;
-            }
-            // DIGEST-MD5 requires '--server-fqdn zk-sasl-md5' for historical reasons on zk c client
-            if (dsn::utils::equals(FLAGS_sasl_mechanisms_type, "DIGEST-MD5")) {
-                param_host = "zk-sasl-md5";
-            }
-
-            zoo_sasl_params_t sasl_params = {0};
-            sasl_params.service = FLAGS_sasl_service_name;
-            sasl_params.mechlist = FLAGS_sasl_mechanisms_type;
-            sasl_params.host = param_host;
-            sasl_params.callbacks = zoo_sasl_make_basic_callbacks(
-                FLAGS_sasl_user_name, FLAGS_sasl_realm, FLAGS_sasl_password_file);
-
-            _handle = zookeeper_init_sasl(FLAGS_hosts_list,
-                                          global_watcher,
-                                          FLAGS_timeout_ms,
-                                          nullptr,
-                                          this,
-                                          0,
-                                          nullptr,
-                                          &sasl_params);
+        if (!utils::is_empty(FLAGS_sasl_password_file)) {
+            CHECK(utils::filesystem::file_exists(FLAGS_sasl_password_file),
+                  "sasl_password_file {} not exist!",
+                  FLAGS_sasl_password_file);
         }
 
-        CHECK_NOTNULL(_handle, "zookeeper session init failed");
-    }
+        auto param_host = "";
+        if (!utils::is_empty(FLAGS_sasl_service_fqdn)) {
+            rpc_address addr;
+            CHECK(dsn::rpc_address::from_host_port(FLAGS_sasl_service_fqdn),
+                  "sasl_service_fqdn {} is invalid",
+                  FLAGS_sasl_service_fqdn);
+            param_host = FLAGS_sasl_service_fqdn;
+        }
+        // DIGEST-MD5 requires '--server-fqdn zk-sasl-md5' for historical reasons on zk c client
+        if (dsn::utils::equals(FLAGS_sasl_mechanisms_type, "DIGEST-MD5")) {
+            param_host = "zk-sasl-md5";
+        }
+
+        zoo_sasl_params_t sasl_params = {0};
+        sasl_params.service = FLAGS_sasl_service_name;
+        sasl_params.mechlist = FLAGS_sasl_mechanisms_type;
+        sasl_params.host = param_host;
+        sasl_params.callbacks = zoo_sasl_make_basic_callbacks(
+            FLAGS_sasl_user_name, FLAGS_sasl_realm, FLAGS_sasl_password_file);
+
+        _handle = zookeeper_init_sasl(FLAGS_hosts_list,
+                                      global_watcher,
+                                      FLAGS_timeout_ms,
+                                      nullptr,
+                                      this,
+                                      0,
+                                      nullptr,
+                                      &sasl_params);
+    } while (false);
+
+    CHECK_NOTNULL(_handle, "zookeeper session init failed");
 
     _watchers.push_back(watcher_object());
     _watchers.back().watcher_path = "";

--- a/src/zookeeper/zookeeper_session.cpp
+++ b/src/zookeeper/zookeeper_session.cpp
@@ -41,6 +41,14 @@
 #include "zookeeper_session.h"
 
 DSN_DECLARE_bool(enable_zookeeper_kerberos);
+DSN_DEFINE_string(security,
+                  zookeeper_kerberos_service_name,
+                  "",
+                  "[Deprecated] zookeeper kerberos service name");
+DSN_DEFINE_string(security,
+                  zookeeper_sasl_service_fqdn,
+                  "",
+                  "[Deprecated] The FQDN of a Zookeeper server, used in Kerberos Principal");
 // TODO(yingchun): to keep compatibility, the global name is FLAGS_timeout_ms. The name is not very
 //  suitable, maybe improve the macro to us another global name.
 DSN_DEFINE_int32(zookeeper,
@@ -68,6 +76,22 @@ DSN_DEFINE_group_validator(enable_zookeeper_kerberos, [](std::string &message) -
         !dsn::utils::equals(FLAGS_sasl_mechanisms_type, "GSSAPI")) {
         message = "Please set [zookeeper] sasl_mechanisms_type to GSSAPI if [security] "
                   "enable_zookeeper_kerberos is true.";
+        return false;
+    }
+
+    return true;
+});
+DSN_DEFINE_group_validator(consistency_between_configurations, [](std::string &message) -> bool {
+    if (!dsn::utils::is_empty(FLAGS_zookeeper_kerberos_service_name) &&
+        !dsn::utils::equals(FLAGS_zookeeper_kerberos_service_name, FLAGS_sasl_service_name)) {
+        message = "zookeeper_kerberos_service_name deprecated, if set should be same as "
+                  "sasl_service_name.";
+        return false;
+    }
+    if (!dsn::utils::is_empty(FLAGS_zookeeper_sasl_service_fqdn) &&
+        !dsn::utils::equals(FLAGS_zookeeper_sasl_service_fqdn, FLAGS_sasl_service_fqdn)) {
+        message =
+            "zookeeper_sasl_service_fqdn deprecated, if set should be same as sasl_service_fqdn.";
         return false;
     }
 


### PR DESCRIPTION
Reference:
zookeeper 3.7 client
https://github.com/apache/zookeeper/blob/branch-3.7/zookeeper-client/zookeeper-client-c/src/cli.c

Notes:
If you want to use kerberos zookeeper before, you just need to set [security]
enable_zookeeper_kerberos to "true" and do some kerberos configurations. 
After this commit, you also need to set [zookeeper] sasl_mechanisms_type
to "GSSAPI". Otherwise, you'll get an error log prompting you to make changes.

Some configurations are added:
```diff
[zookeeper]
sasl_service_name = zookeeper
sasl_service_fqdn =
sasl_mechanisms_type =
sasl_user_name =
sasl_realm =
sasl_password_file =
```