### PR TITLE
fix(partition_split): Fix the missing garbage partition

### DIFF
--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1942,7 +1942,10 @@ bool replica_stub::validate_replica_dir(const std::string &dir,
         return false;
     }
 
-    if (ai.partition_count < pidx) {
+    // When the online partition split function aborted, the garbage partitions are with pidx in
+    // the range of [ai.partition_count, 2 * ai.partition_count), which means the partitions with
+    // pidx >= ai.partition_count are garbage partitions.
+    if (ai.partition_count <= pidx) {
         hint_message = fmt::format(
             "partition[{}], count={}, this replica may be partition split garbage partition, "
             "ignore it",

--- a/src/utils/blob.h
+++ b/src/utils/blob.h
@@ -113,6 +113,7 @@ public:
 
     unsigned int length() const noexcept { return _length; }
     unsigned int size() const noexcept { return _length; }
+    bool empty() const noexcept { return _length == 0; }
 
     std::shared_ptr<char> buffer() const { return _holder; }
 


### PR DESCRIPTION
This patch fixes the bug of the garbage partition with pidx of N is missing
gargabed after partition split function aborted on the table which has N
partitions.

Also add a small convenient function `bool empty()` for class blob.