### PR TITLE
refactor: Fix some clang warnings

### DIFF
--- a/src/client/partition_resolver_manager.cpp
+++ b/src/client/partition_resolver_manager.cpp
@@ -24,7 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include <algorithm>
 #include <memory>
 
 #include "client/partition_resolver.h"
@@ -34,6 +33,7 @@
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/autoref_ptr.h"
 #include "utils/fmt_logging.h"
+#include "utils/utils.h"
 
 namespace dsn {
 
@@ -45,12 +45,14 @@ bool vector_equal(const std::vector<T> &a, const std::vector<T> &b)
     if (a.size() != b.size())
         return false;
     for (const T &item : a) {
-        if (std::find(b.begin(), b.end(), item) == b.end())
+        if (!utils::contains(b, item)) {
             return false;
+        }
     }
     for (const T &item : b) {
-        if (std::find(a.begin(), a.end(), item) == a.end())
+        if (!utils::contains(a, item)) {
             return false;
+        }
     }
     return true;
 }

--- a/src/client/partition_resolver_simple.cpp
+++ b/src/client/partition_resolver_simple.cpp
@@ -417,13 +417,13 @@ host_port partition_resolver_simple::get_host_port(const partition_configuration
 {
     if (_app_is_stateful) {
         return config.hp_primary;
-    } else {
-        if (config.hp_last_drops.size() == 0) {
-            return host_port();
-        } else {
-            return config.hp_last_drops[rand::next_u32(0, config.last_drops.size() - 1)];
-        }
     }
+
+    if (config.hp_last_drops.empty()) {
+        return host_port();
+    }
+
+    return config.hp_last_drops[rand::next_u32(0, config.last_drops.size() - 1)];
 }
 
 error_code partition_resolver_simple::get_host_port(int partition_index, /*out*/ host_port &hp)

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -27,8 +27,6 @@
 #include "common/replication_common.h"
 
 #include <string.h>
-// IWYU pragma: no_include <ext/alloc_traits.h>
-#include <algorithm>
 #include <fstream>
 #include <memory>
 
@@ -43,6 +41,7 @@
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/strings.h"
+#include "utils/utils.h"
 
 DSN_DEFINE_bool(replication, duplication_enabled, true, "is duplication enabled");
 
@@ -179,15 +178,15 @@ int32_t replication_options::app_mutation_2pc_min_replica_count(int32_t app_max_
     if (node == partition_config.hp_primary) {
         replica_config.status = partition_status::PS_PRIMARY;
         return true;
-    } else if (std::find(partition_config.hp_secondaries.begin(),
-                         partition_config.hp_secondaries.end(),
-                         node) != partition_config.hp_secondaries.end()) {
+    }
+
+    if (utils::contains(partition_config.hp_secondaries, node)) {
         replica_config.status = partition_status::PS_SECONDARY;
         return true;
-    } else {
-        replica_config.status = partition_status::PS_INACTIVE;
-        return false;
     }
+
+    replica_config.status = partition_status::PS_INACTIVE;
+    return false;
 }
 
 bool replica_helper::load_servers_from_config(const std::string &section,

--- a/src/common/replication_other_types.h
+++ b/src/common/replication_other_types.h
@@ -57,9 +57,7 @@ inline bool is_primary(const partition_configuration &pc, const host_port &node)
 }
 inline bool is_secondary(const partition_configuration &pc, const host_port &node)
 {
-    return node &&
-           std::find(pc.hp_secondaries.begin(), pc.hp_secondaries.end(), node) !=
-               pc.hp_secondaries.end();
+    return node && utils::contains(pc.hp_secondaries, node);
 }
 inline bool is_member(const partition_configuration &pc, const host_port &node)
 {

--- a/src/meta/meta_data.h
+++ b/src/meta/meta_data.h
@@ -55,6 +55,7 @@
 #include "utils/error_code.h"
 #include "utils/extensible_object.h"
 #include "utils/fmt_logging.h"
+#include "utils/utils.h"
 
 namespace dsn {
 class message_ex;
@@ -269,13 +270,11 @@ struct partition_configuration_stateless
     std::vector<dsn::host_port> &hosts() { return config.hp_secondaries; }
     bool is_host(const host_port &node) const
     {
-        return std::find(config.hp_secondaries.begin(), config.hp_secondaries.end(), node) !=
-               config.hp_secondaries.end();
+        return utils::contains(config.hp_secondaries, node);
     }
     bool is_worker(const host_port &node) const
     {
-        return std::find(config.hp_last_drops.begin(), config.hp_last_drops.end(), node) !=
-               config.hp_last_drops.end();
+        return utils::contains(config.hp_last_drops, node);
     }
     bool is_member(const host_port &node) const { return is_host(node) || is_worker(node); }
 };

--- a/src/meta/test/balancer_validator.cpp
+++ b/src/meta/test/balancer_validator.cpp
@@ -238,8 +238,8 @@ void meta_service_test_app::balance_config_file()
         migration_list ml;
 
         // iterate 1000 times
-        for (int i = 0; i < 1000 && lb->balance({&apps, &nodes}, ml); ++i) {
-            LOG_DEBUG("the {}th round of balancer", i);
+        for (int j = 0; j < 1000 && lb->balance({&apps, &nodes}, ml); ++j) {
+            LOG_DEBUG("the {}th round of balancer", j);
             migration_check_and_apply(apps, nodes, ml, nullptr);
             lb->check({&apps, &nodes}, ml);
             LOG_DEBUG("balance checker operation count = {}", ml.size());

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -17,7 +17,6 @@
 
 #include <boost/lexical_cast.hpp>
 #include <string.h>
-#include <type_traits>
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
@@ -25,6 +24,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -58,6 +58,7 @@
 #include "utils/fail_point.h"
 #include "utils/filesystem.h"
 #include "utils/fmt_logging.h"
+#include "utils/utils.h"
 
 namespace dsn {
 namespace replication {
@@ -1033,8 +1034,7 @@ TEST_F(bulk_load_process_test, ingestion_one_succeed_update)
     ASSERT_EQ(pinfo.status, bulk_load_status::BLS_SUCCEED);
     ASSERT_TRUE(pinfo.ever_ingest_succeed);
     ASSERT_EQ(pinfo.host_ports.size(), 3);
-    ASSERT_EQ(std::find(pinfo.host_ports.begin(), pinfo.host_ports.end(), SECONDARY3_HP),
-              pinfo.host_ports.end());
+    ASSERT_FALSE(utils::contains(pinfo.host_ports, SECONDARY3_HP));
 }
 
 TEST_F(bulk_load_process_test, normal_succeed)

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -67,6 +67,7 @@
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
+#include "utils/utils.h"
 #include "utils/zlocks.h"
 
 DSN_DECLARE_int32(node_live_percentage_threshold_for_update);
@@ -277,8 +278,7 @@ void meta_service_test_app::update_configuration_test()
     state_validator validator1 = [pc0](const app_mapper &apps) {
         const dsn::partition_configuration *pc = get_config(apps, pc0.pid);
         return pc->ballot == pc0.ballot + 2 && pc->hp_secondaries.size() == 1 &&
-               std::find(pc0.hp_secondaries.begin(), pc0.hp_secondaries.end(), pc->hp_primary) !=
-                   pc0.hp_secondaries.end();
+               utils::contains(pc0.hp_secondaries, pc->hp_primary);
     };
 
     // test kickoff secondary

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -591,8 +591,8 @@ void replica_bulk_loader::download_sst_file(const std::string &remote_dir,
 
     // download next file
     if (file_index + 1 < _metadata.files.size()) {
-        const file_meta &f_meta = _metadata.files[file_index + 1];
-        _download_files_task[f_meta.name] =
+        const file_meta &next_f_meta = _metadata.files[file_index + 1];
+        _download_files_task[next_f_meta.name] =
             tasking::enqueue(LPC_BACKGROUND_BULK_LOAD,
                              tracker(),
                              std::bind(&replica_bulk_loader::download_sst_file,

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -395,7 +395,7 @@ private:
     void remove(configuration_update_request &proposal);
     void update_configuration_on_meta_server(config_type::type type,
                                              const host_port &node,
-                                             partition_configuration &newConfig);
+                                             partition_configuration &new_config);
     void
     on_update_configuration_on_meta_server_reply(error_code err,
                                                  dsn::message_ex *request,

--- a/src/replica/replica_context.cpp
+++ b/src/replica/replica_context.cpp
@@ -24,7 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include <algorithm>
 #include <atomic>
 #include <vector>
 
@@ -36,6 +35,7 @@
 #include "replica_stub.h"
 #include "runtime/rpc/rpc_address.h"
 #include "utils/error_code.h"
+#include "utils/utils.h"
 
 namespace dsn {
 namespace replication {
@@ -137,9 +137,7 @@ bool primary_context::check_exist(const ::dsn::host_port &node, partition_status
     case partition_status::PS_PRIMARY:
         return membership.hp_primary == node;
     case partition_status::PS_SECONDARY:
-        return std::find(membership.hp_secondaries.begin(),
-                         membership.hp_secondaries.end(),
-                         node) != membership.hp_secondaries.end();
+        return utils::contains(membership.hp_secondaries, node);
     case partition_status::PS_POTENTIAL_SECONDARY:
         return learners.find(node) != learners.end();
     default:

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1302,7 +1302,7 @@ void replica_stub::on_node_query_reply(error_code err,
 {
     LOG_INFO("query node partitions replied, err = {}", err);
 
-    zauto_lock l(_state_lock);
+    zauto_lock sl(_state_lock);
     _config_query_task = nullptr;
     if (err != ERR_OK) {
         if (_state == NS_Connecting) {
@@ -1347,7 +1347,7 @@ void replica_stub::on_node_query_reply(error_code err,
 
         replicas rs;
         {
-            zauto_read_lock l(_replicas_lock);
+            zauto_read_lock rl(_replicas_lock);
             rs = _replicas;
         }
 
@@ -1490,7 +1490,7 @@ void replica_stub::on_meta_server_disconnected()
 {
     LOG_INFO("meta server disconnected");
 
-    zauto_lock l(_state_lock);
+    zauto_lock sl(_state_lock);
     if (NS_Disconnected == _state)
         return;
 
@@ -1498,7 +1498,7 @@ void replica_stub::on_meta_server_disconnected()
 
     replicas rs;
     {
-        zauto_read_lock l(_replicas_lock);
+        zauto_read_lock rl(_replicas_lock);
         rs = _replicas;
     }
 

--- a/src/replica/storage/simple_kv/test/checker.cpp
+++ b/src/replica/storage/simple_kv/test/checker.cpp
@@ -217,16 +217,16 @@ bool test_checker::init(const std::string &name, const std::vector<service_app *
     const auto &nodes = dsn::service_engine::instance().get_all_nodes();
     for (const auto &node : nodes) {
         int id = node.second->id();
-        std::string name = node.second->full_name();
+        std::string addr = node.second->full_name();
         const auto &hp = node.second->rpc()->primary_host_port();
         int port = hp.port();
-        _node_to_host_port[name] = hp;
-        LOG_INFO("=== node_to_address[{}]={}", name, hp);
-        _address_to_node[port] = name;
-        LOG_INFO("=== address_to_node[{}]={}", port, name);
+        _node_to_host_port[addr] = hp;
+        LOG_INFO("=== node_to_address[{}]={}", addr, hp);
+        _address_to_node[port] = addr;
+        LOG_INFO("=== address_to_node[{}]={}", port, addr);
         if (id != port) {
-            _address_to_node[id] = name;
-            LOG_INFO("=== address_to_node[{}]={}", id, name);
+            _address_to_node[id] = addr;
+            LOG_INFO("=== address_to_node[{}]={}", id, addr);
         }
     }
 

--- a/src/replica/storage/simple_kv/test/common.cpp
+++ b/src/replica/storage/simple_kv/test/common.cpp
@@ -320,8 +320,9 @@ void parti_config::convert_from(const partition_configuration &c)
     pid = c.pid;
     ballot = c.ballot;
     primary = address_to_node(c.hp_primary);
-    for (auto &s : c.hp_secondaries)
+    for (auto &s : c.hp_secondaries) {
         secondaries.push_back(address_to_node(s));
+    }
     std::sort(secondaries.begin(), secondaries.end());
 }
 }

--- a/src/runtime/global_config.cpp
+++ b/src/runtime/global_config.cpp
@@ -39,6 +39,7 @@
 #include "utils/fmt_logging.h"
 #include "utils/string_conv.h"
 #include "utils/strings.h"
+#include "utils/utils.h"
 
 namespace dsn {
 
@@ -171,7 +172,7 @@ static bool build_server_network_confs(const char *section,
                 return false;
             }
         } else {
-            if (std::find(ports.begin(), ports.end(), port) == ports.end()) {
+            if (!utils::contains(ports, port)) {
                 // TODO(yingchun): return false or continue?
                 continue;
             }
@@ -327,8 +328,7 @@ bool service_spec::init_app_specs()
     service_app::register_factory<service_app>(mimic_app_role_name);
     if (enable_default_app_mimic) {
         std::string mimic_section_name("apps.mimic");
-        if (std::find(all_section_names.begin(), all_section_names.end(), mimic_section_name) ==
-            all_section_names.end()) {
+        if (!utils::contains(all_section_names, mimic_section_name)) {
             dsn_config_set("apps.mimic", "type", mimic_app_role_name, "");
             dsn_config_set("apps.mimic", "pools", "THREAD_POOL_DEFAULT", "");
             all_section_names.push_back("apps.mimic");

--- a/src/runtime/rpc/group_address.h
+++ b/src/runtime/rpc/group_address.h
@@ -120,7 +120,7 @@ inline bool rpc_group_address::add(rpc_address addr)
     CHECK_EQ_MSG(addr.type(), HOST_TYPE_IPV4, "rpc group address member must be ipv4");
 
     alw_t l(_lock);
-    if (_members.end() == std::find(_members.begin(), _members.end(), addr)) {
+    if (!utils::contains(_members, addr)) {
         _members.push_back(addr);
         return true;
     } else {
@@ -189,7 +189,7 @@ inline bool rpc_group_address::remove(rpc_address addr)
 inline bool rpc_group_address::contains(rpc_address addr) const
 {
     alr_t l(_lock);
-    return _members.end() != std::find(_members.begin(), _members.end(), addr);
+    return utils::contains(_members, addr);
 }
 
 inline int rpc_group_address::count() const

--- a/src/runtime/rpc/group_host_port.h
+++ b/src/runtime/rpc/group_host_port.h
@@ -150,7 +150,7 @@ inline bool rpc_group_host_port::add(const host_port &hp)
     CHECK_EQ_MSG(hp.type(), HOST_TYPE_IPV4, "rpc group host_port member must be ipv4");
 
     awl_t l(_lock);
-    if (_members.end() == std::find(_members.begin(), _members.end(), hp)) {
+    if (!utils::contains(_members, hp)) {
         _members.push_back(hp);
         return true;
     } else {
@@ -224,7 +224,7 @@ inline bool rpc_group_host_port::remove(const host_port &hp)
 inline bool rpc_group_host_port::contains(const host_port &hp) const
 {
     arl_t l(_lock);
-    return _members.end() != std::find(_members.begin(), _members.end(), hp);
+    return utils::contains(_members, hp);
 }
 
 inline int rpc_group_host_port::count() const

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -1275,17 +1275,17 @@ bool hash_scan(command_executor *e, shell_context *sc, arguments args)
                 stderr, "ERROR: get scanner failed: %s\n", sc->pg_client->get_error_string(ret));
         }
     } else {
-        std::string hash_key;
+        std::string got_hash_key;
         std::string sort_key;
         std::string value;
         pegasus::pegasus_client::internal_info info;
         while ((max_count <= 0 || count < max_count) &&
-               !(ret = scanner->next(hash_key, sort_key, value, &info))) {
+               !(ret = scanner->next(got_hash_key, sort_key, value, &info))) {
             if (!validate_filter(value_filter_type, value_filter_pattern, value))
                 continue;
             fprintf(file,
                     "\"%s\" : \"%s\"",
-                    pegasus::utils::c_escape_string(hash_key, sc->escape_all).c_str(),
+                    pegasus::utils::c_escape_string(got_hash_key, sc->escape_all).c_str(),
                     pegasus::utils::c_escape_string(sort_key, sc->escape_all).c_str());
             if (!options.no_value) {
                 fprintf(file,
@@ -1512,13 +1512,13 @@ bool full_scan(command_executor *e, shell_context *sc, arguments args)
         for (int i = 0; i < scanners.size(); i++) {
             if (partition >= 0 && partition != i)
                 continue;
-            std::string hash_key;
+            std::string got_hash_key;
             std::string sort_key;
             std::string value;
             pegasus::pegasus_client::internal_info info;
             pegasus::pegasus_client::pegasus_scanner *scanner = scanners[i];
             while ((max_count <= 0 || count < max_count) &&
-                   !(ret = scanner->next(hash_key, sort_key, value, &info))) {
+                   !(ret = scanner->next(got_hash_key, sort_key, value, &info))) {
                 if (sort_key_filter_type == pegasus::pegasus_client::FT_MATCH_EXACT &&
                     sort_key.length() > sort_key_filter_pattern.length())
                     continue;
@@ -1526,7 +1526,7 @@ bool full_scan(command_executor *e, shell_context *sc, arguments args)
                     continue;
                 fprintf(file,
                         "\"%s\" : \"%s\"",
-                        pegasus::utils::c_escape_string(hash_key, sc->escape_all).c_str(),
+                        pegasus::utils::c_escape_string(got_hash_key, sc->escape_all).c_str(),
                         pegasus::utils::c_escape_string(sort_key, sc->escape_all).c_str());
                 if (!options.no_value) {
                     fprintf(file,

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -311,8 +311,8 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
                                       status);
     }
 
-    std::map<dsn::host_port, dsn::replication::node_status::type> nodes;
-    auto r = sc->ddl_client->list_nodes(s, nodes);
+    std::map<dsn::host_port, dsn::replication::node_status::type> status_by_hp;
+    auto r = sc->ddl_client->list_nodes(s, status_by_hp);
     if (r != dsn::ERR_OK) {
         std::cout << "list nodes failed, error=" << r << std::endl;
         return true;
@@ -320,7 +320,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
 
     std::map<dsn::host_port, list_nodes_helper> tmp_map;
     int alive_node_count = 0;
-    for (auto &kv : nodes) {
+    for (auto &kv : status_by_hp) {
         if (kv.second == dsn::replication::node_status::NS_ALIVE)
             alive_node_count++;
         std::string status_str = dsn::enum_to_string(kv.second);
@@ -532,9 +532,9 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
     mtp.add(std::move(tp));
 
     dsn::utils::table_printer tp_count("summary");
-    tp_count.add_row_name_and_data("total_node_count", nodes.size());
+    tp_count.add_row_name_and_data("total_node_count", status_by_hp.size());
     tp_count.add_row_name_and_data("alive_node_count", alive_node_count);
-    tp_count.add_row_name_and_data("unalive_node_count", nodes.size() - alive_node_count);
+    tp_count.add_row_name_and_data("unalive_node_count", status_by_hp.size() - alive_node_count);
     mtp.add(std::move(tp_count));
 
     mtp.output(out, json ? tp_output_format::kJsonPretty : tp_output_format::kTabular);

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -368,10 +368,10 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
             auto f3 = count_map.find(p.hp_primary);
             if (f3 != count_map.end()) {
                 auto &sub_map = f3->second;
-                auto f3 = sub_map.find(p.pid.get_partition_index());
-                if (f3 != sub_map.end()) {
+                auto f4 = sub_map.find(p.pid.get_partition_index());
+                if (f4 != sub_map.end()) {
                     count_found = true;
-                    count_value = f3->second;
+                    count_value = f4->second;
                 }
             }
             std::stringstream oss;

--- a/src/utils/metrics.h
+++ b/src/utils/metrics.h
@@ -58,6 +58,7 @@
 #include "utils/string_conv.h"
 #include "utils/synchronize.h"
 #include "utils/time_utils.h"
+#include "utils/utils.h"
 
 namespace boost {
 namespace system {
@@ -469,7 +470,7 @@ struct metric_filters
         RETURN_MATCHED_WITH_EMPTY_WHITE_LIST(white_list);
         // Will use `bool operator==(const string &lhs, const char *rhs);` to compare each element
         // in `white_list` with `candidate`.
-        return std::find(white_list.begin(), white_list.end(), candidate) != white_list.end();
+        return utils::contains(white_list, candidate);
     }
 
     static inline bool match(const std::string &candidate,

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -104,5 +104,11 @@ std::set<T> get_intersection(const std::set<T> &set1, const std::set<T> &set2)
                           std::inserter(intersection, intersection.begin()));
     return intersection;
 }
+
+template <typename SeqContainer, typename Elem>
+bool contains(const SeqContainer &container, const Elem &elem)
+{
+    return std::find(container.begin(), container.end(), elem) != container.end();
+}
 } // namespace utils
 } // namespace dsn


### PR DESCRIPTION
This patch includes minor refactor works:
- Unify to use underscore naming (xxx_xxx_xxx) instead of camel case naming
- Redude if-else depth for pieces of code
- Rename some variable names because of variable shadowing
- Introduce `utils::contains` to simplify code