### PR TITLE
refactor(FQDN): Simplify function generate_node_list()

### DIFF
--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -43,6 +43,7 @@
 #include "meta_service_test_app.h"
 #include "meta_test_base.h"
 #include "runtime/api_layer1.h"
+#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_holder.h"
 #include "runtime/rpc/rpc_host_port.h"

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -499,16 +499,17 @@ TEST_F(policy_context_test, test_app_dropped_during_backup)
         int64_t cur_start_time_ms = static_cast<int64_t>(dsn_now_ms());
         {
             zauto_lock l(_mp._lock);
-            std::vector<std::pair<dsn::host_port, dsn::rpc_address>> node_list;
+            std::vector<dsn::host_port> node_list;
             generate_node_list(node_list, 3, 3);
 
             app_state *app = state->_all_apps[3].get();
             app->status = dsn::app_status::AS_AVAILABLE;
             for (partition_configuration &pc : app->partitions) {
-                pc.primary = node_list[0].second;
-                pc.secondaries = {node_list[1].second, node_list[2].second};
-                pc.__set_hp_primary(node_list[0].first);
-                pc.__set_hp_secondaries({node_list[1].first, node_list[2].first});
+                pc.primary = dsn::dns_resolver::instance().resolve_address(node_list[0]);
+                pc.secondaries = {dsn::dns_resolver::instance().resolve_address(node_list[1]),
+                                  dsn::dns_resolver::instance().resolve_address(node_list[2])};
+                pc.__set_hp_primary(node_list[0]);
+                pc.__set_hp_secondaries({node_list[1], node_list[2]});
             }
 
             _mp._backup_history.clear();

--- a/src/meta/test/balancer_simulator/balancer_simulator.cpp
+++ b/src/meta/test/balancer_simulator/balancer_simulator.cpp
@@ -42,7 +42,6 @@
 #include "meta/test/misc/misc.h"
 #include "meta_admin_types.h"
 #include "runtime/app_model.h"
-#include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/fmt_logging.h"
 

--- a/src/meta/test/balancer_simulator/balancer_simulator.cpp
+++ b/src/meta/test/balancer_simulator/balancer_simulator.cpp
@@ -166,12 +166,8 @@ void greedy_balancer_perfect_move_primary()
 {
     app_mapper apps;
     node_mapper nodes;
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> node_pairs;
     std::vector<dsn::host_port> node_list;
-    generate_node_list(node_pairs, 19, 100);
-    for (const auto &p : node_pairs) {
-        node_list.emplace_back(p.first);
-    }
+    generate_node_list(node_list, 19, 100);
 
     generate_balanced_apps(apps, nodes, node_list);
 

--- a/src/meta/test/balancer_validator.cpp
+++ b/src/meta/test/balancer_validator.cpp
@@ -120,12 +120,8 @@ static void check_cure(app_mapper &apps, node_mapper &nodes, ::dsn::partition_co
 
 void meta_service_test_app::balancer_validator()
 {
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> node_pairs;
     std::vector<dsn::host_port> node_list;
-    generate_node_list(node_pairs, 20, 100);
-    for (const auto &p : node_pairs) {
-        node_list.emplace_back(p.first);
-    }
+    generate_node_list(node_list, 20, 100);
 
     app_mapper apps;
     node_mapper nodes;

--- a/src/meta/test/meta_data.cpp
+++ b/src/meta/test/meta_data.cpp
@@ -131,7 +131,7 @@ TEST(meta_data, collect_replica)
     dsn::partition_configuration &pc = *get_config(app, rep.pid);
     config_context &cc = *get_config_context(app, rep.pid);
 
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> node_list;
+    std::vector<dsn::host_port> node_list;
     generate_node_list(node_list, 10, 10);
 
 #define CLEAR_REPLICA                                                                              \
@@ -153,59 +153,60 @@ TEST(meta_data, collect_replica)
     CLEAR_REPLICA;                                                                                 \
     CLEAR_DROP_LIST
 
+    const auto addr = dsn::dns_resolver::instance().resolve_address(node_list[0]);
     {
         // replica is primary of partition
         CLEAR_ALL;
         rep.ballot = 10;
         pc.ballot = 9;
-        pc.primary = node_list[0].second;
-        pc.__set_hp_primary(node_list[0].first);
-        ASSERT_TRUE(collect_replica(view, node_list[0].first, rep));
+        pc.primary = addr;
+        pc.__set_hp_primary(node_list[0]);
+        ASSERT_TRUE(collect_replica(view, node_list[0], rep));
     }
 
     {
         // replica is secondary of partition
         CLEAR_ALL;
-        pc.secondaries.push_back(node_list[0].second);
-        pc.hp_secondaries.push_back(node_list[0].first);
-        ASSERT_TRUE(collect_replica(view, node_list[0].first, rep));
+        pc.secondaries.push_back(addr);
+        pc.hp_secondaries.push_back(node_list[0]);
+        ASSERT_TRUE(collect_replica(view, node_list[0], rep));
     }
 
     {
         // replica has been in the drop_list
         CLEAR_ALL;
-        cc.dropped.push_back({node_list[0].first, 5, 0, 0});
-        ASSERT_TRUE(collect_replica(view, node_list[0].first, rep));
+        cc.dropped.push_back({node_list[0], 5, 0, 0});
+        ASSERT_TRUE(collect_replica(view, node_list[0], rep));
     }
 
     {
         // drop_list all have timestamp, full
         CLEAR_ALL;
         cc.dropped = {
-            dropped_replica{node_list[0].first, 5, 1, 1, 2},
-            dropped_replica{node_list[1].first, 6, 1, 1, 2},
-            dropped_replica{node_list[2].first, 7, 1, 1, 2},
-            dropped_replica{node_list[3].first, 8, 1, 1, 2},
+            dropped_replica{node_list[0], 5, 1, 1, 2},
+            dropped_replica{node_list[1], 6, 1, 1, 2},
+            dropped_replica{node_list[2], 7, 1, 1, 2},
+            dropped_replica{node_list[3], 8, 1, 1, 2},
         };
         rep.ballot = 10;
         rep.last_prepared_decree = 10;
-        ASSERT_FALSE(collect_replica(view, node_list[5].first, rep));
+        ASSERT_FALSE(collect_replica(view, node_list[5], rep));
     }
 
     {
         // drop_list all have timestamp, not full
         CLEAR_ALL;
         cc.dropped = {
-            dropped_replica{node_list[0].first, 5, 1, 1, 2},
-            dropped_replica{node_list[1].first, 6, 1, 1, 2},
-            dropped_replica{node_list[2].first, 7, 1, 1, 2},
+            dropped_replica{node_list[0], 5, 1, 1, 2},
+            dropped_replica{node_list[1], 6, 1, 1, 2},
+            dropped_replica{node_list[2], 7, 1, 1, 2},
         };
         rep.ballot = 10;
         rep.last_durable_decree = 6;
         rep.last_committed_decree = 8;
         rep.last_prepared_decree = 10;
 
-        ASSERT_TRUE(collect_replica(view, node_list[4].first, rep));
+        ASSERT_TRUE(collect_replica(view, node_list[4], rep));
         dropped_replica &d = cc.dropped.front();
         ASSERT_EQ(d.ballot, rep.ballot);
         ASSERT_EQ(d.last_prepared_decree, rep.last_prepared_decree);
@@ -215,33 +216,33 @@ TEST(meta_data, collect_replica)
         // drop_list mixed, full, minimal position
         CLEAR_ALL;
         cc.dropped = {
-            dropped_replica{node_list[0].first, dropped_replica::INVALID_TIMESTAMP, 2, 3, 5},
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 2, 4, 5},
-            dropped_replica{node_list[2].first, 7, 1, 1, 5},
-            dropped_replica{node_list[3].first, 8, 1, 1, 5},
+            dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 2, 3, 5},
+            dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 2, 4, 5},
+            dropped_replica{node_list[2], 7, 1, 1, 5},
+            dropped_replica{node_list[3], 8, 1, 1, 5},
         };
 
         rep.ballot = 1;
         rep.last_committed_decree = 3;
         rep.last_prepared_decree = 5;
-        ASSERT_FALSE(collect_replica(view, node_list[5].first, rep));
+        ASSERT_FALSE(collect_replica(view, node_list[5], rep));
     }
 
     {
         // drop_list mixed, not full, minimal position
         CLEAR_ALL;
         cc.dropped = {
-            dropped_replica{node_list[0].first, dropped_replica::INVALID_TIMESTAMP, 2, 3, 5},
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 2, 4, 5},
-            dropped_replica{node_list[2].first, 7, 1, 1, 6},
+            dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 2, 3, 5},
+            dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 2, 4, 5},
+            dropped_replica{node_list[2], 7, 1, 1, 6},
         };
 
         rep.ballot = 1;
         rep.last_committed_decree = 3;
         rep.last_prepared_decree = 5;
-        ASSERT_TRUE(collect_replica(view, node_list[5].first, rep));
+        ASSERT_TRUE(collect_replica(view, node_list[5], rep));
         dropped_replica &d = cc.dropped.front();
-        ASSERT_EQ(d.node, node_list[5].first);
+        ASSERT_EQ(d.node, node_list[5]);
         ASSERT_EQ(d.ballot, rep.ballot);
         ASSERT_EQ(d.last_prepared_decree, rep.last_prepared_decree);
     }
@@ -250,16 +251,16 @@ TEST(meta_data, collect_replica)
         // drop_list mixed, full, not minimal position
         CLEAR_ALL;
         cc.dropped = {
-            dropped_replica{node_list[0].first, dropped_replica::INVALID_TIMESTAMP, 2, 2, 6},
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 2, 4, 6},
-            dropped_replica{node_list[2].first, 7, 1, 1, 6},
-            dropped_replica{node_list[3].first, 8, 1, 1, 6},
+            dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 2, 2, 6},
+            dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 2, 4, 6},
+            dropped_replica{node_list[2], 7, 1, 1, 6},
+            dropped_replica{node_list[3], 8, 1, 1, 6},
         };
 
         rep.ballot = 2;
         rep.last_committed_decree = 3;
         rep.last_prepared_decree = 6;
-        ASSERT_TRUE(collect_replica(view, node_list[5].first, rep));
+        ASSERT_TRUE(collect_replica(view, node_list[5], rep));
         dropped_replica &d = cc.dropped.front();
         ASSERT_EQ(rep.ballot, d.ballot);
         ASSERT_EQ(rep.last_committed_decree, rep.last_committed_decree);
@@ -270,21 +271,20 @@ TEST(meta_data, collect_replica)
     {
         // drop_list mixed, not full, not minimal position
         CLEAR_ALL;
-        cc.dropped = {
-            dropped_replica{node_list[0].first, dropped_replica::INVALID_TIMESTAMP, 2, 2, 6},
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 2, 4, 6},
-            dropped_replica{node_list[2].first, 7, 1, 1, 6}};
+        cc.dropped = {dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 2, 2, 6},
+                      dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 2, 4, 6},
+                      dropped_replica{node_list[2], 7, 1, 1, 6}};
 
         rep.ballot = 3;
         rep.last_committed_decree = 1;
         rep.last_prepared_decree = 6;
-        ASSERT_TRUE(collect_replica(view, node_list[5].first, rep));
+        ASSERT_TRUE(collect_replica(view, node_list[5], rep));
 
         std::vector<dropped_replica> result_dropped = {
-            dropped_replica{node_list[0].first, dropped_replica::INVALID_TIMESTAMP, 2, 2, 6},
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 2, 4, 6},
-            dropped_replica{node_list[5].first, dropped_replica::INVALID_TIMESTAMP, 3, 1, 6},
-            dropped_replica{node_list[2].first, 7, 1, 1, 6}};
+            dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 2, 2, 6},
+            dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 2, 4, 6},
+            dropped_replica{node_list[5], dropped_replica::INVALID_TIMESTAMP, 3, 1, 6},
+            dropped_replica{node_list[2], 7, 1, 1, 6}};
 
         ASSERT_TRUE(vec_equal(result_dropped, cc.dropped));
     }
@@ -293,38 +293,38 @@ TEST(meta_data, collect_replica)
         // drop_list no timestamp, full, minimal position
         CLEAR_ALL;
         cc.dropped = {
-            dropped_replica{node_list[0].first, dropped_replica::INVALID_TIMESTAMP, 2, 2, 8},
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 2, 4, 8},
-            dropped_replica{node_list[2].first, dropped_replica::INVALID_TIMESTAMP, 2, 6, 8},
-            dropped_replica{node_list[3].first, dropped_replica::INVALID_TIMESTAMP, 4, 2, 8},
+            dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 2, 2, 8},
+            dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 2, 4, 8},
+            dropped_replica{node_list[2], dropped_replica::INVALID_TIMESTAMP, 2, 6, 8},
+            dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 4, 2, 8},
         };
 
         rep.ballot = 1;
         rep.last_committed_decree = 7;
         rep.last_prepared_decree = 10;
-        ASSERT_FALSE(collect_replica(view, node_list[5].first, rep));
+        ASSERT_FALSE(collect_replica(view, node_list[5], rep));
     }
 
     {
         // drop_list no timestamp, full, middle position
         CLEAR_ALL;
         cc.dropped = {
-            dropped_replica{node_list[0].first, dropped_replica::INVALID_TIMESTAMP, 2, 2, 8},
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 2, 4, 8},
-            dropped_replica{node_list[2].first, dropped_replica::INVALID_TIMESTAMP, 2, 6, 8},
-            dropped_replica{node_list[3].first, dropped_replica::INVALID_TIMESTAMP, 4, 2, 8},
+            dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 2, 2, 8},
+            dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 2, 4, 8},
+            dropped_replica{node_list[2], dropped_replica::INVALID_TIMESTAMP, 2, 6, 8},
+            dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 4, 2, 8},
         };
 
         rep.ballot = 3;
         rep.last_committed_decree = 6;
         rep.last_prepared_decree = 8;
-        ASSERT_TRUE(collect_replica(view, node_list[5].first, rep));
+        ASSERT_TRUE(collect_replica(view, node_list[5], rep));
 
         std::vector<dropped_replica> result_dropped = {
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 2, 4, 8},
-            dropped_replica{node_list[2].first, dropped_replica::INVALID_TIMESTAMP, 2, 6, 8},
-            dropped_replica{node_list[5].first, dropped_replica::INVALID_TIMESTAMP, 3, 6, 8},
-            dropped_replica{node_list[3].first, dropped_replica::INVALID_TIMESTAMP, 4, 2, 8},
+            dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 2, 4, 8},
+            dropped_replica{node_list[2], dropped_replica::INVALID_TIMESTAMP, 2, 6, 8},
+            dropped_replica{node_list[5], dropped_replica::INVALID_TIMESTAMP, 3, 6, 8},
+            dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 4, 2, 8},
         };
 
         ASSERT_TRUE(vec_equal(result_dropped, cc.dropped));
@@ -333,22 +333,21 @@ TEST(meta_data, collect_replica)
     {
         // drop_list no timestamp, full, largest position
         CLEAR_ALL;
-        cc.dropped = {
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 2, 4, 8},
-            dropped_replica{node_list[2].first, dropped_replica::INVALID_TIMESTAMP, 2, 6, 8},
-            dropped_replica{node_list[3].first, dropped_replica::INVALID_TIMESTAMP, 4, 2, 8},
-            dropped_replica{node_list[4].first, dropped_replica::INVALID_TIMESTAMP, 4, 6, 8}};
+        cc.dropped = {dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 2, 4, 8},
+                      dropped_replica{node_list[2], dropped_replica::INVALID_TIMESTAMP, 2, 6, 8},
+                      dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 4, 2, 8},
+                      dropped_replica{node_list[4], dropped_replica::INVALID_TIMESTAMP, 4, 6, 8}};
 
         rep.ballot = 4;
         rep.last_committed_decree = 8;
         rep.last_prepared_decree = 8;
-        ASSERT_TRUE(collect_replica(view, node_list[5].first, rep));
+        ASSERT_TRUE(collect_replica(view, node_list[5], rep));
 
         std::vector<dropped_replica> result_dropped = {
-            dropped_replica{node_list[2].first, dropped_replica::INVALID_TIMESTAMP, 2, 6, 8},
-            dropped_replica{node_list[3].first, dropped_replica::INVALID_TIMESTAMP, 4, 2, 8},
-            dropped_replica{node_list[4].first, dropped_replica::INVALID_TIMESTAMP, 4, 6, 8},
-            dropped_replica{node_list[5].first, dropped_replica::INVALID_TIMESTAMP, 4, 8, 8}};
+            dropped_replica{node_list[2], dropped_replica::INVALID_TIMESTAMP, 2, 6, 8},
+            dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 4, 2, 8},
+            dropped_replica{node_list[4], dropped_replica::INVALID_TIMESTAMP, 4, 6, 8},
+            dropped_replica{node_list[5], dropped_replica::INVALID_TIMESTAMP, 4, 8, 8}};
 
         ASSERT_TRUE(vec_equal(result_dropped, cc.dropped));
     }
@@ -381,7 +380,7 @@ TEST(meta_data, construct_replica)
     dsn::partition_configuration &pc = *get_config(app, rep.pid);
     config_context &cc = *get_config_context(app, rep.pid);
 
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> node_list;
+    std::vector<dsn::host_port> node_list;
     generate_node_list(node_list, 10, 10);
 
 #define CLEAR_REPLICA                                                                              \
@@ -413,10 +412,9 @@ TEST(meta_data, construct_replica)
     // only have one node in drop_list
     {
         CLEAR_ALL;
-        cc.dropped = {
-            dropped_replica{node_list[0].first, dropped_replica::INVALID_TIMESTAMP, 5, 10, 12}};
+        cc.dropped = {dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 5, 10, 12}};
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-        ASSERT_EQ(node_list[0].first, pc.hp_primary);
+        ASSERT_EQ(node_list[0], pc.hp_primary);
         ASSERT_TRUE(pc.hp_secondaries.empty());
         ASSERT_TRUE(cc.dropped.empty());
         ASSERT_EQ(-1, cc.prefered_dropped);
@@ -425,16 +423,15 @@ TEST(meta_data, construct_replica)
     // have multiple nodes, ballots are not same
     {
         CLEAR_ALL;
-        cc.dropped = {
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 6, 10, 12},
-            dropped_replica{node_list[2].first, dropped_replica::INVALID_TIMESTAMP, 7, 10, 12},
-            dropped_replica{node_list[3].first, dropped_replica::INVALID_TIMESTAMP, 8, 10, 12},
-            dropped_replica{node_list[4].first, dropped_replica::INVALID_TIMESTAMP, 9, 11, 12}};
+        cc.dropped = {dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 6, 10, 12},
+                      dropped_replica{node_list[2], dropped_replica::INVALID_TIMESTAMP, 7, 10, 12},
+                      dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 8, 10, 12},
+                      dropped_replica{node_list[4], dropped_replica::INVALID_TIMESTAMP, 9, 11, 12}};
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-        ASSERT_EQ(node_list[4].first, pc.hp_primary);
+        ASSERT_EQ(node_list[4], pc.hp_primary);
         ASSERT_TRUE(pc.hp_secondaries.empty());
 
-        std::vector<dsn::host_port> nodes = {node_list[2].first, node_list[3].first};
+        std::vector<dsn::host_port> nodes = {node_list[2], node_list[3]};
         ASSERT_EQ(nodes, pc.hp_last_drops);
         ASSERT_EQ(3, cc.dropped.size());
         ASSERT_EQ(2, cc.prefered_dropped);
@@ -443,16 +440,15 @@ TEST(meta_data, construct_replica)
     // have multiple node, two have same ballots
     {
         CLEAR_ALL;
-        cc.dropped = {
-            dropped_replica{node_list[0].first, dropped_replica::INVALID_TIMESTAMP, 5, 10, 12},
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 7, 11, 12},
-            dropped_replica{node_list[2].first, dropped_replica::INVALID_TIMESTAMP, 7, 12, 12}};
+        cc.dropped = {dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 5, 10, 12},
+                      dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 7, 11, 12},
+                      dropped_replica{node_list[2], dropped_replica::INVALID_TIMESTAMP, 7, 12, 12}};
 
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-        ASSERT_EQ(node_list[2].first, pc.hp_primary);
+        ASSERT_EQ(node_list[2], pc.hp_primary);
         ASSERT_TRUE(pc.hp_secondaries.empty());
 
-        std::vector<dsn::host_port> nodes = {node_list[0].first, node_list[1].first};
+        std::vector<dsn::host_port> nodes = {node_list[0], node_list[1]};
         ASSERT_EQ(nodes, pc.hp_last_drops);
         ASSERT_EQ(2, cc.dropped.size());
         ASSERT_EQ(1, cc.prefered_dropped);
@@ -461,17 +457,16 @@ TEST(meta_data, construct_replica)
     // have multiple nodes, all have same ballots
     {
         CLEAR_ALL;
-        cc.dropped = {
-            dropped_replica{node_list[0].first, dropped_replica::INVALID_TIMESTAMP, 7, 11, 14},
-            dropped_replica{node_list[1].first, dropped_replica::INVALID_TIMESTAMP, 7, 12, 14},
-            dropped_replica{node_list[2].first, dropped_replica::INVALID_TIMESTAMP, 7, 13, 14},
-            dropped_replica{node_list[3].first, dropped_replica::INVALID_TIMESTAMP, 7, 14, 14}};
+        cc.dropped = {dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 7, 11, 14},
+                      dropped_replica{node_list[1], dropped_replica::INVALID_TIMESTAMP, 7, 12, 14},
+                      dropped_replica{node_list[2], dropped_replica::INVALID_TIMESTAMP, 7, 13, 14},
+                      dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 7, 14, 14}};
 
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-        ASSERT_EQ(node_list[3].first, pc.hp_primary);
+        ASSERT_EQ(node_list[3], pc.hp_primary);
         ASSERT_TRUE(pc.hp_secondaries.empty());
 
-        std::vector<dsn::host_port> nodes = {node_list[1].first, node_list[2].first};
+        std::vector<dsn::host_port> nodes = {node_list[1], node_list[2]};
         ASSERT_EQ(nodes, pc.hp_last_drops);
 
         ASSERT_EQ(3, cc.dropped.size());

--- a/src/meta/test/meta_data.cpp
+++ b/src/meta/test/meta_data.cpp
@@ -26,7 +26,6 @@
 
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "client/partition_resolver.h"
@@ -36,6 +35,7 @@
 #include "meta/meta_data.h"
 #include "metadata_types.h"
 #include "misc/misc.h"
+#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 

--- a/src/meta/test/meta_duplication_service_test.cpp
+++ b/src/meta/test/meta_duplication_service_test.cpp
@@ -817,13 +817,14 @@ TEST_F(meta_duplication_service_test, fail_mode)
     ASSERT_EQ(dup->status(), duplication_status::DS_PAUSE);
 
     // ensure dup_sync will synchronize fail_mode
-    auto node = generate_node_list(3)[0];
+    const auto hp = generate_node_list(3)[0];
+    const auto addr = dsn::dns_resolver::instance().resolve_address(hp);
     for (partition_configuration &pc : app->partitions) {
-        pc.primary = node.second;
-        pc.__set_hp_primary(node.first);
+        pc.primary = addr;
+        pc.__set_hp_primary(hp);
     }
     initialize_node_state();
-    auto sync_resp = duplication_sync(node.second, node.first, {});
+    auto sync_resp = duplication_sync(addr, hp, {});
     ASSERT_TRUE(sync_resp.dup_map[app->app_id][dup->id].__isset.fail_mode);
     ASSERT_EQ(sync_resp.dup_map[app->app_id][dup->id].fail_mode, duplication_fail_mode::FAIL_SKIP);
 

--- a/src/meta/test/meta_partition_guardian_test.cpp
+++ b/src/meta/test/meta_partition_guardian_test.cpp
@@ -54,6 +54,7 @@
 #include "meta_service_test_app.h"
 #include "meta_test_base.h"
 #include "metadata_types.h"
+#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "runtime/rpc/rpc_message.h"

--- a/src/meta/test/meta_partition_guardian_test.cpp
+++ b/src/meta/test/meta_partition_guardian_test.cpp
@@ -204,12 +204,8 @@ void meta_partition_guardian_test::cure_test()
     ASSERT_TRUE(state->spin_wait_staging(20));
     svc->_started = true;
 
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> nodes;
+    std::vector<dsn::host_port> nodes;
     generate_node_list(nodes, 4, 4);
-    std::vector<dsn::host_port> nodes_list;
-    for (const auto &p : nodes) {
-        nodes_list.emplace_back(p.first);
-    }
 
     dsn::partition_configuration &pc = app->partitions[0];
     config_context &cc = *get_config_context(state->_all_apps, dsn::gpid(1, 0));
@@ -225,11 +221,12 @@ void meta_partition_guardian_test::cure_test()
     state->_nodes.clear();
     pc.primary.set_invalid();
     pc.hp_primary.reset();
-    pc.secondaries = {nodes[0].second, nodes[1].second};
-    pc.__set_hp_secondaries({nodes[0].first, nodes[1].first});
+    pc.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes[0]),
+                      dsn::dns_resolver::instance().resolve_address(nodes[1])};
+    pc.__set_hp_secondaries({nodes[0], nodes[1]});
     pc.ballot = 1;
     state->initialize_node_state();
-    svc->set_node_state(nodes_list, true);
+    svc->set_node_state(nodes, true);
     proposal_sent = false;
 
     // check partitions, then ignore the proposal
@@ -287,11 +284,12 @@ void meta_partition_guardian_test::cure_test()
     state->_nodes.clear();
     pc.primary.set_invalid();
     pc.hp_primary.reset();
-    pc.secondaries = {nodes[0].second, nodes[1].second};
-    pc.__set_hp_secondaries({nodes[0].first, nodes[1].first});
+    pc.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes[0]),
+                      dsn::dns_resolver::instance().resolve_address(nodes[1])};
+    pc.__set_hp_secondaries({nodes[0], nodes[1]});
     pc.ballot = 1;
     state->initialize_node_state();
-    svc->set_node_state(nodes_list, true);
+    svc->set_node_state(nodes, true);
     proposal_sent = false;
 
     // check partitions, then inject a event that node[0] is dead
@@ -348,13 +346,13 @@ void meta_partition_guardian_test::cure_test()
     std::cerr << "Case: add secondary, and the message lost" << std::endl;
     // initialize
     state->_nodes.clear();
-    pc.primary = nodes[0].second;
-    pc.secondaries = {nodes[1].second};
-    pc.__set_hp_primary(nodes[0].first);
-    pc.__set_hp_secondaries({nodes[1].first});
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes[0]);
+    pc.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes[1])};
+    pc.__set_hp_primary(nodes[0]);
+    pc.__set_hp_secondaries({nodes[1]});
     pc.ballot = 1;
     state->initialize_node_state();
-    svc->set_node_state(nodes_list, true);
+    svc->set_node_state(nodes, true);
     proposal_sent = false;
 
     // check partitions, then ignore the proposal
@@ -366,7 +364,7 @@ void meta_partition_guardian_test::cure_test()
 
         EXPECT_EQ(update_req->type, config_type::CT_ADD_SECONDARY);
         EXPECT_FALSE(is_secondary(pc, update_req->hp_node));
-        EXPECT_EQ(target, nodes[0].first);
+        EXPECT_EQ(target, nodes[0]);
 
         last_addr = update_req->hp_node;
         proposal_sent = true;
@@ -389,7 +387,7 @@ void meta_partition_guardian_test::cure_test()
 
         EXPECT_EQ(update_req->type, config_type::CT_ADD_SECONDARY);
         EXPECT_EQ(update_req->hp_node, last_addr);
-        EXPECT_EQ(target, nodes[0].first);
+        EXPECT_EQ(target, nodes[0]);
 
         proposal_sent = true;
         apply_update_request(*update_req);
@@ -409,13 +407,13 @@ void meta_partition_guardian_test::cure_test()
     std::cerr << "Case: add secondary, but the primary is removing another" << std::endl;
     // initialize
     state->_nodes.clear();
-    pc.primary = nodes[0].second;
-    pc.secondaries = {nodes[1].second};
-    pc.__set_hp_primary(nodes[0].first);
-    pc.__set_hp_secondaries({nodes[1].first});
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes[0]);
+    pc.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes[1])};
+    pc.__set_hp_primary(nodes[0]);
+    pc.__set_hp_secondaries({nodes[1]});
     pc.ballot = 1;
     state->initialize_node_state();
-    svc->set_node_state(nodes_list, true);
+    svc->set_node_state(nodes, true);
     proposal_sent = false;
 
     // check partitions, then inject another update_request
@@ -427,7 +425,7 @@ void meta_partition_guardian_test::cure_test()
 
         EXPECT_EQ(update_req->type, config_type::CT_ADD_SECONDARY);
         EXPECT_FALSE(is_secondary(pc, update_req->hp_node));
-        EXPECT_EQ(target, nodes[0].first);
+        EXPECT_EQ(target, nodes[0]);
 
         update_req->config.ballot++;
         update_req->type = config_type::CT_DOWNGRADE_TO_INACTIVE;
@@ -454,13 +452,13 @@ void meta_partition_guardian_test::cure_test()
     std::cerr << "Case: add secondary, and the added secondary is dead" << std::endl;
     // initialize
     state->_nodes.clear();
-    pc.primary = nodes[0].second;
-    pc.secondaries = {nodes[1].second};
-    pc.__set_hp_primary(nodes[0].first);
-    pc.__set_hp_secondaries({nodes[1].first});
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes[0]);
+    pc.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes[1])};
+    pc.__set_hp_primary(nodes[0]);
+    pc.__set_hp_secondaries({nodes[1]});
     pc.ballot = 1;
     state->initialize_node_state();
-    svc->set_node_state(nodes_list, true);
+    svc->set_node_state(nodes, true);
     proposal_sent = false;
 
     // check partitions, then inject the nodes[2] dead
@@ -472,7 +470,7 @@ void meta_partition_guardian_test::cure_test()
 
         EXPECT_EQ(update_req->type, config_type::CT_ADD_SECONDARY);
         EXPECT_FALSE(is_secondary(pc, update_req->hp_node));
-        EXPECT_EQ(target, nodes[0].first);
+        EXPECT_EQ(target, nodes[0]);
 
         last_addr = update_req->hp_node;
         svc->set_node_state({update_req->hp_node}, false);
@@ -497,7 +495,7 @@ void meta_partition_guardian_test::cure_test()
         EXPECT_EQ(update_req->type, config_type::CT_ADD_SECONDARY);
         EXPECT_NE(update_req->hp_node, last_addr);
         EXPECT_FALSE(is_secondary(pc, update_req->hp_node));
-        EXPECT_EQ(target, nodes[0].first);
+        EXPECT_EQ(target, nodes[0]);
 
         proposal_sent = true;
         last_addr = update_req->hp_node;
@@ -518,13 +516,13 @@ void meta_partition_guardian_test::cure_test()
     std::cerr << "Case: add secondary, and the primary is dead" << std::endl;
     // initialize
     state->_nodes.clear();
-    pc.primary = nodes[0].second;
-    pc.__set_hp_primary(nodes[0].first);
-    pc.secondaries = {nodes[1].second};
-    pc.__set_hp_secondaries({nodes[1].first});
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes[0]);
+    pc.__set_hp_primary(nodes[0]);
+    pc.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes[1])};
+    pc.__set_hp_secondaries({nodes[1]});
     pc.ballot = 1;
     state->initialize_node_state();
-    svc->set_node_state(nodes_list, true);
+    svc->set_node_state(nodes, true);
     proposal_sent = false;
 
     // check partitions, then ignore the proposal
@@ -550,18 +548,20 @@ void meta_partition_guardian_test::cure_test()
                               server_state::sStateHash);
     t->wait();
     PROPOSAL_FLAG_CHECK;
-    CONDITION_CHECK([&] { return pc.hp_primary == nodes[1].first; });
+    CONDITION_CHECK([&] { return pc.hp_primary == nodes[1]; });
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     state->_nodes.clear();
     pc.primary.set_invalid();
     pc.hp_primary.reset();
     pc.hp_secondaries.clear();
-    pc.last_drops = {nodes[0].second, nodes[1].second, nodes[2].second};
-    pc.__set_hp_last_drops({nodes[0].first, nodes[1].first, nodes[2].first});
+    pc.last_drops = {dsn::dns_resolver::instance().resolve_address(nodes[0]),
+                     dsn::dns_resolver::instance().resolve_address(nodes[1]),
+                     dsn::dns_resolver::instance().resolve_address(nodes[2])};
+    pc.__set_hp_last_drops({nodes[0], nodes[1], nodes[2]});
     pc.ballot = 4;
     state->initialize_node_state();
-    svc->set_node_state(nodes_list, true);
+    svc->set_node_state(nodes, true);
 
     svc->set_filter([&](const dsn::host_port &target, dsn::message_ex *req) -> cur_ptr {
         dsn::message_ex *recv_request = create_corresponding_receive(req);
@@ -570,8 +570,8 @@ void meta_partition_guardian_test::cure_test()
         destroy_message(recv_request);
 
         EXPECT_EQ(update_req->type, config_type::CT_ASSIGN_PRIMARY);
-        EXPECT_EQ(update_req->hp_node, nodes[2].first);
-        EXPECT_EQ(target, nodes[2].first);
+        EXPECT_EQ(update_req->hp_node, nodes[2]);
+        EXPECT_EQ(target, nodes[2]);
 
         proposal_sent = true;
         svc->set_filter(default_filter);
@@ -580,11 +580,11 @@ void meta_partition_guardian_test::cure_test()
     });
 
     std::cerr << "Case: recover from DDD state, nodes[1] isn't alive" << std::endl;
-    svc->set_node_state({nodes[1].first}, false);
+    svc->set_node_state({nodes[1]}, false);
     cc.dropped = {
-        dropped_replica{nodes[0].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
-        dropped_replica{nodes[1].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
-        dropped_replica{nodes[2].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+        dropped_replica{nodes[0], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+        dropped_replica{nodes[1], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+        dropped_replica{nodes[2], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
     };
     t = dsn::tasking::enqueue(LPC_META_STATE_NORMAL,
                               nullptr,
@@ -596,9 +596,9 @@ void meta_partition_guardian_test::cure_test()
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     std::cerr << "Case: recover from DDD state, nodes[2] is not in dropped" << std::endl;
-    svc->set_node_state({nodes[1].first}, true);
-    cc.dropped = {dropped_replica{nodes[0].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
-                  dropped_replica{nodes[1].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1}};
+    svc->set_node_state({nodes[1]}, true);
+    cc.dropped = {dropped_replica{nodes[0], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+                  dropped_replica{nodes[1], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1}};
 
     t = dsn::tasking::enqueue(LPC_META_STATE_NORMAL,
                               nullptr,
@@ -612,9 +612,9 @@ void meta_partition_guardian_test::cure_test()
     std::cerr << "Case: recover from DDD state, haven't collect nodes[2]'s info from replica, and "
                  "nodes[2]'s info haven't updated"
               << std::endl;
-    cc.dropped = {dropped_replica{nodes[0].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
-                  dropped_replica{nodes[1].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
-                  dropped_replica{nodes[2].first, 500, -1, -1, -1}};
+    cc.dropped = {dropped_replica{nodes[0], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+                  dropped_replica{nodes[1], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+                  dropped_replica{nodes[2], 500, -1, -1, -1}};
 
     t = dsn::tasking::enqueue(LPC_META_STATE_NORMAL,
                               nullptr,
@@ -635,8 +635,8 @@ void meta_partition_guardian_test::cure_test()
         destroy_message(recv_request);
 
         EXPECT_EQ(update_req->type, config_type::CT_ASSIGN_PRIMARY);
-        EXPECT_EQ(update_req->hp_node, nodes[1].first);
-        EXPECT_EQ(target, nodes[1].first);
+        EXPECT_EQ(update_req->hp_node, nodes[1]);
+        EXPECT_EQ(target, nodes[1]);
 
         proposal_sent = true;
         svc->set_filter(default_filter);
@@ -644,11 +644,11 @@ void meta_partition_guardian_test::cure_test()
         return update_req;
     });
 
-    cc.dropped = {dropped_replica{nodes[0].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
-                  dropped_replica{nodes[1].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
-                  dropped_replica{nodes[2].first, 500, -1, -1, -1}};
+    cc.dropped = {dropped_replica{nodes[0], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+                  dropped_replica{nodes[1], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+                  dropped_replica{nodes[2], 500, -1, -1, -1}};
     pc.last_committed_decree = 0;
-    get_node_state(state->_nodes, nodes[2].first, false)->set_replicas_collect_flag(true);
+    get_node_state(state->_nodes, nodes[2], false)->set_replicas_collect_flag(true);
     t = dsn::tasking::enqueue(LPC_META_STATE_NORMAL,
                               nullptr,
                               std::bind(&server_state::check_all_partitions, state),
@@ -656,23 +656,25 @@ void meta_partition_guardian_test::cure_test()
 
     t->wait();
     PROPOSAL_FLAG_CHECK;
-    CONDITION_CHECK([&] { return pc.hp_primary == nodes[1].first; });
+    CONDITION_CHECK([&] { return pc.hp_primary == nodes[1]; });
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     std::cerr << "Case: recover from DDD, haven't collect nodes[1/2]'s info from replica, and "
                  "nodes[1/2]'s info both have updated"
               << std::endl;
-    cc.dropped = {dropped_replica{nodes[0].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
-                  dropped_replica{nodes[1].first, 500, -1, -1, -1},
-                  dropped_replica{nodes[2].first, 500, -1, -1, -1}};
-    get_node_state(state->_nodes, nodes[1].first, false)->set_replicas_collect_flag(true);
-    get_node_state(state->_nodes, nodes[2].first, false)->set_replicas_collect_flag(true);
+    cc.dropped = {dropped_replica{nodes[0], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+                  dropped_replica{nodes[1], 500, -1, -1, -1},
+                  dropped_replica{nodes[2], 500, -1, -1, -1}};
+    get_node_state(state->_nodes, nodes[1], false)->set_replicas_collect_flag(true);
+    get_node_state(state->_nodes, nodes[2], false)->set_replicas_collect_flag(true);
 
     pc.primary.set_invalid();
     pc.hp_primary.reset();
     pc.hp_secondaries.clear();
-    pc.last_drops = {nodes[0].second, nodes[1].second, nodes[2].second};
-    pc.__set_hp_last_drops({nodes[0].first, nodes[1].first, nodes[2].first});
+    pc.last_drops = {dsn::dns_resolver::instance().resolve_address(nodes[0]),
+                     dsn::dns_resolver::instance().resolve_address(nodes[1]),
+                     dsn::dns_resolver::instance().resolve_address(nodes[2])};
+    pc.__set_hp_last_drops({nodes[0], nodes[1], nodes[2]});
 
     t = dsn::tasking::enqueue(LPC_META_STATE_NORMAL,
                               nullptr,
@@ -686,9 +688,9 @@ void meta_partition_guardian_test::cure_test()
     std::cerr << "Case: recover from DDD state, larger ballot not match with larger decree"
               << std::endl;
     cc.dropped = {
-        dropped_replica{nodes[0].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
-        dropped_replica{nodes[1].first, dropped_replica::INVALID_TIMESTAMP, 1, 0, 1},
-        dropped_replica{nodes[2].first, dropped_replica::INVALID_TIMESTAMP, 0, 1, 1},
+        dropped_replica{nodes[0], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+        dropped_replica{nodes[1], dropped_replica::INVALID_TIMESTAMP, 1, 0, 1},
+        dropped_replica{nodes[2], dropped_replica::INVALID_TIMESTAMP, 0, 1, 1},
     };
 
     t = dsn::tasking::enqueue(LPC_META_STATE_NORMAL,
@@ -702,9 +704,9 @@ void meta_partition_guardian_test::cure_test()
 
     std::cerr << "Case: recover from DDD state, committed decree less than meta's" << std::endl;
     cc.dropped = {
-        dropped_replica{nodes[0].first, dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
-        dropped_replica{nodes[1].first, dropped_replica::INVALID_TIMESTAMP, 1, 10, 15},
-        dropped_replica{nodes[2].first, dropped_replica::INVALID_TIMESTAMP, 1, 15, 15},
+        dropped_replica{nodes[0], dropped_replica::INVALID_TIMESTAMP, 1, 1, 1},
+        dropped_replica{nodes[1], dropped_replica::INVALID_TIMESTAMP, 1, 10, 15},
+        dropped_replica{nodes[2], dropped_replica::INVALID_TIMESTAMP, 1, 15, 15},
     };
     pc.last_committed_decree = 30;
     t = dsn::tasking::enqueue(LPC_META_STATE_NORMAL,
@@ -719,9 +721,9 @@ void meta_partition_guardian_test::cure_test()
     std::cerr << "Case: recover from DDD state, select primary from config_context::dropped"
               << std::endl;
     cc.dropped = {
-        dropped_replica{nodes[0].first, 12344, -1, -1, -1},
-        dropped_replica{nodes[2].first, dropped_replica::INVALID_TIMESTAMP, 4, 2, 4},
-        dropped_replica{nodes[1].first, dropped_replica::INVALID_TIMESTAMP, 4, 3, 4},
+        dropped_replica{nodes[0], 12344, -1, -1, -1},
+        dropped_replica{nodes[2], dropped_replica::INVALID_TIMESTAMP, 4, 2, 4},
+        dropped_replica{nodes[1], dropped_replica::INVALID_TIMESTAMP, 4, 3, 4},
     };
     pc.last_committed_decree = 2;
     svc->set_filter([&](const dsn::host_port &target, dsn::message_ex *req) -> cur_ptr {
@@ -731,8 +733,8 @@ void meta_partition_guardian_test::cure_test()
         destroy_message(recv_request);
 
         EXPECT_EQ(update_req->type, config_type::CT_ASSIGN_PRIMARY);
-        EXPECT_EQ(update_req->hp_node, nodes[1].first);
-        EXPECT_EQ(target, nodes[1].first);
+        EXPECT_EQ(update_req->hp_node, nodes[1]);
+        EXPECT_EQ(target, nodes[1]);
 
         proposal_sent = true;
         svc->set_filter(default_filter);
@@ -746,7 +748,7 @@ void meta_partition_guardian_test::cure_test()
                               server_state::sStateHash);
     t->wait();
     PROPOSAL_FLAG_CHECK;
-    CONDITION_CHECK([&] { return pc.hp_primary == nodes[1].first; });
+    CONDITION_CHECK([&] { return pc.hp_primary == nodes[1]; });
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     std::cerr << "Case: recover from DDD state, only one primary" << std::endl;
@@ -757,8 +759,8 @@ void meta_partition_guardian_test::cure_test()
         destroy_message(recv_request);
 
         EXPECT_EQ(update_req->type, config_type::CT_ASSIGN_PRIMARY);
-        EXPECT_EQ(update_req->hp_node, nodes[0].first);
-        EXPECT_EQ(target, nodes[0].first);
+        EXPECT_EQ(update_req->hp_node, nodes[0]);
+        EXPECT_EQ(target, nodes[0]);
 
         proposal_sent = true;
         svc->set_filter(default_filter);
@@ -769,12 +771,12 @@ void meta_partition_guardian_test::cure_test()
     pc.primary.set_invalid();
     pc.hp_primary.reset();
     pc.hp_secondaries.clear();
-    pc.last_drops = {nodes[0].second};
-    pc.__set_hp_last_drops({nodes[0].first});
+    pc.last_drops = {dsn::dns_resolver::instance().resolve_address(nodes[0])};
+    pc.__set_hp_last_drops({nodes[0]});
     state->_nodes.clear();
     pc.ballot = 1;
     state->initialize_node_state();
-    svc->set_node_state({nodes[0].first, nodes[1].first, nodes[2].first}, true);
+    svc->set_node_state({nodes[0], nodes[1], nodes[2]}, true);
 
     t = dsn::tasking::enqueue(LPC_META_STATE_NORMAL,
                               nullptr,
@@ -782,7 +784,7 @@ void meta_partition_guardian_test::cure_test()
                               server_state::sStateHash);
     t->wait();
     PROPOSAL_FLAG_CHECK;
-    CONDITION_CHECK([&] { return pc.hp_primary == nodes[0].first; });
+    CONDITION_CHECK([&] { return pc.hp_primary == nodes[0]; });
 }
 
 static void check_nodes_loads(node_mapper &nodes)
@@ -803,12 +805,8 @@ static void check_nodes_loads(node_mapper &nodes)
 
 void meta_partition_guardian_test::cure()
 {
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> nodes_pairs;
     std::vector<dsn::host_port> nodes_list;
-    generate_node_list(nodes_pairs, 20, 100);
-    for (const auto &p : nodes_pairs) {
-        nodes_list.emplace_back(p.first);
-    }
+    generate_node_list(nodes_list, 20, 100);
 
     app_mapper app;
     node_mapper nodes;
@@ -860,7 +858,7 @@ void meta_partition_guardian_test::cure()
 
 void meta_partition_guardian_test::from_proposal_test()
 {
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> nodes_list;
+    std::vector<dsn::host_port> nodes_list;
     generate_node_list(nodes_list, 3, 3);
 
     app_mapper app;
@@ -880,8 +878,8 @@ void meta_partition_guardian_test::from_proposal_test()
     std::shared_ptr<app_state> the_app = app_state::create(info);
 
     app.emplace(the_app->app_id, the_app);
-    for (const auto &p : nodes_list) {
-        get_node_state(nodes, p.first, true)->set_alive(true);
+    for (const auto &hp : nodes_list) {
+        get_node_state(nodes, hp, true)->set_alive(true);
     }
 
     meta_view mv{&app, &nodes};
@@ -897,49 +895,43 @@ void meta_partition_guardian_test::from_proposal_test()
     ASSERT_EQ(config_type::CT_INVALID, cpa.type);
 
     std::cerr << "Case 2: test invalid proposal: invalid target" << std::endl;
-    cpa2 = new_proposal_action(
-        dsn::host_port(), nodes_list[0].first, config_type::CT_UPGRADE_TO_PRIMARY);
+    cpa2 = new_proposal_action(dsn::host_port(), nodes_list[0], config_type::CT_UPGRADE_TO_PRIMARY);
     cc.lb_actions.assign_balancer_proposals({cpa2});
     ASSERT_FALSE(guardian.from_proposals(mv, p, cpa));
     ASSERT_EQ(config_type::CT_INVALID, cpa.type);
 
     std::cerr << "Case 3: test invalid proposal: invalid node" << std::endl;
-    cpa2 = new_proposal_action(
-        nodes_list[0].first, dsn::host_port(), config_type::CT_UPGRADE_TO_PRIMARY);
+    cpa2 = new_proposal_action(nodes_list[0], dsn::host_port(), config_type::CT_UPGRADE_TO_PRIMARY);
     cc.lb_actions.assign_balancer_proposals({cpa2});
     ASSERT_FALSE(guardian.from_proposals(mv, p, cpa));
     ASSERT_EQ(config_type::CT_INVALID, cpa.type);
 
     std::cerr << "Case 4: test invalid proposal: dead target" << std::endl;
-    cpa2 = new_proposal_action(
-        nodes_list[0].first, nodes_list[0].first, config_type::CT_UPGRADE_TO_PRIMARY);
+    cpa2 = new_proposal_action(nodes_list[0], nodes_list[0], config_type::CT_UPGRADE_TO_PRIMARY);
     cc.lb_actions.assign_balancer_proposals({cpa2});
-    get_node_state(nodes, nodes_list[0].first, false)->set_alive(false);
+    get_node_state(nodes, nodes_list[0], false)->set_alive(false);
     ASSERT_FALSE(guardian.from_proposals(mv, p, cpa));
     ASSERT_EQ(config_type::CT_INVALID, cpa.type);
-    get_node_state(nodes, nodes_list[0].first, false)->set_alive(true);
+    get_node_state(nodes, nodes_list[0], false)->set_alive(true);
 
     std::cerr << "Case 5: test invalid proposal: dead node" << std::endl;
-    cpa2 = new_proposal_action(
-        nodes_list[0].first, nodes_list[1].first, config_type::CT_ADD_SECONDARY);
+    cpa2 = new_proposal_action(nodes_list[0], nodes_list[1], config_type::CT_ADD_SECONDARY);
     cc.lb_actions.assign_balancer_proposals({cpa2});
-    get_node_state(nodes, nodes_list[1].first, false)->set_alive(false);
+    get_node_state(nodes, nodes_list[1], false)->set_alive(false);
     ASSERT_FALSE(guardian.from_proposals(mv, p, cpa));
     ASSERT_EQ(config_type::CT_INVALID, cpa.type);
-    get_node_state(nodes, nodes_list[1].first, false)->set_alive(true);
+    get_node_state(nodes, nodes_list[1], false)->set_alive(true);
 
     std::cerr << "Case 6: test invalid proposal: already have priamry but assign" << std::endl;
-    cpa2 = new_proposal_action(
-        nodes_list[0].first, nodes_list[0].first, config_type::CT_ASSIGN_PRIMARY);
+    cpa2 = new_proposal_action(nodes_list[0], nodes_list[0], config_type::CT_ASSIGN_PRIMARY);
     cc.lb_actions.assign_balancer_proposals({cpa2});
-    pc.primary = nodes_list[1].second;
-    pc.__set_hp_primary(nodes_list[1].first);
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes_list[1]);
+    pc.__set_hp_primary(nodes_list[1]);
     ASSERT_FALSE(guardian.from_proposals(mv, p, cpa));
     ASSERT_EQ(config_type::CT_INVALID, cpa.type);
 
     std::cerr << "Case 7: test invalid proposal: upgrade non-secondary" << std::endl;
-    cpa2 = new_proposal_action(
-        nodes_list[0].first, nodes_list[0].first, config_type::CT_UPGRADE_TO_PRIMARY);
+    cpa2 = new_proposal_action(nodes_list[0], nodes_list[0], config_type::CT_UPGRADE_TO_PRIMARY);
     cc.lb_actions.assign_balancer_proposals({cpa2});
     pc.primary.set_invalid();
     pc.hp_primary.reset();
@@ -947,30 +939,28 @@ void meta_partition_guardian_test::from_proposal_test()
     ASSERT_EQ(config_type::CT_INVALID, cpa.type);
 
     std::cerr << "Case 8: test invalid proposal: add exist secondary" << std::endl;
-    cpa2 = new_proposal_action(
-        nodes_list[0].first, nodes_list[1].first, config_type::CT_ADD_SECONDARY);
+    cpa2 = new_proposal_action(nodes_list[0], nodes_list[1], config_type::CT_ADD_SECONDARY);
     cc.lb_actions.assign_balancer_proposals({cpa2});
-    pc.primary = nodes_list[1].second;
-    pc.__set_hp_primary(nodes_list[1].first);
-    pc.secondaries = {nodes_list[1].second};
-    pc.__set_hp_secondaries({nodes_list[1].first});
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes_list[1]);
+    pc.__set_hp_primary(nodes_list[1]);
+    pc.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes_list[1])};
+    pc.__set_hp_secondaries({nodes_list[1]});
     ASSERT_FALSE(guardian.from_proposals(mv, p, cpa));
     ASSERT_EQ(config_type::CT_INVALID, cpa.type);
 
     std::cerr << "Case 9: test invalid proposal: downgrade non member" << std::endl;
-    cpa2 = new_proposal_action(nodes_list[0].first, nodes_list[1].first, config_type::CT_REMOVE);
+    cpa2 = new_proposal_action(nodes_list[0], nodes_list[1], config_type::CT_REMOVE);
     cc.lb_actions.assign_balancer_proposals({cpa2});
-    pc.primary = nodes_list[0].second;
-    pc.__set_hp_primary(nodes_list[0].first);
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes_list[0]);
+    pc.__set_hp_primary(nodes_list[0]);
     pc.hp_secondaries.clear();
     ASSERT_FALSE(guardian.from_proposals(mv, p, cpa));
     ASSERT_EQ(config_type::CT_INVALID, cpa.type);
 
     std::cerr << "Case 10: test abnormal learning detect" << std::endl;
-    cpa2 = new_proposal_action(
-        nodes_list[0].first, nodes_list[1].first, config_type::CT_ADD_SECONDARY);
-    pc.primary = nodes_list[0].second;
-    pc.__set_hp_primary(nodes_list[0].first);
+    cpa2 = new_proposal_action(nodes_list[0], nodes_list[1], config_type::CT_ADD_SECONDARY);
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes_list[0]);
+    pc.__set_hp_primary(nodes_list[0]);
     pc.hp_secondaries.clear();
     cc.lb_actions.assign_balancer_proposals({cpa2});
 
@@ -982,12 +972,12 @@ void meta_partition_guardian_test::from_proposal_test()
     i.last_committed_decree = 10;
     i.last_prepared_decree = 10;
 
-    collect_replica(mv, nodes_list[1].first, i);
+    collect_replica(mv, nodes_list[1], i);
     ASSERT_TRUE(guardian.from_proposals(mv, p, cpa));
     ASSERT_EQ(config_type::CT_ADD_SECONDARY, cpa.type);
 
     i.status = partition_status::PS_ERROR;
-    collect_replica(mv, nodes_list[1].first, i);
+    collect_replica(mv, nodes_list[1], i);
     ASSERT_FALSE(guardian.from_proposals(mv, p, cpa));
     ASSERT_EQ(config_type::CT_INVALID, cpa.type);
 }

--- a/src/meta/test/meta_test_base.cpp
+++ b/src/meta/test/meta_test_base.cpp
@@ -161,10 +161,7 @@ std::vector<host_port> meta_test_base::ensure_enough_alive_nodes(int min_node_co
         return nodes;
     }
 
-    auto node_pairs = generate_node_list(min_node_count);
-    for (const auto &p : node_pairs) {
-        nodes.emplace_back(p.first);
-    }
+    nodes = generate_node_list(min_node_count);
     _ms->set_node_state(nodes, true);
 
     while (true) {

--- a/src/meta/test/misc/misc.cpp
+++ b/src/meta/test/misc/misc.cpp
@@ -61,15 +61,12 @@ uint32_t random32(uint32_t min, uint32_t max)
     return res + min;
 }
 
-void generate_node_list(std::vector<std::pair<dsn::host_port, dsn::rpc_address>> &output_list,
-                        int min_count,
-                        int max_count)
+void generate_node_list(std::vector<dsn::host_port> &output_list, int min_count, int max_count)
 {
     const auto count = random32(min_count, max_count);
-    output_list.resize(count);
+    output_list.reserve(count);
     for (int i = 0; i < count; ++i) {
-        const dsn::host_port hp("localhost", i + 1);
-        output_list[i] = std::make_pair(hp, dsn::dns_resolver::instance().resolve_address(hp));
+        output_list.emplace_back(dsn::host_port("localhost", i + 1));
     }
 }
 

--- a/src/meta/test/misc/misc.h
+++ b/src/meta/test/misc/misc.h
@@ -68,20 +68,15 @@ uint32_t random32(uint32_t min, uint32_t max);
 // Generates a random number [min_count, max_count] of node addresses
 // each node is given a random port value in range of [min_count, max_count]
 void generate_node_list(
-    /*out*/ std::vector<std::pair<dsn::host_port, dsn::rpc_address>> &output_list,
-    int min_count,
-    int max_count);
+    /*out*/ std::vector<dsn::host_port> &output_list, int min_count, int max_count);
 
-// Generates `size` of node addresses, each with port value in range [start_port, start_port + size]
-inline std::vector<std::pair<dsn::host_port, dsn::rpc_address>>
-generate_node_list(size_t size, int start_port = 12321)
+// Generates `size` of node host_port, each with port value in range [start_port, start_port + size]
+inline std::vector<dsn::host_port> generate_node_list(size_t size, int start_port = 12321)
 {
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> result;
-    result.resize(size);
+    std::vector<dsn::host_port> result;
+    result.reserve(size);
     for (int i = 0; i < size; ++i) {
-        const dsn::host_port hp("localhost", static_cast<uint16_t>(start_port + i + 1));
-        result[i].first = hp;
-        result[i].second = dsn::dns_resolver::instance().resolve_address(hp);
+        result.emplace_back(dsn::host_port("localhost", static_cast<uint16_t>(start_port + i + 1)));
     }
     return result;
 }

--- a/src/meta/test/misc/misc.h
+++ b/src/meta/test/misc/misc.h
@@ -33,13 +33,10 @@
 #include <functional>
 #include <map>
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 
 #include "meta/meta_data.h"
-#include "runtime/rpc/dns_resolver.h"
-#include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 
 namespace dsn {

--- a/src/meta/test/state_sync_test.cpp
+++ b/src/meta/test/state_sync_test.cpp
@@ -46,6 +46,7 @@
 #include "meta/test/misc/misc.h"
 #include "meta_admin_types.h"
 #include "meta_service_test_app.h"
+#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "runtime/task/task.h"

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -247,27 +247,29 @@ void meta_service_test_app::update_configuration_test()
 
     ss->_all_apps.emplace(1, app);
 
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> nodes;
+    std::vector<dsn::host_port> nodes;
     generate_node_list(nodes, 4, 4);
 
     dsn::partition_configuration &pc0 = app->partitions[0];
-    pc0.primary = nodes[0].second;
-    pc0.__set_hp_primary(nodes[0].first);
-    pc0.secondaries = {nodes[1].second, nodes[2].second};
-    pc0.__set_hp_secondaries({nodes[1].first, nodes[2].first});
+    pc0.primary = dsn::dns_resolver::instance().resolve_address(nodes[0]);
+    pc0.__set_hp_primary(nodes[0]);
+    pc0.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes[1]),
+                       dsn::dns_resolver::instance().resolve_address(nodes[2])};
+    pc0.__set_hp_secondaries({nodes[1], nodes[2]});
     pc0.ballot = 3;
 
     dsn::partition_configuration &pc1 = app->partitions[1];
-    pc1.primary = nodes[1].second;
-    pc1.__set_hp_primary(nodes[1].first);
-    pc1.secondaries = {nodes[0].second, nodes[2].second};
-    pc1.__set_hp_secondaries({nodes[0].first, nodes[2].first});
+    pc1.primary = dsn::dns_resolver::instance().resolve_address(nodes[1]);
+    pc1.__set_hp_primary(nodes[1]);
+    pc1.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes[0]),
+                       dsn::dns_resolver::instance().resolve_address(nodes[2])};
+    pc1.__set_hp_secondaries({nodes[0], nodes[2]});
     pc1.ballot = 3;
 
     ss->sync_apps_to_remote_storage();
     ASSERT_TRUE(ss->spin_wait_staging(30));
     ss->initialize_node_state();
-    svc->set_node_state({nodes[0].first, nodes[1].first, nodes[2].first}, true);
+    svc->set_node_state({nodes[0], nodes[1], nodes[2]}, true);
     svc->_started = true;
 
     // test remove primary
@@ -279,19 +281,19 @@ void meta_service_test_app::update_configuration_test()
     };
 
     // test kickoff secondary
-    auto hp = nodes[0].first;
+    const auto &hp = nodes[0];
     state_validator validator2 = [pc1, hp](const app_mapper &apps) {
         const dsn::partition_configuration *pc = get_config(apps, pc1.pid);
         return pc->ballot == pc1.ballot + 1 && pc->hp_secondaries.size() == 1 &&
                pc->hp_secondaries.front() != hp;
     };
 
-    svc->set_node_state({nodes[0].first}, false);
+    svc->set_node_state({nodes[0]}, false);
     ASSERT_TRUE(wait_state(ss, validator1, 30));
     ASSERT_TRUE(wait_state(ss, validator2, 30));
 
     // test add secondary
-    svc->set_node_state({nodes[3].first}, true);
+    svc->set_node_state({nodes[3]}, true);
     state_validator validator3 = [pc0](const app_mapper &apps) {
         const dsn::partition_configuration *pc = get_config(apps, pc0.pid);
         return pc->ballot == pc0.ballot + 1 && pc->hp_secondaries.size() == 2;
@@ -329,41 +331,38 @@ void meta_service_test_app::adjust_dropped_size()
 
     ss->_all_apps.emplace(1, app);
 
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> nodes;
+    std::vector<dsn::host_port> nodes;
     generate_node_list(nodes, 10, 10);
 
     // first, the replica is healthy, and there are 2 dropped
     dsn::partition_configuration &pc = app->partitions[0];
-    pc.primary = nodes[0].second;
-    pc.__set_hp_primary(nodes[0].first);
-    pc.secondaries = {nodes[1].second, nodes[2].second};
-    pc.__set_hp_secondaries({nodes[1].first, nodes[2].first});
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes[0]);
+    pc.__set_hp_primary(nodes[0]);
+    pc.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes[1]),
+                      dsn::dns_resolver::instance().resolve_address(nodes[2])};
+    pc.__set_hp_secondaries({nodes[1], nodes[2]});
     pc.ballot = 10;
 
     config_context &cc = *get_config_context(ss->_all_apps, pc.pid);
     cc.dropped = {
-        dropped_replica{nodes[3].first, dropped_replica::INVALID_TIMESTAMP, 7, 11, 14},
-        dropped_replica{nodes[4].first, 20, invalid_ballot, invalid_decree, invalid_decree},
+        dropped_replica{nodes[3], dropped_replica::INVALID_TIMESTAMP, 7, 11, 14},
+        dropped_replica{nodes[4], 20, invalid_ballot, invalid_decree, invalid_decree},
     };
 
     ss->sync_apps_to_remote_storage();
 
-    std::vector<dsn::host_port> hps;
-    for (const auto &p : nodes) {
-        hps.emplace_back(p.first);
-    }
-    generate_node_mapper(ss->_nodes, ss->_all_apps, hps);
+    generate_node_mapper(ss->_nodes, ss->_all_apps, nodes);
 
     // then we receive a request for upgrade a node to secondary
     std::shared_ptr<configuration_update_request> req =
         std::make_shared<configuration_update_request>();
     req->config = pc;
     req->config.ballot++;
-    req->config.secondaries.push_back(nodes[5].second);
-    req->config.__set_hp_secondaries({nodes[5].first});
+    req->config.secondaries.push_back(dsn::dns_resolver::instance().resolve_address(nodes[5]));
+    req->config.__set_hp_secondaries({nodes[5]});
     req->info = info;
-    req->node = nodes[5].second;
-    req->__set_hp_node(nodes[5].first);
+    req->node = dsn::dns_resolver::instance().resolve_address(nodes[5]);
+    req->__set_hp_node(nodes[5]);
     req->type = config_type::CT_UPGRADE_TO_SECONDARY;
     call_update_configuration(svc.get(), req);
 
@@ -372,8 +371,8 @@ void meta_service_test_app::adjust_dropped_size()
     // then receive a config_sync request fro nodes[4], which has less data than node[3]
     std::shared_ptr<configuration_query_by_node_request> req2 =
         std::make_shared<configuration_query_by_node_request>();
-    req2->node = nodes[4].second;
-    req2->__set_hp_node(nodes[4].first);
+    req2->node = dsn::dns_resolver::instance().resolve_address(nodes[4]);
+    req2->__set_hp_node(nodes[4]);
 
     replica_info rep_info;
     rep_info.pid = pc.pid;
@@ -393,7 +392,7 @@ void meta_service_test_app::adjust_dropped_size()
         dropped_replica &d = cc.dropped[0];
         if (d.time != dropped_replica::INVALID_TIMESTAMP)
             return false;
-        if (d.node != nodes[4].first)
+        if (d.node != nodes[4])
             return false;
         if (d.last_committed_decree != rep_info.last_committed_decree)
             return false;
@@ -429,13 +428,8 @@ void meta_service_test_app::apply_balancer_test()
     meta_svc->_balancer.reset(new greedy_load_balancer(meta_svc.get()));
 
     // initialize data structure
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> node_list;
-    generate_node_list(node_list, 5, 10);
-
     std::vector<dsn::host_port> hps;
-    for (const auto &p : node_list) {
-        hps.emplace_back(p.first);
-    }
+    generate_node_list(hps, 5, 10);
 
     server_state *ss = meta_svc->_state.get();
     generate_apps(ss->_all_apps, hps, 5, 5, std::pair<uint32_t, uint32_t>(2, 5), false);
@@ -506,7 +500,7 @@ void meta_service_test_app::cannot_run_balancer_test()
     svc->_balancer.reset(new dummy_balancer(svc.get()));
     svc->_partition_guardian.reset(new dummy_partition_guardian(svc.get()));
 
-    std::vector<std::pair<dsn::host_port, dsn::rpc_address>> nodes;
+    std::vector<dsn::host_port> nodes;
     generate_node_list(nodes, 10, 10);
 
     dsn::app_info info;
@@ -525,19 +519,15 @@ void meta_service_test_app::cannot_run_balancer_test()
     svc->_state->_table_metric_entities.create_entity(info.app_id, info.partition_count);
 
     dsn::partition_configuration &pc = the_app->partitions[0];
-    pc.primary = nodes[0].second;
-    pc.__set_hp_primary(nodes[0].first);
-    pc.secondaries = {nodes[1].second, nodes[2].second};
-    pc.__set_hp_secondaries({nodes[1].first, nodes[2].first});
-
-    std::vector<dsn::host_port> hps;
-    for (const auto &p : nodes) {
-        hps.emplace_back(p.first);
-    }
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes[0]);
+    pc.__set_hp_primary(nodes[0]);
+    pc.secondaries = {dsn::dns_resolver::instance().resolve_address(nodes[1]),
+                      dsn::dns_resolver::instance().resolve_address(nodes[2])};
+    pc.__set_hp_secondaries({nodes[1], nodes[2]});
 
 #define REGENERATE_NODE_MAPPER                                                                     \
     svc->_state->_nodes.clear();                                                                   \
-    generate_node_mapper(svc->_state->_nodes, svc->_state->_all_apps, hps)
+    generate_node_mapper(svc->_state->_nodes, svc->_state->_all_apps, nodes)
 
     REGENERATE_NODE_MAPPER;
     // stage are freezed
@@ -557,8 +547,8 @@ void meta_service_test_app::cannot_run_balancer_test()
     ASSERT_FALSE(svc->_state->check_all_partitions());
 
     // some dropped node still exists in nodes
-    pc.primary = nodes[0].second;
-    pc.__set_hp_primary(nodes[0].first);
+    pc.primary = dsn::dns_resolver::instance().resolve_address(nodes[0]);
+    pc.__set_hp_primary(nodes[0]);
     REGENERATE_NODE_MAPPER;
     get_node_state(svc->_state->_nodes, pc.hp_primary, true)->set_alive(false);
     ASSERT_FALSE(svc->_state->check_all_partitions());

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -54,6 +54,7 @@
 #include "meta_admin_types.h"
 #include "meta_service_test_app.h"
 #include "metadata_types.h"
+#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_holder.h"
 #include "runtime/rpc/rpc_host_port.h"


### PR DESCRIPTION
Simplify the 2 forms of generate_node_list(...), they are widely used in
tests, they generate a std::vector with std::pair<host_port, rpc_address>
before, this patch simplify the code to generate std::vector with host_host
elements only.
