### PR TITLE
fix(image): enable verifying certificate for CentOS 7

### DIFF
--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -49,6 +49,7 @@ RUN yum -y install centos-release-scl \
                    krb5-devel \
                    cyrus-sasl-devel \
                    patch; \
+		   yum -y install ca-certificates; \
                    yum clean all; \
                    rm -rf /var/cache/yum;
 

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -49,7 +49,7 @@ RUN yum -y install centos-release-scl \
                    krb5-devel \
                    cyrus-sasl-devel \
                    patch; \
-		   yum -y install ca-certificates; \
+                   yum -y install ca-certificates; \
                    yum clean all; \
                    rm -rf /var/cache/yum;
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1940

The problem is that docker image for compilation environment failed to be built due to "cannot verify archive.apache.org's certificate":

```
#8 [4/6] RUN wget --progress=dot:giga https://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /opt/maven     && cd /opt/maven     && tar -zxf apache-maven-3.8.3-bin.tar.gz     && rm apache-maven-3.8.3-bin.tar.gz
#8 0.086 --2024-03-08 08:48:50--  https://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz
#8 0.092 Resolving archive.apache.org (archive.apache.org)... 65.108.204.189, 2a01:4f9:1a:a084::2
#8 0.124 Connecting to archive.apache.org (archive.apache.org)|65.108.204.189|:443... connected.
#8 0.479 ERROR: cannot verify archive.apache.org's certificate, issued by '/C=US/O=Let\'s Encrypt/CN=R3':
#8 0.479   Issued certificate has expired.
#8 0.479 To connect to archive.apache.org insecurely, use `--no-check-certificate'.
#8 ERROR: process "/bin/sh -c wget --progress=dot:giga https://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /opt/maven     && cd /opt/maven     && tar -zxf apache-maven-3.8.3-bin.tar.gz     && rm apache-maven-3.8.3-bin.tar.gz" did not complete successfully: exit code: 5
------
 > [4/6] RUN wget --progress=dot:giga https://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /opt/maven     && cd /opt/maven     && tar -zxf apache-maven-3.8.3-bin.tar.gz     && rm apache-maven-3.8.3-bin.tar.gz:
connected.
0.479 ERROR: cannot verify archive.apache.org's certificate, issued by '/C=US/O=Let\'s Encrypt/CN=R3':
0.479   Issued certificate has expired.
0.479 To connect to archive.apache.org insecurely, use `--no-check-certificate'.
```

To solve this problem, `ca-certificates` was installed. After fixed, `apache-maven-3.8.3-bin.tar.gz` was downloaded successfully as below:

```
#8 [4/6] RUN wget --progress=dot:giga https://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /opt/maven     && cd /opt/maven     && tar -zxf apache-maven-3.8.3-bin.tar.gz     && rm apache-maven-3.8.3-bin.tar.gz
#8 0.086 --2024-03-08 09:32:09--  https://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz
#8 0.092 Resolving archive.apache.org (archive.apache.org)... 65.108.204.189, 2a01:4f9:1a:a084::2
#8 0.098 Connecting to archive.apache.org (archive.apache.org)|65.108.204.189|:443... connected.
#8 0.451 HTTP request sent, awaiting response... 200 OK
#8 0.569 Length: 9042049 (8.6M) [application/x-gzip]
#8 0.569 Saving to: '/opt/maven/apache-maven-3.8.3-bin.tar.gz'
#8 1.287 
#8 1.287      0K ........                           100%  838K=11s
#8 11.10 
#8 11.10 2024-03-08 09:32:20 (838 KB/s) - '/opt/maven/apache-maven-3.8.3-bin.tar.gz' saved [9042049/9042049]
#8 11.10 
#8 DONE 11.2s
```