### PR TITLE
refactor(FQDN): Add some convenient macros and update idl/dsn.layer2.thrift related code

### DIFF
--- a/src/client/partition_resolver_simple.cpp
+++ b/src/client/partition_resolver_simple.cpp
@@ -304,11 +304,10 @@ void partition_resolver_simple::query_config_reply(error_code err,
             for (auto it = resp.partitions.begin(); it != resp.partitions.end(); ++it) {
                 auto &new_config = *it;
 
-                LOG_DEBUG_PREFIX("query config reply, gpid = {}, ballot = {}, primary = {}({})",
+                LOG_DEBUG_PREFIX("query config reply, gpid = {}, ballot = {}, primary = {}",
                                  new_config.pid,
                                  new_config.ballot,
-                                 new_config.hp_primary,
-                                 new_config.primary);
+                                 FMT_HOST_PORT_AND_IP(new_config, primary));
 
                 auto it2 = _config_cache.find(new_config.pid.get_partition_index());
                 if (it2 == _config_cache.end()) {

--- a/src/meta/cluster_balance_policy.cpp
+++ b/src/meta/cluster_balance_policy.cpp
@@ -26,6 +26,8 @@
 
 #include "dsn.layer2_types.h"
 #include "meta/load_balance_policy.h"
+#include "runtime/rpc/rpc_address.h"
+#include "runtime/rpc/rpc_host_port.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/utils.h"
@@ -542,10 +544,10 @@ bool cluster_balance_policy::apply_move(const move_info &move,
     it->second.erase(move.pid);
     node_target.future_partitions.insert(move.pid);
 
-    // add into migration list and selected_pid
+    // add into the migration list and selected_pid
     partition_configuration pc;
     pc.pid = move.pid;
-    pc.hp_primary = primary_hp;
+    SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, primary_hp);
     list[move.pid] = generate_balancer_request(*_global_view->apps, pc, move.type, source, target);
     _migration_result->emplace(
         move.pid, generate_balancer_request(*_global_view->apps, pc, move.type, source, target));

--- a/src/meta/cluster_balance_policy.cpp
+++ b/src/meta/cluster_balance_policy.cpp
@@ -26,6 +26,7 @@
 
 #include "dsn.layer2_types.h"
 #include "meta/load_balance_policy.h"
+#include "runtime/rpc/dns_resolver.h" // IWYU pragma: keep
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/flags.h"

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -518,17 +518,8 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                           const host_port secondary2("localhost", 34803);
 
                           partition_configuration p;
-                          p.primary = dsn::dns_resolver::instance().resolve_address(primary);
-                          p.secondaries.emplace_back(
-                              dsn::dns_resolver::instance().resolve_address(secondary1));
-                          p.secondaries.emplace_back(
-                              dsn::dns_resolver::instance().resolve_address(secondary2));
-
-                          p.__set_hp_primary(primary);
-                          p.__set_hp_secondaries({});
-                          p.hp_secondaries.emplace_back(secondary1);
-                          p.hp_secondaries.emplace_back(secondary2);
-
+                          SET_IP_AND_HOST_PORT_BY_DNS(p, primary, primary);
+                          SET_IPS_AND_HOST_PORTS_BY_DNS(p, secondaries, secondary1, secondary2);
                           resp.partitions.emplace_back(p);
                       }
                   });

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -31,6 +31,7 @@
 #include "common/replication_enums.h"
 #include "meta_data.h"
 #include "runtime/api_layer1.h"
+#include "runtime/rpc/dns_resolver.h" // IWYU pragma: keep
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_message.h"
 #include "utils/flags.h"

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -759,8 +759,7 @@ void meta_service::on_query_configuration_by_index(configuration_query_by_index_
     if (!check_status_and_authz(rpc, &forward_hp)) {
         if (forward_hp) {
             partition_configuration config;
-            config.primary = dsn::dns_resolver::instance().resolve_address(forward_hp);
-            config.__set_hp_primary(forward_hp);
+            SET_IP_AND_HOST_PORT_BY_DNS(config, primary, forward_hp);
             response.partitions.push_back(std::move(config));
         }
         return;

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -347,19 +347,17 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                     break;
                 }
             }
-            LOG_INFO("{}: config_context.last_drops[{}({})]: node({}), dropped_index({})",
+            LOG_INFO("{}: config_context.last_drops[{}]: node({}), dropped_index({})",
                      gpid_name,
                      i,
-                     pc.hp_last_drops[i],
-                     pc.last_drops[i],
+                     FMT_HOST_PORT_AND_IP(pc, last_drops[i]),
                      dropped_index);
         }
 
         if (pc.hp_last_drops.size() == 1) {
-            LOG_WARNING("{}: the only node({}({})) is dead, waiting it to come back",
+            LOG_WARNING("{}: the only node({}) is dead, waiting it to come back",
                         gpid_name,
-                        pc.hp_last_drops.back(),
-                        pc.last_drops.back());
+                        FMT_HOST_PORT_AND_IP(pc, last_drops.back()));
             action.hp_node = pc.hp_last_drops.back();
             action.node = pc.last_drops.back();
         } else {

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -571,9 +571,9 @@ dsn::error_code server_state::sync_apps_from_remote_storage()
                 if (ec == ERR_OK) {
                     partition_configuration pc;
                     // TODO(yingchun): check if the fields will be set after decoding.
-                    //                    pc.__isset.hp_secondaries = true;
-                    //                    pc.__isset.hp_last_drops = true;
-                    //                    pc.__isset.hp_primary = true;
+                    //  pc.__isset.hp_secondaries = true;
+                    //  pc.__isset.hp_last_drops = true;
+                    //  pc.__isset.hp_primary = true;
                     dsn::json::json_forwarder<partition_configuration>::decode(value, pc);
 
                     CHECK(pc.pid.get_app_id() == app->app_id &&
@@ -1812,7 +1812,8 @@ void server_state::drop_partition(std::shared_ptr<app_state> &app, int pidx)
 
     request.info = *app;
     request.type = config_type::CT_DROP_PARTITION;
-    SET_IP_AND_HOST_PORT(request, node, pc.primary, pc.hp_primary);
+    request.node = pc.primary;
+    request.__set_hp_node(pc.hp_primary);
 
     request.config = pc;
     for (auto &node : pc.hp_secondaries) {
@@ -1884,7 +1885,8 @@ void server_state::downgrade_primary_to_inactive(std::shared_ptr<app_state> &app
     request.info = *app;
     request.config = pc;
     request.type = config_type::CT_DOWNGRADE_TO_INACTIVE;
-    SET_IP_AND_HOST_PORT(request, node, pc.primary, pc.hp_primary);
+    request.node = pc.primary;
+    request.__set_hp_node(pc.hp_primary);
     request.config.ballot++;
     RESET_IP_AND_HOST_PORT(request.config, primary);
     maintain_drops(request.config.hp_last_drops, pc.hp_primary, request.type);

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -571,9 +571,9 @@ dsn::error_code server_state::sync_apps_from_remote_storage()
                 if (ec == ERR_OK) {
                     partition_configuration pc;
                     // TODO(yingchun): check if the fields will be set after decoding.
-                    //  pc.__isset.hp_secondaries = true;
-                    //  pc.__isset.hp_last_drops = true;
-                    //  pc.__isset.hp_primary = true;
+                    pc.__isset.hp_secondaries = true;
+                    pc.__isset.hp_last_drops = true;
+                    pc.__isset.hp_primary = true;
                     dsn::json::json_forwarder<partition_configuration>::decode(value, pc);
 
                     CHECK(pc.pid.get_app_id() == app->app_id &&

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -43,7 +43,6 @@
 #include "meta_service_test_app.h"
 #include "meta_test_base.h"
 #include "runtime/api_layer1.h"
-#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_holder.h"
 #include "runtime/rpc/rpc_host_port.h"
@@ -506,11 +505,8 @@ TEST_F(policy_context_test, test_app_dropped_during_backup)
             app_state *app = state->_all_apps[3].get();
             app->status = dsn::app_status::AS_AVAILABLE;
             for (partition_configuration &pc : app->partitions) {
-                pc.primary = dsn::dns_resolver::instance().resolve_address(node_list[0]);
-                pc.secondaries = {dsn::dns_resolver::instance().resolve_address(node_list[1]),
-                                  dsn::dns_resolver::instance().resolve_address(node_list[2])};
-                pc.__set_hp_primary(node_list[0]);
-                pc.__set_hp_secondaries({node_list[1], node_list[2]});
+                SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, node_list[0]);
+                SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, node_list[1], node_list[2]);
             }
 
             _mp._backup_history.clear();

--- a/src/meta/test/balancer_simulator/balancer_simulator.cpp
+++ b/src/meta/test/balancer_simulator/balancer_simulator.cpp
@@ -42,6 +42,7 @@
 #include "meta/test/misc/misc.h"
 #include "meta_admin_types.h"
 #include "runtime/app_model.h"
+#include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/fmt_logging.h"
 
@@ -100,7 +101,7 @@ void generate_balanced_apps(/*out*/ app_mapper &apps,
     for (dsn::partition_configuration &pc : the_app->partitions) {
         const auto &n = pq1.pop();
         nodes[n].put_partition(pc.pid, true);
-        pc.hp_primary = n;
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, n);
         pq1.push(n);
     }
 

--- a/src/meta/test/balancer_simulator/balancer_simulator.cpp
+++ b/src/meta/test/balancer_simulator/balancer_simulator.cpp
@@ -42,6 +42,7 @@
 #include "meta/test/misc/misc.h"
 #include "meta_admin_types.h"
 #include "runtime/app_model.h"
+#include "runtime/rpc/dns_resolver.h" // IWYU pragma: keep
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/fmt_logging.h"

--- a/src/meta/test/cluster_balance_policy_test.cpp
+++ b/src/meta/test/cluster_balance_policy_test.cpp
@@ -36,6 +36,7 @@
 #include "meta/meta_service.h"
 #include "meta_admin_types.h"
 #include "metadata_types.h"
+#include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/defer.h"
 #include "utils/fail_point.h"
@@ -118,7 +119,7 @@ TEST(cluster_balance_policy, get_app_migration_info)
     info.app_name = appname;
     info.partition_count = 1;
     auto app = std::make_shared<app_state>(info);
-    app->partitions[0].hp_primary = hp;
+    SET_IP_AND_HOST_PORT_BY_DNS(app->partitions[0], primary, hp);
 
     node_state ns;
     ns.set_hp(hp);
@@ -161,7 +162,7 @@ TEST(cluster_balance_policy, get_node_migration_info)
     info.app_name = appname;
     info.partition_count = 1;
     auto app = std::make_shared<app_state>(info);
-    app->partitions[0].hp_primary = hp;
+    SET_IP_AND_HOST_PORT_BY_DNS(app->partitions[0], primary, hp);
     serving_replica sr;
     sr.node = hp;
     std::string disk_tag = "disk1";
@@ -514,9 +515,8 @@ TEST(cluster_balance_policy, calc_potential_moving)
     info.partition_count = 4;
     std::shared_ptr<app_state> app = app_state::create(info);
     partition_configuration pc;
-    pc.hp_primary = hp1;
-    pc.hp_secondaries.push_back(hp2);
-    pc.hp_secondaries.push_back(hp3);
+    SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, hp1);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, hp2, hp3);
     app->partitions[0] = pc;
     app->partitions[1] = pc;
 

--- a/src/meta/test/ford_fulkerson_test.cpp
+++ b/src/meta/test/ford_fulkerson_test.cpp
@@ -27,6 +27,7 @@
 #include "gtest/gtest.h"
 #include "meta/load_balance_policy.h"
 #include "meta/meta_data.h"
+#include "runtime/rpc/dns_resolver.h" // IWYU pragma: keep
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 

--- a/src/meta/test/ford_fulkerson_test.cpp
+++ b/src/meta/test/ford_fulkerson_test.cpp
@@ -27,6 +27,7 @@
 #include "gtest/gtest.h"
 #include "meta/load_balance_policy.h"
 #include "meta/meta_data.h"
+#include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 
 namespace dsn {
@@ -96,8 +97,7 @@ TEST(ford_fulkerson, update_decree)
     info.partition_count = 1;
     std::shared_ptr<app_state> app = app_state::create(info);
     partition_configuration pc;
-    pc.hp_secondaries.push_back(hp2);
-    pc.hp_secondaries.push_back(hp3);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, hp2, hp3);
     app->partitions.push_back(pc);
     app->partitions.push_back(pc);
 
@@ -134,9 +134,8 @@ TEST(ford_fulkerson, find_shortest_path)
     std::shared_ptr<app_state> app = app_state::create(info);
 
     partition_configuration pc;
-    pc.hp_primary = hp1;
-    pc.hp_secondaries.push_back(hp2);
-    pc.hp_secondaries.push_back(hp3);
+    SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, hp1);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, hp2, hp3);
     app->partitions[0] = pc;
     app->partitions[1] = pc;
 

--- a/src/meta/test/meta_bulk_load_ingestion_test.cpp
+++ b/src/meta/test/meta_bulk_load_ingestion_test.cpp
@@ -27,6 +27,7 @@
 #include "meta/meta_bulk_load_ingestion_context.h"
 #include "meta/meta_data.h"
 #include "meta_test_base.h"
+#include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/fail_point.h"
 
@@ -229,9 +230,8 @@ public:
                         config_context &cc)
     {
         config.pid = gpid(APP_ID, pidx);
-        config.hp_primary = nodes[0];
-        config.hp_secondaries.emplace_back(nodes[1]);
-        config.hp_secondaries.emplace_back(nodes[2]);
+        SET_IP_AND_HOST_PORT_BY_DNS(config, primary, nodes[0]);
+        SET_IPS_AND_HOST_PORTS_BY_DNS(config, secondaries, nodes[1], nodes[2]);
 
         auto count = nodes.size();
         for (auto i = 0; i < count; i++) {

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -178,13 +178,8 @@ public:
         config.pid = gpid(app->app_id, 0);
         config.max_replica_count = 3;
         config.ballot = BALLOT;
-        config.primary = PRIMARY;
-        config.secondaries.emplace_back(SECONDARY1);
-        config.secondaries.emplace_back(SECONDARY2);
-        config.hp_primary = PRIMARY_HP;
-        config.__set_hp_secondaries(std::vector<host_port>());
-        config.hp_secondaries.emplace_back(SECONDARY1_HP);
-        config.hp_secondaries.emplace_back(SECONDARY2_HP);
+        SET_IP_AND_HOST_PORT_BY_DNS(config, primary, PRIMARY_HP);
+        SET_IPS_AND_HOST_PORTS_BY_DNS(config, secondaries, SECONDARY1_HP, SECONDARY2_HP);
         app->partitions.clear();
         app->partitions.emplace_back(config);
         mock_meta_bulk_load_context(app->app_id, app->partition_count, status);
@@ -199,12 +194,10 @@ public:
     {
         std::shared_ptr<app_state> app = find_app(name);
         if (mock_primary_invalid) {
-            app->partitions[pid.get_partition_index()].primary.set_invalid();
-            app->partitions[pid.get_partition_index()].hp_primary.reset();
+            RESET_IP_AND_HOST_PORT(app->partitions[pid.get_partition_index()], primary);
         }
         if (mock_lack_secondary) {
-            app->partitions[pid.get_partition_index()].secondaries.clear();
-            app->partitions[pid.get_partition_index()].hp_secondaries.clear();
+            CLEAR_IP_AND_HOST_PORT(app->partitions[pid.get_partition_index()], secondaries);
         }
         partition_configuration pconfig;
         bool flag = bulk_svc().check_partition_status(
@@ -242,25 +235,17 @@ public:
         set_partition_bulk_load_info(pid, ever_ingest_succeed);
         partition_configuration config;
         config.pid = pid;
-        config.primary = PRIMARY;
-        config.__set_hp_primary(PRIMARY_HP);
-        config.__set_hp_secondaries(std::vector<host_port>());
+        SET_IP_AND_HOST_PORT_BY_DNS(config, primary, PRIMARY_HP);
         if (same) {
-            config.secondaries.emplace_back(SECONDARY1);
-            config.secondaries.emplace_back(SECONDARY2);
-            config.hp_secondaries.emplace_back(SECONDARY1_HP);
-            config.hp_secondaries.emplace_back(SECONDARY2_HP);
+            ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY1_HP);
+            ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY2_HP);
         } else {
-            config.secondaries.emplace_back(SECONDARY1);
-            config.hp_secondaries.emplace_back(SECONDARY1_HP);
+            ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY1_HP);
             if (secondary_count == 2) {
-                config.secondaries.emplace_back(SECONDARY3);
-                config.hp_secondaries.emplace_back(SECONDARY3_HP);
+                ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY3_HP);
             } else if (secondary_count >= 3) {
-                config.secondaries.emplace_back(SECONDARY2);
-                config.secondaries.emplace_back(SECONDARY3);
-                config.hp_secondaries.emplace_back(SECONDARY2_HP);
-                config.hp_secondaries.emplace_back(SECONDARY3_HP);
+                ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY2_HP);
+                ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY3_HP);
             }
         }
         auto flag = bulk_svc().check_ever_ingestion_succeed(config, APP_NAME, pid);

--- a/src/meta/test/meta_data.cpp
+++ b/src/meta/test/meta_data.cpp
@@ -35,7 +35,6 @@
 #include "meta/meta_data.h"
 #include "metadata_types.h"
 #include "misc/misc.h"
-#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 
@@ -136,12 +135,9 @@ TEST(meta_data, collect_replica)
 
 #define CLEAR_REPLICA                                                                              \
     do {                                                                                           \
-        pc.__set_hp_primary(dsn::host_port());                                                     \
-        pc.__set_hp_secondaries({});                                                               \
-        pc.__set_hp_last_drops({});                                                                \
-        pc.primary.set_invalid();                                                                  \
-        pc.secondaries.clear();                                                                    \
-        pc.last_drops.clear();                                                                     \
+        RESET_IP_AND_HOST_PORT(pc, primary);                                                       \
+        CLEAR_IP_AND_HOST_PORT(pc, secondaries);                                                   \
+        CLEAR_IP_AND_HOST_PORT(pc, last_drops);                                                    \
     } while (false)
 
 #define CLEAR_DROP_LIST                                                                            \
@@ -153,22 +149,19 @@ TEST(meta_data, collect_replica)
     CLEAR_REPLICA;                                                                                 \
     CLEAR_DROP_LIST
 
-    const auto addr = dsn::dns_resolver::instance().resolve_address(node_list[0]);
     {
         // replica is primary of partition
         CLEAR_ALL;
         rep.ballot = 10;
         pc.ballot = 9;
-        pc.primary = addr;
-        pc.__set_hp_primary(node_list[0]);
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, node_list[0]);
         ASSERT_TRUE(collect_replica(view, node_list[0], rep));
     }
 
     {
         // replica is secondary of partition
         CLEAR_ALL;
-        pc.secondaries.push_back(addr);
-        pc.hp_secondaries.push_back(node_list[0]);
+        ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, node_list[0]);
         ASSERT_TRUE(collect_replica(view, node_list[0], rep));
     }
 
@@ -385,12 +378,9 @@ TEST(meta_data, construct_replica)
 
 #define CLEAR_REPLICA                                                                              \
     do {                                                                                           \
-        pc.hp_primary.reset();                                                                     \
-        pc.hp_secondaries.clear();                                                                 \
-        pc.hp_last_drops.clear();                                                                  \
-        pc.__set_hp_primary(dsn::host_port());                                                     \
-        pc.__set_hp_secondaries({});                                                               \
-        pc.__set_hp_last_drops({});                                                                \
+        RESET_IP_AND_HOST_PORT(pc, primary);                                                       \
+        CLEAR_IP_AND_HOST_PORT(pc, secondaries);                                                   \
+        CLEAR_IP_AND_HOST_PORT(pc, last_drops);                                                    \
     } while (false)
 
 #define CLEAR_DROP_LIST                                                                            \

--- a/src/meta/test/meta_data.cpp
+++ b/src/meta/test/meta_data.cpp
@@ -35,6 +35,7 @@
 #include "meta/meta_data.h"
 #include "metadata_types.h"
 #include "misc/misc.h"
+#include "runtime/rpc/dns_resolver.h" // IWYU pragma: keep
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 

--- a/src/meta/test/meta_duplication_service_test.cpp
+++ b/src/meta/test/meta_duplication_service_test.cpp
@@ -595,8 +595,7 @@ TEST_F(meta_duplication_service_test, duplication_sync)
     for (partition_configuration &pc : app->partitions) {
         pc.ballot = random32(1, 10000);
         SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, server_nodes[0]);
-        ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, server_nodes[1]);
-        ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, server_nodes[2]);
+        SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, server_nodes[1], server_nodes[2]);
     }
 
     initialize_node_state();

--- a/src/meta/test/meta_duplication_service_test.cpp
+++ b/src/meta/test/meta_duplication_service_test.cpp
@@ -587,9 +587,6 @@ TEST_F(meta_duplication_service_test, remove_dup)
 TEST_F(meta_duplication_service_test, duplication_sync)
 {
     const auto &server_nodes = ensure_enough_alive_nodes(3);
-    const auto &node = server_nodes[0];
-    const auto &addr = dsn::dns_resolver::instance().resolve_address(server_nodes[0]);
-
     const std::string test_app = "test_app_0";
     create_app(test_app);
     auto app = find_app(test_app);
@@ -597,14 +594,15 @@ TEST_F(meta_duplication_service_test, duplication_sync)
     // generate all primaries on node[0]
     for (partition_configuration &pc : app->partitions) {
         pc.ballot = random32(1, 10000);
-        pc.primary = addr;
-        pc.__set_hp_primary(server_nodes[0]);
-        pc.hp_secondaries.push_back(server_nodes[1]);
-        pc.hp_secondaries.push_back(server_nodes[2]);
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, server_nodes[0]);
+        ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, server_nodes[1]);
+        ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, server_nodes[2]);
     }
 
     initialize_node_state();
 
+    const auto &node = server_nodes[0];
+    const auto &addr = dsn::dns_resolver::instance().resolve_address(server_nodes[0]);
     const dupid_t dupid = create_dup(test_app).dupid;
     auto dup = app->duplications[dupid];
     for (int i = 0; i < app->partition_count; i++) {
@@ -818,12 +816,11 @@ TEST_F(meta_duplication_service_test, fail_mode)
 
     // ensure dup_sync will synchronize fail_mode
     const auto hp = generate_node_list(3)[0];
-    const auto addr = dsn::dns_resolver::instance().resolve_address(hp);
     for (partition_configuration &pc : app->partitions) {
-        pc.primary = addr;
-        pc.__set_hp_primary(hp);
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, hp);
     }
     initialize_node_state();
+    const auto addr = dsn::dns_resolver::instance().resolve_address(hp);
     auto sync_resp = duplication_sync(addr, hp, {});
     ASSERT_TRUE(sync_resp.dup_map[app->app_id][dup->id].__isset.fail_mode);
     ASSERT_EQ(sync_resp.dup_map[app->app_id][dup->id].fail_mode, duplication_fail_mode::FAIL_SKIP);

--- a/src/meta/test/misc/misc.cpp
+++ b/src/meta/test/misc/misc.cpp
@@ -47,6 +47,7 @@
 #include "duplication_types.h"
 #include "meta_admin_types.h"
 #include "metadata_types.h"
+#include "runtime/rpc/dns_resolver.h" // IWYU pragma: keep
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/fmt_logging.h"

--- a/src/meta/test/misc/misc.cpp
+++ b/src/meta/test/misc/misc.cpp
@@ -47,7 +47,6 @@
 #include "duplication_types.h"
 #include "meta_admin_types.h"
 #include "metadata_types.h"
-#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/fmt_logging.h"
@@ -125,14 +124,10 @@ void generate_app(/*out*/ std::shared_ptr<app_state> &app,
         indices[2] = random32(indices[1] + 1, node_list.size() - 1);
 
         int p = random32(0, 2);
-        pc.__set_hp_primary(node_list[indices[p]]);
-        pc.__set_hp_secondaries({});
-        pc.primary = dsn::dns_resolver::instance().resolve_address(node_list[indices[p]]);
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, node_list[indices[p]]);
         for (unsigned int i = 0; i != indices.size(); ++i) {
             if (i != p) {
-                pc.secondaries.push_back(
-                    dsn::dns_resolver::instance().resolve_address(node_list[indices[i]]));
-                pc.hp_secondaries.push_back(node_list[indices[i]]);
+                ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, node_list[indices[i]]);
             }
         }
 
@@ -314,8 +309,7 @@ void proposal_action_check_and_apply(const configuration_proposal_action &act,
         CHECK(pc.hp_secondaries.empty(), "");
         CHECK(pc.secondaries.empty(), "");
 
-        pc.primary = act.node;
-        pc.__set_hp_primary(hp_node);
+        SET_IP_AND_HOST_PORT(pc, primary, act.node, hp_node);
         ns = &nodes[hp_node];
         CHECK_EQ(ns->served_as(pc.pid), partition_status::PS_INACTIVE);
         ns->put_partition(pc.pid, true);
@@ -326,8 +320,7 @@ void proposal_action_check_and_apply(const configuration_proposal_action &act,
         CHECK_EQ(act.target, pc.primary);
         CHECK(!is_member(pc, hp_node), "");
 
-        pc.hp_secondaries.push_back(hp_node);
-        pc.secondaries.push_back(act.node);
+        ADD_IP_AND_HOST_PORT(pc, secondaries, act.node, hp_node);
         ns = &nodes[hp_node];
         CHECK_EQ(ns->served_as(pc.pid), partition_status::PS_INACTIVE);
         ns->put_partition(pc.pid, false);
@@ -342,10 +335,8 @@ void proposal_action_check_and_apply(const configuration_proposal_action &act,
         CHECK(nodes.find(hp_node) != nodes.end(), "");
         CHECK(!is_secondary(pc, pc.hp_primary), "");
         nodes[hp_node].remove_partition(pc.pid, true);
-        pc.secondaries.push_back(pc.primary);
-        pc.hp_secondaries.push_back(pc.hp_primary);
-        pc.primary.set_invalid();
-        pc.__set_hp_primary(dsn::host_port());
+        ADD_IP_AND_HOST_PORT(pc, secondaries, pc.primary, pc.hp_primary);
+        RESET_IP_AND_HOST_PORT(pc, primary);
         break;
 
     case config_type::CT_UPGRADE_TO_PRIMARY:
@@ -357,8 +348,7 @@ void proposal_action_check_and_apply(const configuration_proposal_action &act,
         CHECK(nodes.find(hp_node) != nodes.end(), "");
 
         ns = &nodes[hp_node];
-        pc.hp_primary = hp_node;
-        pc.primary = act.node;
+        SET_IP_AND_HOST_PORT(pc, primary, act.node, hp_node);
         CHECK(replica_helper::remove_node(hp_node, pc.hp_secondaries), "");
         CHECK(replica_helper::remove_node(act.node, pc.secondaries), "");
         ns->put_partition(pc.pid, true);
@@ -370,11 +360,7 @@ void proposal_action_check_and_apply(const configuration_proposal_action &act,
         CHECK(!is_member(pc, hp_node), "");
         CHECK(act.hp_node, "");
         CHECK(act.node, "");
-        if (!pc.__isset.hp_secondaries) {
-            pc.__set_hp_secondaries({});
-        }
-        pc.hp_secondaries.push_back(hp_node);
-        pc.secondaries.push_back(act.node);
+        ADD_IP_AND_HOST_PORT(pc, secondaries, act.node, hp_node);
 
         ns = &nodes[hp_node];
         ns->put_partition(pc.pid, false);

--- a/src/meta/test/state_sync_test.cpp
+++ b/src/meta/test/state_sync_test.cpp
@@ -54,6 +54,7 @@
 #include "utils/flags.h"
 #include "utils/strings.h"
 #include "utils/utils.h"
+#include "utils/test_macros.h"
 
 DSN_DECLARE_string(cluster_root);
 DSN_DECLARE_string(meta_state_service_type);
@@ -245,7 +246,7 @@ void meta_service_test_app::state_sync_test()
         dsn::error_code ec = ss2->initialize_data_structure();
         ASSERT_EQ(ec, dsn::ERR_OK);
 
-        app_mapper_compare(ss1->_all_apps, ss2->_all_apps);
+        NO_FATALS(app_mapper_compare(ss1->_all_apps, ss2->_all_apps));
         ASSERT_EQ(ss1->_exist_apps.size(), ss2->_exist_apps.size());
         for (const auto &iter : ss1->_exist_apps) {
             ASSERT_TRUE(ss2->_exist_apps.find(iter.first) != ss2->_exist_apps.end());
@@ -266,7 +267,7 @@ void meta_service_test_app::state_sync_test()
         dsn::error_code ec = ss2->restore_from_local_storage("meta_state.dump3");
         ASSERT_EQ(ec, dsn::ERR_OK);
 
-        app_mapper_compare(ss1->_all_apps, ss2->_all_apps);
+        NO_FATALS(app_mapper_compare(ss1->_all_apps, ss2->_all_apps));
         ASSERT_TRUE(ss1->_exist_apps.size() == ss2->_exist_apps.size());
         for (const auto &iter : ss1->_exist_apps) {
             ASSERT_TRUE(ss2->_exist_apps.find(iter.first) != ss2->_exist_apps.end());

--- a/src/meta/test/state_sync_test.cpp
+++ b/src/meta/test/state_sync_test.cpp
@@ -46,7 +46,6 @@
 #include "meta/test/misc/misc.h"
 #include "meta_admin_types.h"
 #include "meta_service_test_app.h"
-#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "runtime/task/task.h"
@@ -83,22 +82,14 @@ static void random_assign_partition_config(std::shared_ptr<app_state> &app,
             start = indices.back() + 1;
         }
         const auto &primary = get_server(indices[0]);
-        pc.primary = dsn::dns_resolver::instance().resolve_address(primary);
-        pc.__set_hp_primary(primary);
-        if (!pc.__isset.hp_secondaries) {
-            pc.__set_hp_secondaries({});
-        }
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, primary);
         for (int i = 1; i < indices.size(); ++i) {
             const auto &secondary = get_server(indices[i]);
             if (secondary) {
-                pc.secondaries.push_back(dsn::dns_resolver::instance().resolve_address(secondary));
-                pc.hp_secondaries.push_back(secondary);
+                ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, secondary);
             }
         }
-        const auto hp = server_list.back();
-        const auto addr = dsn::dns_resolver::instance().resolve_address(hp);
-        pc.__set_hp_last_drops({hp});
-        pc.last_drops = {addr};
+        SET_IPS_AND_HOST_PORTS_BY_DNS(pc, last_drops, server_list.back());
     }
 }
 

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -249,14 +249,12 @@ void meta_service_test_app::update_configuration_test()
 
     dsn::partition_configuration &pc0 = app->partitions[0];
     SET_IP_AND_HOST_PORT_BY_DNS(pc0, primary, nodes[0]);
-    ADD_IP_AND_HOST_PORT_BY_DNS(pc0, secondaries, nodes[1]);
-    ADD_IP_AND_HOST_PORT_BY_DNS(pc0, secondaries, nodes[2]);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(pc0, secondaries, nodes[1], nodes[2]);
     pc0.ballot = 3;
 
     dsn::partition_configuration &pc1 = app->partitions[1];
     SET_IP_AND_HOST_PORT_BY_DNS(pc0, primary, nodes[1]);
-    ADD_IP_AND_HOST_PORT_BY_DNS(pc0, secondaries, nodes[0]);
-    ADD_IP_AND_HOST_PORT_BY_DNS(pc0, secondaries, nodes[2]);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(pc0, secondaries, nodes[0], nodes[2]);
     pc1.ballot = 3;
 
     ss->sync_apps_to_remote_storage();
@@ -329,8 +327,7 @@ void meta_service_test_app::adjust_dropped_size()
     // first, the replica is healthy, and there are 2 dropped
     dsn::partition_configuration &pc = app->partitions[0];
     SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, nodes[0]);
-    ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, nodes[1]);
-    ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, nodes[2]);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, nodes[1], nodes[2]);
     pc.ballot = 10;
 
     config_context &cc = *get_config_context(ss->_all_apps, pc.pid);
@@ -348,7 +345,7 @@ void meta_service_test_app::adjust_dropped_size()
         std::make_shared<configuration_update_request>();
     req->config = pc;
     req->config.ballot++;
-    ADD_IP_AND_HOST_PORT_BY_DNS(req->config, secondaries, nodes[5]);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(req->config, secondaries, nodes[5]);
     req->info = info;
     req->node = dsn::dns_resolver::instance().resolve_address(nodes[5]);
     req->__set_hp_node(nodes[5]);
@@ -509,8 +506,7 @@ void meta_service_test_app::cannot_run_balancer_test()
 
     dsn::partition_configuration &pc = the_app->partitions[0];
     SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, nodes[0]);
-    ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, nodes[1]);
-    ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, nodes[2]);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, nodes[1], nodes[2]);
 
 #define REGENERATE_NODE_MAPPER                                                                     \
     svc->_state->_nodes.clear();                                                                   \

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -253,8 +253,8 @@ void meta_service_test_app::update_configuration_test()
     pc0.ballot = 3;
 
     dsn::partition_configuration &pc1 = app->partitions[1];
-    SET_IP_AND_HOST_PORT_BY_DNS(pc0, primary, nodes[1]);
-    SET_IPS_AND_HOST_PORTS_BY_DNS(pc0, secondaries, nodes[0], nodes[2]);
+    SET_IP_AND_HOST_PORT_BY_DNS(pc1, primary, nodes[1]);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(pc1, secondaries, nodes[0], nodes[2]);
     pc1.ballot = 3;
 
     ss->sync_apps_to_remote_storage();

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -246,10 +246,9 @@ void replica_bulk_loader::on_group_bulk_load(const group_bulk_load_request &requ
         return;
     }
 
-    LOG_INFO_PREFIX("receive group_bulk_load request, primary address = {}({}), ballot = {}, "
+    LOG_INFO_PREFIX("receive group_bulk_load request, primary address = {}, ballot = {}, "
                     "meta bulk_load_status = {}, local bulk_load_status = {}",
-                    request.config.hp_primary,
-                    request.config.primary,
+                    FMT_HOST_PORT_AND_IP(request.config, primary),
                     request.config.ballot,
                     enum_to_string(request.meta_bulk_load_status),
                     enum_to_string(_status));
@@ -933,9 +932,8 @@ void replica_bulk_loader::report_group_download_progress(/*out*/ bulk_load_respo
                                     _replica->_primary_states.membership.primary,
                                     _replica->_primary_states.membership.hp_primary,
                                     primary_state);
-    LOG_INFO_PREFIX("primary = {}({}), download progress = {}%, status = {}",
-                    _replica->_primary_states.membership.hp_primary,
-                    _replica->_primary_states.membership.primary,
+    LOG_INFO_PREFIX("primary = {}, download progress = {}%, status = {}",
+                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.membership, primary),
                     primary_state.download_progress,
                     primary_state.download_status);
 
@@ -976,9 +974,8 @@ void replica_bulk_loader::report_group_ingestion_status(/*out*/ bulk_load_respon
                                     _replica->_primary_states.membership.primary,
                                     _replica->_primary_states.membership.hp_primary,
                                     primary_state);
-    LOG_INFO_PREFIX("primary = {}({}), ingestion status = {}",
-                    _replica->_primary_states.membership.hp_primary,
-                    _replica->_primary_states.membership.primary,
+    LOG_INFO_PREFIX("primary = {}, ingestion status = {}",
+                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.membership, primary),
                     enum_to_string(primary_state.ingest_status));
 
     bool is_group_ingestion_finish =
@@ -1025,7 +1022,7 @@ void replica_bulk_loader::report_group_cleaned_up(bulk_load_response &response)
                                     _replica->_primary_states.membership.hp_primary,
                                     primary_state);
     LOG_INFO_PREFIX("primary = {}, bulk load states cleaned_up = {}",
-                    _replica->_primary_states.membership.primary,
+                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.membership, primary),
                     primary_state.is_cleaned_up);
 
     bool group_flag = (primary_state.is_cleaned_up) &&
@@ -1063,9 +1060,8 @@ void replica_bulk_loader::report_group_is_paused(bulk_load_response &response)
                                     _replica->_primary_states.membership.primary,
                                     _replica->_primary_states.membership.hp_primary,
                                     primary_state);
-    LOG_INFO_PREFIX("primary = {}({}), bulk_load is_paused = {}",
-                    _replica->_primary_states.membership.hp_primary,
-                    _replica->_primary_states.membership.primary,
+    LOG_INFO_PREFIX("primary = {}, bulk_load is_paused = {}",
+                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.membership, primary),
                     primary_state.is_paused);
 
     bool group_is_paused = primary_state.is_paused &&

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -241,13 +241,9 @@ public:
         config.max_replica_count = 3;
         config.pid = PID;
         config.ballot = BALLOT;
-        config.primary = PRIMARY;
-        config.secondaries.emplace_back(SECONDARY);
-        config.secondaries.emplace_back(SECONDARY2);
-        config.__set_hp_primary(PRIMARY_HP);
-        config.__set_hp_secondaries({});
-        config.hp_secondaries.emplace_back(SECONDARY_HP);
-        config.hp_secondaries.emplace_back(SECONDARY_HP2);
+        SET_IP_AND_HOST_PORT_BY_DNS(config, primary, PRIMARY_HP);
+        ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY_HP);
+        ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY_HP2);
         _replica->set_primary_partition_configuration(config);
     }
 

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -242,8 +242,7 @@ public:
         config.pid = PID;
         config.ballot = BALLOT;
         SET_IP_AND_HOST_PORT_BY_DNS(config, primary, PRIMARY_HP);
-        ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY_HP);
-        ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY_HP2);
+        SET_IPS_AND_HOST_PORTS_BY_DNS(config, secondaries, SECONDARY_HP, SECONDARY_HP2);
         _replica->set_primary_partition_configuration(config);
     }
 

--- a/src/replica/duplication/replica_follower.cpp
+++ b/src/replica/duplication/replica_follower.cpp
@@ -186,10 +186,9 @@ error_code replica_follower::update_master_replica_config(error_code err, query_
     // since the request just specify one partition, the result size is single
     _master_replica_config = resp.partitions[0];
     LOG_INFO_PREFIX(
-        "query master[{}]({}) config successfully and update local config: remote={}, gpid={}",
+        "query master[{}] config successfully and update local config: remote={}, gpid={}",
         master_replica_name(),
-        _master_replica_config.hp_primary,
-        _master_replica_config.primary,
+        FMT_HOST_PORT_AND_IP(_master_replica_config, primary),
         _master_replica_config.pid);
     return ERR_OK;
 }

--- a/src/replica/duplication/replica_follower.h
+++ b/src/replica/duplication/replica_follower.h
@@ -26,7 +26,6 @@
 #include "common/gpid.h"
 #include "dsn.layer2_types.h"
 #include "replica/replica_base.h"
-#include "runtime/rpc/rpc_address.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "runtime/task/task_tracker.h"
 #include "utils/error_code.h"

--- a/src/replica/duplication/replica_follower.h
+++ b/src/replica/duplication/replica_follower.h
@@ -80,10 +80,9 @@ private:
     {
         std::string app_info = fmt::format("{}.{}", _master_cluster_name, _master_app_name);
         if (_master_replica_config.hp_primary) {
-            return fmt::format("{}({}({})|{})",
+            return fmt::format("{}({}|{})",
                                app_info,
-                               _master_replica_config.hp_primary,
-                               _master_replica_config.primary,
+                               FMT_HOST_PORT_AND_IP(_master_replica_config, primary),
                                _master_replica_config.pid);
         }
         return app_info;

--- a/src/replica/duplication/test/replica_follower_test.cpp
+++ b/src/replica/duplication/test/replica_follower_test.cpp
@@ -241,8 +241,7 @@ TEST_P(replica_follower_test, test_update_master_replica_config)
     ASSERT_FALSE(master_replica_config(follower).hp_primary);
 
     resp.partitions.clear();
-    p.primary = {};
-    p.__set_hp_primary(host_port());
+    RESET_IP_AND_HOST_PORT(p, primary);
     p.pid = gpid(2, 1);
     resp.partitions.emplace_back(p);
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_INVALID_STATE);
@@ -256,13 +255,9 @@ TEST_P(replica_follower_test, test_update_master_replica_config)
     const host_port secondary1("localhost", 34802);
     const host_port secondary2("localhost", 34803);
 
-    p.primary = dsn::dns_resolver::instance().resolve_address(primary);
-    p.secondaries.emplace_back(dsn::dns_resolver::instance().resolve_address(secondary1));
-    p.secondaries.emplace_back(dsn::dns_resolver::instance().resolve_address(secondary2));
-    p.__set_hp_primary(primary);
-    p.__set_hp_secondaries({});
-    p.hp_secondaries.emplace_back(secondary1);
-    p.hp_secondaries.emplace_back(secondary2);
+    SET_IP_AND_HOST_PORT_BY_DNS(p, primary, primary);
+    ADD_IP_AND_HOST_PORT_BY_DNS(p, secondaries, secondary1);
+    ADD_IP_AND_HOST_PORT_BY_DNS(p, secondaries, secondary2);
     resp.partitions.emplace_back(p);
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_OK);
     ASSERT_EQ(master_replica_config(follower).primary, p.primary);

--- a/src/replica/duplication/test/replica_follower_test.cpp
+++ b/src/replica/duplication/test/replica_follower_test.cpp
@@ -256,8 +256,7 @@ TEST_P(replica_follower_test, test_update_master_replica_config)
     const host_port secondary2("localhost", 34803);
 
     SET_IP_AND_HOST_PORT_BY_DNS(p, primary, primary);
-    ADD_IP_AND_HOST_PORT_BY_DNS(p, secondaries, secondary1);
-    ADD_IP_AND_HOST_PORT_BY_DNS(p, secondaries, secondary2);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(p, secondaries, secondary1, secondary2);
     resp.partitions.emplace_back(p);
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_OK);
     ASSERT_EQ(master_replica_config(follower).primary, p.primary);

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1471,8 +1471,7 @@ void replica_stub::remove_replica_on_meta_server(const app_info &info,
     request->type = config_type::CT_DOWNGRADE_TO_INACTIVE;
 
     if (_primary_host_port == config.hp_primary) {
-        request->config.primary.set_invalid();
-        request->config.hp_primary.reset();
+        RESET_IP_AND_HOST_PORT(request->config, primary);
     } else if (replica_helper::remove_node(primary_address(), request->config.secondaries) &&
                replica_helper::remove_node(_primary_host_port, request->config.hp_secondaries)) {
     } else {

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -991,8 +991,7 @@ void replica_split_manager::register_child_on_meta(ballot b) // on primary paren
     partition_configuration child_config = _replica->_primary_states.membership;
     child_config.ballot++;
     child_config.last_committed_decree = 0;
-    child_config.last_drops.clear();
-    child_config.hp_last_drops.clear();
+    CLEAR_IP_AND_HOST_PORT(child_config, last_drops);
     child_config.pid.set_partition_index(_replica->_app_info.partition_count +
                                          get_gpid().get_partition_index());
 

--- a/src/replica/split/test/replica_split_test.cpp
+++ b/src/replica/split/test/replica_split_test.cpp
@@ -191,13 +191,10 @@ public:
         config.max_replica_count = 3;
         config.pid = PARENT_GPID;
         config.ballot = INIT_BALLOT;
-        config.hp_primary = PRIMARY;
-        config.primary = PRIMARY_ADDR;
-        config.__set_hp_secondaries({SECONDARY});
-        config.secondaries.emplace_back(SECONDARY_ADDR);
+        SET_IP_AND_HOST_PORT_BY_DNS(config, primary, PRIMARY);
+        ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY);
         if (!lack_of_secondary) {
-            config.secondaries.emplace_back(SECONDARY_ADDR2);
-            config.hp_secondaries.emplace_back(SECONDARY2);
+            ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY2);
         }
         _parent_replica->set_primary_partition_configuration(config);
     }
@@ -363,8 +360,7 @@ public:
         req.parent_config.pid = PARENT_GPID;
         req.parent_config.ballot = INIT_BALLOT;
         req.parent_config.last_committed_decree = DECREE;
-        req.parent_config.primary = PRIMARY_ADDR;
-        req.parent_config.__set_hp_primary(PRIMARY);
+        SET_IP_AND_HOST_PORT_BY_DNS(req.parent_config, primary, PRIMARY);
         req.child_config.pid = CHILD_GPID;
         req.child_config.ballot = INIT_BALLOT + 1;
         req.child_config.last_committed_decree = 0;

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -94,7 +94,7 @@ class TProtocol;
         _obj.__set_hp_##field({});                                                                 \
     } while (0)
 
-// Add 'addr' and 'hp' to the '<field>' and optional vector 'hp_<field>' of 'obj'. The types
+// Add 'addr' and 'hp' to the vector '<field>' and optional vector 'hp_<field>' of 'obj'. The types
 // of the fields are std::vector<rpc_address> and std::vector<host_port>, respectively.
 #define ADD_IP_AND_HOST_PORT(obj, field, addr, hp)                                                 \
     do {                                                                                           \
@@ -107,6 +107,9 @@ class TProtocol;
         }                                                                                          \
     } while (0)
 
+// Add 'hp' and its DNS resolved rpc_address to the optional vector 'hp_<field>' and vector
+// '<field>' of 'obj'. The types of the fields are std::vector<rpc_address> and
+// std::vector<host_port>, respectively.
 #define ADD_IP_AND_HOST_PORT_BY_DNS(obj, field, hp)                                                \
     do {                                                                                           \
         auto &_obj = (obj);                                                                        \
@@ -149,6 +152,10 @@ class TProtocol;
 #define SET_IPS_AND_HOST_PORTS_BY_DNS_GET_MACRO(hp1, hp2, hp3, NAME, ...) NAME
 #define SET_IPS_AND_HOST_PORTS_BY_DNS_GET_MACRO_(tuple)                                            \
     SET_IPS_AND_HOST_PORTS_BY_DNS_GET_MACRO tuple
+
+// Set ... and their DNS resolved rpc_addresses to the vector '<field>' and optional vector
+// 'hp_<field>' of 'obj'. The types of the fields are std::vector<rpc_address> and
+// std::vector<host_port>, respectively.
 #define SET_IPS_AND_HOST_PORTS_BY_DNS(obj, field, ...)                                             \
     SET_IPS_AND_HOST_PORTS_BY_DNS_GET_MACRO_((__VA_ARGS__,                                         \
                                               SET_IPS_AND_HOST_PORTS_BY_DNS_3,                     \
@@ -156,6 +163,9 @@ class TProtocol;
                                               SET_IPS_AND_HOST_PORTS_BY_DNS_1))                    \
     (obj, field, __VA_ARGS__);
 
+// Head insert 'hp' and its DNS resolved rpc_address to the optional vector 'hp_<field>' and vector
+// '<field>' of 'obj'. The types of the fields are std::vector<rpc_address> and
+// std::vector<host_port>, respectively.
 #define HEAD_INSERT_IP_AND_HOST_PORT_BY_DNS(obj, field, hp)                                        \
     do {                                                                                           \
         auto &_obj = (obj);                                                                        \

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -168,6 +168,7 @@ class TProtocol;
         }                                                                                          \
     } while (0)
 
+// TODO(yingchun): the 'hp' can be reduced.
 // Set 'value' to the '<field>' map and optional 'hp_<field>' map of 'obj'. The key of the
 // maps are rpc_address and host_port type and indexed by 'addr' and 'hp', respectively.
 #define SET_VALUE_FROM_IP_AND_HOST_PORT(obj, field, addr, hp, value)                               \

--- a/src/runtime/rpc/rpc_host_port.h
+++ b/src/runtime/rpc/rpc_host_port.h
@@ -49,20 +49,123 @@ class TProtocol;
 #define GET_HOST_PORT(obj, field, target)                                                          \
     do {                                                                                           \
         const auto &_obj = (obj);                                                                  \
+        auto &_target = (target);                                                                  \
         if (_obj.__isset.hp_##field) {                                                             \
-            target = _obj.hp_##field;                                                              \
+            _target = _obj.hp_##field;                                                             \
         } else {                                                                                   \
-            target = std::move(dsn::host_port::from_address(_obj.field));                          \
+            _target = std::move(dsn::host_port::from_address(_obj.field));                         \
         }                                                                                          \
     } while (0)
 
-// Set 'addr' and 'hp' to the '<field>' and optional 'hp_<field>' of 'obj'. The type of the
+// Set 'addr' and 'hp' to the '<field>' and optional 'hp_<field>' of 'obj'. The types of the
 // fields are rpc_address and host_port, respectively.
 #define SET_IP_AND_HOST_PORT(obj, field, addr, hp)                                                 \
     do {                                                                                           \
         auto &_obj = (obj);                                                                        \
-        _obj.field = addr;                                                                         \
+        _obj.field = (addr);                                                                       \
         _obj.__set_hp_##field(hp);                                                                 \
+    } while (0)
+
+// Set 'hp' and its DNS resolved rpc_address to the optional 'hp_<field>' and '<field>' of 'obj'.
+// The types of the fields are host_port and rpc_address, respectively.
+#define SET_IP_AND_HOST_PORT_BY_DNS(obj, field, hp)                                                \
+    do {                                                                                           \
+        auto &_obj = (obj);                                                                        \
+        const auto &_hp = (hp);                                                                    \
+        _obj.field = dsn::dns_resolver::instance().resolve_address(_hp);                           \
+        _obj.__set_hp_##field(_hp);                                                                \
+    } while (0)
+
+// Reset the '<field>' and optional 'hp_<field>' of 'obj'. The types of the fields are rpc_address
+// and host_port, respectively.
+#define RESET_IP_AND_HOST_PORT(obj, field)                                                         \
+    do {                                                                                           \
+        auto &_obj = (obj);                                                                        \
+        _obj.field.set_invalid();                                                                  \
+        _obj.hp_##field.reset();                                                                   \
+    } while (0)
+
+// Clear the '<field>' and optional 'hp_<field>' of 'obj'. The types of the fields are std::vector
+// with rpc_address and host_port elements, respectively.
+#define CLEAR_IP_AND_HOST_PORT(obj, field)                                                         \
+    do {                                                                                           \
+        auto &_obj = (obj);                                                                        \
+        _obj.field.clear();                                                                        \
+        _obj.__set_hp_##field({});                                                                 \
+    } while (0)
+
+// Add 'addr' and 'hp' to the '<field>' and optional vector 'hp_<field>' of 'obj'. The types
+// of the fields are std::vector<rpc_address> and std::vector<host_port>, respectively.
+#define ADD_IP_AND_HOST_PORT(obj, field, addr, hp)                                                 \
+    do {                                                                                           \
+        auto &_obj = (obj);                                                                        \
+        _obj.field.push_back(addr);                                                                \
+        if (!_obj.__isset.hp_##field) {                                                            \
+            _obj.__set_hp_##field({hp});                                                           \
+        } else {                                                                                   \
+            _obj.hp_##field.push_back(hp);                                                         \
+        }                                                                                          \
+    } while (0)
+
+#define ADD_IP_AND_HOST_PORT_BY_DNS(obj, field, hp)                                                \
+    do {                                                                                           \
+        auto &_obj = (obj);                                                                        \
+        auto &_hp = (hp);                                                                          \
+        _obj.field.push_back(dsn::dns_resolver::instance().resolve_address(_hp));                  \
+        if (!_obj.__isset.hp_##field) {                                                            \
+            _obj.__set_hp_##field({_hp});                                                          \
+        } else {                                                                                   \
+            _obj.hp_##field.push_back(_hp);                                                        \
+        }                                                                                          \
+    } while (0)
+
+#define SET_IPS_AND_HOST_PORTS_BY_DNS_1(obj, field, hp1)                                           \
+    do {                                                                                           \
+        auto &_obj = (obj);                                                                        \
+        auto &_hp1 = (hp1);                                                                        \
+        _obj.field = {dsn::dns_resolver::instance().resolve_address(_hp1)};                        \
+        _obj.__set_hp_##field({_hp1});                                                             \
+    } while (0)
+#define SET_IPS_AND_HOST_PORTS_BY_DNS_2(obj, field, hp1, hp2)                                      \
+    do {                                                                                           \
+        auto &_obj = (obj);                                                                        \
+        auto &_hp1 = (hp1);                                                                        \
+        auto &_hp2 = (hp2);                                                                        \
+        _obj.field = {dsn::dns_resolver::instance().resolve_address(_hp1),                         \
+                      dsn::dns_resolver::instance().resolve_address(_hp2)};                        \
+        _obj.__set_hp_##field({_hp1, _hp2});                                                       \
+    } while (0)
+#define SET_IPS_AND_HOST_PORTS_BY_DNS_3(obj, field, hp1, hp2, hp3)                                 \
+    do {                                                                                           \
+        auto &_obj = (obj);                                                                        \
+        auto &_hp1 = (hp1);                                                                        \
+        auto &_hp2 = (hp2);                                                                        \
+        auto &_hp3 = (hp3);                                                                        \
+        _obj.field = {dsn::dns_resolver::instance().resolve_address(_hp1),                         \
+                      dsn::dns_resolver::instance().resolve_address(_hp2),                         \
+                      dsn::dns_resolver::instance().resolve_address(_hp3)};                        \
+        _obj.__set_hp_##field({_hp1, _hp2, _hp3});                                                 \
+    } while (0)
+#define SET_IPS_AND_HOST_PORTS_BY_DNS_GET_MACRO(hp1, hp2, hp3, NAME, ...) NAME
+#define SET_IPS_AND_HOST_PORTS_BY_DNS_GET_MACRO_(tuple)                                            \
+    SET_IPS_AND_HOST_PORTS_BY_DNS_GET_MACRO tuple
+#define SET_IPS_AND_HOST_PORTS_BY_DNS(obj, field, ...)                                             \
+    SET_IPS_AND_HOST_PORTS_BY_DNS_GET_MACRO_((__VA_ARGS__,                                         \
+                                              SET_IPS_AND_HOST_PORTS_BY_DNS_3,                     \
+                                              SET_IPS_AND_HOST_PORTS_BY_DNS_2,                     \
+                                              SET_IPS_AND_HOST_PORTS_BY_DNS_1))                    \
+    (obj, field, __VA_ARGS__);
+
+#define HEAD_INSERT_IP_AND_HOST_PORT_BY_DNS(obj, field, hp)                                        \
+    do {                                                                                           \
+        auto &_obj = (obj);                                                                        \
+        auto &_hp = (hp);                                                                          \
+        _obj.field.insert(_obj.field.begin(), dsn::dns_resolver::instance().resolve_address(_hp)); \
+        if (!_obj.__isset.hp_##field) {                                                            \
+            _obj.__set_hp_##field({_hp});                                                          \
+        } else {                                                                                   \
+            _obj.hp_##field.insert(_obj.hp_##field.begin(), _hp);                                  \
+        }                                                                                          \
     } while (0)
 
 // Set 'value' to the '<field>' map and optional 'hp_<field>' map of 'obj'. The key of the
@@ -70,11 +173,12 @@ class TProtocol;
 #define SET_VALUE_FROM_IP_AND_HOST_PORT(obj, field, addr, hp, value)                               \
     do {                                                                                           \
         auto &_obj = (obj);                                                                        \
-        _obj.field[addr] = value;                                                                  \
+        const auto &_value = (value);                                                              \
+        _obj.field[addr] = _value;                                                                 \
         if (!_obj.__isset.hp_##field) {                                                            \
             _obj.__set_hp_##field({});                                                             \
         }                                                                                          \
-        _obj.hp_##field[hp] = value;                                                               \
+        _obj.hp_##field[hp] = _value;                                                              \
     } while (0)
 
 // Set 'value' to the '<field>' map and optional 'hp_<field>' map of 'obj'. The key of the
@@ -82,8 +186,9 @@ class TProtocol;
 // 'addr', respectively.
 #define SET_VALUE_FROM_HOST_PORT(obj, field, hp, value)                                            \
     do {                                                                                           \
-        const auto addr = dsn::dns_resolver::instance().resolve_address(hp);                       \
-        SET_VALUE_FROM_IP_AND_HOST_PORT(obj, field, addr, hp, value);                              \
+        const auto &_hp = (hp);                                                                    \
+        const auto addr = dsn::dns_resolver::instance().resolve_address(_hp);                      \
+        SET_VALUE_FROM_IP_AND_HOST_PORT(obj, field, addr, _hp, value);                             \
     } while (0)
 
 #define FMT_HOST_PORT_AND_IP(obj, field) fmt::format("{}({})", (obj).hp_##field, (obj).field)

--- a/src/runtime/test/host_port_test.cpp
+++ b/src/runtime/test/host_port_test.cpp
@@ -22,6 +22,9 @@
 #include <utility>
 #include <vector>
 
+#include "bulk_load_types.h"
+#include "common/serialization_helper/dsn.layer2_types.h"
+#include "fd_types.h"
 #include "gtest/gtest.h"
 #include "runtime/rpc/group_address.h"
 #include "runtime/rpc/group_host_port.h"
@@ -253,6 +256,166 @@ TEST(host_port_test, thrift_parser)
     host_port hp2("localhost", 1010);
     send_and_check_host_port_by_serialize(hp2, DSF_THRIFT_BINARY);
     send_and_check_host_port_by_serialize(hp2, DSF_THRIFT_JSON);
+}
+
+TEST(host_port_test, test_macros)
+{
+    static const host_port kHp1("localhost", 8081);
+    static const host_port kHp2("localhost", 8082);
+    static const host_port kHp3("localhost", 8083);
+    static const rpc_address kAddr1 = dns_resolver::instance().resolve_address(kHp1);
+    static const rpc_address kAddr2 = dns_resolver::instance().resolve_address(kHp2);
+    static const rpc_address kAddr3 = dns_resolver::instance().resolve_address(kHp3);
+
+    // Test GET_HOST_PORT-1.
+    {
+        fd::beacon_msg beacon;
+        host_port hp_from_node;
+        GET_HOST_PORT(beacon, from_node, hp_from_node);
+        ASSERT_FALSE(hp_from_node);
+    }
+    // Test GET_HOST_PORT-2.
+    {
+        fd::beacon_msg beacon;
+        host_port hp_from_node;
+        beacon.from_node = kAddr1;
+        GET_HOST_PORT(beacon, from_node, hp_from_node);
+        ASSERT_TRUE(hp_from_node);
+        ASSERT_EQ(kHp1, hp_from_node);
+        ASSERT_EQ(kAddr1, dns_resolver::instance().resolve_address(hp_from_node));
+    }
+    // Test GET_HOST_PORT-3.
+    {
+        fd::beacon_msg beacon;
+        host_port hp_from_node;
+        beacon.__set_hp_from_node(kHp1);
+        GET_HOST_PORT(beacon, from_node, hp_from_node);
+        ASSERT_TRUE(hp_from_node);
+        ASSERT_EQ(kHp1, hp_from_node);
+        ASSERT_EQ(kAddr1, dns_resolver::instance().resolve_address(hp_from_node));
+    }
+
+    // Test SET_IP_AND_HOST_PORT.
+    {
+        fd::beacon_msg beacon;
+        SET_IP_AND_HOST_PORT(beacon, from_node, kAddr1, kHp1);
+        ASSERT_EQ(kAddr1, beacon.from_node);
+        ASSERT_EQ(kHp1, beacon.hp_from_node);
+    }
+
+    // Test SET_IP_AND_HOST_PORT_BY_DNS.
+    {
+        fd::beacon_msg beacon;
+        SET_IP_AND_HOST_PORT_BY_DNS(beacon, from_node, kHp1);
+        ASSERT_EQ(kAddr1, beacon.from_node);
+        ASSERT_EQ(kHp1, beacon.hp_from_node);
+    }
+
+    // Test RESET_IP_AND_HOST_PORT.
+    {
+        fd::beacon_msg beacon;
+        SET_IP_AND_HOST_PORT_BY_DNS(beacon, from_node, kHp1);
+        ASSERT_EQ(kAddr1, beacon.from_node);
+        ASSERT_EQ(kHp1, beacon.hp_from_node);
+        RESET_IP_AND_HOST_PORT(beacon, from_node);
+        ASSERT_FALSE(beacon.from_node);
+        ASSERT_FALSE(beacon.hp_from_node);
+    }
+
+    // Test ADD_IP_AND_HOST_PORT.
+    {
+        partition_configuration pc;
+        ADD_IP_AND_HOST_PORT(pc, secondaries, kAddr1, kHp1);
+        ASSERT_EQ(1, pc.secondaries.size());
+        ASSERT_EQ(1, pc.hp_secondaries.size());
+        ASSERT_EQ(kAddr1, pc.secondaries[0]);
+        ASSERT_EQ(kHp1, pc.hp_secondaries[0]);
+        ADD_IP_AND_HOST_PORT(pc, secondaries, kAddr2, kHp2);
+        ASSERT_EQ(2, pc.secondaries.size());
+        ASSERT_EQ(2, pc.hp_secondaries.size());
+        ASSERT_EQ(kAddr2, pc.secondaries[1]);
+        ASSERT_EQ(kHp2, pc.hp_secondaries[1]);
+    }
+
+    // Test ADD_IP_AND_HOST_PORT_BY_DNS.
+    {
+        partition_configuration pc;
+        ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, kHp1);
+        ASSERT_EQ(1, pc.secondaries.size());
+        ASSERT_EQ(1, pc.hp_secondaries.size());
+        ASSERT_EQ(kAddr1, pc.secondaries[0]);
+        ASSERT_EQ(kHp1, pc.hp_secondaries[0]);
+        ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, kHp2);
+        ASSERT_EQ(2, pc.secondaries.size());
+        ASSERT_EQ(2, pc.hp_secondaries.size());
+        ASSERT_EQ(kAddr2, pc.secondaries[1]);
+        ASSERT_EQ(kHp2, pc.hp_secondaries[1]);
+    }
+
+    // Test SET_IPS_AND_HOST_PORTS_BY_DNS.
+    {
+        partition_configuration pc;
+        SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, kHp1);
+        ASSERT_EQ(1, pc.secondaries.size());
+        ASSERT_EQ(1, pc.hp_secondaries.size());
+        ASSERT_EQ(kAddr1, pc.secondaries[0]);
+        ASSERT_EQ(kHp1, pc.hp_secondaries[0]);
+
+        SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, kHp2, kHp3);
+        ASSERT_EQ(2, pc.secondaries.size());
+        ASSERT_EQ(2, pc.hp_secondaries.size());
+        ASSERT_EQ(kAddr2, pc.secondaries[0]);
+        ASSERT_EQ(kHp2, pc.hp_secondaries[0]);
+        ASSERT_EQ(kAddr3, pc.secondaries[1]);
+        ASSERT_EQ(kHp3, pc.hp_secondaries[1]);
+    }
+
+    // Test CLEAR_IP_AND_HOST_PORT.
+    {
+        partition_configuration pc;
+        ADD_IP_AND_HOST_PORT(pc, secondaries, kAddr1, kHp1);
+        CLEAR_IP_AND_HOST_PORT(pc, secondaries);
+        ASSERT_TRUE(pc.secondaries.empty());
+        ASSERT_TRUE(pc.hp_secondaries.empty());
+    }
+
+    // Test SET_VALUE_FROM_IP_AND_HOST_PORT.
+    {
+        static const int kProgress = 88;
+        replication::bulk_load_response response;
+        replication::partition_bulk_load_state primary_state;
+        primary_state.__set_download_progress(kProgress);
+        SET_VALUE_FROM_IP_AND_HOST_PORT(
+            response, group_bulk_load_state, kAddr1, kHp1, primary_state);
+        ASSERT_EQ(1, response.group_bulk_load_state.size());
+        ASSERT_EQ(1, response.hp_group_bulk_load_state.size());
+        ASSERT_EQ(kAddr1, response.group_bulk_load_state.begin()->first);
+        ASSERT_EQ(kHp1, response.hp_group_bulk_load_state.begin()->first);
+        ASSERT_EQ(kProgress, response.group_bulk_load_state.begin()->second.download_progress);
+        ASSERT_EQ(kProgress, response.hp_group_bulk_load_state.begin()->second.download_progress);
+    }
+
+    // Test SET_VALUE_FROM_HOST_PORT.
+    {
+        static const int kProgress = 88;
+        replication::bulk_load_response response;
+        replication::partition_bulk_load_state primary_state;
+        primary_state.__set_download_progress(kProgress);
+        SET_VALUE_FROM_HOST_PORT(response, group_bulk_load_state, kHp1, primary_state);
+        ASSERT_EQ(1, response.group_bulk_load_state.size());
+        ASSERT_EQ(1, response.hp_group_bulk_load_state.size());
+        ASSERT_EQ(kAddr1, response.group_bulk_load_state.begin()->first);
+        ASSERT_EQ(kHp1, response.hp_group_bulk_load_state.begin()->first);
+        ASSERT_EQ(kProgress, response.group_bulk_load_state.begin()->second.download_progress);
+        ASSERT_EQ(kProgress, response.hp_group_bulk_load_state.begin()->second.download_progress);
+    }
+
+    // Test FMT_HOST_PORT_AND_IP.
+    {
+        fd::beacon_msg beacon;
+        SET_IP_AND_HOST_PORT_BY_DNS(beacon, from_node, kHp1);
+        ASSERT_EQ(fmt::format("{}({})", kHp1, kAddr1), FMT_HOST_PORT_AND_IP(beacon, from_node));
+    }
 }
 
 } // namespace dsn

--- a/src/runtime/test/host_port_test.cpp
+++ b/src/runtime/test/host_port_test.cpp
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include <fmt/core.h>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
@@ -26,6 +28,7 @@
 #include "common/serialization_helper/dsn.layer2_types.h"
 #include "fd_types.h"
 #include "gtest/gtest.h"
+#include "runtime/rpc/dns_resolver.h"
 #include "runtime/rpc/group_address.h"
 #include "runtime/rpc/group_host_port.h"
 #include "runtime/rpc/rpc_address.h"

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -27,6 +27,7 @@
 #include "common/gpid.h"
 #include "common/serialization_helper/dsn.layer2_types.h"
 #include "perf_counter/perf_counter.h"
+#include "runtime/rpc/rpc_host_port.h"
 #include "server/hotspot_partition_stat.h"
 #include "shell/command_executor.h"
 #include "utils/error_code.h"
@@ -226,12 +227,12 @@ void hotspot_partition_calculator::send_detect_hotkey_request(
     auto error = _shell_context->ddl_client->detect_hotkey(
         partitions[partition_index].hp_primary, req, resp);
 
-    LOG_INFO("{} {} hotkey detection in {}.{}, server host_port: {}",
+    LOG_INFO("{} {} hotkey detection in {}.{}, server: {}",
              (action == dsn::replication::detect_action::STOP) ? "Stop" : "Start",
              (hotkey_type == dsn::replication::hotkey_type::WRITE) ? "write" : "read",
              app_name,
              partition_index,
-             partitions[partition_index].hp_primary);
+             FMT_HOST_PORT_AND_IP(partitions[partition_index], primary));
 
     if (error != dsn::ERR_OK) {
         LOG_ERROR("Hotkey detect rpc sending failed, in {}.{}, error_hint:{}",


### PR DESCRIPTION
- Add new convenient macros:
  - SET_IP_AND_HOST_PORT_BY_DNS
  - RESET_IP_AND_HOST_PORT
  - CLEAR_IP_AND_HOST_PORT
  - ADD_IP_AND_HOST_PORT
  - ADD_IP_AND_HOST_PORT_BY_DNS
  - SET_IPS_AND_HOST_PORTS_BY_DNS
  - HEAD_INSERT_IP_AND_HOST_PORT_BY_DNS
- To ensure every references of rpc_address fields in idl/dsn.layer2.thrift
  are get/set together with the related host_port fields, I use the following
  steps:
  - Rename the rpc_address and host_port field names (e.g. append a `1`
    character) in idl/dsn.layer2.thrift
  - Update the C++ code to make sure the project can be built succeed
  - Find out all the changes, and use the macros to set/get the rpc_address
    and host_port fields.
  - Revert the renaming
  - Build and test the project