### PR TITLE
fix(duplication): get duplication manager as shared_ptr in case raw pointer has been reset to null

### DIFF
--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -281,7 +281,7 @@ replica::replica(replica_stub *stub,
       _cur_download_size(0),
       _restore_progress(0),
       _restore_status(ERR_OK),
-      _duplication_mgr(new replica_duplicator_manager(this)),
+      _duplication_mgr(std::make_shared<replica_duplicator_manager>(this)),
       // todo(jiashuo1): app.duplicating need rename
       _is_duplication_master(app.duplicating),
       _is_duplication_follower(is_duplication_follower),

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -239,7 +239,10 @@ public:
     //
     error_code trigger_manual_emergency_checkpoint(decree old_decree);
     void on_query_last_checkpoint(learn_response &response);
-    replica_duplicator_manager *get_duplication_manager() const { return _duplication_mgr.get(); }
+    std::shared_ptr<replica_duplicator_manager> get_duplication_manager() const
+    {
+        return _duplication_mgr;
+    }
     bool is_duplication_master() const { return _is_duplication_master; }
     bool is_duplication_follower() const { return _is_duplication_follower; }
     bool is_duplication_plog_checking() const { return _is_duplication_plog_checking.load(); }
@@ -621,7 +624,7 @@ private:
     throttling_controller _backup_request_qps_throttling_controller;
 
     // duplication
-    std::unique_ptr<replica_duplicator_manager> _duplication_mgr;
+    std::shared_ptr<replica_duplicator_manager> _duplication_mgr;
     bool _is_manual_emergency_checkpointing{false};
     bool _is_duplication_master{false};
     bool _is_duplication_follower{false};


### PR DESCRIPTION
It is not safe to get `_duplication_mgr` as raw pointer or `std::unique_ptr`. For example,
`r->close()`would be called in `replica_stub::close_replica` without protection of any lock.
Once `_duplication_mgr.reset()` is called in `replica::close()`(`r->close()`), `std::unique_ptr`
or raw pointer would become `nullptr`, which is not thread-safe among multiple threads.
Since `_duplication_mgr` might be called and reset in different threads, it's better to use
`std::shared_ptr` instead. See also https://github.com/apache/incubator-pegasus/pull/1608.