### PR TITLE
Feature: Supports node black list for load balance

### DIFF
--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -66,6 +66,12 @@ app_balance_policy::app_balance_policy(meta_service *svc) : load_balance_policy(
 void app_balance_policy::balance(bool checker, const meta_view *global_view, migration_list *list)
 {
     init(global_view, list);
+
+    if (_alive_nodes - _balancer_ignored_nodes.size() < 2){
+        LOG_WARNING("the nodes that could balance is less 2");
+        return;
+    }
+
     const app_mapper &apps = *_global_view->apps;
     if (!execute_balance(apps,
                          checker,
@@ -116,7 +122,7 @@ bool app_balance_policy::copy_secondary(const std::shared_ptr<app_state> &app, b
     int replicas_low = app->partition_count / _alive_nodes;
 
     std::unique_ptr<copy_replica_operation> operation = std::make_unique<copy_secondary_operation>(
-        app, apps, nodes, host_port_vec, host_port_id, replicas_low);
+        app, apps, nodes, host_port_vec, host_port_id, _balancer_ignored_nodes, replicas_low);
     return operation->start(_migration_result);
 }
 
@@ -126,16 +132,17 @@ copy_secondary_operation::copy_secondary_operation(
     node_mapper &nodes,
     const std::vector<dsn::host_port> &host_port_vec,
     const std::unordered_map<dsn::host_port, int> &host_port_id,
+    const std::set<dsn::host_port> balancer_ignored_nodes,
     int replicas_low)
-    : copy_replica_operation(app, apps, nodes, host_port_vec, host_port_id),
+    : copy_replica_operation(app, apps, nodes, host_port_vec, host_port_id, balancer_ignored_nodes),
       _replicas_low(replicas_low)
 {
 }
 
 bool copy_secondary_operation::can_continue()
 {
-    int id_min = *_ordered_host_port_ids.begin();
-    int id_max = *_ordered_host_port_ids.rbegin();
+    int id_min = find_min_load_nodes_without_blacklist();
+    int id_max = find_max_load_nodes_without_blacklist();
     if (_partition_counts[id_max] <= _replicas_low ||
         _partition_counts[id_max] - _partition_counts[id_min] <= 1) {
         LOG_INFO("{}: stop copy secondary coz it will be balanced later", _app->get_logname());
@@ -151,7 +158,7 @@ int copy_secondary_operation::get_partition_count(const node_state &ns) const
 
 bool copy_secondary_operation::can_select(gpid pid, migration_list *result)
 {
-    int id_max = *_ordered_host_port_ids.rbegin();
+    int id_max = find_max_load_nodes_without_blacklist();
     const node_state &max_ns = _nodes.at(_host_port_vec[id_max]);
     if (max_ns.served_as(pid) == partition_status::PS_PRIMARY) {
         LOG_DEBUG("{}: skip gpid({}.{}) coz it is primary",
@@ -170,7 +177,7 @@ bool copy_secondary_operation::can_select(gpid pid, migration_list *result)
         return false;
     }
 
-    int id_min = *_ordered_host_port_ids.begin();
+    int id_min = find_min_load_nodes_without_blacklist();
     const node_state &min_ns = _nodes.at(_host_port_vec[id_min]);
     if (min_ns.served_as(pid) != partition_status::PS_INACTIVE) {
         LOG_DEBUG("{}: skip gpid({}.{}) coz it is already a member on the target node",

--- a/src/meta/app_balance_policy.h
+++ b/src/meta/app_balance_policy.h
@@ -51,6 +51,11 @@ private:
     bool _balancer_in_turn;
     bool _only_primary_balancer;
     bool _only_move_primary;
+
+    std::set<dsn::host_port> ignored_nodes;
+
+    friend class meta_service_test_app;
+    friend class meta_service_test;
 };
 
 class copy_secondary_operation : public copy_replica_operation
@@ -61,6 +66,7 @@ public:
                              node_mapper &nodes,
                              const std::vector<dsn::host_port> &address_vec,
                              const std::unordered_map<dsn::host_port, int> &address_id,
+                             const std::set<dsn::host_port> balancer_ignored_nodes,
                              int replicas_low);
     ~copy_secondary_operation() = default;
 

--- a/src/meta/cluster_balance_policy.cpp
+++ b/src/meta/cluster_balance_policy.cpp
@@ -67,10 +67,20 @@ uint32_t get_partition_count(const node_state &ns, balance_type type, int32_t ap
     return (uint32_t)count;
 }
 
-uint32_t get_skew(const std::map<host_port, uint32_t> &count_map)
+uint32_t get_skew(const std::map<host_port, uint32_t> &count_map,
+                    std::set<dsn::host_port> balancer_ignored_nodes)
 {
     uint32_t min = UINT_MAX, max = 0;
+
+    for (auto iter : balancer_ignored_nodes){
+        LOG_INFO("get_skew the ignored node is {}", iter);
+    }
+
     for (const auto &kv : count_map) {
+        if (balancer_ignored_nodes.count(kv.first) != 0){
+            continue;
+        }
+        LOG_INFO("the  node is {}", kv.first);
         if (kv.second < min) {
             min = kv.second;
         }
@@ -83,17 +93,30 @@ uint32_t get_skew(const std::map<host_port, uint32_t> &count_map)
 
 void get_min_max_set(const std::map<host_port, uint32_t> &node_count_map,
                      /*out*/ std::set<host_port> &min_set,
-                     /*out*/ std::set<host_port> &max_set)
+                     /*out*/ std::set<host_port> &max_set,
+                     std::set<dsn::host_port> balancer_ignored_nodes)
 {
     std::multimap<uint32_t, host_port> count_multimap = utils::flip_map(node_count_map);
 
-    auto range = count_multimap.equal_range(count_multimap.begin()->first);
-    for (auto iter = range.first; iter != range.second; ++iter) {
+    auto iter = count_multimap.begin();
+    while (iter != count_multimap.end() && balancer_ignored_nodes.count(iter->second) != 0){
+        ++iter;
+    }
+    auto min_range = count_multimap.equal_range(iter->first);
+    for (auto iter = min_range.first; iter != min_range.second; ++iter) {
+        if (balancer_ignored_nodes.count(iter->second) != 0)
+            continue;
         min_set.insert(iter->second);
     }
-
-    range = count_multimap.equal_range(count_multimap.rbegin()->first);
-    for (auto iter = range.first; iter != range.second; ++iter) {
+    
+    auto iter_max = count_multimap.rbegin();
+    while (iter_max != count_multimap.rend() && balancer_ignored_nodes.count(iter_max->second) != 0){
+        --iter_max;
+    }
+    auto max_range = count_multimap.equal_range(iter_max->first);
+    for (auto iter = max_range.first; iter != max_range.second; ++iter){
+        if (balancer_ignored_nodes.count(iter->second) != 0)
+            continue;
         max_set.insert(iter->second);
     }
 }
@@ -105,6 +128,11 @@ void cluster_balance_policy::balance(bool checker,
                                      migration_list *list)
 {
     init(global_view, list);
+
+    if (_alive_nodes - _ignored_nodes.size() < 2){
+        LOG_WARNING("the nodes that could balance is less 2");
+        return;
+    }
 
     if (!execute_balance(*_global_view->apps,
                          false, /* balance_checker */
@@ -198,8 +226,8 @@ bool cluster_balance_policy::get_cluster_migration_info(
         if (!get_app_migration_info(app, nodes, type, info)) {
             return false;
         }
+        cluster_info.apps_skew[kv.first] = get_skew(info.replicas_count, _balancer_ignored_nodes);
         cluster_info.apps_info.emplace(kv.first, std::move(info));
-        cluster_info.apps_skew[kv.first] = get_skew(info.replicas_count);
     }
 
     for (const auto &kv : nodes) {
@@ -282,7 +310,7 @@ bool cluster_balance_policy::get_next_move(const cluster_migration_info &cluster
         return false;
     }
 
-    auto server_skew = get_skew(cluster_info.replicas_count);
+    auto server_skew = get_skew(cluster_info.replicas_count, _balancer_ignored_nodes);
     if (max_app_skew <= 1 && server_skew <= 1) {
         LOG_INFO("every app is balanced and the cluster as a whole is balanced");
         return false;
@@ -295,7 +323,7 @@ bool cluster_balance_policy::get_next_move(const cluster_migration_info &cluster
      **/
     std::set<host_port> cluster_min_count_nodes;
     std::set<host_port> cluster_max_count_nodes;
-    get_min_max_set(cluster_info.replicas_count, cluster_min_count_nodes, cluster_max_count_nodes);
+    get_min_max_set(cluster_info.replicas_count, cluster_min_count_nodes, cluster_max_count_nodes, _balancer_ignored_nodes);
 
     bool found = false;
     auto app_range = app_skew_multimap.equal_range(max_app_skew);
@@ -308,7 +336,7 @@ bool cluster_balance_policy::get_next_move(const cluster_migration_info &cluster
         auto app_map = it->second.replicas_count;
         std::set<host_port> app_min_count_nodes;
         std::set<host_port> app_max_count_nodes;
-        get_min_max_set(app_map, app_min_count_nodes, app_max_count_nodes);
+        get_min_max_set(app_map, app_min_count_nodes, app_max_count_nodes, _balancer_ignored_nodes);
 
         /**
          * Compute the intersection of the replica servers most loaded for the app
@@ -327,7 +355,17 @@ bool cluster_balance_policy::get_next_move(const cluster_migration_info &cluster
          * cluster skew the same or make it worse while keeping the app balanced.
          **/
         std::multimap<uint32_t, host_port> app_count_multimap = utils::flip_map(app_map);
-        if (app_count_multimap.rbegin()->first <= app_count_multimap.begin()->first + 1 &&
+
+        auto app_min_partition = app_count_multimap.begin();
+        while (app_min_partition != app_count_multimap.end() && is_ignored_node(app_min_partition->second)){
+            ++app_min_partition;
+        }
+        auto app_max_partition = app_count_multimap.rbegin();
+        while (app_max_partition != app_count_multimap.rend() && is_ignored_node(app_max_partition->second)){
+            --app_max_partition;
+        }
+
+        if (app_max_partition->first <= app_min_partition->first + 1 &&
             (app_cluster_min_set.empty() || app_cluster_max_set.empty())) {
             LOG_INFO("do not move replicas of a balanced app({}) if the least (most) loaded "
                      "servers overall do not intersect the servers hosting the least (most) "
@@ -554,7 +592,7 @@ bool cluster_balance_policy::apply_move(const move_info &move,
         move.pid, generate_balancer_request(*_global_view->apps, pc, move.type, source, target));
     selected_pids.insert(move.pid);
 
-    cluster_info.apps_skew[app_id] = get_skew(app_info.replicas_count);
+    cluster_info.apps_skew[app_id] = get_skew(app_info.replicas_count, _balancer_ignored_nodes);
     cluster_info.apps_info[app_id] = app_info;
     cluster_info.nodes_info[source] = node_source;
     cluster_info.nodes_info[target] = node_target;

--- a/src/meta/cluster_balance_policy.h
+++ b/src/meta/cluster_balance_policy.h
@@ -39,10 +39,12 @@ namespace replication {
 class meta_service;
 
 uint32_t get_partition_count(const node_state &ns, balance_type type, int32_t app_id);
-uint32_t get_skew(const std::map<host_port, uint32_t> &count_map);
+uint32_t get_skew(const std::map<host_port, uint32_t> &count_map, std::set<dsn::host_port> balancer_ignored_nodes);
 void get_min_max_set(const std::map<host_port, uint32_t> &node_count_map,
                      /*out*/ std::set<host_port> &min_set,
-                     /*out*/ std::set<host_port> &max_set);
+                     /*out*/ std::set<host_port> &max_set,
+                     std::set<dsn::host_port> balancer_ignored_nodes);     
+
 
 class cluster_balance_policy : public load_balance_policy
 {
@@ -58,6 +60,7 @@ private:
     struct cluster_migration_info;
     struct move_info;
     struct node_migration_info;
+    std::set<dsn::host_port> _ignored_nodes;
 
     bool cluster_replica_balance(const meta_view *global_view,
                                  const balance_type type,
@@ -174,6 +177,8 @@ private:
         balance_type type;
     };
 
+    friend class meta_service_test_app;
+    friend class meta_service_test;
     FRIEND_TEST(cluster_balance_policy, app_migration_info);
     FRIEND_TEST(cluster_balance_policy, node_migration_info);
     FRIEND_TEST(cluster_balance_policy, get_skew);

--- a/src/meta/greedy_load_balancer.h
+++ b/src/meta/greedy_load_balancer.h
@@ -78,6 +78,8 @@ private:
     std::unique_ptr<load_balance_policy> _cluster_balance_policy;
 
     std::unique_ptr<command_deregister> _get_balance_operation_count;
+    friend class meta_service_test_app;
+    friend class meta_service_test;
 
 private:
     void greedy_balancer(bool balance_checker);

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -196,8 +196,11 @@ generate_balancer_request(const app_mapper &apps,
     return std::make_shared<configuration_balancer_request>(std::move(result));
 }
 
+std::set<app_id> load_balance_policy::_balancer_ignored_apps;
+std::set<dsn::host_port> load_balance_policy::_balancer_ignored_nodes;
+
 load_balance_policy::load_balance_policy(meta_service *svc)
-    : _svc(svc), _ctrl_balancer_ignored_apps(nullptr)
+    : _svc(svc), _ctrl_balancer_ignored_apps(nullptr), _ctrl_balancer_ignored_nodes(nullptr)
 {
     static std::once_flag flag;
     std::call_once(flag, [&]() {
@@ -208,6 +211,13 @@ load_balance_policy::load_balance_policy(meta_service *svc)
             [this](const std::vector<std::string> &args) {
                 return remote_command_balancer_ignored_app_ids(args);
             });
+        _ctrl_balancer_ignored_nodes = dsn::command_manager::instance().register_single_command(
+            "meta.lb.ignored_nodes_list",
+            "meta.lb.ignored_nodes_list <get|set|clear> [node_addr1,nodes_addr2..]",
+            "get, set and clear balancer ignored_node_list",
+            [this](const std::vector<std::string> &args){
+                return remote_command_balancer_ignored_node_addrs(args);
+            }); 
     });
 }
 
@@ -259,7 +269,7 @@ bool load_balance_policy::copy_primary(const std::shared_ptr<app_state> &app,
     int replicas_low = app->partition_count / _alive_nodes;
 
     auto operation = std::make_unique<copy_primary_operation>(
-        app, apps, nodes, host_port_vec, host_port_id, still_have_less_than_average, replicas_low);
+        app, apps, nodes, host_port_vec, host_port_id,_balancer_ignored_nodes,still_have_less_than_average, replicas_low);
     return operation->start(_migration_result);
 }
 
@@ -490,6 +500,84 @@ bool load_balance_policy::is_ignored_app(app_id app_id)
     return _balancer_ignored_apps.find(app_id) != _balancer_ignored_apps.end();
 }
 
+std::string load_balance_policy::remote_command_balancer_ignored_node_addrs(const std::vector<std::string> &args)
+{
+    static const std::string invalid_arguments_message("invalid arguments");
+    nlohmann::json info;
+    do {
+        if (args.empty()) {
+            break;
+        }
+        if (args[0] == "set") {
+            return set_balancer_ignored_node_addrs(args);
+        }else if (args[0] == "get") {
+            return get_balancer_ignored_node_addrs();
+        }else if (args[0] == "clear") {
+            return clear_balancer_ignored_node_addrs();
+        }
+    } while (false);
+    info["error"] = invalid_arguments_message;
+    return info.dump(2);
+}
+
+std::string load_balance_policy::set_balancer_ignored_node_addrs(const std::vector<std::string> &args)
+{
+    nlohmann::json info;
+    info["error"] = "invalid argument";
+    if (args.size() != 2) {
+        return info.dump(2);
+    }
+
+    std::vector<std::string> ip_ports;
+    dsn::utils::split_args(args[1].c_str(), ip_ports, ',');
+    if (ip_ports.empty()) {
+        return info.dump(2);
+    }
+
+    std::set<dsn::host_port> addr_list;
+    for (const std::string &ip_port_str : ip_ports) {
+        const auto hp = host_port::from_string(ip_port_str);
+        if (!hp) {
+            return info.dump(2);
+        }
+        addr_list.insert(hp);
+    }
+
+    {
+        dsn::zauto_write_lock l(_balancer_ignored_nodes_lock);
+        _balancer_ignored_nodes = std::move(addr_list);
+    }
+    info["error"] = "ok";
+    return info.dump(2);
+}
+
+std::string load_balance_policy::get_balancer_ignored_node_addrs()
+{
+    nlohmann::json data;
+    {
+        dsn::zauto_read_lock l(_balancer_ignored_nodes_lock);
+        data["ignored_node_addr_list"] = fmt::format("{}", fmt::join(_balancer_ignored_nodes, ","));
+    }
+    return data.dump(2);
+}
+
+std::string load_balance_policy::clear_balancer_ignored_node_addrs()
+{
+    {
+       dsn::zauto_write_lock l(_balancer_ignored_nodes_lock);
+        _balancer_ignored_nodes.clear(); 
+    }
+    nlohmann::json info;
+    info["error"] = "ok";
+    return info.dump(2);
+}
+
+bool load_balance_policy::is_ignored_node(dsn::host_port hp)
+{
+    dsn::zauto_read_lock l(_balancer_ignored_nodes_lock);
+    return _balancer_ignored_nodes.count(hp) != 0;
+}
+
 void load_balance_policy::number_nodes(const node_mapper &nodes)
 {
     int current_id = 1;
@@ -643,12 +731,14 @@ copy_replica_operation::copy_replica_operation(
     const app_mapper &apps,
     node_mapper &nodes,
     const std::vector<dsn::host_port> &host_port_vec,
-    const std::unordered_map<dsn::host_port, int> &host_port_id)
+    const std::unordered_map<dsn::host_port, int> &host_port_id,
+    const std::set<dsn::host_port> balancer_ignored_nodes)
     : _app(app),
       _apps(apps),
       _nodes(nodes),
       _host_port_vec(host_port_vec),
-      _host_port_id(host_port_id)
+      _host_port_id(host_port_id),
+      _balancer_ignored_nodes(balancer_ignored_nodes)
 {
 }
 
@@ -678,7 +768,7 @@ bool copy_replica_operation::start(migration_list *result)
 
 const partition_set *copy_replica_operation::get_all_partitions()
 {
-    int id_max = *_ordered_host_port_ids.rbegin();
+    int id_max = find_max_load_nodes_without_blacklist();
     const node_state &ns = _nodes.find(_host_port_vec[id_max])->second;
     const partition_set *partitions = ns.partitions(_app->app_id, only_copy_primary());
     return partitions;
@@ -687,7 +777,7 @@ const partition_set *copy_replica_operation::get_all_partitions()
 gpid copy_replica_operation::select_max_load_gpid(const partition_set *partitions,
                                                   migration_list *result)
 {
-    int id_max = *_ordered_host_port_ids.rbegin();
+    int id_max = find_max_load_nodes_without_blacklist();
     const auto &load_on_max = _node_loads.at(_host_port_vec[id_max]);
 
     gpid selected_pid(-1, -1);
@@ -709,8 +799,8 @@ gpid copy_replica_operation::select_max_load_gpid(const partition_set *partition
 
 void copy_replica_operation::copy_once(gpid selected_pid, migration_list *result)
 {
-    const auto &from = _host_port_vec[*_ordered_host_port_ids.rbegin()];
-    const auto &to = _host_port_vec[*_ordered_host_port_ids.begin()];
+    const auto &from = _host_port_vec[find_max_load_nodes_without_blacklist()];
+    const auto &to = _host_port_vec[find_min_load_nodes_without_blacklist()];
 
     auto pc = _app->partitions[selected_pid.get_partition_index()];
     auto request = generate_balancer_request(_apps, pc, get_balance_type(), from, to);
@@ -719,13 +809,13 @@ void copy_replica_operation::copy_once(gpid selected_pid, migration_list *result
 
 void copy_replica_operation::update_ordered_host_port_ids()
 {
-    int id_min = *_ordered_host_port_ids.begin();
-    int id_max = *_ordered_host_port_ids.rbegin();
+    int id_min = find_min_load_nodes_without_blacklist();
+    int id_max = find_max_load_nodes_without_blacklist();
     --_partition_counts[id_max];
     ++_partition_counts[id_min];
 
-    _ordered_host_port_ids.erase(_ordered_host_port_ids.begin());
-    _ordered_host_port_ids.erase(--_ordered_host_port_ids.end());
+    earse_max_node_without_blacknode();
+    earse_min_node_without_blacknode();
 
     _ordered_host_port_ids.insert(id_max);
     _ordered_host_port_ids.insert(id_min);
@@ -750,13 +840,63 @@ void copy_replica_operation::init_ordered_host_port_ids()
         ordered_queue.insert(id);
     }
     _ordered_host_port_ids.swap(ordered_queue);
+    for (auto iter : _balancer_ignored_nodes){
+        if (_host_port_id.count(iter) == 0)
+            continue;
+        _balancer_ignored_nodes_id.insert(_host_port_id.at(iter));
+        LOG_INFO("the ignored node id is {}", _host_port_id.at(iter));
+    }
+}
+
+
+int copy_replica_operation::find_max_load_nodes_without_blacklist()
+{
+    auto iter = --_ordered_host_port_ids.end();
+    while (_balancer_ignored_nodes_id.count(*iter) != 0)
+    {
+        --iter;
+    }
+    return *iter;
+}
+
+int copy_replica_operation::find_min_load_nodes_without_blacklist()
+{
+    auto iter = _ordered_host_port_ids.begin();
+    while (_balancer_ignored_nodes_id.count(*iter) != 0)
+    {
+        iter++;
+    }
+    return *iter;
+}
+
+void copy_replica_operation::earse_max_node_without_blacknode(){
+    auto iter = --_ordered_host_port_ids.end();
+    while (_balancer_ignored_nodes_id.count(*iter) != 0)
+    {
+        --iter;
+    }
+    _ordered_host_port_ids.erase(iter);
+}
+
+void copy_replica_operation::earse_min_node_without_blacknode(){
+    auto iter = _ordered_host_port_ids.begin();
+    while (_balancer_ignored_nodes_id.count(*iter) != 0)
+    {
+        iter++;
+    }
+    _ordered_host_port_ids.erase(iter);
+}
+
+bool copy_replica_operation::is_ignored_node(dsn::host_port hp)
+{
+    return _balancer_ignored_nodes.count(hp) != 0;
 }
 
 gpid copy_replica_operation::select_partition(migration_list *result)
 {
     const partition_set *partitions = get_all_partitions();
 
-    int id_max = *_ordered_host_port_ids.rbegin();
+    int id_max = find_max_load_nodes_without_blacklist();
     const node_state &ns = _nodes.find(_host_port_vec[id_max])->second;
     CHECK(partitions != nullptr && !partitions->empty(),
           "max load({}) shouldn't empty",
@@ -771,9 +911,10 @@ copy_primary_operation::copy_primary_operation(
     node_mapper &nodes,
     const std::vector<dsn::host_port> &host_port_vec,
     const std::unordered_map<dsn::host_port, int> &host_port_id,
+    const std::set<dsn::host_port> balancer_ignored_nodes,
     bool have_lower_than_average,
     int replicas_low)
-    : copy_replica_operation(app, apps, nodes, host_port_vec, host_port_id)
+    : copy_replica_operation(app, apps, nodes, host_port_vec, host_port_id, balancer_ignored_nodes)
 {
     _have_lower_than_average = have_lower_than_average;
     _replicas_low = replicas_low;
@@ -791,14 +932,14 @@ bool copy_primary_operation::can_select(gpid pid, migration_list *result)
 
 bool copy_primary_operation::can_continue()
 {
-    int id_min = *_ordered_host_port_ids.begin();
+    int id_min = find_min_load_nodes_without_blacklist();
+    int id_max = find_max_load_nodes_without_blacklist();
     if (_have_lower_than_average && _partition_counts[id_min] >= _replicas_low) {
         LOG_INFO("{}: stop the copy due to primaries on all nodes will reach low later.",
                  _app->get_logname());
         return false;
     }
 
-    int id_max = *_ordered_host_port_ids.rbegin();
     if (!_have_lower_than_average && _partition_counts[id_max] - _partition_counts[id_min] <= 1) {
         LOG_INFO("{}: stop the copy due to the primary will be balanced later.",
                  _app->get_logname());

--- a/src/meta/load_balance_policy.h
+++ b/src/meta/load_balance_policy.h
@@ -84,12 +84,11 @@ public:
     virtual ~load_balance_policy();
 
     virtual void balance(bool checker, const meta_view *global_view, migration_list *list) = 0;
-    bool is_ignored_app(app_id app_id);
-    bool is_ignored_node(dsn::host_port hp);
 
 protected:
     void init(const meta_view *global_view, migration_list *list);
-
+    bool is_ignored_app(app_id app_id);
+    bool is_ignored_node(dsn::host_port hp);
     bool execute_balance(
         const app_mapper &apps,
         bool balance_checker,

--- a/src/meta/load_balance_policy.h
+++ b/src/meta/load_balance_policy.h
@@ -84,10 +84,11 @@ public:
     virtual ~load_balance_policy();
 
     virtual void balance(bool checker, const meta_view *global_view, migration_list *list) = 0;
+    bool is_ignored_app(app_id app_id);
+    bool is_ignored_node(dsn::host_port hp);
 
 protected:
     void init(const meta_view *global_view, migration_list *list);
-    bool is_ignored_app(app_id app_id);
 
     bool execute_balance(
         const app_mapper &apps,
@@ -110,9 +111,14 @@ protected:
 
     // the app set which won't be re-balanced
     dsn::zrwlock_nr _balancer_ignored_apps_lock; // {
-    std::set<app_id> _balancer_ignored_apps;
+    static std::set<app_id> _balancer_ignored_apps;
     // }
     std::unique_ptr<command_deregister> _ctrl_balancer_ignored_apps;
+
+    // the node set which won't be re-balanced
+    dsn::zrwlock_nr _balancer_ignored_nodes_lock;
+    static std::set<dsn::host_port> _balancer_ignored_nodes;
+    std::unique_ptr<command_deregister> _ctrl_balancer_ignored_nodes;
 
 private:
     void start_moving_primary(const std::shared_ptr<app_state> &app,
@@ -136,6 +142,13 @@ private:
     std::string get_balancer_ignored_app_ids();
     std::string clear_balancer_ignored_app_ids();
 
+    std::string remote_command_balancer_ignored_node_addrs(const std::vector<std::string> &args);
+    std::string set_balancer_ignored_node_addrs(const std::vector<std::string> &args);
+    std::string get_balancer_ignored_node_addrs();
+    std::string clear_balancer_ignored_node_addrs();
+
+    friend class meta_service_test_app;
+    friend class meta_service_test;
     FRIEND_TEST(cluster_balance_policy, calc_potential_moving);
 };
 
@@ -245,7 +258,8 @@ public:
                            const app_mapper &apps,
                            node_mapper &nodes,
                            const std::vector<dsn::host_port> &host_port_vec,
-                           const std::unordered_map<dsn::host_port, int> &host_port_id);
+                           const std::unordered_map<dsn::host_port, int> &host_port_id,
+                           const std::set<dsn::host_port> balancer_ignored_nodes);
     virtual ~copy_replica_operation() = default;
 
     bool start(migration_list *result);
@@ -253,6 +267,12 @@ public:
 protected:
     void init_ordered_host_port_ids();
     virtual int get_partition_count(const node_state &ns) const = 0;
+    bool is_ignored_node(dsn::host_port hp);
+    void update_ignored_nodes_order();
+    int find_max_load_nodes_without_blacklist();
+    int find_min_load_nodes_without_blacklist();
+    void earse_max_node_without_blacknode();
+    void earse_min_node_without_blacknode();
 
     gpid select_partition(migration_list *result);
     const partition_set *get_all_partitions();
@@ -272,6 +292,8 @@ protected:
     const std::unordered_map<dsn::host_port, int> &_host_port_id;
     std::unordered_map<dsn::host_port, disk_load> _node_loads;
     std::vector<int> _partition_counts;
+    const std::set<dsn::host_port> _balancer_ignored_nodes;
+    std::set<int> _balancer_ignored_nodes_id;
 
     FRIEND_TEST(copy_primary_operation, misc);
     FRIEND_TEST(copy_replica_operation, get_all_partitions);
@@ -285,6 +307,7 @@ public:
                            node_mapper &nodes,
                            const std::vector<dsn::host_port> &host_port_vec,
                            const std::unordered_map<dsn::host_port, int> &host_port_id,
+                           const std::set<dsn::host_port> balancer_ignored_nodes,
                            bool have_lower_than_average,
                            int replicas_low);
     ~copy_primary_operation() = default;

--- a/src/meta/test/cluster_balance_policy_test.cpp
+++ b/src/meta/test/cluster_balance_policy_test.cpp
@@ -89,8 +89,11 @@ TEST(cluster_balance_policy, get_skew)
         {host_port("localhost", 10086), 3},
         {host_port("localhost", 10087), 5},
     };
+    std::set<dsn::host_port> balancer_ignored_nodes;
 
-    ASSERT_EQ(get_skew(count_map), count_map.rbegin()->second - count_map.begin()->second);
+    ASSERT_EQ(get_skew(count_map, balancer_ignored_nodes), count_map.rbegin()->second - count_map.begin()->second);
+    balancer_ignored_nodes.insert(host_port("localhost", 10085));
+    ASSERT_EQ(get_skew(count_map, balancer_ignored_nodes), 2);
 }
 
 TEST(cluster_balance_policy, get_partition_count)
@@ -194,16 +197,29 @@ TEST(cluster_balance_policy, get_node_migration_info)
 TEST(cluster_balance_policy, get_min_max_set)
 {
     std::map<host_port, uint32_t> node_count_map;
+    std::set<dsn::host_port> balancer_ignored_nodes;
     node_count_map.emplace(host_port("localhost", 10081), 1);
     node_count_map.emplace(host_port("localhost", 10082), 3);
     node_count_map.emplace(host_port("localhost", 10083), 5);
     node_count_map.emplace(host_port("localhost", 10084), 5);
 
     std::set<host_port> min_set, max_set;
-    get_min_max_set(node_count_map, min_set, max_set);
+    get_min_max_set(node_count_map, min_set, max_set, balancer_ignored_nodes);
 
     ASSERT_EQ(min_set.size(), 1);
     ASSERT_EQ(*min_set.begin(), host_port("localhost", 10081));
+    ASSERT_EQ(max_set.size(), 2);
+    ASSERT_EQ(*max_set.begin(), host_port("localhost", 10083));
+    ASSERT_EQ(*max_set.rbegin(), host_port("localhost", 10084));
+
+    node_count_map.emplace(host_port("localhost", 10085), 6);
+    balancer_ignored_nodes.insert(host_port("localhost", 10081));
+    balancer_ignored_nodes.insert(host_port("localhost", 10085));
+    min_set.clear();
+    max_set.clear();
+    get_min_max_set(node_count_map, min_set, max_set, balancer_ignored_nodes);
+    ASSERT_EQ(min_set.size(), 1);
+    ASSERT_EQ(*min_set.begin(), host_port("localhost", 10082));
     ASSERT_EQ(max_set.size(), 2);
     ASSERT_EQ(*max_set.begin(), host_port("localhost", 10083));
     ASSERT_EQ(*max_set.rbegin(), host_port("localhost", 10084));

--- a/src/meta/test/copy_replica_operation_test.cpp
+++ b/src/meta/test/copy_replica_operation_test.cpp
@@ -68,7 +68,8 @@ TEST(copy_primary_operation, misc)
     host_port_id[hp1] = 0;
     host_port_id[hp2] = 1;
     host_port_id[hp3] = 2;
-    copy_primary_operation op(app, apps, nodes, host_port_vec, host_port_id, false, 0);
+    std::set<dsn::host_port> balancer_ignored_nodes;
+    copy_primary_operation op(app, apps, nodes, host_port_vec, host_port_id, balancer_ignored_nodes, false, 0);
 
     /**
      * Test init_ordered_host_port_ids
@@ -168,7 +169,8 @@ TEST(copy_primary_operation, can_select)
     node_mapper nodes;
     std::vector<dsn::host_port> host_port_vec;
     std::unordered_map<dsn::host_port, int> host_port_id;
-    copy_primary_operation op(nullptr, apps, nodes, host_port_vec, host_port_id, false, false);
+    std::set<dsn::host_port> balancer_ignored_nodes;
+    copy_primary_operation op(nullptr, apps, nodes, host_port_vec, host_port_id, balancer_ignored_nodes, false, false);
 
     gpid cannot_select_gpid(1, 1);
     gpid can_select_gpid(1, 2);
@@ -185,7 +187,8 @@ TEST(copy_primary_operation, only_copy_primary)
     node_mapper nodes;
     std::vector<dsn::host_port> host_port_vec;
     std::unordered_map<dsn::host_port, int> host_port_id;
-    copy_primary_operation op(nullptr, apps, nodes, host_port_vec, host_port_id, false, false);
+    std::set<dsn::host_port> balancer_ignored_nodes;
+    copy_primary_operation op(nullptr, apps, nodes, host_port_vec, host_port_id, balancer_ignored_nodes, false, false);
 
     ASSERT_TRUE(op.only_copy_primary());
 }
@@ -221,7 +224,8 @@ TEST(copy_secondary_operation, misc)
     host_port_id[hp1] = 0;
     host_port_id[hp2] = 1;
     host_port_id[hp3] = 2;
-    copy_secondary_operation op(app, apps, nodes, host_port_vec, host_port_id, 0);
+    std::set<dsn::host_port> balancer_ignored_nodes;
+    copy_secondary_operation op(app, apps, nodes, host_port_vec, host_port_id, balancer_ignored_nodes, 0);
     op.init_ordered_host_port_ids();
 
     /**

--- a/src/meta/test/main.cpp
+++ b/src/meta/test/main.cpp
@@ -83,6 +83,10 @@ TEST(meta, adjust_dropped_size) { g_app->adjust_dropped_size(); }
 
 TEST(meta, app_envs_basic_test) { g_app->app_envs_basic_test(); }
 
+TEST(meta, app_balancer_nodes_blacklist_test) {g_app->app_balancer_nodes_blacklist_test();}
+
+TEST(meta, cluster_balancer_nodes_blacklist_test) {g_app->cluster_balancer_nodes_blacklist_test();}
+
 dsn::error_code meta_service_test_app::start(const std::vector<std::string> &args)
 {
     if (FLAGS_random_seed == 0) {

--- a/src/meta/test/meta_service_test_app.h
+++ b/src/meta/test/meta_service_test_app.h
@@ -131,6 +131,8 @@ public:
     void apply_balancer_test();
     void cannot_run_balancer_test();
     void construct_apps_test();
+    void app_balancer_nodes_blacklist_test();
+    void cluster_balancer_nodes_blacklist_test();
 
     void json_compacity();
 

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -44,6 +44,8 @@
 #include "dummy_balancer.h"
 #include "gtest/gtest.h"
 #include "meta/greedy_load_balancer.h"
+#include "meta/app_balance_policy.h"
+#include "meta/cluster_balance_policy.h"
 #include "meta/meta_data.h"
 #include "meta/meta_server_failure_detector.h"
 #include "meta/meta_service.h"
@@ -545,6 +547,147 @@ void meta_service_test_app::cannot_run_balancer_test()
 
     // recover original FLAGS_min_live_node_count_for_unfreeze
     FLAGS_min_live_node_count_for_unfreeze = reserved_min_live_node_count_for_unfreeze;
+}
+
+void meta_service_test_app::app_balancer_nodes_blacklist_test()
+{
+    app_mapper apps;
+    node_mapper nodes;
+    nodes_fs_manager manager;
+    srand((unsigned)time(NULL)); 
+    std::vector<dsn::host_port> node_list;
+    generate_node_list(node_list, 5, 10);
+
+    int disk_on_node = 5;
+
+    generate_apps(apps, node_list, 5, disk_on_node, std::pair<uint32_t, uint32_t>(32, 128), true);
+    generate_node_mapper(nodes, apps, node_list);
+    generate_node_fs_manager(apps, nodes, manager, disk_on_node);
+
+    // set ignored nodes
+    std::string ignored_nodeslist = "localhost:1,localhost:2";
+    std::vector<std::string> args = {"set"};
+    args.emplace_back(ignored_nodeslist);
+    
+    
+    LOG_INFO("the ignored nodes is {}", ignored_nodeslist);
+
+    for (const auto &iter : nodes) {
+        LOG_INFO("node({}) have {} primaries, {} partitions",
+                 iter.first,
+                 iter.second.primary_count(),
+                 iter.second.partition_count());
+    }
+    greedy_load_balancer greedy_lb(nullptr);
+    greedy_lb._app_balance_policy.reset();
+    
+    std::unique_ptr<load_balance_policy> _app_balance(new app_balance_policy(nullptr));
+    _app_balance->remote_command_balancer_ignored_node_addrs(args);
+    //_app_balance->clear_balancer_ignored_node_addrs();
+    greedy_lb._app_balance_policy.reset(_app_balance.release());
+    
+    migration_list ml;
+    // iterate 100 times balance
+
+    for (int i = 0; i < 1000 && greedy_lb.balance({&apps, &nodes}, ml); ++i) {
+        LOG_DEBUG("the {}th round of balancer", i);
+        migration_check_and_apply(apps, nodes, ml, &manager);
+        for (const auto &ml_pair : ml) {
+            // If the migration_list does not contain the ignored app's gpid, it indicates that the
+            // app blacklist is effective.
+            for(configuration_proposal_action it : ml_pair.second->action_list){
+                if(it.type == 2 || it.type == 5)
+                    continue;
+                CHECK_TRUE(greedy_lb._app_balance_policy->_balancer_ignored_nodes.count(it.hp_node) == 0);
+            }
+            
+        }
+        greedy_lb.check({&apps, &nodes}, ml);
+        LOG_DEBUG("balance checker operation count = {}", ml.size());
+    }
+
+    for (const auto &iter : nodes) {
+        LOG_INFO("node({}) have {} primaries, {} partitions",
+                 iter.first,
+                 iter.second.primary_count(),
+                 iter.second.partition_count());
+    }
+}
+
+void meta_service_test_app::cluster_balancer_nodes_blacklist_test()
+{
+    app_mapper apps;
+    node_mapper nodes;
+    nodes_fs_manager manager;
+    srand((unsigned)time(NULL)); 
+    std::vector<dsn::host_port> node_list;
+    generate_node_list(node_list, 5,10);
+
+    int disk_on_node = 5;
+
+    generate_apps(apps, node_list, 5, disk_on_node, std::pair<uint32_t, uint32_t>(32, 128), true);
+    generate_node_mapper(nodes, apps, node_list);
+    generate_node_fs_manager(apps, nodes, manager, disk_on_node);
+
+    // set ignored nodes
+    std::string ignored_nodeslist = "localhost:2";
+    std::vector<std::string> args = {"set"};
+    args.emplace_back(ignored_nodeslist);
+    
+    
+    LOG_INFO("the ignored nodes is {}", ignored_nodeslist);
+
+    for (const auto &iter : nodes) {
+        LOG_INFO("node({}) have {} primaries, {} partitions",
+                 iter.first,
+                 iter.second.primary_count(),
+                 iter.second.partition_count());
+    }
+
+    greedy_load_balancer greedy_lb(nullptr);
+    greedy_lb._cluster_balance_policy.reset();
+    std::unique_ptr<load_balance_policy> _cluster_balance(new cluster_balance_policy(nullptr));
+    _cluster_balance->remote_command_balancer_ignored_node_addrs(args);
+    //_cluster_balance->clear_balancer_ignored_node_addrs();
+    greedy_lb._cluster_balance_policy.reset(_cluster_balance.release());
+    
+    update_flag("balance_cluster", "true");
+
+    migration_list ml;
+    // iterate 100 times balance
+    for (int i = 0; i < 10000 && greedy_lb.balance({&apps, &nodes}, ml); ++i) {
+        LOG_DEBUG("the {} th round of balancer", i);
+        migration_check_and_apply(apps, nodes, ml, &manager);
+        for (const auto &ml_pair : ml) {
+            // If the migration_list does not contain the ignored app's gpid, it indicates that the
+            // app blacklist is effective.
+            for(configuration_proposal_action it : ml_pair.second->action_list){
+                if(it.type == 2 || it.type == 5)
+                    continue;
+                CHECK_TRUE(greedy_lb._cluster_balance_policy->_balancer_ignored_nodes.count(it.hp_node) == 0);
+            }
+            
+        }
+        LOG_DEBUG("balance checker operation count = {}", ml.size());
+        greedy_lb.check({&apps, &nodes}, ml);
+    }
+
+    for (const auto &iter : nodes) {
+        LOG_INFO("node({}) have {} primaries, {} partitions",
+                 iter.first,
+                 iter.second.primary_count(),
+                 iter.second.partition_count());
+    }
+
+    for (const auto & iter : apps){
+        for (auto node : nodes) {
+             LOG_INFO("app {} node({}) have {} primaries, {} partitions",
+                 iter.first,
+                 node.first,
+                 node.second.primary_count(iter.first),
+                 node.second.partition_count(iter.first));
+        }
+    }
 }
 } // namespace replication
 } // namespace dsn


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#1976 

In addition this, solve two issues for cluster_balance_policy.
1. 
https://github.com/apache/incubator-pegasus/blob/cd1682d5e2e4668f4263073d5ddb04b8bd7574c4/src/meta/cluster_balance_policy.cpp#L201-L202
std::move(info) is before use the variable info,  causes the skew is wrong.

2.
https://github.com/apache/incubator-pegasus/blob/cd1682d5e2e4668f4263073d5ddb04b8bd7574c4/src/meta/load_balance_policy.h#L113
https://github.com/apache/incubator-pegasus/blob/cd1682d5e2e4668f4263073d5ddb04b8bd7574c4/src/meta/greedy_load_balancer.h#L77-L78

The variable _balancer_ignored_apps is not static, that causes _app_balance_policy and _cluster_balance_policy  have separate _balancer_ignored_apps. So, when we set _balancer_ignored_apps, it only takes effect on _app_balance_policy.

Both issues will be fixed in this pr.
### What is changed and how does it work?

- command

``
meta.lb.ignored_nodes_list <get|set|clear> [node_addr1,nodes_addr2..]
``
Supports get, set, and clear commands.
The number of blacklisted nodes must not exceed the number of alive_nodes minus 2, otherwise balancing will not be possible.
- app_balance_policy  
  - Move primary
  No increase or decrease in node slicing is involved, so no restriction is applied.
  - copy primary and copy secondary
  The balancing strategy is the same for both phases, so the restriction method is the same.
  ```  
  Sort the nodes by the number of primary replica from smallest to largest to get pri_queue
  On the pri_queue, id_min always points to the head node of the pri_queue and id_max always points to the tail node of the pri_queue, 
  as shown below.
   +------+------+------+------+------+------+------+------+
   |                                                       |
   V                                                       V
  id_min                                                  id_max
  For all replicas on the current id_max, find their corresponding disks and obtain their disk loads, select the disk with the highest load and its corresponding primary replica, and perform the relocation.
  +1/-1 for the current number of primaries pointed to by id_min/id_max, respectively. reorder and loop through the above steps until the number of primaries on the id_min node >= N/M, at which point balance is reached
  ```
  The difference between copy primary and copy secondary is simply that the queue for copy primary is sorted based on the 
  number of primary slices of the table on each node. Copy secondary is sorted based on the number of all slices of the table 
  on each node.
  Therefore, it is sufficient to exclude the blacklisted nodes when choosing id_min/id_max.

- cluster_balance_policy 
  - Move primary:
   No increase or decrease in node slicing is involved, so no restriction is applied.
  - copy primary and copy secondary
  The balancing strategy is the same for both phases, so the restriction method is the same.
  The difference between copy primary and copy secondary is simply that the number of slices computed for copy primary is the primary slice and the number of slices computed for copy secondary is the slave slice (excluding the primary slice).
  The strategy to implement node blacklisting is:
     1. Ignore the blacklisted on nodes when calculating skew. That is, when calculating both app_skew and server_skew, the nodes on the node blacklist are not counted, and it is sufficient for the remaining nodes to reach balance.
     2. When calculating cluster_min_count_nodes, cluster_max_count_nodes, app_min_count_nodes, app_max_count_nodes, ignore the blacklisted nodes.
     4. Similar to app_balance, i.e., ignore nodes when selecting max and min nodes.


### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test
```
// 测试app balance
export GTEST_FILTER=meta.app_balancer_nodes_blacklist_test
./run.sh test -m dsn.meta.test

// 测试cluster balance
export GTEST_FILTER=meta.cluster_balancer_nodes_blacklist_test
./run.sh test -m dsn.meta.test
```
- Manual test (add detailed scripts or steps below)
1. Building unbalanced clusters with onebox.
    Use node restart and the command remote_command -t meta-server meta.lb.assign_secondary_black_list $address_list
2. set node blacklist
3. use command set_meta_level lively.
  - app_balance_policy
  The initial state of the cluster is:
   ![image](https://github.com/apache/incubator-pegasus/assets/46274877/4d98354e-6549-4ff6-aa8c-b74127b8edd7)
  Set 172.17.0.2:34801, 172.17.0.2:34806 as blacklisted, and then load-balance with a termination state of:
   ![image (1)](https://github.com/apache/incubator-pegasus/assets/46274877/139712c5-9302-4903-a776-92594b1e4536)
  It can be seen that the number of slices for two nodes, 172.17.0.2:34801 and 172.17.0.2:34806, did not change, and the other four nodes reached a balanced state. After clear ignored_node_list, perform balance, the result is:
  ![image](https://github.com/apache/incubator-pegasus/assets/46274877/e7fee2f7-a68d-441a-90e7-67d44081559e)
   - cluster_balance_policy
  The initial state of the cluster is:
  ![image (1)](https://github.com/apache/incubator-pegasus/assets/46274877/6587456e-19b5-4002-a165-db71e1cb8812)
  Set 172.17.0.2:34801, 172.17.0.2:34806 as blacklisted, and then load-balance with a termination state of:
  ![image](https://github.com/apache/incubator-pegasus/assets/46274877/46382308-fd90-4f44-838d-de21b02e29bf)
  It can be seen that the number of slices for two nodes, 172.17.0.2:34801 and 172.17.0.2:34806, did not change, and the other four nodes reached a balanced state. After clear ignored_node_list, perform balance, the result is:
  ![image (1)](https://github.com/apache/incubator-pegasus/assets/46274877/a905426e-a87f-416c-bd93-4d72f81daccb)

