### PR TITLE
fix(balance): Distinguish cluster balanced or collecting balance info interruptted

### DIFF
--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -63,7 +63,7 @@ greedy_load_balancer::greedy_load_balancer(meta_service *_svc) : server_load_bal
 {
     _app_balance_policy = std::make_unique<app_balance_policy>(_svc);
     _cluster_balance_policy = std::make_unique<cluster_balance_policy>(_svc);
-    _all_replca_info = false;
+    _all_replca_infos_collected = false;
 
     ::memset(t_operation_counters, 0, sizeof(t_operation_counters));
 }
@@ -164,10 +164,10 @@ void greedy_load_balancer::greedy_balancer(const bool balance_checker)
     for (auto &kv : *(t_global_view->nodes)) {
         node_state &ns = kv.second;
         if (!all_replica_infos_collected(ns)) {
-            _all_replca_info = false;
+            _all_replca_infos_collected = false;
             return;
         } else {
-            _all_replca_info = true;
+            _all_replca_infos_collected = true;
         }
     }
 
@@ -239,13 +239,13 @@ void greedy_load_balancer::report(const dsn::replication::migration_list &list,
         }
     }
 
-    if (!_all_replca_info) {
+    if (!_all_replca_infos_collected) {
         counters[ALL_COUNT] = -1;
     }
 
     ::memcpy(t_operation_counters, counters, sizeof(counters));
     LOG_DEBUG(
-        "balance checker operation count = %d, due to meta server hasn't collected all replica",
+        "balance checker operation count = {}, due to meta server hasn't collected all replica",
         t_operation_counters[ALL_COUNT]);
     METRIC_SET_GREEDY_BALANCE_STATS(_svc->get_server_state()->get_table_metric_entities(),
                                     balance_stats);

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -241,12 +241,12 @@ void greedy_load_balancer::report(const dsn::replication::migration_list &list,
 
     if (!_all_replca_infos_collected) {
         counters[ALL_COUNT] = -1;
+        LOG_DEBUG(
+            "balance checker operation count = {}, due to meta server hasn't collected all replica",
+            counters[ALL_COUNT]);
     }
 
     ::memcpy(t_operation_counters, counters, sizeof(counters));
-    LOG_DEBUG(
-        "balance checker operation count = {}, due to meta server hasn't collected all replica",
-        t_operation_counters[ALL_COUNT]);
     METRIC_SET_GREEDY_BALANCE_STATS(_svc->get_server_state()->get_table_metric_entities(),
                                     balance_stats);
 

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -244,7 +244,9 @@ void greedy_load_balancer::report(const dsn::replication::migration_list &list,
     }
 
     ::memcpy(t_operation_counters, counters, sizeof(counters));
-    LOG_DEBUG("balance checker operation count = %d, due to meta server hasn't collected all replica", t_operation_counters[ALL_COUNT]);
+    LOG_DEBUG(
+        "balance checker operation count = %d, due to meta server hasn't collected all replica",
+        t_operation_counters[ALL_COUNT]);
     METRIC_SET_GREEDY_BALANCE_STATS(_svc->get_server_state()->get_table_metric_entities(),
                                     balance_stats);
 

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -163,11 +163,9 @@ void greedy_load_balancer::greedy_balancer(const bool balance_checker)
 
     for (auto &kv : *(t_global_view->nodes)) {
         node_state &ns = kv.second;
-        if (!all_replica_infos_collected(ns)) {
-            _all_replca_infos_collected = false;
+        _all_replca_infos_collected = all_replica_infos_collected(ns);
+        if (!_all_replca_infos_collected) {
             return;
-        } else {
-            _all_replca_infos_collected = true;
         }
     }
 

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -63,6 +63,7 @@ greedy_load_balancer::greedy_load_balancer(meta_service *_svc) : server_load_bal
 {
     _app_balance_policy = std::make_unique<app_balance_policy>(_svc);
     _cluster_balance_policy = std::make_unique<cluster_balance_policy>(_svc);
+    _all_replca_info = false;
 
     ::memset(t_operation_counters, 0, sizeof(t_operation_counters));
 }
@@ -163,7 +164,10 @@ void greedy_load_balancer::greedy_balancer(const bool balance_checker)
     for (auto &kv : *(t_global_view->nodes)) {
         node_state &ns = kv.second;
         if (!all_replica_infos_collected(ns)) {
+            _all_replca_info = false;
             return;
+        } else {
+            _all_replca_info = true;
         }
     }
 
@@ -235,7 +239,12 @@ void greedy_load_balancer::report(const dsn::replication::migration_list &list,
         }
     }
 
+    if (!_all_replca_info) {
+        counters[ALL_COUNT] = -1;
+    }
+
     ::memcpy(t_operation_counters, counters, sizeof(counters));
+    LOG_DEBUG("balance checker operation count = %d, due to meta server hasn't collected all replica", t_operation_counters[ALL_COUNT]);
     METRIC_SET_GREEDY_BALANCE_STATS(_svc->get_server_state()->get_table_metric_entities(),
                                     balance_stats);
 

--- a/src/meta/greedy_load_balancer.h
+++ b/src/meta/greedy_load_balancer.h
@@ -74,6 +74,7 @@ private:
     migration_list *t_migration_result;
     int t_alive_nodes;
     int t_operation_counters[MAX_COUNT];
+    bool _all_replca_info;
 
     std::unique_ptr<load_balance_policy> _app_balance_policy;
     std::unique_ptr<load_balance_policy> _cluster_balance_policy;

--- a/src/meta/greedy_load_balancer.h
+++ b/src/meta/greedy_load_balancer.h
@@ -74,7 +74,7 @@ private:
     migration_list *t_migration_result;
     int t_alive_nodes;
     int t_operation_counters[MAX_COUNT];
-    bool _all_replca_info;
+    bool _all_replca_infos_collected;
 
     std::unique_ptr<load_balance_policy> _app_balance_policy;
     std::unique_ptr<load_balance_policy> _cluster_balance_policy;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
After scaling out, Pegasus determines whether the shards are balanced by checking if the balance operation counts are equal to 0. However, since the meta server returns counts = 0 when it cannot collect all replicas information, this leads to the premature termination of balancing. Therefore, in such cases, the counts should be equal to -1


### What is changed and how does it work?
A new bool variable  introduce into class greedy_load_balancer to control balance operation count whether be -1.
```
class greedy_load_balancer{
private:
    bool _all_replca_infos_collected;
}
```

