### PR TITLE
feat(new_metrics): show table stats by shell `app_stat` command based on new metrics (part 2)

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -1373,16 +1373,19 @@ inline std::unique_ptr<aggregate_stats_calcs> create_table_aggregate_stats_calcs
     }
 
     auto calcs = std::make_unique<aggregate_stats_calcs>();
-    calcs->create_sums<partition_aggregate_stats>(entity_type, std::move(sums), partitions);
+    calcs->create_sums<table_aggregate_stats>(entity_type, std::move(sums), partitions);
     calcs->create_increases<table_aggregate_stats>(entity_type, std::move(increases), partitions);
     calcs->create_rates<table_aggregate_stats>(entity_type, std::move(rates), partitions);
     return calcs;
 }
 
 // Create all aggregations for the partition-level stats.
-inline std::unique_ptr<aggregate_stats_calcs> create_partition_aggregate_stats_calcs(
-    const int32_t table_id, const std::vector<dsn::partition_configuration> &partitions;
-    const dsn::rpc_address &node, const std::string &entity_type, std::vector<row_data> &rows)
+inline std::unique_ptr<aggregate_stats_calcs>
+create_partition_aggregate_stats_calcs(const int32_t table_id,
+                                       const std::vector<dsn::partition_configuration> &partitions,
+                                       const dsn::rpc_address &node,
+                                       const std::string &entity_type,
+                                       std::vector<row_data> &rows)
 {
     CHECK_EQ(rows.size(), partitions.size());
 
@@ -1743,8 +1746,6 @@ inline bool get_partition_stats(shell_context *sc,
     std::this_thread::sleep_for(std::chrono::milliseconds(sample_interval_ms));
     const auto &results_end = get_metrics(nodes, query_string);
 
-    // TODO(wangdan): use partition_aggregate_stats to implement partition-level stats
-    // for a specific table.
     rows.clear();
     rows.reserve(partition_count);
     for (int32_t i = 0; i < partition_count; ++i) {

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -390,10 +390,10 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             return true;
         }
 
-        const auto filters = rw_requests_filters();
-        const auto &results_start = get_metrics(nodes, filters.to_query_string());
+        const auto query_string = rw_requests_filters().to_query_string();
+        const auto &results_start = get_metrics(nodes, query_string);
         std::this_thread::sleep_for(std::chrono::milliseconds(FLAGS_nodes_sample_interval_ms));
-        const auto &results_end = get_metrics(nodes, filters.to_query_string());
+        const auto &results_end = get_metrics(nodes, query_string);
 
         for (size_t i = 0; i < nodes.size(); ++i) {
             auto tmp_it = tmp_map.find(nodes[i].address);

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -390,9 +390,10 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             return true;
         }
 
-        const auto &results_start = get_metrics(nodes, rw_requests_filters().to_query_string());
+        const auto filters = rw_requests_filters();
+        const auto &results_start = get_metrics(nodes, filters.to_query_string());
         std::this_thread::sleep_for(std::chrono::milliseconds(FLAGS_nodes_sample_interval_ms));
-        const auto &results_end = get_metrics(nodes, rw_requests_filters().to_query_string());
+        const auto &results_end = get_metrics(nodes, filters.to_query_string());
 
         for (size_t i = 0; i < nodes.size(); ++i) {
             auto tmp_it = tmp_map.find(nodes[i].address);


### PR DESCRIPTION
This is the 2nd part of migrating metrics for `app_stat` to new framework,
implementing partition-level aggregations for a specific table.