### PR TITLE
feat(FQDN): Use chkpt_<host>_<port> as the backup path

### DIFF
--- a/src/common/backup_common.cpp
+++ b/src/common/backup_common.cpp
@@ -18,8 +18,9 @@
 #include "backup_common.h"
 
 #include "common/gpid.h"
+#include "fmt/core.h"
 #include "runtime/api_layer1.h"
-#include "runtime/rpc/rpc_address.h"
+#include "runtime/rpc/rpc_host_port.h"
 
 namespace dsn {
 namespace replication {
@@ -100,10 +101,8 @@ std::string get_current_chkpt_file(const std::string &root,
 
 std::string get_remote_chkpt_dirname()
 {
-    // here using server address as suffix of remote_chkpt_dirname
-    std::string local_address = dsn_primary_address().ipv4_str();
-    std::string port = std::to_string(dsn_primary_address().port());
-    return "chkpt_" + local_address + "_" + port;
+    return fmt::format(
+        "chkpt_{}_{}", dsn_primary_host_port().host(), dsn_primary_host_port().port());
 }
 
 std::string get_remote_chkpt_dir(const std::string &root,

--- a/src/common/backup_common.h
+++ b/src/common/backup_common.h
@@ -160,7 +160,7 @@ std::string get_current_chkpt_file(const std::string &root,
 
 // compose the checkpoint directory name on block service
 // return:
-//      checkpoint directory name: checkpoint@<ip:port>
+//      checkpoint directory name: chkpt_<host>_<port>
 std::string get_remote_chkpt_dirname();
 
 // compose the absolute path(AP) of checkpoint dir for replica on block service

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -523,7 +523,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
                                          LOG_INFO("{}@{}: load replica '{}' success, <durable, "
                                                   "commit> = <{}, {}>, last_prepared_decree = {}",
                                                   r->get_gpid(),
-                                                  dsn_primary_address(),
+                                                  dsn_primary_host_port(),
                                                   dir,
                                                   r->last_durable_decree(),
                                                   r->last_committed_decree(),


### PR DESCRIPTION
Behavior changes:
Change the checkpoint directory name in remote storage system (e.g. HDFS)
from chkpt_<ip>_<port> to chkpt_<host>_<port>.