### PR TITLE
refactor(partition_resolver): Make get_partition_index() as public accessable

### DIFF
--- a/src/client/partition_resolver.cpp
+++ b/src/client/partition_resolver.cpp
@@ -45,6 +45,11 @@ partition_resolver_ptr partition_resolver::get_resolver(const char *cluster_name
     return partition_resolver_manager::instance().find_or_create(cluster_name, meta_list, app_name);
 }
 
+int partition_resolver::get_partition_index(int partition_count, uint64_t partition_hash)
+{
+    return partition_hash % static_cast<uint64_t>(partition_count);
+}
+
 DEFINE_TASK_CODE(LPC_RPC_DELAY_CALL, TASK_PRIORITY_COMMON, THREAD_POOL_DEFAULT)
 
 static inline bool error_retry(error_code err)

--- a/src/client/partition_resolver.h
+++ b/src/client/partition_resolver.h
@@ -56,6 +56,16 @@ public:
                  const std::vector<dsn::rpc_address> &meta_list,
                  const char *app_name);
 
+    /**
+     * get zero-based partition index
+     *
+     * \param partition_count number of partitions.
+     * \param partition_hash  the partition hash.
+     *
+     * \return zero-based partition index.
+     */
+    static int get_partition_index(int partition_count, uint64_t partition_hash);
+
     template <typename TReq, typename TCallback>
     dsn::rpc_response_task_ptr call_op(dsn::task_code code,
                                        TReq &&request,
@@ -130,17 +140,6 @@ protected:
      this is usually to trigger new round of address resolve
      */
     virtual void on_access_failure(int partition_index, error_code err) = 0;
-
-    /**
-     * get zero-based partition index
-     *
-     * \param partition_count number of partitions.
-     * \param partition_hash  the partition hash.
-     *
-     * \return zero-based partition index.
-     */
-
-    virtual int get_partition_index(int partition_count, uint64_t partition_hash) = 0;
 
     std::string _cluster_name;
     std::string _app_name;

--- a/src/client/partition_resolver_simple.cpp
+++ b/src/client/partition_resolver_simple.cpp
@@ -448,9 +448,5 @@ error_code partition_resolver_simple::get_address(int partition_index, /*out*/ r
     }
 }
 
-int partition_resolver_simple::get_partition_index(int partition_count, uint64_t partition_hash)
-{
-    return partition_hash % static_cast<uint64_t>(partition_count);
-}
 } // namespace replication
 } // namespace dsn

--- a/src/client/partition_resolver_simple.h
+++ b/src/client/partition_resolver_simple.h
@@ -59,8 +59,6 @@ public:
 
     virtual void on_access_failure(int partition_index, error_code err) override;
 
-    virtual int get_partition_index(int partition_count, uint64_t partition_hash) override;
-
     int get_partition_count() const { return _app_partition_count; }
 
 private:


### PR DESCRIPTION
Make get_partition_index() as public accessable, then we can reuse it in
CLI tools, for example https://github.com/apache/incubator-pegasus/pull/1930.