### PR TITLE
refactor(duplication): move get_all_replicas/get_all_primaries from duplication_sync_timer to replica_stub

### DIFF
--- a/src/replica/duplication/duplication_sync_timer.cpp
+++ b/src/replica/duplication/duplication_sync_timer.cpp
@@ -19,13 +19,12 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "common/duplication_common.h"
 #include "common/replication.codes.h"
 #include "duplication_sync_timer.h"
-#include "metadata_types.h"
 #include "replica/replica.h"
 #include "replica/replica_stub.h"
 #include "replica_duplicator_manager.h"
@@ -39,10 +38,6 @@
 #include "utils/fmt_logging.h"
 #include "utils/metrics.h"
 #include "utils/threadpool_code.h"
-
-namespace dsn {
-class app_info;
-} // namespace dsn
 
 DSN_DEFINE_uint64(
     replication,

--- a/src/replica/duplication/duplication_sync_timer.cpp
+++ b/src/replica/duplication/duplication_sync_timer.cpp
@@ -40,6 +40,10 @@
 #include "utils/metrics.h"
 #include "utils/threadpool_code.h"
 
+namespace dsn {
+class app_info;
+} // namespace dsn
+
 DSN_DEFINE_uint64(
     replication,
     duplication_sync_period_second,
@@ -74,7 +78,7 @@ void duplication_sync_timer::run()
     req->__set_hp_node(_stub->primary_host_port());
 
     // collects confirm points from all primaries on this server
-    for (const replica_ptr &r : get_all_primaries()) {
+    for (const replica_ptr &r : _stub->get_all_primaries()) {
         auto confirmed = r->get_duplication_manager()->get_duplication_confirms_to_update();
         if (!confirmed.empty()) {
             req->confirm_list[r->get_gpid()] = std::move(confirmed);
@@ -112,8 +116,8 @@ void duplication_sync_timer::on_duplication_sync_reply(error_code err,
 void duplication_sync_timer::update_duplication_map(
     const std::map<int32_t, std::map<int32_t, duplication_entry>> &dup_map)
 {
-    for (replica_ptr &r : get_all_replicas()) {
-        auto it = dup_map.find(r->get_gpid().get_app_id());
+    for (replica_ptr &r : _stub->get_all_replicas()) {
+        const auto &it = dup_map.find(r->get_gpid().get_app_id());
         if (it == dup_map.end()) {
             // no duplication is assigned to this app
             r->get_duplication_manager()->update_duplication_map({});
@@ -126,35 +130,6 @@ void duplication_sync_timer::update_duplication_map(
 duplication_sync_timer::duplication_sync_timer(replica_stub *stub) : _stub(stub) {}
 
 duplication_sync_timer::~duplication_sync_timer() {}
-
-std::vector<replica_ptr> duplication_sync_timer::get_all_primaries()
-{
-    std::vector<replica_ptr> replica_vec;
-    {
-        zauto_read_lock l(_stub->_replicas_lock);
-        for (auto &kv : _stub->_replicas) {
-            replica_ptr r = kv.second;
-            if (r->status() != partition_status::PS_PRIMARY) {
-                continue;
-            }
-            replica_vec.emplace_back(std::move(r));
-        }
-    }
-    return replica_vec;
-}
-
-std::vector<replica_ptr> duplication_sync_timer::get_all_replicas()
-{
-    std::vector<replica_ptr> replica_vec;
-    {
-        zauto_read_lock l(_stub->_replicas_lock);
-        for (auto &kv : _stub->_replicas) {
-            replica_ptr r = kv.second;
-            replica_vec.emplace_back(std::move(r));
-        }
-    }
-    return replica_vec;
-}
 
 void duplication_sync_timer::close()
 {
@@ -191,8 +166,8 @@ duplication_sync_timer::get_dup_states(int app_id, /*out*/ bool *app_found)
 {
     *app_found = false;
     std::multimap<dupid_t, replica_dup_state> result;
-    for (const replica_ptr &r : get_all_primaries()) {
-        gpid rid = r->get_gpid();
+    for (const replica_ptr &r : _stub->get_all_primaries()) {
+        const gpid rid = r->get_gpid();
         if (rid.get_app_id() != app_id) {
             continue;
         }

--- a/src/replica/duplication/duplication_sync_timer.h
+++ b/src/replica/duplication/duplication_sync_timer.h
@@ -71,10 +71,6 @@ private:
 
     void on_duplication_sync_reply(error_code err, const duplication_sync_response &resp);
 
-    std::vector<replica_ptr> get_all_primaries();
-
-    std::vector<replica_ptr> get_all_replicas();
-
 private:
     friend class duplication_sync_timer_test;
 

--- a/src/replica/duplication/duplication_sync_timer.h
+++ b/src/replica/duplication/duplication_sync_timer.h
@@ -19,13 +19,11 @@
 
 #include <map>
 #include <string>
-#include <vector>
 
 #include "common//duplication_common.h"
 #include "common/gpid.h"
 #include "common/replication_other_types.h"
 #include "duplication_types.h"
-#include "replica/replica.h"
 #include "runtime/task/task.h"
 #include "utils/zlocks.h"
 

--- a/src/replica/duplication/test/duplication_sync_timer_test.cpp
+++ b/src/replica/duplication/test/duplication_sync_timer_test.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "common/duplication_common.h"
 #include "common/replication.codes.h"

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -736,12 +736,10 @@ std::vector<replica_ptr> replica_stub::get_all_replicas() const
     std::vector<replica_ptr> result;
     {
         zauto_read_lock l(_replicas_lock);
-            std::transform(_replicas.begin(),
-                           _replicas.end(),
-                           std::back_inserter(result),
-                           [](const std::pair<gpid, replica_ptr> &r) {
-                               return r.second;
-                           });
+        std::transform(_replicas.begin(),
+                       _replicas.end(),
+                       std::back_inserter(result),
+                       [](const std::pair<gpid, replica_ptr> &r) { return r.second; });
     }
     return result;
 }
@@ -751,7 +749,7 @@ std::vector<replica_ptr> replica_stub::get_all_primaries() const
     std::vector<replica_ptr> result;
     {
         zauto_read_lock l(_replicas_lock);
-        for (const auto &[_, r] : _replicas) {
+        for (const auto & [ _, r ] : _replicas) {
             if (r->status() != partition_status::PS_PRIMARY) {
                 continue;
             }

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -731,6 +731,36 @@ dsn::error_code replica_stub::on_kill_replica(gpid id)
     }
 }
 
+std::vector<replica_ptr> replica_stub::get_all_replicas() const
+{
+    std::vector<replica_ptr> result;
+    {
+        zauto_read_lock l(_replicas_lock);
+            std::transform(_replicas.begin(),
+                           _replicas.end(),
+                           std::back_inserter(result),
+                           [](const std::pair<gpid, replica_ptr> &r) {
+                               return r.second;
+                           });
+    }
+    return result;
+}
+
+std::vector<replica_ptr> replica_stub::get_all_primaries() const
+{
+    std::vector<replica_ptr> result;
+    {
+        zauto_read_lock l(_replicas_lock);
+        for (const auto &[_, r] : _replicas) {
+            if (r->status() != partition_status::PS_PRIMARY) {
+                continue;
+            }
+            result.push_back(r);
+        }
+    }
+    return result;
+}
+
 replica_ptr replica_stub::get_replica(gpid id) const
 {
     zauto_read_lock l(_replicas_lock);

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -35,6 +35,7 @@
 #include <chrono>
 #include <cstdint>
 #include <deque>
+#include <iterator>
 #include <mutex>
 #include <ostream>
 #include <set>

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -195,6 +195,8 @@ public:
     //
     // common routines for inquiry
     //
+    std::vector<replica_ptr> get_all_replicas() const;
+    std::vector<replica_ptr> get_all_primaries() const;
     replica_ptr get_replica(gpid id) const;
     replication_options &options() { return _options; }
     const replication_options &options() const { return _options; }


### PR DESCRIPTION
Actually both `get_all_primaries()` and `get_all_replicas()` are operating the members
of `replica_stub`, thus it's better to move both of them to `replica_stub`. See also
https://github.com/apache/incubator-pegasus/pull/1608.