### PR TITLE
refactor(replica): Unify some unique variables to reduce redundances

### DIFF
--- a/src/block_service/test/main.cpp
+++ b/src/block_service/test/main.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 
+#include "common/replication_common.h"
 #include "runtime/app_model.h"
 #include "runtime/service_app.h"
 #include "utils/error_code.h"
@@ -47,7 +48,8 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
-    dsn::service_app::register_factory<gtest_app>("replica");
+    dsn::service_app::register_factory<gtest_app>(
+        dsn::replication::replication_options::kReplicaAppType.c_str());
 
     dsn_run_config("config-test.ini", false);
     while (g_test_count == 0) {

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -109,6 +109,8 @@ DSN_DEFINE_string(replication,
 
 namespace dsn {
 namespace replication {
+const std::string replication_options::kRepsDir = "reps";
+const std::string replication_options::kAppType = "replica";
 
 replication_options::~replication_options() {}
 
@@ -276,7 +278,7 @@ replication_options::get_data_dir_and_tag(const std::string &config_dirs_str,
     for (unsigned i = 0; i < dirs.size(); ++i) {
         const std::string &dir = dirs[i];
         LOG_INFO("data_dirs[{}] = {}, tag = {}", i + 1, dir, dir_tags[i]);
-        data_dirs.push_back(utils::filesystem::path_combine(dir, "reps"));
+        data_dirs.push_back(utils::filesystem::path_combine(dir, kRepsDir));
         data_dir_tags.push_back(dir_tags[i]);
     }
     return true;

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -110,7 +110,7 @@ DSN_DEFINE_string(replication,
 namespace dsn {
 namespace replication {
 const std::string replication_options::kRepsDir = "reps";
-const std::string replication_options::kAppType = "replica";
+const std::string replication_options::kReplicaAppType = "replica";
 
 replication_options::~replication_options() {}
 

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -56,6 +56,10 @@ typedef rpc_holder<query_replica_info_request, query_replica_info_response> quer
 class replication_options
 {
 public:
+    static const std::string kRepsDir;
+    // TODO(yingchun): there are many duplicate "replica" words in the codebase, refactor it later.
+    static const std::string kAppType;
+
     std::vector<::dsn::rpc_address> meta_servers;
 
     std::string app_name;

--- a/src/common/replication_common.h
+++ b/src/common/replication_common.h
@@ -57,8 +57,7 @@ class replication_options
 {
 public:
     static const std::string kRepsDir;
-    // TODO(yingchun): there are many duplicate "replica" words in the codebase, refactor it later.
-    static const std::string kAppType;
+    static const std::string kReplicaAppType;
 
     std::vector<::dsn::rpc_address> meta_servers;
 

--- a/src/common/test/main.cpp
+++ b/src/common/test/main.cpp
@@ -30,6 +30,7 @@
 #include <thread>
 #include <vector>
 
+#include "common/replication_common.h"
 #include "runtime/app_model.h"
 #include "runtime/service_app.h"
 #include "utils/error_code.h"
@@ -56,7 +57,8 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
-    dsn::service_app::register_factory<gtest_app>("replica");
+    dsn::service_app::register_factory<gtest_app>(
+        dsn::replication::replication_options::kReplicaAppType.c_str());
 
     dsn_run_config("config-test.ini", false);
     while (g_test_count == 0) {

--- a/src/common/test/replication_common_test.cpp
+++ b/src/common/test/replication_common_test.cpp
@@ -61,8 +61,12 @@ TEST(replication_common, get_data_dir_test)
     for (const auto &test : tests) {
         data_dirs.clear();
         data_dir_tags.clear();
-        bool flag = replication_options::get_data_dir_and_tag(
-            test.data_dir_str, "test_dir", "replica", data_dirs, data_dir_tags, err_msg);
+        bool flag = replication_options::get_data_dir_and_tag(test.data_dir_str,
+                                                              "test_dir",
+                                                              replication_options::kAppType,
+                                                              data_dirs,
+                                                              data_dir_tags,
+                                                              err_msg);
         ASSERT_EQ(flag, test.expected_val);
         ASSERT_EQ(data_dirs.size(), data_dir_tags.size());
         ASSERT_EQ(data_dirs.size(), test.expected_length);

--- a/src/common/test/replication_common_test.cpp
+++ b/src/common/test/replication_common_test.cpp
@@ -63,7 +63,7 @@ TEST(replication_common, get_data_dir_test)
         data_dir_tags.clear();
         bool flag = replication_options::get_data_dir_and_tag(test.data_dir_str,
                                                               "test_dir",
-                                                              replication_options::kAppType,
+                                                              replication_options::kReplicaAppType,
                                                               data_dirs,
                                                               data_dir_tags,
                                                               err_msg);

--- a/src/replica/backup/test/main.cpp
+++ b/src/replica/backup/test/main.cpp
@@ -47,7 +47,8 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
-    dsn::service_app::register_factory<gtest_app>("replica");
+    dsn::service_app::register_factory<gtest_app>(
+        dsn::replication::replication_options::kReplicaAppType.c_str());
 
     dsn_run_config("config-test.ini", false);
     while (g_test_count == 0) {

--- a/src/replica/backup/test/main.cpp
+++ b/src/replica/backup/test/main.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 
+#include "common/replication_common.h"
 #include "runtime/app_model.h"
 #include "runtime/service_app.h"
 #include "utils/error_code.h"

--- a/src/replica/bulk_load/test/main.cpp
+++ b/src/replica/bulk_load/test/main.cpp
@@ -47,7 +47,8 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
-    dsn::service_app::register_factory<gtest_app>("replica");
+    dsn::service_app::register_factory<gtest_app>(
+        dsn::replication::replication_options::kReplicaAppType.c_str());
 
     dsn_run_config("config-test.ini", false);
     while (g_test_count == 0) {

--- a/src/replica/bulk_load/test/main.cpp
+++ b/src/replica/bulk_load/test/main.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 
+#include "common/replication_common.h"
 #include "runtime/app_model.h"
 #include "runtime/service_app.h"
 #include "utils/error_code.h"

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -23,6 +23,7 @@
 
 #include "common/bulk_load_common.h"
 #include "common/gpid.h"
+#include "common/replication_common.h"
 #include "dsn.layer2_types.h"
 #include "gtest/gtest.h"
 #include "replica/test/mock_utils.h"

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -23,7 +23,6 @@
 
 #include "common/bulk_load_common.h"
 #include "common/gpid.h"
-#include "common/replication_common.h"
 #include "dsn.layer2_types.h"
 #include "gtest/gtest.h"
 #include "replica/test/mock_utils.h"
@@ -71,7 +70,7 @@ public:
     error_code test_start_downloading()
     {
         const std::string remote_dir = _bulk_loader->get_remote_bulk_load_dir(
-            replication_options::kReplicaAppType, CLUSTER, ROOT_PATH, PID.get_partition_index());
+            APP_NAME, CLUSTER, ROOT_PATH, PID.get_partition_index());
         auto err = _bulk_loader->start_download(remote_dir, PROVIDER);
         _bulk_loader->tracker()->wait_outstanding_tasks();
         return err;
@@ -196,7 +195,7 @@ public:
     void
     create_bulk_load_request(bulk_load_status::type status, ballot b, int32_t downloading_count = 0)
     {
-        _req.app_name = replication_options::kReplicaAppType;
+        _req.app_name = APP_NAME;
         _req.ballot = b;
         _req.cluster_name = CLUSTER;
         _req.meta_bulk_load_status = status;
@@ -216,7 +215,7 @@ public:
 
     void create_group_bulk_load_request(bulk_load_status::type status, ballot b)
     {
-        _group_req.app_name = replication_options::kReplicaAppType;
+        _group_req.app_name = APP_NAME;
         _group_req.meta_bulk_load_status = status;
         _group_req.config.status = partition_status::PS_SECONDARY;
         _group_req.config.ballot = b;
@@ -405,6 +404,7 @@ public:
     file_meta _file_meta;
     bulk_load_metadata _metadata;
 
+    std::string APP_NAME = "replica_bulk_loader_test";
     std::string CLUSTER = "cluster";
     std::string PROVIDER = "local_service";
     std::string ROOT_PATH = "bulk_load_root";

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -70,7 +70,7 @@ public:
     error_code test_start_downloading()
     {
         const std::string remote_dir = _bulk_loader->get_remote_bulk_load_dir(
-            APP_NAME, CLUSTER, ROOT_PATH, PID.get_partition_index());
+            replication_options::kReplicaAppType, CLUSTER, ROOT_PATH, PID.get_partition_index());
         auto err = _bulk_loader->start_download(remote_dir, PROVIDER);
         _bulk_loader->tracker()->wait_outstanding_tasks();
         return err;
@@ -195,7 +195,7 @@ public:
     void
     create_bulk_load_request(bulk_load_status::type status, ballot b, int32_t downloading_count = 0)
     {
-        _req.app_name = APP_NAME;
+        _req.app_name = replication_options::kReplicaAppType;
         _req.ballot = b;
         _req.cluster_name = CLUSTER;
         _req.meta_bulk_load_status = status;
@@ -215,7 +215,7 @@ public:
 
     void create_group_bulk_load_request(bulk_load_status::type status, ballot b)
     {
-        _group_req.app_name = APP_NAME;
+        _group_req.app_name = replication_options::kReplicaAppType;
         _group_req.meta_bulk_load_status = status;
         _group_req.config.status = partition_status::PS_SECONDARY;
         _group_req.config.ballot = b;
@@ -404,7 +404,6 @@ public:
     file_meta _file_meta;
     bulk_load_metadata _metadata;
 
-    std::string APP_NAME = "replica";
     std::string CLUSTER = "cluster";
     std::string PROVIDER = "local_service";
     std::string ROOT_PATH = "bulk_load_root";

--- a/src/replica/duplication/test/main.cpp
+++ b/src/replica/duplication/test/main.cpp
@@ -47,7 +47,8 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
-    dsn::service_app::register_factory<gtest_app>("replica");
+    dsn::service_app::register_factory<gtest_app>(
+        dsn::replication::replication_options::kReplicaAppType.c_str());
 
     dsn_run_config("config-test.ini", false);
     while (g_test_count == 0) {

--- a/src/replica/duplication/test/main.cpp
+++ b/src/replica/duplication/test/main.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 
+#include "common/replication_common.h"
 #include "runtime/app_model.h"
 #include "runtime/service_app.h"
 #include "utils/error_code.h"

--- a/src/replica/duplication/test/replica_follower_test.cpp
+++ b/src/replica/duplication/test/replica_follower_test.cpp
@@ -23,6 +23,7 @@
 
 #include "common/duplication_common.h"
 #include "common/gpid.h"
+#include "common/replication_common.h"
 #include "consensus_types.h"
 #include "dsn.layer2_types.h"
 #include "duplication_test_base.h"

--- a/src/replica/duplication/test/replica_follower_test.cpp
+++ b/src/replica/duplication/test/replica_follower_test.cpp
@@ -48,7 +48,7 @@ public:
     {
         _app_info.app_id = 2;
         _app_info.app_name = "follower";
-        _app_info.app_type = "replica";
+        _app_info.app_type = replication_options::kReplicaAppType;
         _app_info.is_stateful = true;
         _app_info.max_replica_count = 3;
         _app_info.partition_count = 8;

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -265,15 +265,13 @@ METRIC_DEFINE_counter(replica,
 namespace dsn {
 namespace replication {
 
-const std::string replica::kAppInfo = ".app-info";
-
 replica::replica(replica_stub *stub,
                  gpid gpid,
                  const app_info &app,
                  dir_node *dn,
                  bool need_restore,
                  bool is_duplication_follower)
-    : serverlet<replica>("replica"),
+    : serverlet<replica>(replication_options::kAppType.c_str()),
       replica_base(gpid, fmt::format("{}@{}", gpid, stub->_primary_address_str), app.app_name),
       _app_info(app),
       _primary_states(gpid, FLAGS_staleness_for_commit, FLAGS_batch_write_disabled),
@@ -693,7 +691,8 @@ uint32_t replica::query_data_version() const
 error_code replica::store_app_info(app_info &info, const std::string &path)
 {
     replica_app_info new_info((app_info *)&info);
-    const auto &info_path = path.empty() ? utils::filesystem::path_combine(_dir, kAppInfo) : path;
+    const auto &info_path =
+        path.empty() ? utils::filesystem::path_combine(_dir, replica_app_info::kAppInfo) : path;
     auto err = new_info.store(info_path);
     if (dsn_unlikely(err != ERR_OK)) {
         LOG_ERROR_PREFIX("failed to save app_info to {}, error = {}", info_path, err);

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -271,7 +271,7 @@ replica::replica(replica_stub *stub,
                  dir_node *dn,
                  bool need_restore,
                  bool is_duplication_follower)
-    : serverlet<replica>(replication_options::kAppType.c_str()),
+    : serverlet<replica>(replication_options::kReplicaAppType.c_str()),
       replica_base(gpid, fmt::format("{}@{}", gpid, stub->_primary_address_str), app.app_name),
       _app_info(app),
       _primary_states(gpid, FLAGS_staleness_for_commit, FLAGS_batch_write_disabled),

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -38,6 +38,7 @@
 #include "common/fs_manager.h"
 #include "common/gpid.h"
 #include "common/replica_envs.h"
+#include "common/replication_common.h"
 #include "common/replication_enums.h"
 #include "consensus_types.h"
 #include "duplication/replica_duplicator_manager.h"

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -286,8 +286,6 @@ public:
     METRIC_DEFINE_INCREMENT(backup_file_upload_successful_count)
     METRIC_DEFINE_INCREMENT_BY(backup_file_upload_total_bytes)
 
-    static const std::string kAppInfo;
-
 protected:
     // this method is marked protected to enable us to mock it in unit tests.
     virtual decree max_gced_decree_no_lock() const;

--- a/src/replica/replica_disk_migrator.cpp
+++ b/src/replica/replica_disk_migrator.cpp
@@ -266,7 +266,7 @@ bool replica_disk_migrator::migrate_replica_app_info(const replica_disk_migrate_
 
     const auto &store_info_err = _replica->store_app_info(
         _replica->_app_info,
-        utils::filesystem::path_combine(_target_replica_dir, replica::kAppInfo));
+        utils::filesystem::path_combine(_target_replica_dir, replica_app_info::kAppInfo));
     if (store_info_err != ERR_OK) {
         LOG_ERROR_PREFIX("disk migration(origin={}, target={}) stores app info failed({})",
                          req.origin_disk,

--- a/src/replica/replica_http_service.h
+++ b/src/replica/replica_http_service.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <string>
 
+#include "common/replication_common.h"
 #include "http/http_server.h"
 #include "metadata_types.h"
 #include "utils/fmt_logging.h"
@@ -58,7 +59,7 @@ public:
         deregister_http_call("replica/manual_compaction");
     }
 
-    std::string path() const override { return "replica"; }
+    std::string path() const override { return replication_options::kReplicaAppType; }
 
     void query_duplication_handler(const http_request &req, http_response &resp);
     void query_app_data_version_handler(const http_request &req, http_response &resp);

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -982,8 +982,12 @@ void replica_stub::on_add_new_disk(add_new_disk_rpc rpc)
     std::vector<std::string> data_dir_tags;
     std::string err_msg;
     if (disk_str.empty() ||
-        !replication_options::get_data_dir_and_tag(
-            disk_str, "", replication_options::kAppType, data_dirs, data_dir_tags, err_msg)) {
+        !replication_options::get_data_dir_and_tag(disk_str,
+                                                   "",
+                                                   replication_options::kReplicaAppType,
+                                                   data_dirs,
+                                                   data_dir_tags,
+                                                   err_msg)) {
         resp.err = ERR_INVALID_PARAMETERS;
         resp.__set_err_hint(fmt::format("invalid str({}), err_msg: {}", disk_str, err_msg));
         return;

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -983,7 +983,7 @@ void replica_stub::on_add_new_disk(add_new_disk_rpc rpc)
     std::string err_msg;
     if (disk_str.empty() ||
         !replication_options::get_data_dir_and_tag(
-            disk_str, "", "replica", data_dirs, data_dir_tags, err_msg)) {
+            disk_str, "", replication_options::kAppType, data_dirs, data_dir_tags, err_msg)) {
         resp.err = ERR_INVALID_PARAMETERS;
         resp.__set_err_hint(fmt::format("invalid str({}), err_msg: {}", disk_str, err_msg));
         return;

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1927,7 +1927,7 @@ replica *replica_stub::load_replica(dir_node *dn, const char *dir)
 
     dsn::app_info info;
     replica_app_info info2(&info);
-    std::string path = utils::filesystem::path_combine(dir, replica::kAppInfo);
+    std::string path = utils::filesystem::path_combine(dir, replica_app_info::kAppInfo);
     auto err = info2.load(path);
     if (ERR_OK != err) {
         LOG_ERROR("load app-info from {} failed, err = {}", path, err);

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -120,8 +120,8 @@ error_code replica_app_info::store(const std::string &fname)
         fname, writer.get_buffer(), dsn::utils::FileDataType::kSensitive);
 }
 
-const std::string replication_app_base::kDataDirPostfix = "data";
-const std::string replication_app_base::kRdbPostfix = "rdb";
+const std::string replication_app_base::kDataDir = "data";
+const std::string replication_app_base::kRdbDir = "rdb";
 
 /*static*/
 void replication_app_base::register_storage_engine(const std::string &name, factory f)
@@ -139,7 +139,7 @@ replication_app_base *replication_app_base::new_storage_instance(const std::stri
 replication_app_base::replication_app_base(replica *replica)
     : replica_base(replica), METRIC_VAR_INIT_replica(committed_requests)
 {
-    _dir_data = utils::filesystem::path_combine(replica->dir(), kDataDirPostfix);
+    _dir_data = utils::filesystem::path_combine(replica->dir(), kDataDir);
     _dir_learn = utils::filesystem::path_combine(replica->dir(), "learn");
     _dir_backup = utils::filesystem::path_combine(replica->dir(), "backup");
     _dir_bulk_load = utils::filesystem::path_combine(replica->dir(),

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -68,6 +68,7 @@ namespace dsn {
 
 namespace replication {
 
+const std::string replica_app_info::kAppInfo = ".app-info";
 const std::string replica_init_info::kInitInfo = ".init-info";
 const std::string kms_info::kKmsInfo = ".kms-info";
 
@@ -119,6 +120,9 @@ error_code replica_app_info::store(const std::string &fname)
         fname, writer.get_buffer(), dsn::utils::FileDataType::kSensitive);
 }
 
+const std::string replication_app_base::kDataDirPostfix = "data";
+const std::string replication_app_base::kRdbPostfix = "rdb";
+
 /*static*/
 void replication_app_base::register_storage_engine(const std::string &name, factory f)
 {
@@ -135,7 +139,7 @@ replication_app_base *replication_app_base::new_storage_instance(const std::stri
 replication_app_base::replication_app_base(replica *replica)
     : replica_base(replica), METRIC_VAR_INIT_replica(committed_requests)
 {
-    _dir_data = utils::filesystem::path_combine(replica->dir(), "data");
+    _dir_data = utils::filesystem::path_combine(replica->dir(), kDataDirPostfix);
     _dir_learn = utils::filesystem::path_combine(replica->dir(), "learn");
     _dir_backup = utils::filesystem::path_combine(replica->dir(), "backup");
     _dir_bulk_load = utils::filesystem::path_combine(replica->dir(),

--- a/src/replica/replication_app_base.h
+++ b/src/replica/replication_app_base.h
@@ -76,6 +76,9 @@ private:
 
 class replica_app_info
 {
+public:
+    static const std::string kAppInfo;
+
 private:
     app_info *_app;
 
@@ -123,6 +126,8 @@ public:
     typedef replication_app_base *factory(replica *r);
     static void register_storage_engine(const std::string &name, factory f);
     static replication_app_base *new_storage_instance(const std::string &name, replica *r);
+    static const std::string kDataDirPostfix;
+    static const std::string kRdbPostfix;
 
     virtual ~replication_app_base() {}
 

--- a/src/replica/replication_app_base.h
+++ b/src/replica/replication_app_base.h
@@ -126,8 +126,8 @@ public:
     typedef replication_app_base *factory(replica *r);
     static void register_storage_engine(const std::string &name, factory f);
     static replication_app_base *new_storage_instance(const std::string &name, replica *r);
-    static const std::string kDataDirPostfix;
-    static const std::string kRdbPostfix;
+    static const std::string kDataDir;
+    static const std::string kRdbDir;
 
     virtual ~replication_app_base() {}
 

--- a/src/replica/replication_service_app.cpp
+++ b/src/replica/replication_service_app.cpp
@@ -40,7 +40,8 @@ namespace replication {
 
 void replication_service_app::register_all()
 {
-    dsn::service_app::register_factory<replication_service_app>("replica");
+    dsn::service_app::register_factory<replication_service_app>(
+        replication_options::kReplicaAppType.c_str());
 }
 
 replication_service_app::replication_service_app(const service_app_info *info) : service_app(info)

--- a/src/replica/split/test/main.cpp
+++ b/src/replica/split/test/main.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 
+#include "common/replication_common.h"
 #include "runtime/app_model.h"
 #include "runtime/service_app.h"
 #include "utils/error_code.h"
@@ -47,7 +48,8 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
-    dsn::service_app::register_factory<gtest_app>("replica");
+    dsn::service_app::register_factory<gtest_app>(
+        dsn::replication::replication_options::kReplicaAppType.c_str());
 
     dsn_run_config("config-test.ini", false);
     while (g_test_count == 0) {

--- a/src/replica/split/test/replica_split_test.cpp
+++ b/src/replica/split/test/replica_split_test.cpp
@@ -71,7 +71,7 @@ public:
     {
         _app_info.app_id = APP_ID;
         _app_info.app_name = APP_NAME;
-        _app_info.app_type = "replica";
+        _app_info.app_type = replication_options::kAppType;
         _app_info.is_stateful = true;
         _app_info.max_replica_count = 3;
         _app_info.partition_count = OLD_PARTITION_COUNT;

--- a/src/replica/split/test/replica_split_test.cpp
+++ b/src/replica/split/test/replica_split_test.cpp
@@ -71,7 +71,7 @@ public:
     {
         _app_info.app_id = APP_ID;
         _app_info.app_name = APP_NAME;
-        _app_info.app_type = replication_options::kAppType;
+        _app_info.app_type = replication_options::kReplicaAppType;
         _app_info.is_stateful = true;
         _app_info.max_replica_count = 3;
         _app_info.partition_count = OLD_PARTITION_COUNT;

--- a/src/replica/storage/simple_kv/test/checker.cpp
+++ b/src/replica/storage/simple_kv/test/checker.cpp
@@ -35,6 +35,7 @@
 
 #include "case.h"
 #include "checker.h"
+#include "common/replication_common.h"
 #include "common/replication_other_types.h"
 #include "dsn.layer2_types.h"
 #include "meta/meta_server_failure_detector.h"

--- a/src/replica/storage/simple_kv/test/checker.cpp
+++ b/src/replica/storage/simple_kv/test/checker.cpp
@@ -186,7 +186,8 @@ bool test_checker::init(const std::string &name, const std::vector<service_app *
                 std::bind(&test_checker::on_config_change, this, std::placeholders::_1));
             FLAGS_partition_guardian_type = "checker_partition_guardian";
             _meta_servers.push_back(meta_app);
-        } else if (app->info().type == "replica") {
+        } else if (app->info().type ==
+                   dsn::replication::replication_options::kReplicaAppType.c_str()) {
             replication_service_app *replica_app = (replication_service_app *)app;
             replica_app->_stub->set_replica_state_subscriber_for_test(
                 std::bind(&test_checker::on_replica_state_change,

--- a/src/replica/test/main.cpp
+++ b/src/replica/test/main.cpp
@@ -68,7 +68,8 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
-    dsn::service_app::register_factory<replication_service_test_app>("replica");
+    dsn::service_app::register_factory<replication_service_test_app>(
+        dsn::replication::replication_options::kReplicaAppType.c_str());
 
     dsn_run_config("config-test.ini", false);
     while (gtest_flags == 0) {

--- a/src/replica/test/main.cpp
+++ b/src/replica/test/main.cpp
@@ -20,6 +20,7 @@
 #include <thread>
 #include <vector>
 
+#include "common/replication_common.h"
 #include "gtest/gtest.h"
 #include "replication_service_test_app.h"
 #include "runtime/app_model.h"

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -125,7 +125,7 @@ public:
 
     void register_service()
     {
-        _app->register_storage_engine("replica",
+        _app->register_storage_engine(replication_options::kReplicaAppType,
                                       replication_app_base::create<mock_replication_app_base>);
     }
 
@@ -236,7 +236,7 @@ create_mock_replica(replica_stub *stub, int app_id = 1, int partition_index = 1)
 {
     gpid pid(app_id, partition_index);
     app_info app_info;
-    app_info.app_type = "replica";
+    app_info.app_type = replication_options::kReplicaAppType;
     app_info.app_name = "temp";
 
     auto *dn = stub->get_fs_manager()->create_replica_dir_if_necessary(app_info.app_type, pid);

--- a/src/replica/test/open_replica_test.cpp
+++ b/src/replica/test/open_replica_test.cpp
@@ -48,7 +48,7 @@ INSTANTIATE_TEST_SUITE_P(, open_replica_test, ::testing::Values(false, true));
 TEST_P(open_replica_test, open_replica_add_decree_and_ballot_check)
 {
     app_info ai;
-    ai.app_type = "replica";
+    ai.app_type = replication_options::kReplicaAppType;
     ai.is_stateful = true;
     ai.max_replica_count = 3;
     ai.partition_count = 8;

--- a/src/replica/test/open_replica_test.cpp
+++ b/src/replica/test/open_replica_test.cpp
@@ -21,6 +21,7 @@
 #include <unordered_map>
 
 #include "common/gpid.h"
+#include "common/replication_common.h"
 #include "common/replication_other_types.h"
 #include "dsn.layer2_types.h"
 #include "gtest/gtest.h"

--- a/src/replica/test/replica_disk_migrate_test.cpp
+++ b/src/replica/test/replica_disk_migrate_test.cpp
@@ -251,8 +251,10 @@ TEST_P(replica_disk_migrate_test, disk_migrate_replica_run)
                                                         request.target_disk,
                                                         request.pid,
                                                         replica_init_info::kInitInfo);
-    const std::string kTargetAppInfoFile = fmt::format(
-        "./{}/{}.replica.disk.migrate.tmp/{}", request.target_disk, request.pid, replica::kAppInfo);
+    const std::string kTargetAppInfoFile = fmt::format("./{}/{}.replica.disk.migrate.tmp/{}",
+                                                       request.target_disk,
+                                                       request.pid,
+                                                       replica_app_info::kAppInfo);
 
     init_migration_target_dir(fake_migrate_rpc);
     ASSERT_TRUE(utils::filesystem::directory_exists(kTargetDataDir));

--- a/src/replica/test/replica_disk_test_base.h
+++ b/src/replica/test/replica_disk_test_base.h
@@ -134,14 +134,14 @@ private:
     {
         app_info_1.app_id = 1;
         app_info_1.app_name = "disk_test_1";
-        app_info_1.app_type = "replica";
+        app_info_1.app_type = replication_options::kReplicaAppType;
         app_info_1.is_stateful = true;
         app_info_1.max_replica_count = 3;
         app_info_1.partition_count = 8;
 
         app_info_2.app_id = 2;
         app_info_2.app_name = "disk_test_2";
-        app_info_2.app_type = "replica";
+        app_info_2.app_type = replication_options::kReplicaAppType;
         app_info_2.is_stateful = true;
         app_info_2.max_replica_count = 3;
         app_info_2.partition_count = 16;

--- a/src/replica/test/replica_learn_test.cpp
+++ b/src/replica/test/replica_learn_test.cpp
@@ -45,7 +45,7 @@ public:
     {
         gpid pid(1, 0);
         app_info ai;
-        ai.app_type = "replica";
+        ai.app_type = replication_options::kReplicaAppType;
         ai.duplicating = true;
 
         dir_node *dn = stub->get_fs_manager()->find_best_dir_for_new_replica(pid);

--- a/src/replica/test/replica_learn_test.cpp
+++ b/src/replica/test/replica_learn_test.cpp
@@ -21,6 +21,7 @@
 
 #include "common/fs_manager.h"
 #include "common/gpid.h"
+#include "common/replication_common.h"
 #include "common/replication_other_types.h"
 #include "consensus_types.h"
 #include "dsn.layer2_types.h"

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -226,8 +226,8 @@ public:
         dsn::app_info info;
         replica_app_info replica_info(&info);
 
-        auto path = dsn::utils::filesystem::path_combine(_mock_replica->_dir,
-                                                         dsn::replication::replica::kAppInfo);
+        auto path = dsn::utils::filesystem::path_combine(
+            _mock_replica->_dir, dsn::replication::replica_app_info::kAppInfo);
         std::cout << "the path of .app-info file is " << path << std::endl;
 
         // load new max_replica_count from file

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -33,6 +33,7 @@
 #include "common/gpid.h"
 #include "common/replica_envs.h"
 #include "common/replication.codes.h"
+#include "common/replication_common.h"
 #include "common/replication_enums.h"
 #include "common/replication_other_types.h"
 #include "consensus_types.h"

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -141,7 +141,7 @@ public:
     {
         _app_info.app_id = 2;
         _app_info.app_name = "replica_test";
-        _app_info.app_type = "replica";
+        _app_info.app_type = replication_options::kReplicaAppType;
         _app_info.is_stateful = true;
         _app_info.max_replica_count = 3;
         _app_info.partition_count = 8;

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "backup_types.h"
+#include "common/replication_common.h"
 #include "compaction_operation.h"
 #include "info_collector_app.h"
 #include "meta/meta_service_app.h"

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -69,7 +69,8 @@ void dsn_app_registration_pegasus()
 {
     dsn::service::meta_service_app::register_components();
     service_app::register_factory<pegasus::server::pegasus_meta_service_app>("meta");
-    service_app::register_factory<pegasus::server::pegasus_replication_service_app>("replica");
+    service_app::register_factory<pegasus::server::pegasus_replication_service_app>(
+        dsn::replication::replication_options::kReplicaAppType.c_str());
     service_app::register_factory<pegasus::server::info_collector_app>("collector");
     pegasus::server::pegasus_server_impl::register_service();
     pegasus::server::register_compaction_operations();

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1585,7 +1585,7 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
     //          3, restore_dir is exist
     //
     bool db_exist = true;
-    auto rdb_path = dsn::utils::filesystem::path_combine(data_dir(), "rdb");
+    auto rdb_path = dsn::utils::filesystem::path_combine(data_dir(), replication_app_base::kRdbDir);
     auto duplication_path = duplication_dir();
     if (dsn::utils::filesystem::path_exists(rdb_path)) {
         // only case 1
@@ -1891,7 +1891,7 @@ void pegasus_server_impl::cancel_background_work(bool wait)
 
     if (clear_state) {
         // when clean the data dir, please clean the checkpoints first.
-        // otherwise, if the "rdb" is removed but the checkpoints remains,
+        // otherwise, if the replication_app_base::kRdbDir is removed but the checkpoints remains,
         // the storage engine can't be opened again
         for (auto iter = reserved_checkpoints.begin(); iter != reserved_checkpoints.end(); ++iter) {
             std::string chkpt_path =
@@ -2295,7 +2295,8 @@ pegasus_server_impl::storage_apply_checkpoint(chkpt_apply_mode mode,
 
         // move learned files from learn_dir to data_dir/rdb
         std::string learn_dir = ::dsn::utils::filesystem::remove_file_name(state.files[0]);
-        std::string new_dir = ::dsn::utils::filesystem::path_combine(data_dir(), "rdb");
+        std::string new_dir =
+            ::dsn::utils::filesystem::path_combine(data_dir(), replication_app_base::kRdbDir);
         if (!::dsn::utils::filesystem::rename_path(learn_dir, new_dir)) {
             LOG_ERROR_PREFIX("rename directory {} to {} failed", learn_dir, new_dir);
             return ::dsn::ERR_FILE_OPERATION_FAILED;

--- a/src/server/test/main.cpp
+++ b/src/server/test/main.cpp
@@ -52,7 +52,8 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
-    dsn::service_app::register_factory<gtest_app>("replica");
+    dsn::service_app::register_factory<gtest_app>(
+        dsn::replication::replication_options::kReplicaAppType.c_str());
 
     dsn::replication::replication_app_base::register_storage_engine(
         "pegasus",

--- a/src/server/test/main.cpp
+++ b/src/server/test/main.cpp
@@ -24,6 +24,7 @@
 #include <thread>
 #include <vector>
 
+#include "common/replication_common.h"
 #include "replica/replication_app_base.h"
 #include "runtime/app_model.h"
 #include "runtime/service_app.h"

--- a/src/server/test/pegasus_server_test_base.h
+++ b/src/server/test/pegasus_server_test_base.h
@@ -67,7 +67,8 @@ public:
         auto *dn = _replica_stub->get_fs_manager()->find_best_dir_for_new_replica(_gpid);
         CHECK_NOTNULL(dn, "");
         _replica = new dsn::replication::replica(_replica_stub, _gpid, app_info, dn, false, false);
-        const auto dir_data = dsn::utils::filesystem::path_combine(_replica->dir(), "data");
+        const auto dir_data = dsn::utils::filesystem::path_combine(
+            _replica->dir(), dsn::replication::replication_app_base::kDataDir);
         CHECK(dsn::utils::filesystem::create_directory(dir_data),
               "create data dir {} failed",
               dir_data);

--- a/src/test/kill_test/job.h
+++ b/src/test/kill_test/job.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "common/replication_common.h"
+
 namespace pegasus {
 namespace test {
 
@@ -40,7 +42,7 @@ inline const char *job_type_str(enum job_type type)
     case META:
         return "meta";
     case REPLICA:
-        return "replica";
+        return dsn::replication::replication_options::kReplicaAppType.c_str();
     case ZOOKEEPER:
         return "zookeeper";
     default:

--- a/src/test/kill_test/killer_handler_shell.cpp
+++ b/src/test/kill_test/killer_handler_shell.cpp
@@ -24,6 +24,7 @@
 #include <cstdlib>
 #include <sstream> // IWYU pragma: keep
 
+#include "common/replication_common.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/process_utils.h"
@@ -82,14 +83,15 @@ bool killer_handler_shell::kill_meta(int index)
 
 bool killer_handler_shell::kill_replica(int index)
 {
-    std::string cmd = generate_cmd(index, "replica", "stop");
+    std::string cmd =
+        generate_cmd(index, dsn::replication::replication_options::kReplicaAppType, "stop");
     int res = system(cmd.c_str());
     LOG_INFO("kill replica command: {}", cmd);
     if (res != 0) {
         LOG_INFO("kill meta encounter error({})", dsn::utils::safe_strerror(errno));
         return false;
     }
-    return check("replica", index, "stop");
+    return check(dsn::replication::replication_options::kReplicaAppType, index, "stop");
 }
 
 bool killer_handler_shell::kill_zookeeper(int index)
@@ -112,7 +114,8 @@ bool killer_handler_shell::start_meta(int index)
 
 bool killer_handler_shell::start_replica(int index)
 {
-    std::string cmd = generate_cmd(index, "replica", "start");
+    std::string cmd =
+        generate_cmd(index, dsn::replication::replication_options::kReplicaAppType, "start");
 
     int res = system(cmd.c_str());
     LOG_INFO("start replica command: {}", cmd);
@@ -175,7 +178,7 @@ killer_handler_shell::generate_cmd(int index, const std::string &job, const std:
         res << " stop_onebox_instance ";
     else
         res << " start_onebox_instance ";
-    if (job == "replica")
+    if (job == dsn::replication::replication_options::kReplicaAppType)
         res << "-r " << index;
     else
         res << "-m " << index;


### PR DESCRIPTION
Unify some string variables:
- kRepsDir: "reps"
- kReplicaAppType: "replica"
- kDataDirPostfix: "data"
- kRdbPostfix: "rdb"