### PR TITLE
fix(cmake): increase the minimum required version of cmake to 3.24.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.11.0)
+cmake_minimum_required(VERSION 3.24.0)
 project(pegasus)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 ##############################################################################
 
-cmake_minimum_required(VERSION 3.11.0)
+cmake_minimum_required(VERSION 3.24.0)
 project(pegasus_thirdparties)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1927

Since `DOWNLOAD_EXTRACT_TIMESTAMP` was introduced in version 3.24,
the minimum required version of cmake should be increased from 3.11.0 to
3.24.0. The document of the website would also be updated.