### PR TITLE
feat(shell): support options `sample_interval_ms` for shell `app_stat` and `nodes` commands

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -59,6 +59,7 @@
 #include "utils/errors.h"
 #include "utils/metrics.h"
 #include "utils/ports.h"
+#include "utils/string_conv.h"
 #include "utils/strings.h"
 #include "utils/synchronize.h"
 #include "utils/time_utils.h"
@@ -75,6 +76,12 @@ using namespace dsn::replication;
 
 DEFINE_TASK_CODE(LPC_SCAN_DATA, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
 DEFINE_TASK_CODE(LPC_GET_METRICS, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
+
+#define RETURN_FALSE_IF_SAMPLE_INTERVAL_MS_INVALID()                                               \
+    verify_logged(dsn::buf2uint32(optarg, sample_interval_ms),                                     \
+                  "parse sample_interval_ms(%s) failed",                                           \
+                  optarg);                                                                         \
+    verify_logged(sample_interval_ms > 0, "sample_interval_ms should be > 0")
 
 enum scan_data_operator
 {

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -79,9 +79,9 @@ DEFINE_TASK_CODE(LPC_GET_METRICS, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAU
 
 #define RETURN_FALSE_IF_SAMPLE_INTERVAL_MS_INVALID()                                               \
     verify_logged(dsn::buf2uint32(optarg, sample_interval_ms),                                     \
-                  "parse sample_interval_ms(%s) failed",                                           \
+                  "parse sample_interval_ms(%s) failed\n",                                         \
                   optarg);                                                                         \
-    verify_logged(sample_interval_ms > 0, "sample_interval_ms should be > 0")
+    verify_logged(sample_interval_ms > 0, "sample_interval_ms should be > 0\n")
 
 enum scan_data_operator
 {

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -56,6 +56,7 @@
 #include "utils/utils.h"
 
 DSN_DEFINE_uint32(shell, nodes_sample_interval_ms, 1000, "The interval between sampling metrics.");
+DSN_DEFINE_validator(nodes_sample_interval_ms, [](uint32_t value) -> bool { return value > 0; });
 
 bool query_cluster_info(command_executor *e, shell_context *sc, arguments args)
 {
@@ -285,9 +286,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             output_file = optarg;
             break;
         case 't':
-            verify_logged(dsn::buf2uint32(optarg, sample_interval_ms),
-                          "parse sample_interval_ms(%s) failed",
-                          optarg);
+            RETURN_FALSE_IF_SAMPLE_INTERVAL_MS_INVALID();
             break;
         default:
             return false;

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -51,7 +51,6 @@
 #include "utils/metrics.h"
 #include "utils/output_utils.h"
 #include "utils/ports.h"
-#include "utils/string_conv.h"
 #include "utils/strings.h"
 #include "utils/utils.h"
 

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -50,6 +50,7 @@
 #include "utils/metrics.h"
 #include "utils/output_utils.h"
 #include "utils/ports.h"
+#include "utils/string_conv.h"
 #include "utils/strings.h"
 #include "utils/utils.h"
 

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -50,11 +50,11 @@
 #include "utils/metrics.h"
 #include "utils/output_utils.h"
 #include "utils/ports.h"
-#include "utils/string_conv.h"
 #include "utils/strings.h"
 #include "utils/utils.h"
 
 DSN_DEFINE_uint32(shell, tables_sample_interval_ms, 1000, "The interval between sampling metrics.");
+DSN_DEFINE_validator(tables_sample_interval_ms, [](uint32_t value) -> bool { return value > 0; });
 
 double convert_to_ratio(double hit, double total)
 {
@@ -520,9 +520,7 @@ bool app_stat(command_executor *e, shell_context *sc, arguments args)
             out_file = optarg;
             break;
         case 't':
-            verify_logged(dsn::buf2uint32(optarg, sample_interval_ms),
-                          "parse sample_interval_ms(%s) failed",
-                          optarg);
+            RETURN_FALSE_IF_SAMPLE_INTERVAL_MS_INVALID();
             break;
         default:
             return false;

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -86,15 +86,16 @@ static command_executor commands[] = {
     {
         "ls",
         "list all apps",
-        "[-a|-all] [-d|--detailed] [-j|--json] [-o|--output file_name]"
+        "[-a|-all] [-d|--detailed] [-j|--json] [-o|--output file_name] "
         "[-s|--status all|available|creating|dropping|dropped]",
         ls_apps,
     },
     {
         "nodes",
         "get the node status for this cluster",
-        "[-d|--detailed] [-j|--json] [-r|--resolve_ip] [-u|--resource_usage]"
-        "[-o|--output file_name] [-s|--status all|alive|unalive] [-q|--qps]",
+        "[-d|--detailed] [-j|--json] [-r|--resolve_ip] [-u|--resource_usage] "
+        "[-o|--output file_name] [-s|--status all|alive|unalive] [-q|--qps] "
+        "[-t|--sample_interval_ms num]",
         ls_nodes,
     },
     {
@@ -352,7 +353,7 @@ static command_executor commands[] = {
         "app_stat",
         "get stat of apps",
         "[-a|--app_name str] [-q|--only_qps] [-u|--only_usage] [-j|--json] "
-        "[-o|--output file_name]",
+        "[-o|--output file_name] [-t|--sample_interval_ms num]",
         app_stat,
     },
     {


### PR DESCRIPTION
 Support specifying `sample_interval_ms` options while executing
commands `app_stat` and `nodes`, to give the custom duration
while aggregating rates on stats.