### PR TITLE
refactor(FQDN): Use operator bool to simplify code

### DIFF
--- a/src/aio/aio_provider.h
+++ b/src/aio/aio_provider.h
@@ -50,7 +50,6 @@ struct linux_fd_t
     int fd;
 
     explicit linux_fd_t(int f) : fd(f) {}
-    inline bool is_invalid() const { return fd == DSN_INVALID_FILE_HANDLE; }
 };
 
 class aio_provider

--- a/src/client/partition_resolver_simple.cpp
+++ b/src/client/partition_resolver_simple.cpp
@@ -439,7 +439,7 @@ error_code partition_resolver_simple::get_host_port(int partition_index, /*out*/
                 return ERR_CHILD_NOT_READY;
             }
             hp = get_host_port(it->second->config);
-            if (hp.is_invalid()) {
+            if (!hp) {
                 return ERR_IO_PENDING;
             } else {
                 return ERR_OK;

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -165,8 +165,7 @@ dsn::error_code replication_ddl_client::wait_app_ready(const std::string &app_na
         int ready_count = 0;
         for (int i = 0; i < partition_count; i++) {
             const partition_configuration &pc = query_resp.partitions[i];
-            if (!pc.hp_primary.is_invalid() &&
-                (pc.hp_secondaries.size() + 1 >= max_replica_count)) {
+            if (pc.hp_primary && (pc.hp_secondaries.size() + 1 >= max_replica_count)) {
                 ready_count++;
             }
         }
@@ -435,11 +434,11 @@ dsn::error_code replication_ddl_client::list_apps(const dsn::app_status::type st
             for (int i = 0; i < partitions.size(); i++) {
                 const dsn::partition_configuration &p = partitions[i];
                 int replica_count = 0;
-                if (!p.hp_primary.is_invalid()) {
+                if (p.hp_primary) {
                     replica_count++;
                 }
                 replica_count += p.hp_secondaries.size();
-                if (!p.hp_primary.is_invalid()) {
+                if (p.hp_primary) {
                     if (replica_count >= p.max_replica_count)
                         fully_healthy++;
                     else if (replica_count < 2)
@@ -573,7 +572,7 @@ dsn::error_code replication_ddl_client::list_nodes(const dsn::replication::node_
 
             for (int i = 0; i < partitions.size(); i++) {
                 const dsn::partition_configuration &p = partitions[i];
-                if (!p.hp_primary.is_invalid()) {
+                if (p.hp_primary) {
                     auto find = tmp_map.find(p.hp_primary);
                     if (find != tmp_map.end()) {
                         find->second.primary_count++;
@@ -766,14 +765,14 @@ dsn::error_code replication_ddl_client::list_app(const std::string &app_name,
         int read_unhealthy = 0;
         for (const auto &p : partitions) {
             int replica_count = 0;
-            if (!p.hp_primary.is_invalid()) {
+            if (p.hp_primary) {
                 replica_count++;
                 node_stat[p.hp_primary].first++;
                 total_prim_count++;
             }
             replica_count += p.hp_secondaries.size();
             total_sec_count += p.hp_secondaries.size();
-            if (!p.hp_primary.is_invalid()) {
+            if (p.hp_primary) {
                 if (replica_count >= p.max_replica_count)
                     fully_healthy++;
                 else if (replica_count < 2)
@@ -787,7 +786,7 @@ dsn::error_code replication_ddl_client::list_app(const std::string &app_name,
             std::stringstream oss;
             oss << replica_count << "/" << p.max_replica_count;
             tp_details.append_data(oss.str());
-            tp_details.append_data((p.hp_primary.is_invalid() ? "-" : p.hp_primary.to_string()));
+            tp_details.append_data(p.hp_primary ? p.hp_primary.to_string() : "-");
             oss.str("");
             oss << "[";
             // TODO (yingchun) join

--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -423,7 +423,7 @@ inline bool json_decode(const dsn::json::JsonObject &in, dsn::rpc_address &addre
     }
 
     address = dsn::rpc_address::from_host_port(rpc_address_string);
-    return !address.is_invalid();
+    return static_cast<bool>(address);
 }
 
 // json serialization for rpc host_port, we use the string representation of a host_port
@@ -439,7 +439,7 @@ inline bool json_decode(const dsn::json::JsonObject &in, dsn::host_port &hp)
         return true;
     }
     hp = host_port::from_string(host_port_string);
-    return !hp.is_invalid();
+    return static_cast<bool>(hp);
 }
 
 inline void json_encode(JsonWriter &out, const dsn::partition_configuration &config);

--- a/src/common/replication_other_types.h
+++ b/src/common/replication_other_types.h
@@ -53,11 +53,11 @@ typedef int64_t decree;
 
 inline bool is_primary(const partition_configuration &pc, const host_port &node)
 {
-    return !node.is_invalid() && pc.hp_primary == node;
+    return node && pc.hp_primary == node;
 }
 inline bool is_secondary(const partition_configuration &pc, const host_port &node)
 {
-    return !node.is_invalid() &&
+    return node &&
            std::find(pc.hp_secondaries.begin(), pc.hp_secondaries.end(), node) !=
                pc.hp_secondaries.end();
 }

--- a/src/failure_detector/failure_detector_multimaster.cpp
+++ b/src/failure_detector/failure_detector_multimaster.cpp
@@ -100,7 +100,7 @@ void slave_failure_detector_with_multimaster::end_ping(::dsn::error_code err,
     } else {
         if (ack.is_master) {
             // do nothing
-        } else if (hp_primary_node.is_invalid()) {
+        } else if (!hp_primary_node) {
             auto next = _meta_servers.group_host_port()->next(hp_this_node);
             if (next != hp_this_node) {
                 _meta_servers.group_host_port()->set_leader(next);

--- a/src/meta/backup_engine.cpp
+++ b/src/meta/backup_engine.cpp
@@ -185,7 +185,7 @@ void backup_engine::backup_app_partition(const gpid &pid)
         partition_primary = app->partitions[pid.get_partition_index()].hp_primary;
     }
 
-    if (partition_primary.is_invalid()) {
+    if (!partition_primary) {
         LOG_WARNING(
             "backup_id({}): partition {} doesn't have a primary now, retry to backup it later.",
             _cur_backup.backup_id,

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -541,7 +541,7 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                           query_err = ERR_INCONSISTENT_STATE;
                       } else {
                           for (const auto &partition : resp.partitions) {
-                              if (partition.hp_primary.is_invalid()) {
+                              if (!partition.hp_primary) {
                                   query_err = ERR_INACTIVE_STATE;
                                   break;
                               }
@@ -552,7 +552,7 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                               }
 
                               for (const auto &secondary : partition.hp_secondaries) {
-                                  if (secondary.is_invalid()) {
+                                  if (!secondary) {
                                       query_err = ERR_INACTIVE_STATE;
                                       break;
                                   }

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -497,8 +497,7 @@ void load_balance_policy::number_nodes(const node_mapper &nodes)
     host_port_id.clear();
     host_port_vec.resize(_alive_nodes + 2);
     for (auto iter = nodes.begin(); iter != nodes.end(); ++iter) {
-        CHECK(!iter->first.is_invalid() && !iter->second.host_port().is_invalid(),
-              "invalid address");
+        CHECK(iter->first && iter->second.host_port(), "invalid address");
         CHECK(iter->second.alive(), "dead node");
 
         host_port_id[iter->first] = current_id;

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -526,7 +526,7 @@ void policy_context::start_backup_partition_unlocked(gpid pid)
         }
         partition_primary = app->partitions[pid.get_partition_index()].hp_primary;
     }
-    if (partition_primary.is_invalid()) {
+    if (!partition_primary) {
         LOG_WARNING("{}: partition {} doesn't have a primary now, retry to backup it later",
                     _backup_sig,
                     pid);

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -369,7 +369,7 @@ bool bulk_load_service::check_partition_status(
     }
 
     pconfig = app->partitions[pid.get_partition_index()];
-    if (pconfig.hp_primary.is_invalid()) {
+    if (!pconfig.hp_primary) {
         LOG_WARNING("app({}) partition({}) primary is invalid, try it later", app_name, pid);
         tasking::enqueue(LPC_META_STATE_NORMAL,
                          _meta_svc->tracker(),

--- a/src/meta/meta_data.h
+++ b/src/meta/meta_data.h
@@ -492,7 +492,7 @@ inline config_context *get_config_context(app_mapper &apps, const dsn::gpid &gpi
 
 inline int replica_count(const partition_configuration &pc)
 {
-    int ans = (pc.hp_primary.is_invalid()) ? 0 : 1;
+    int ans = pc.hp_primary ? 1 : 0;
     return ans + pc.hp_secondaries.size();
 }
 
@@ -510,12 +510,12 @@ enum health_status
 inline health_status partition_health_status(const partition_configuration &pc,
                                              int mutation_2pc_min_replica_count)
 {
-    if (pc.hp_primary.is_invalid()) {
+    if (!pc.hp_primary) {
         if (pc.hp_secondaries.empty())
             return HS_DEAD;
         else
             return HS_UNREADABLE;
-    } else { // !pc.primary.is_invalid()
+    } else {
         int n = pc.hp_secondaries.size() + 1;
         if (n < mutation_2pc_min_replica_count)
             return HS_UNWRITABLE;

--- a/src/meta/meta_http_service.cpp
+++ b/src/meta/meta_http_service.cpp
@@ -143,14 +143,14 @@ void meta_http_service::get_app_handler(const http_request &req, http_response &
         int read_unhealthy = 0;
         for (const auto &p : response.partitions) {
             int replica_count = 0;
-            if (!p.hp_primary.is_invalid()) {
+            if (p.hp_primary) {
                 replica_count++;
                 node_stat[p.hp_primary].first++;
                 total_prim_count++;
             }
             replica_count += p.hp_secondaries.size();
             total_sec_count += p.hp_secondaries.size();
-            if (!p.hp_primary.is_invalid()) {
+            if (p.hp_primary) {
                 if (replica_count >= p.max_replica_count)
                     fully_healthy++;
                 else if (replica_count < 2)
@@ -164,7 +164,7 @@ void meta_http_service::get_app_handler(const http_request &req, http_response &
             std::stringstream oss;
             oss << replica_count << "/" << p.max_replica_count;
             tp_details.append_data(oss.str());
-            tp_details.append_data((p.hp_primary.is_invalid() ? "-" : p.hp_primary.to_string()));
+            tp_details.append_data(p.hp_primary ? p.hp_primary.to_string() : "-");
             oss.str("");
             oss << "[";
             for (int j = 0; j < p.hp_secondaries.size(); j++) {
@@ -325,11 +325,11 @@ void meta_http_service::list_app_handler(const http_request &req, http_response 
             for (int i = 0; i < response.partitions.size(); i++) {
                 const dsn::partition_configuration &p = response.partitions[i];
                 int replica_count = 0;
-                if (!p.hp_primary.is_invalid()) {
+                if (p.hp_primary) {
                     replica_count++;
                 }
                 replica_count += p.hp_secondaries.size();
-                if (!p.hp_primary.is_invalid()) {
+                if (p.hp_primary) {
                     if (replica_count >= p.max_replica_count)
                         fully_healthy++;
                     else if (replica_count < 2)
@@ -415,7 +415,7 @@ void meta_http_service::list_node_handler(const http_request &req, http_response
 
             for (int i = 0; i < response_app.partitions.size(); i++) {
                 const dsn::partition_configuration &p = response_app.partitions[i];
-                if (!p.hp_primary.is_invalid()) {
+                if (p.hp_primary) {
                     auto find = tmp_map.find(p.hp_primary);
                     if (find != tmp_map.end()) {
                         find->second.primary_count++;

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -575,7 +575,7 @@ meta_leader_state meta_service::check_leader(dsn::message_ex *req, dsn::host_por
         }
 
         LOG_DEBUG("leader address: {}", leader);
-        if (!leader.is_invalid()) {
+        if (leader) {
             dsn_rpc_forward(req, dsn::dns_resolver::instance().resolve_address(leader));
             return meta_leader_state::kNotLeaderAndCanForwardRpc;
         } else {
@@ -757,7 +757,7 @@ void meta_service::on_query_configuration_by_index(configuration_query_by_index_
     query_cfg_response &response = rpc.response();
     host_port forward_hp;
     if (!check_status_and_authz(rpc, &forward_hp)) {
-        if (!forward_hp.is_invalid()) {
+        if (forward_hp) {
             partition_configuration config;
             config.primary = dsn::dns_resolver::instance().resolve_address(forward_hp);
             config.__set_hp_primary(forward_hp);

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -402,7 +402,7 @@ meta_leader_state meta_service::check_leader(TRpcHolder rpc, host_port *forward_
             return meta_leader_state::kNotLeaderAndCannotForwardRpc;
         }
 
-        if (!leader.is_invalid()) {
+        if (leader) {
             rpc.forward(dsn::dns_resolver::instance().resolve_address(leader));
             return meta_leader_state::kNotLeaderAndCanForwardRpc;
         } else {

--- a/src/meta/server_load_balancer.cpp
+++ b/src/meta/server_load_balancer.cpp
@@ -174,8 +174,8 @@ void server_load_balancer::register_proposals(meta_view view,
         // to send the proposal to.
         // for these proposals, they should keep the target empty and
         // the meta-server will fill primary as target.
-        if (act.target.is_invalid()) {
-            if (!pc.hp_primary.is_invalid()) {
+        if (!act.target) {
+            if (pc.hp_primary) {
                 act.target = pc.primary;
                 act.__set_hp_target(pc.hp_primary);
             } else {

--- a/src/meta/server_state_restore.cpp
+++ b/src/meta/server_state_restore.cpp
@@ -251,7 +251,7 @@ void server_state::on_query_restore_status(configuration_query_restore_rpc rpc)
     for (int32_t i = 0; i < app->partition_count; i++) {
         const auto &r_state = app->helpers->restore_states[i];
         const auto &p = app->partitions[i];
-        if (!p.hp_primary.is_invalid() || !p.hp_secondaries.empty()) {
+        if (p.hp_primary || !p.hp_secondaries.empty()) {
             // already have primary, restore succeed
             continue;
         }

--- a/src/meta/test/balancer_validator.cpp
+++ b/src/meta/test/balancer_validator.cpp
@@ -68,7 +68,7 @@ static void check_cure(app_mapper &apps, node_mapper &nodes, ::dsn::partition_co
             break;
         switch (act.type) {
         case config_type::CT_ASSIGN_PRIMARY:
-            CHECK(pc.hp_primary.is_invalid(), "");
+            CHECK(!pc.hp_primary, "");
             CHECK(pc.hp_secondaries.empty(), "");
             CHECK_EQ(act.hp_node, act.hp_target);
             CHECK(nodes.find(act.hp_node) != nodes.end(), "");
@@ -103,7 +103,7 @@ static void check_cure(app_mapper &apps, node_mapper &nodes, ::dsn::partition_co
 
     ps = guardian.cure({&apps, &nodes}, pc.pid, act);
     CHECK_EQ(act.type, config_type::CT_UPGRADE_TO_PRIMARY);
-    CHECK(pc.hp_primary.is_invalid(), "");
+    CHECK(!pc.hp_primary, "");
     CHECK_EQ(act.hp_node, act.hp_target);
     CHECK(is_secondary(pc, act.hp_node), "");
     CHECK(nodes.find(act.hp_node) != nodes.end(), "");
@@ -161,7 +161,7 @@ void meta_service_test_app::balancer_validator()
 
     std::shared_ptr<app_state> &the_app = apps[1];
     for (::dsn::partition_configuration &pc : the_app->partitions) {
-        CHECK(!pc.hp_primary.is_invalid(), "");
+        CHECK(pc.hp_primary, "");
         CHECK_GE(pc.secondaries.size(), pc.max_replica_count - 1);
     }
 

--- a/src/meta/test/json_compacity.cpp
+++ b/src/meta/test/json_compacity.cpp
@@ -93,8 +93,8 @@ void meta_service_test_app::json_compacity()
     dsn::json::json_forwarder<dsn::partition_configuration>::decode(
         dsn::blob(json3, 0, strlen(json3)), pc);
     ASSERT_EQ(234, pc.ballot);
-    ASSERT_TRUE(pc.hp_primary.is_invalid());
-    ASSERT_TRUE(pc.primary.is_invalid());
+    ASSERT_TRUE(!pc.hp_primary);
+    ASSERT_TRUE(!pc.primary);
     ASSERT_EQ(1, pc.hp_secondaries.size());
     ASSERT_EQ(1, pc.secondaries.size());
     ASSERT_STREQ("127.0.0.1:6", pc.secondaries[0].to_string());

--- a/src/meta/test/meta_partition_guardian_test.cpp
+++ b/src/meta/test/meta_partition_guardian_test.cpp
@@ -341,7 +341,7 @@ void meta_partition_guardian_test::cure_test()
                               server_state::sStateHash);
     t->wait();
     PROPOSAL_FLAG_CHECK;
-    CONDITION_CHECK([&] { return !pc.hp_primary.is_invalid() && pc.hp_primary != last_addr; });
+    CONDITION_CHECK([&] { return pc.hp_primary && pc.hp_primary != last_addr; });
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     std::cerr << "Case: add secondary, and the message lost" << std::endl;
@@ -593,7 +593,7 @@ void meta_partition_guardian_test::cure_test()
                               server_state::sStateHash);
     t->wait();
     ASSERT_FALSE(proposal_sent);
-    CONDITION_CHECK([&] { return pc.hp_primary.is_invalid(); });
+    CONDITION_CHECK([&] { return !pc.hp_primary; });
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     std::cerr << "Case: recover from DDD state, nodes[2] is not in dropped" << std::endl;
@@ -607,7 +607,7 @@ void meta_partition_guardian_test::cure_test()
                               server_state::sStateHash);
     t->wait();
     ASSERT_FALSE(proposal_sent);
-    CONDITION_CHECK([&] { return pc.hp_primary.is_invalid(); });
+    CONDITION_CHECK([&] { return !pc.hp_primary; });
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     std::cerr << "Case: recover from DDD state, haven't collect nodes[2]'s info from replica, and "
@@ -623,7 +623,7 @@ void meta_partition_guardian_test::cure_test()
                               server_state::sStateHash);
     t->wait();
     ASSERT_FALSE(proposal_sent);
-    CONDITION_CHECK([&] { return pc.hp_primary.is_invalid(); });
+    CONDITION_CHECK([&] { return !pc.hp_primary; });
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     std::cerr << "Case: recover from DDD state, haven't collect nodes[2]'s info from replica, and "
@@ -683,7 +683,7 @@ void meta_partition_guardian_test::cure_test()
                               server_state::sStateHash);
     t->wait();
     ASSERT_FALSE(proposal_sent);
-    CONDITION_CHECK([&] { return pc.hp_primary.is_invalid(); });
+    CONDITION_CHECK([&] { return !pc.hp_primary; });
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     std::cerr << "Case: recover from DDD state, larger ballot not match with larger decree"
@@ -700,7 +700,7 @@ void meta_partition_guardian_test::cure_test()
                               server_state::sStateHash);
     t->wait();
     ASSERT_FALSE(proposal_sent);
-    CONDITION_CHECK([&] { return pc.hp_primary.is_invalid(); });
+    CONDITION_CHECK([&] { return !pc.hp_primary; });
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     std::cerr << "Case: recover from DDD state, committed decree less than meta's" << std::endl;
@@ -716,7 +716,7 @@ void meta_partition_guardian_test::cure_test()
                               server_state::sStateHash);
     t->wait();
     ASSERT_FALSE(proposal_sent);
-    CONDITION_CHECK([&] { return pc.hp_primary.is_invalid(); });
+    CONDITION_CHECK([&] { return !pc.hp_primary; });
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     std::cerr << "Case: recover from DDD state, select primary from config_context::dropped"

--- a/src/meta/test/state_sync_test.cpp
+++ b/src/meta/test/state_sync_test.cpp
@@ -90,7 +90,7 @@ static void random_assign_partition_config(std::shared_ptr<app_state> &app,
         }
         for (int i = 1; i < indices.size(); ++i) {
             const auto &secondary = get_server(indices[i]);
-            if (!secondary.is_invalid()) {
+            if (secondary) {
                 pc.secondaries.push_back(dsn::dns_resolver::instance().resolve_address(secondary));
                 pc.hp_secondaries.push_back(secondary);
             }

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -164,7 +164,7 @@ public:
     {
         action.type = config_type::CT_INVALID;
         const dsn::partition_configuration &pc = *get_config(*view.apps, gpid);
-        if (!pc.hp_primary.is_invalid() && pc.hp_secondaries.size() == 2)
+        if (pc.hp_primary && pc.hp_secondaries.size() == 2)
             return pc_status::healthy;
         return pc_status::ill;
     }

--- a/src/replica/duplication/replica_follower.cpp
+++ b/src/replica/duplication/replica_follower.cpp
@@ -84,7 +84,7 @@ void replica_follower::init_master_info()
     CHECK(!master_metas.empty(), "master cluster meta list is invalid!");
     for (const auto &meta : master_metas) {
         const auto node = host_port::from_string(meta);
-        CHECK(!node.is_invalid(), "{} is invalid meta host_port", meta);
+        CHECK(node, "{} is invalid meta host_port", meta);
         _master_meta_list.emplace_back(std::move(node));
     }
 }
@@ -178,7 +178,7 @@ error_code replica_follower::update_master_replica_config(error_code err, query_
         return ERR_INCONSISTENT_STATE;
     }
 
-    if (dsn_unlikely(resp.partitions[0].hp_primary == host_port::s_invalid_host_port)) {
+    if (dsn_unlikely(!resp.partitions[0].hp_primary)) {
         LOG_ERROR_PREFIX("master[{}] partition address is invalid", master_replica_name());
         return ERR_INVALID_STATE;
     }

--- a/src/replica/duplication/replica_follower.h
+++ b/src/replica/duplication/replica_follower.h
@@ -79,7 +79,7 @@ private:
     std::string master_replica_name()
     {
         std::string app_info = fmt::format("{}.{}", _master_cluster_name, _master_app_name);
-        if (_master_replica_config.hp_primary != host_port::s_invalid_host_port) {
+        if (_master_replica_config.hp_primary) {
             return fmt::format("{}({}({})|{})",
                                app_info,
                                _master_replica_config.hp_primary,

--- a/src/replica/duplication/test/replica_follower_test.cpp
+++ b/src/replica/duplication/test/replica_follower_test.cpp
@@ -217,37 +217,37 @@ TEST_P(replica_follower_test, test_update_master_replica_config)
 
     query_cfg_response resp;
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_INCONSISTENT_STATE);
-    ASSERT_EQ(master_replica_config(follower).primary, rpc_address::s_invalid_address);
-    ASSERT_EQ(master_replica_config(follower).hp_primary, host_port::s_invalid_host_port);
+    ASSERT_FALSE(master_replica_config(follower).primary);
+    ASSERT_FALSE(master_replica_config(follower).hp_primary);
 
     resp.partition_count = 100;
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_INCONSISTENT_STATE);
-    ASSERT_EQ(master_replica_config(follower).primary, rpc_address::s_invalid_address);
-    ASSERT_EQ(master_replica_config(follower).hp_primary, host_port::s_invalid_host_port);
+    ASSERT_FALSE(master_replica_config(follower).primary);
+    ASSERT_FALSE(master_replica_config(follower).hp_primary);
 
     resp.partition_count = _app_info.partition_count;
     partition_configuration p;
     resp.partitions.emplace_back(p);
     resp.partitions.emplace_back(p);
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_INVALID_DATA);
-    ASSERT_EQ(master_replica_config(follower).primary, rpc_address::s_invalid_address);
-    ASSERT_EQ(master_replica_config(follower).hp_primary, host_port::s_invalid_host_port);
+    ASSERT_FALSE(master_replica_config(follower).primary);
+    ASSERT_FALSE(master_replica_config(follower).hp_primary);
 
     resp.partitions.clear();
     p.pid = gpid(2, 100);
     resp.partitions.emplace_back(p);
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_INCONSISTENT_STATE);
-    ASSERT_EQ(master_replica_config(follower).primary, rpc_address::s_invalid_address);
-    ASSERT_EQ(master_replica_config(follower).hp_primary, host_port::s_invalid_host_port);
+    ASSERT_FALSE(master_replica_config(follower).primary);
+    ASSERT_FALSE(master_replica_config(follower).hp_primary);
 
     resp.partitions.clear();
-    p.primary = rpc_address::s_invalid_address;
-    p.__set_hp_primary(host_port::s_invalid_host_port);
+    p.primary = {};
+    p.__set_hp_primary(host_port());
     p.pid = gpid(2, 1);
     resp.partitions.emplace_back(p);
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_INVALID_STATE);
-    ASSERT_EQ(master_replica_config(follower).primary, rpc_address::s_invalid_address);
-    ASSERT_EQ(master_replica_config(follower).hp_primary, host_port::s_invalid_host_port);
+    ASSERT_FALSE(master_replica_config(follower).primary);
+    ASSERT_FALSE(master_replica_config(follower).hp_primary);
 
     resp.partitions.clear();
     p.pid = gpid(2, 1);

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -1094,8 +1094,7 @@ void replica::on_config_sync(const app_info &info,
         if (status() == partition_status::PS_INACTIVE && !_inactive_is_transient) {
             if (config.hp_primary == _stub->primary_host_port() // dead primary
                 ||
-                config.hp_primary
-                    .is_invalid() // primary is dead (otherwise let primary remove this)
+                !config.hp_primary // primary is dead (otherwise let primary remove this)
                 ) {
                 LOG_INFO_PREFIX("downgrade myself as inactive is not transient, remote_config({})",
                                 boost::lexical_cast<std::string>(config));

--- a/src/replica/replica_context.cpp
+++ b/src/replica/replica_context.cpp
@@ -105,7 +105,7 @@ void primary_context::reset_membership(const partition_configuration &config, bo
 
     membership = config;
 
-    if (membership.hp_primary.is_invalid() == false) {
+    if (membership.hp_primary) {
         statuses[membership.hp_primary] = partition_status::PS_PRIMARY;
     }
 

--- a/src/replica/storage/simple_kv/simple_kv.app.example.h
+++ b/src/replica/storage/simple_kv/simple_kv.app.example.h
@@ -45,7 +45,7 @@ public:
             return ::dsn::ERR_INVALID_PARAMETERS;
 
         printf("%s %s %s\n", args[1].c_str(), args[2].c_str(), args[3].c_str());
-        const auto hp = host_port::from_string(args[2].c_str());
+        const auto hp = host_port::from_string(args[2]);
         _simple_kv_client.reset(new simple_kv_client(args[1].c_str(), {hp}, args[3].c_str()));
 
         _timer = ::dsn::tasking::enqueue_timer(LPC_SIMPLE_KV_TEST_TIMER,

--- a/src/replica/storage/simple_kv/test/case.cpp
+++ b/src/replica/storage/simple_kv/test/case.cpp
@@ -815,8 +815,7 @@ bool client_case_line::parse(const std::string &params)
         _config_receiver = node_to_address(kv_map["receiver"]);
         _config_type = parse_config_command(kv_map["type"]);
         _config_node = node_to_address(kv_map["node"]);
-        if (_config_receiver.is_invalid() || _config_type == config_type::CT_INVALID ||
-            _config_node.is_invalid())
+        if (!_config_receiver || _config_type == config_type::CT_INVALID || !_config_node)
             parse_ok = false;
         break;
     }

--- a/src/replica/storage/simple_kv/test/checker.cpp
+++ b/src/replica/storage/simple_kv/test/checker.cpp
@@ -85,7 +85,7 @@ public:
             return pc_status::healthy;
 
         pc_status result;
-        if (pc.hp_primary.is_invalid()) {
+        if (!pc.hp_primary) {
             if (pc.hp_secondaries.size() > 0) {
                 action.node = pc.secondaries[0];
                 action.__set_hp_node(pc.hp_secondaries[0]);
@@ -155,7 +155,7 @@ public:
         sorted_node.clear();
         sorted_node.reserve(nodes.size());
         for (auto &iter : nodes) {
-            if (!iter.first.is_invalid() && iter.second.alive()) {
+            if (iter.first && iter.second.alive()) {
                 sorted_node.push_back(iter.first);
             }
         }

--- a/src/replica/storage/simple_kv/test/common.cpp
+++ b/src/replica/storage/simple_kv/test/common.cpp
@@ -88,8 +88,9 @@ partition_status::type partition_status_from_short_string(const std::string &str
 
 std::string address_to_node(host_port addr)
 {
-    if (addr.is_invalid())
+    if (!addr) {
         return "-";
+    }
     CHECK(test_checker::s_inited, "");
     return test_checker::instance().address_to_node_name(addr);
 }

--- a/src/replica/storage/simple_kv/test/common.h
+++ b/src/replica/storage/simple_kv/test/common.h
@@ -55,7 +55,7 @@ const char *partition_status_to_short_string(partition_status::type s);
 partition_status::type partition_status_from_short_string(const std::string &str);
 
 // transfer primary_address to node_name
-// return "-" if addr.is_invalid()
+// return "-" if addr is invalid
 // return "node@port" if not found
 std::string address_to_node(host_port addr);
 // transfer node_name to primary_address

--- a/src/runtime/rpc/group_address.h
+++ b/src/runtime/rpc/group_address.h
@@ -140,7 +140,7 @@ inline void rpc_group_address::leader_forward()
 inline void rpc_group_address::set_leader(rpc_address addr)
 {
     alw_t l(_lock);
-    if (addr.is_invalid()) {
+    if (!addr) {
         _leader_index = -1;
         return;
     }
@@ -205,7 +205,7 @@ inline rpc_address rpc_group_address::next(rpc_address current) const
         return rpc_address::s_invalid_address;
     }
 
-    if (current.is_invalid()) {
+    if (!current) {
         return _members[rand::next_u32(0, (uint32_t)_members.size() - 1)];
     }
 

--- a/src/runtime/rpc/group_host_port.h
+++ b/src/runtime/rpc/group_host_port.h
@@ -170,7 +170,7 @@ inline void rpc_group_host_port::leader_forward()
 inline void rpc_group_host_port::set_leader(const host_port &hp)
 {
     awl_t l(_lock);
-    if (hp.is_invalid()) {
+    if (!hp) {
         _leader_index = kInvalidIndex;
         return;
     }
@@ -240,7 +240,7 @@ inline host_port rpc_group_host_port::next(const host_port &current) const
         return host_port::s_invalid_host_port;
     }
 
-    if (current.is_invalid()) {
+    if (!current) {
         return _members[random_index_unlocked()];
     }
 

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -433,7 +433,7 @@ void rpc_session::on_failure(bool is_write)
 
 bool rpc_session::on_recv_message(message_ex *msg, int delay_ms)
 {
-    if (msg->header->from_address.is_invalid()) {
+    if (!msg->header->from_address) {
         msg->header->from_address = _remote_addr;
     }
 

--- a/src/runtime/rpc/rpc_address.h
+++ b/src/runtime/rpc/rpc_address.h
@@ -64,8 +64,6 @@ class rpc_group_address;
 class rpc_address
 {
 public:
-    static const rpc_address s_invalid_address;
-
     // Convert IPv4:port to rpc_address, e.g. "192.168.0.1:12345" or "localhost:54321".
     // NOTE:
     //   - IP address without port (e.g. "127.0.0.1") is considered as invalid.
@@ -122,8 +120,7 @@ public:
         return (rpc_group_address *)(uintptr_t)_addr.group.group;
     }
 
-    bool is_invalid() const { return _addr.v4.type == HOST_TYPE_INVALID; }
-    operator bool() const { return !is_invalid(); }
+    operator bool() const { return _addr.v4.type != HOST_TYPE_INVALID; }
 
     // before you assign new value, must call set_invalid() to release original value
     // and you MUST ensure that _addr is INITIALIZED before you call this function
@@ -176,7 +173,12 @@ public:
     uint32_t write(::apache::thrift::protocol::TProtocol *oprot) const;
 
 private:
+    friend class rpc_group_address;
     friend class test_client;
+    template <typename TResponse>
+    friend class rpc_replier;
+
+    static const rpc_address s_invalid_address;
 
     union
     {

--- a/src/runtime/rpc/rpc_engine.cpp
+++ b/src/runtime/rpc/rpc_engine.cpp
@@ -661,8 +661,7 @@ void rpc_engine::call_ip(rpc_address addr,
 {
     DCHECK_EQ_MSG(addr.type(), HOST_TYPE_IPV4, "only IPV4 is now supported");
     DCHECK_GT_MSG(addr.port(), MAX_CLIENT_PORT, "only server address can be called");
-    CHECK(!request->header->from_address.is_invalid(),
-          "from address must be set before call call_ip");
+    CHECK(request->header->from_address, "from address must be set before call call_ip");
 
     while (!request->dl.is_alone()) {
         LOG_WARNING("msg request {} (trace_id = {:#018x}) is in sending queue, try to pick out ...",
@@ -737,7 +736,7 @@ void rpc_engine::reply(message_ex *response, error_code err)
     // when a message doesn't need to reply, we don't do the on_rpc_reply hooks to avoid mistakes
     // for example, the profiler may be mistakenly calculated
     auto s = response->io_session.get();
-    if (s == nullptr && response->to_address.is_invalid()) {
+    if (s == nullptr && !response->to_address) {
         LOG_DEBUG("rpc reply {} is dropped (invalid to-address), trace_id = {:#018x}",
                   response->header->rpc_name,
                   response->header->trace_id);

--- a/src/runtime/rpc/rpc_host_port.cpp
+++ b/src/runtime/rpc/rpc_host_port.cpp
@@ -69,7 +69,7 @@ host_port host_port::from_address(rpc_address addr)
         break;
     }
 
-    // Now is_invalid() return false.
+    // Now is valid.
     hp._type = addr.type();
     return hp;
 }
@@ -95,7 +95,7 @@ host_port host_port::from_string(const std::string &host_port_str)
         return hp;
     }
 
-    // Now is_invalid() return false.
+    // Now is valid.
     hp._type = HOST_TYPE_IPV4;
     return hp;
 }

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -61,7 +61,6 @@ class rpc_group_host_port;
 class host_port
 {
 public:
-    static const host_port s_invalid_host_port;
     explicit host_port() = default;
     explicit host_port(std::string host, uint16_t port);
 
@@ -74,10 +73,7 @@ public:
     dsn_host_type_t type() const { return _type; }
     const std::string &host() const { return _host; }
     uint16_t port() const { return _port; }
-
-    [[nodiscard]] bool is_invalid() const { return _type == HOST_TYPE_INVALID; }
-
-    operator bool() const { return !is_invalid(); }
+    operator bool() const { return _type != HOST_TYPE_INVALID; }
 
     std::string to_string() const;
 
@@ -98,7 +94,7 @@ public:
 
     // Construct a host_port object from 'host_port_str', the latter is in the format of
     // "localhost:8888".
-    // NOTE: The constructed host_port object maybe invalid, remember to check it by is_invalid()
+    // NOTE: The constructed host_port object maybe invalid, remember to check if it's valid
     // before using it.
     static host_port from_string(const std::string &host_port_str);
 
@@ -111,7 +107,10 @@ public:
 
 private:
     friend class dns_resolver;
+    friend class rpc_group_host_port;
     FRIEND_TEST(host_port_test, transfer_rpc_address);
+
+    static const host_port s_invalid_host_port;
 
     // Resolve host_port to rpc_addresses.
     // There may be multiple rpc_addresses for one host_port.

--- a/src/runtime/test/address_test.cpp
+++ b/src/runtime/test/address_test.cpp
@@ -339,15 +339,15 @@ TEST(rpc_address_test, from_host_port)
     for (const auto &test : tests) {
         // Check from_host_port().
         const auto host_port_result = dsn::rpc_address::from_host_port(test.host_port);
-        ASSERT_EQ(test.valid_host_port, !host_port_result.is_invalid()) << test.host_port;
-        if (!host_port_result.is_invalid()) {
+        ASSERT_EQ(test.valid_host_port, static_cast<bool>(host_port_result)) << test.host_port;
+        if (host_port_result) {
             ASSERT_GT(test.expect_ip_ports.count(host_port_result.to_string()), 0);
         }
 
         // Check from_ip_port().
         const auto ip_port_result = dsn::rpc_address::from_ip_port(test.host_port);
-        ASSERT_EQ(test.valid_ip_port, !ip_port_result.is_invalid());
-        if (!ip_port_result.is_invalid()) {
+        ASSERT_EQ(test.valid_ip_port, static_cast<bool>(ip_port_result));
+        if (ip_port_result) {
             ASSERT_GT(test.expect_ip_ports.count(ip_port_result.to_string()), 0);
         }
 
@@ -405,16 +405,16 @@ TEST(rpc_address_test, from_host_port2)
     for (const auto &test : tests) {
         // Check from_host_port().
         const auto host_port_result = dsn::rpc_address::from_host_port(test.host, test.port);
-        ASSERT_EQ(test.valid_host_port, !host_port_result.is_invalid()) << test.host;
-        if (!host_port_result.is_invalid()) {
+        ASSERT_EQ(test.valid_host_port, static_cast<bool>(host_port_result)) << test.host;
+        if (host_port_result) {
             ASSERT_GT(test.expect_ip_ports.count(host_port_result.to_string()), 0)
                 << test.host << " " << host_port_result.to_string();
         }
 
         // Check from_ip_port().
         const auto ip_port_result = dsn::rpc_address::from_ip_port(test.host, test.port);
-        ASSERT_EQ(test.valid_ip_port, !ip_port_result.is_invalid());
-        if (!ip_port_result.is_invalid()) {
+        ASSERT_EQ(test.valid_ip_port, static_cast<bool>(ip_port_result));
+        if (ip_port_result) {
             ASSERT_GT(test.expect_ip_ports.count(ip_port_result.to_string()), 0);
         }
 

--- a/src/runtime/test/host_port_test.cpp
+++ b/src/runtime/test/host_port_test.cpp
@@ -84,21 +84,21 @@ TEST(host_port_test, operators)
 
     host_port hp2;
     ASSERT_NE(hp, hp2);
-    ASSERT_FALSE(hp.is_invalid());
-    ASSERT_TRUE(hp2.is_invalid());
+    ASSERT_TRUE(hp);
+    ASSERT_FALSE(hp2);
 
     std::string hp_str = "localhost:8080";
     host_port hp3;
-    ASSERT_TRUE(hp3.is_invalid());
+    ASSERT_FALSE(hp3);
     hp3 = host_port::from_string(hp_str);
     ASSERT_EQ(hp, hp3);
-    ASSERT_FALSE(hp3.is_invalid());
+    ASSERT_TRUE(hp3);
 
     host_port hp4;
-    ASSERT_TRUE(hp4.is_invalid());
+    ASSERT_FALSE(hp4);
     std::string hp_str2 = "pegasus:8080";
     hp4 = host_port::from_string(hp_str2);
-    ASSERT_TRUE(hp4.is_invalid());
+    ASSERT_FALSE(hp4);
 
     host_port hp5("localhost", 8081);
     ASSERT_LT(hp, hp5);

--- a/src/runtime/test/rpc.cpp
+++ b/src/runtime/test/rpc.cpp
@@ -103,7 +103,7 @@ TEST(core, group_address_change_leader)
         if (ERR_OK == err_code) {
             const auto hp_got = host_port::from_string(result);
             LOG_INFO("talk to others callback, result: {}", result);
-            EXPECT_FALSE(hp_got.is_invalid());
+            EXPECT_TRUE(hp_got);
             EXPECT_EQ(TEST_PORT_END, hp_got.port());
         }
     };

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -348,7 +348,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             }
 
             for (const dsn::partition_configuration &p : partitions) {
-                if (!p.hp_primary.is_invalid()) {
+                if (p.hp_primary) {
                     auto find = tmp_map.find(p.hp_primary);
                     if (find != tmp_map.end()) {
                         find->second.primary_count++;

--- a/src/shell/commands/rebalance.cpp
+++ b/src/shell/commands/rebalance.cpp
@@ -124,8 +124,8 @@ bool propose(command_executor *e, shell_context *sc, arguments args)
         }
     }
 
-    PRINT_AND_RETURN_FALSE_IF_NOT(!target.is_invalid(), "need set target by -t\n");
-    PRINT_AND_RETURN_FALSE_IF_NOT(!node.is_invalid(), "need set node by -n\n");
+    PRINT_AND_RETURN_FALSE_IF_NOT(target, "need set target by -t\n");
+    PRINT_AND_RETURN_FALSE_IF_NOT(node, "need set node by -n\n");
     PRINT_AND_RETURN_FALSE_IF_NOT(request.gpid.get_app_id() != -1, "need set gpid by -g\n");
 
     config_type::type tp =
@@ -213,11 +213,11 @@ bool balance(command_executor *e, shell_context *sc, arguments args)
         return false;
     }
 
-    if (from.is_invalid()) {
+    if (!from) {
         fprintf(stderr, "need set from address by -f\n");
         return false;
     }
-    if (to.is_invalid()) {
+    if (!to) {
         fprintf(stderr, "need set target address by -t\n");
         return false;
     }

--- a/src/shell/commands/recovery.cpp
+++ b/src/shell/commands/recovery.cpp
@@ -328,8 +328,7 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
             out << "    ----" << std::endl;
 
             auto primary = diagnose_recommend(pinfo);
-            out << "    recommend_primary: "
-                << (primary.is_invalid() ? "none" : primary.to_string());
+            out << "    recommend_primary: " << (!primary ? "none" : primary.to_string());
             if (primary == latest_dropped)
                 out << "  <== the latest";
             else if (primary == secondary_latest_dropped)
@@ -337,7 +336,7 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
             out << std::endl;
 
             bool skip_this = false;
-            if (!primary.is_invalid() && !auto_diagnose && !skip_prompt) {
+            if (primary && !auto_diagnose && !skip_prompt) {
                 do {
                     std::cout << "    > Are you sure to use the recommend primary? [y/n/s(skip)]: ";
                     char c;
@@ -356,7 +355,7 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
                 } while (true);
             }
 
-            if (primary.is_invalid() && !skip_prompt && !skip_this) {
+            if (!primary && !skip_prompt && !skip_this) {
                 do {
                     std::cout << "    > Please input the primary node: ";
                     std::string node;
@@ -370,7 +369,7 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
                 } while (true);
             }
 
-            if (!primary.is_invalid() && !skip_this) {
+            if (primary && !skip_this) {
                 dsn::replication::configuration_balancer_request request;
                 request.gpid = pinfo.config.pid;
                 request.action_list = {

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -336,7 +336,7 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
     for (int i = 0; i < partitions.size(); i++) {
         const dsn::partition_configuration &p = partitions[i];
         int replica_count = 0;
-        if (!p.hp_primary.is_invalid()) {
+        if (p.hp_primary) {
             replica_count++;
         }
         replica_count += p.hp_secondaries.size();
@@ -347,7 +347,7 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
             replica_count_str = oss.str();
         }
         std::string primary_str("-");
-        if (!p.hp_primary.is_invalid()) {
+        if (p.hp_primary) {
             bool disk_found = false;
             double disk_value = 0;
             auto f1 = disk_map.find(p.hp_primary);

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -172,7 +172,7 @@ void test_util::wait_table_healthy(const std::string &table_name) const
             std::vector<partition_configuration> pcs;
             ASSERT_EQ(dsn::ERR_OK, ddl_client_->list_app(table_name, table_id, pcount, pcs));
             for (const auto &pc : pcs) {
-                ASSERT_FALSE(pc.primary.is_invalid());
+                ASSERT_TRUE(pc.primary);
                 ASSERT_EQ(1 + pc.secondaries.size(), pc.max_replica_count);
             }
         },

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -40,7 +40,6 @@
 #include "nlohmann/detail/iterators/iter_impl.hpp"
 #include "nlohmann/json_fwd.hpp"
 #include "runtime/api_layer1.h"
-#include "runtime/rpc/rpc_address.h"
 #include "test/function_test/utils/global_env.h"
 #include "test/function_test/utils/utils.h"
 #include "test_util/test_util.h"
@@ -50,6 +49,10 @@
 #include "utils/filesystem.h"
 #include "utils/rand.h"
 #include "utils/test_macros.h"
+
+namespace dsn {
+class rpc_address;
+} // namespace dsn
 
 using dsn::partition_configuration;
 using dsn::replication::replica_helper;

--- a/src/test/kill_test/kill_testor.cpp
+++ b/src/test/kill_test/kill_testor.cpp
@@ -111,7 +111,7 @@ dsn::error_code kill_testor::get_partition_info(bool debug_unhealthy,
         for (int i = 0; i < partitions.size(); i++) {
             const dsn::partition_configuration &p = partitions[i];
             int replica_count = 0;
-            if (!p.hp_primary.is_invalid()) {
+            if (p.hp_primary) {
                 replica_count++;
             }
             replica_count += p.hp_secondaries.size();


### PR DESCRIPTION
Remove the duplicate functions `bool is_invalid() const`, they are
replaced by `operator bool() const`, the latter is more simple.

Hide `s_invalid_address` and `s_invalid_host_port` in private scope,
they are replaced by `operator bool() const` as well.