### PR TITLE
feat(duplication): allow remote replica count to be specified for duplication

### DIFF
--- a/idl/duplication.thrift
+++ b/idl/duplication.thrift
@@ -104,7 +104,7 @@ struct duplication_add_response
     //
     // This field could also be used to check if the meta server supports
     // remote_replica_count(i.e. the version of meta server must be >= v2.6.0).
-    6:optional string remote_replica_count;
+    6:optional i32 remote_replica_count;
 }
 
 // This request is sent from client to meta.
@@ -147,7 +147,7 @@ struct duplication_entry
     // Since v2.6.0.
     // For versions >= v2.6.0, this could be specified by client.
     // For versions < v2.6.0, this must be the same with source replica_count.
-    9:optional string remote_replica_count;
+    9:optional i32 remote_replica_count;
 }
 
 // This request is sent from client to meta.

--- a/idl/duplication.thrift
+++ b/idl/duplication.thrift
@@ -70,6 +70,10 @@ struct duplication_add_request
     // Since v2.6.0.
     // Specify the app name of remote cluster.
     4:optional string remote_app_name;
+
+    // Since v2.6.0.
+    // Specify the replica count of remote app.
+    5:optional i32 remote_replica_count;
 }
 
 struct duplication_add_response
@@ -91,6 +95,16 @@ struct duplication_add_response
     // This field could also be used to check if the meta server supports
     // remote_app_name(i.e. the version of meta server must be >= v2.6.0).
     5:optional string remote_app_name;
+
+    // Since v2.6.0.
+    //
+    // If new duplication is created, this would be its remote_replica_count;
+    // Otherwise, once the duplication has existed, this would be the
+    // remote_replica_count with which the duplication has been created.
+    //
+    // This field could also be used to check if the meta server supports
+    // remote_replica_count(i.e. the version of meta server must be >= v2.6.0).
+    6:optional string remote_replica_count;
 }
 
 // This request is sent from client to meta.
@@ -129,6 +143,11 @@ struct duplication_entry
     // For versions >= v2.6.0, this could be specified by client.
     // For versions < v2.6.0, this must be the same with source app_name.
     8:optional string remote_app_name;
+
+    // Since v2.6.0.
+    // For versions >= v2.6.0, this could be specified by client.
+    // For versions < v2.6.0, this must be the same with source replica_count.
+    9:optional string remote_replica_count;
 }
 
 // This request is sent from client to meta.

--- a/idl/duplication.thrift
+++ b/idl/duplication.thrift
@@ -73,6 +73,7 @@ struct duplication_add_request
 
     // Since v2.6.0.
     // Specify the replica count of remote app.
+    // 0 means that the replica count would be set as the source app.
     5:optional i32 remote_replica_count;
 }
 

--- a/idl/duplication.thrift
+++ b/idl/duplication.thrift
@@ -73,7 +73,8 @@ struct duplication_add_request
 
     // Since v2.6.0.
     // Specify the replica count of remote app.
-    // 0 means that the replica count would be set as the source app.
+    // 0 means that the replica count of the remote app would be the same as
+    // the source app.
     5:optional i32 remote_replica_count;
 }
 

--- a/idl/duplication.thrift
+++ b/idl/duplication.thrift
@@ -88,9 +88,9 @@ struct duplication_add_response
 
     // Since v2.6.0.
     //
-    // If new duplication is created, this would be its remote_app_name;
-    // Otherwise, once the duplication has existed, this would be the
-    // remote_app_name with which the duplication has been created.
+    // If new duplication is created, this would be requested remote_app_name in
+    // duplication_add_request; otherwise, once the duplication has existed, this
+    // would be the remote app name with which the duplication has been created.
     //
     // This field could also be used to check if the meta server supports
     // remote_app_name(i.e. the version of meta server must be >= v2.6.0).
@@ -98,9 +98,9 @@ struct duplication_add_response
 
     // Since v2.6.0.
     //
-    // If new duplication is created, this would be its remote_replica_count;
-    // Otherwise, once the duplication has existed, this would be the
-    // remote_replica_count with which the duplication has been created.
+    // If new duplication is created, this would be requested remote_replica_count in
+    // duplication_add_request; otherwise, once the duplication has existed, this would
+    // be the remote replica count with which the duplication has been created.
     //
     // This field could also be used to check if the meta server supports
     // remote_replica_count(i.e. the version of meta server must be >= v2.6.0).

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1361,7 +1361,7 @@ replication_ddl_client::add_dup(const std::string &app_name,
                                 const std::string &remote_cluster_name,
                                 bool is_duplicating_checkpoint,
                                 const std::string &remote_app_name,
-                                const int32_t remote_replica_count)
+                                const uint32_t remote_replica_count)
 {
     RETURN_EW_NOT_OK_MSG(validate_app_name(remote_app_name, false),
                          duplication_add_response,
@@ -1373,7 +1373,7 @@ replication_ddl_client::add_dup(const std::string &app_name,
     req->remote_cluster_name = remote_cluster_name;
     req->is_duplicating_checkpoint = is_duplicating_checkpoint;
     req->__set_remote_app_name(remote_app_name);
-    req->__set_remote_replica_count(remote_replica_count);
+    req->__set_remote_replica_count(static_cast<int32_t>(remote_replica_count));
     return call_rpc_sync(duplication_add_rpc(std::move(req), RPC_CM_ADD_DUPLICATION));
 }
 

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1360,7 +1360,8 @@ error_with<duplication_add_response>
 replication_ddl_client::add_dup(const std::string &app_name,
                                 const std::string &remote_cluster_name,
                                 bool is_duplicating_checkpoint,
-                                const std::string &remote_app_name)
+                                const std::string &remote_app_name,
+                                const int32_t remote_replica_count)
 {
     RETURN_EW_NOT_OK_MSG(validate_app_name(remote_app_name, false),
                          duplication_add_response,
@@ -1372,6 +1373,7 @@ replication_ddl_client::add_dup(const std::string &app_name,
     req->remote_cluster_name = remote_cluster_name;
     req->is_duplicating_checkpoint = is_duplicating_checkpoint;
     req->__set_remote_app_name(remote_app_name);
+    req->__set_remote_replica_count(remote_replica_count);
     return call_rpc_sync(duplication_add_rpc(std::move(req), RPC_CM_ADD_DUPLICATION));
 }
 

--- a/src/client/replication_ddl_client.h
+++ b/src/client/replication_ddl_client.h
@@ -144,7 +144,8 @@ public:
     error_with<duplication_add_response> add_dup(const std::string &app_name,
                                                  const std::string &remote_address,
                                                  bool is_duplicating_checkpoint,
-                                                 const std::string &remote_app_name);
+                                                 const std::string &remote_app_name,
+                                                 const int32_t remote_replica_count);
 
     error_with<duplication_modify_response>
     change_dup_status(const std::string &app_name, int dupid, duplication_status::type status);

--- a/src/client/replication_ddl_client.h
+++ b/src/client/replication_ddl_client.h
@@ -145,7 +145,7 @@ public:
                                                  const std::string &remote_address,
                                                  bool is_duplicating_checkpoint,
                                                  const std::string &remote_app_name,
-                                                 const int32_t remote_replica_count);
+                                                 const uint32_t remote_replica_count);
 
     error_with<duplication_modify_response>
     change_dup_status(const std::string &app_name, int dupid, duplication_status::type status);

--- a/src/common/duplication_common.cpp
+++ b/src/common/duplication_common.cpp
@@ -159,6 +159,11 @@ static nlohmann::json duplication_entry_to_json(const duplication_entry &ent)
         json["remote_app_name"] = ent.remote_app_name;
     }
 
+    if (ent.__isset.remote_replica_count) {
+        // remote_replica_count is supported since v2.6.0, thus it won't be shown before v2.6.0.
+        json["remote_replica_count"] = ent.remote_replica_count;
+    }
+
     return json;
 }
 

--- a/src/meta/duplication/duplication_info.cpp
+++ b/src/meta/duplication/duplication_info.cpp
@@ -207,7 +207,7 @@ duplication_info_s_ptr duplication_info::decode_from_blob(dupid_t dup_id,
                                                           int32_t app_id,
                                                           const std::string &app_name,
                                                           int32_t partition_count,
-                                                          int32_t remote_replica_count,
+                                                          int32_t replica_count,
                                                           const std::string &store_path,
                                                           const blob &json)
 {
@@ -225,7 +225,7 @@ duplication_info_s_ptr duplication_info::decode_from_blob(dupid_t dup_id,
     if (info.remote_replica_count == 0) {
         // remote_replica_count is missing, which means meta data in remote storage(zk) is
         // still of old version(< v2.6.0).
-        info.remote_replica_count = remote_replica_count;
+        info.remote_replica_count = replica_count;
     }
 
     std::vector<host_port> meta_list;

--- a/src/meta/duplication/duplication_info.h
+++ b/src/meta/duplication/duplication_info.h
@@ -56,6 +56,7 @@ public:
                      int32_t app_id,
                      const std::string &app_name,
                      int32_t partition_count,
+                     int32_t remote_replica_count,
                      uint64_t create_now_ms,
                      const std::string &remote_cluster_name,
                      const std::string &remote_app_name,
@@ -65,6 +66,7 @@ public:
           app_id(app_id),
           app_name(app_name),
           partition_count(partition_count),
+          remote_replica_count(remote_replica_count),
           remote_cluster_name(remote_cluster_name),
           remote_app_name(remote_app_name),
           remote_cluster_metas(std::move(remote_cluster_metas)),
@@ -139,6 +141,7 @@ public:
                                                    int32_t app_id,
                                                    const std::string &app_name,
                                                    int32_t partition_count,
+                                                   int32_t remote_replica_count,
                                                    const std::string &store_path,
                                                    const blob &json);
 
@@ -156,6 +159,7 @@ public:
         entry.status = _status;
         entry.__set_fail_mode(_fail_mode);
         entry.__set_remote_app_name(remote_app_name);
+        entry.__set_remote_replica_count(remote_replica_count);
         entry.__isset.progress = true;
         for (const auto &kv : _progress) {
             if (!kv.second.is_inited) {
@@ -240,11 +244,13 @@ private:
         int64_t create_timestamp_ms;
         duplication_fail_mode::type fail_mode;
         std::string remote_app_name;
+        int32_t remote_replica_count{0};
 
-        // Since there is no remote_cluster_name for old versions(< v2.6.0), remote_app_name is
-        // optional. Following deserialization functions could be compatible with the situations
-        // where remote_app_name is missing.
-        DEFINE_JSON_SERIALIZATION(remote, status, create_timestamp_ms, fail_mode, remote_app_name);
+        // Since there is no remote_cluster_name for old versions(< v2.6.0), remote_app_name
+        // and remote_replica_count are optional. Following deserialization functions could
+        // be compatible with the situations where remote_app_name and remote_replica_count
+        // are missing.
+        DEFINE_JSON_SERIALIZATION(remote, status, create_timestamp_ms, fail_mode, remote_app_name, remote_replica_count);
     };
 
 public:
@@ -252,6 +258,7 @@ public:
     const int32_t app_id{0};
     const std::string app_name;
     const int32_t partition_count{0};
+    const int32_t remote_replica_count{0};
 
     const std::string remote_cluster_name;
     const std::string remote_app_name;

--- a/src/meta/duplication/duplication_info.h
+++ b/src/meta/duplication/duplication_info.h
@@ -141,7 +141,7 @@ public:
                                                    int32_t app_id,
                                                    const std::string &app_name,
                                                    int32_t partition_count,
-                                                   int32_t remote_replica_count,
+                                                   int32_t replica_count,
                                                    const std::string &store_path,
                                                    const blob &json);
 

--- a/src/meta/duplication/duplication_info.h
+++ b/src/meta/duplication/duplication_info.h
@@ -250,7 +250,8 @@ private:
         // and remote_replica_count are optional. Following deserialization functions could
         // be compatible with the situations where remote_app_name and remote_replica_count
         // are missing.
-        DEFINE_JSON_SERIALIZATION(remote, status, create_timestamp_ms, fail_mode, remote_app_name, remote_replica_count);
+        DEFINE_JSON_SERIALIZATION(
+            remote, status, create_timestamp_ms, fail_mode, remote_app_name, remote_replica_count);
     };
 
 public:

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -227,6 +227,13 @@ void meta_duplication_service::add_duplication(duplication_add_rpc rpc)
         request.remote_cluster_name,
         duplication_constants::kClustersSectionName);
 
+    LOG_WARNING_DUP_HINT_AND_RETURN_IF_NOT(
+        remote_replica_count >= 0,
+        response,
+        ERR_INVALID_PARAMETERS,
+        "invalid remote_replica_count({}) which should never be negative",
+        remote_replica_count);
+
     std::shared_ptr<app_state> app;
     duplication_info_s_ptr dup;
     {

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -193,7 +193,8 @@ void meta_duplication_service::add_duplication(duplication_add_rpc rpc)
         remote_app_name = request.app_name;
     }
 
-    int32_t remote_replica_count = request.__isset.remote_replica_count ? request.remote_replica_count : 0;
+    int32_t remote_replica_count =
+        request.__isset.remote_replica_count ? request.remote_replica_count : 0;
 
     LOG_INFO("add duplication for app({}), remote cluster name is {}, "
              "remote app name is {}, remote replica count is {}",
@@ -292,8 +293,11 @@ void meta_duplication_service::add_duplication(duplication_add_rpc rpc)
     }
 
     if (!dup) {
-        dup = new_dup_from_init(
-            request.remote_cluster_name, remote_app_name, remote_replica_count, std::move(meta_list), app);
+        dup = new_dup_from_init(request.remote_cluster_name,
+                                remote_app_name,
+                                remote_replica_count,
+                                std::move(meta_list),
+                                app);
     }
 
     do_add_duplication(app, dup, rpc, remote_app_name);
@@ -752,8 +756,13 @@ void meta_duplication_service::do_restore_duplication(dupid_t dup_id,
         [ dup_id, this, app = std::move(app), store_path ](const blob &json) {
             zauto_write_lock l(app_lock());
 
-            auto dup = duplication_info::decode_from_blob(
-                dup_id, app->app_id, app->app_name, app->partition_count, app->max_replica_count, store_path, json);
+            auto dup = duplication_info::decode_from_blob(dup_id,
+                                                          app->app_id,
+                                                          app->app_name,
+                                                          app->partition_count,
+                                                          app->max_replica_count,
+                                                          store_path,
+                                                          json);
             if (nullptr == dup) {
                 LOG_ERROR("failed to decode json \"{}\" on path {}", json, store_path);
                 return; // fail fast

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -261,7 +261,8 @@ void meta_duplication_service::add_duplication(duplication_add_rpc rpc)
         }
 
         if (remote_replica_count == 0) {
-            // 0 means that the replica count would be set as the source app.
+            // 0 means that the replica count of the remote app would be the same as the
+            // source app.
             remote_replica_count = app->max_replica_count;
         }
 

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -447,7 +447,7 @@ void meta_duplication_service::create_follower_app_for_duplication(
     request.app_name = dup->remote_app_name;
     request.options.app_type = app->app_type;
     request.options.partition_count = app->partition_count;
-    request.options.replica_count = app->max_replica_count;
+    request.options.replica_count = dup->remote_replica_count;
     request.options.success_if_exist = false;
     request.options.envs = app->envs;
     request.options.is_stateful = app->is_stateful;

--- a/src/meta/duplication/meta_duplication_service.h
+++ b/src/meta/duplication/meta_duplication_service.h
@@ -124,6 +124,7 @@ private:
     std::shared_ptr<duplication_info>
     new_dup_from_init(const std::string &remote_cluster_name,
                       const std::string &remote_app_name,
+                      const int32_t remote_replica_count,
                       std::vector<host_port> &&remote_cluster_metas,
                       std::shared_ptr<app_state> &app) const;
 

--- a/src/meta/duplication/meta_duplication_service.h
+++ b/src/meta/duplication/meta_duplication_service.h
@@ -81,7 +81,8 @@ private:
     void do_add_duplication(std::shared_ptr<app_state> &app,
                             duplication_info_s_ptr &dup,
                             duplication_add_rpc &rpc,
-                            const std::string &remote_app_name);
+                            const std::string &remote_app_name,
+                            const int32_t remote_replica_count);
 
     void do_modify_duplication(std::shared_ptr<app_state> &app,
                                duplication_info_s_ptr &dup,

--- a/src/meta/test/duplication_info_test.cpp
+++ b/src/meta/test/duplication_info_test.cpp
@@ -187,8 +187,8 @@ public:
         ASSERT_EQ(dup.remote_replica_count, copy.remote_replica_count);
         ASSERT_EQ(kTestRemoteReplicaCount, copy.remote_replica_count);
 
-        auto dup_sptr =
-            duplication_info::decode_from_blob(1, 1, kTestAppName, 4, kTestRemoteReplicaCount, kTestMetaStorePath, json);
+        auto dup_sptr = duplication_info::decode_from_blob(
+            1, 1, kTestAppName, 4, kTestRemoteReplicaCount, kTestMetaStorePath, json);
         ASSERT_TRUE(dup_sptr->equals_to(dup)) << *dup_sptr << " " << dup;
 
         blob new_json =

--- a/src/meta/test/duplication_info_test.cpp
+++ b/src/meta/test/duplication_info_test.cpp
@@ -55,6 +55,7 @@ public:
                              1,
                              kTestAppName,
                              2,
+                             kTestRemoteReplicaCount,
                              0,
                              kTestRemoteClusterName,
                              kTestRemoteAppName,
@@ -109,6 +110,7 @@ public:
                              1,
                              kTestAppName,
                              4,
+                             kTestRemoteReplicaCount,
                              0,
                              kTestRemoteClusterName,
                              kTestRemoteAppName,
@@ -141,6 +143,7 @@ public:
                              1,
                              kTestAppName,
                              4,
+                             kTestRemoteReplicaCount,
                              0,
                              kTestRemoteClusterName,
                              kTestRemoteAppName,
@@ -161,6 +164,7 @@ public:
                              1,
                              kTestAppName,
                              4,
+                             kTestRemoteReplicaCount,
                              0,
                              kTestRemoteClusterName,
                              kTestRemoteAppName,
@@ -179,6 +183,9 @@ public:
         ASSERT_EQ(dup.create_timestamp_ms, copy.create_timestamp_ms);
         ASSERT_EQ(dup.remote_cluster_name, copy.remote);
         ASSERT_EQ(dup.remote_app_name, copy.remote_app_name);
+        ASSERT_EQ(kTestRemoteAppName, copy.remote_app_name);
+        ASSERT_EQ(dup.remote_replica_count, copy.remote_replica_count);
+        ASSERT_EQ(kTestRemoteReplicaCount, copy.remote_replica_count);
 
         auto dup_sptr =
             duplication_info::decode_from_blob(1, 1, kTestAppName, 4, kTestRemoteReplicaCount, kTestMetaStorePath, json);
@@ -203,6 +210,7 @@ TEST_F(duplication_info_test, alter_status_when_busy)
                          1,
                          kTestAppName,
                          4,
+                         kTestRemoteReplicaCount,
                          0,
                          kTestRemoteClusterName,
                          kTestRemoteAppName,
@@ -276,6 +284,7 @@ TEST_F(duplication_info_test, alter_status)
                              1,
                              kTestAppName,
                              4,
+                             kTestRemoteReplicaCount,
                              0,
                              kTestRemoteClusterName,
                              kTestRemoteAppName,
@@ -307,6 +316,7 @@ TEST_F(duplication_info_test, is_valid)
                          1,
                          kTestAppName,
                          4,
+                         kTestRemoteReplicaCount,
                          0,
                          kTestRemoteClusterName,
                          kTestRemoteAppName,

--- a/src/meta/test/duplication_info_test.cpp
+++ b/src/meta/test/duplication_info_test.cpp
@@ -200,11 +200,11 @@ public:
 
     static void test_encode_and_decode_default()
     {
-        const duplication_info::json_helper copy;
-        const auto json = json::json_forwarder<json_helper>::encode(copy);
-        ASSERT_TRUE(dup.remote_app_name.empty());
-        ASSERT_EQ(0, dup.remote_replica_count);
+        duplication_info::json_helper copy;
+        ASSERT_TRUE(copy.remote_app_name.empty());
+        ASSERT_EQ(0, copy.remote_replica_count);
 
+        const auto json = json::json_forwarder<duplication_info::json_helper>::encode(copy);
         auto dup = duplication_info::decode_from_blob(
             1, 1, kTestAppName, 4, kTestRemoteReplicaCount, kTestMetaStorePath, json);
         ASSERT_EQ(kTestAppName, dup->remote_app_name);

--- a/src/meta/test/duplication_info_test.cpp
+++ b/src/meta/test/duplication_info_test.cpp
@@ -201,6 +201,8 @@ public:
     static void test_encode_and_decode_default()
     {
         duplication_info::json_helper copy;
+        copy.status = duplication_status::DS_INIT;
+        copy.fail_mode = duplication_fail_mode::FAIL_SLOW;
         ASSERT_TRUE(copy.remote_app_name.empty());
         ASSERT_EQ(0, copy.remote_replica_count);
 

--- a/src/meta/test/duplication_info_test.cpp
+++ b/src/meta/test/duplication_info_test.cpp
@@ -200,6 +200,8 @@ public:
 
     static void test_encode_and_decode_default()
     {
+        dsn_run_config("config-test.ini", false);
+
         duplication_info::json_helper copy;
         copy.status = duplication_status::DS_INIT;
         copy.fail_mode = duplication_fail_mode::FAIL_SLOW;

--- a/src/meta/test/duplication_info_test.cpp
+++ b/src/meta/test/duplication_info_test.cpp
@@ -205,6 +205,7 @@ public:
         duplication_info::json_helper copy;
         copy.status = duplication_status::DS_INIT;
         copy.fail_mode = duplication_fail_mode::FAIL_SLOW;
+        copy.remote = kTestRemoteClusterName;
         ASSERT_TRUE(copy.remote_app_name.empty());
         ASSERT_EQ(0, copy.remote_replica_count);
 

--- a/src/meta/test/duplication_info_test.cpp
+++ b/src/meta/test/duplication_info_test.cpp
@@ -41,6 +41,7 @@ public:
     static const std::string kTestRemoteClusterName;
     static const std::string kTestRemoteAppName;
     static const std::string kTestMetaStorePath;
+    static const int32_t kTestRemoteReplicaCount;
 
     void force_update_status(duplication_info &dup, duplication_status::type status)
     {
@@ -180,7 +181,7 @@ public:
         ASSERT_EQ(dup.remote_app_name, copy.remote_app_name);
 
         auto dup_sptr =
-            duplication_info::decode_from_blob(1, 1, kTestAppName, 4, kTestMetaStorePath, json);
+            duplication_info::decode_from_blob(1, 1, kTestAppName, 4, kTestRemoteReplicaCount, kTestMetaStorePath, json);
         ASSERT_TRUE(dup_sptr->equals_to(dup)) << *dup_sptr << " " << dup;
 
         blob new_json =
@@ -194,6 +195,7 @@ const std::string duplication_info_test::kTestAppName = "temp";
 const std::string duplication_info_test::kTestRemoteClusterName = "slave-cluster";
 const std::string duplication_info_test::kTestRemoteAppName = "remote_temp";
 const std::string duplication_info_test::kTestMetaStorePath = "/meta_test/101/duplication/1";
+const int32_t duplication_info_test::kTestRemoteReplicaCount = 3;
 
 TEST_F(duplication_info_test, alter_status_when_busy)
 {

--- a/src/meta/test/meta_duplication_service_test.cpp
+++ b/src/meta/test/meta_duplication_service_test.cpp
@@ -79,14 +79,14 @@ public:
 
     duplication_add_response create_dup(const std::string &app_name,
                                         const std::string &remote_cluster,
-                                        const bool specify,
+                                        const bool specified,
                                         const std::string &remote_app_name,
                                         const int32_t remote_replica_count)
     {
         auto req = std::make_unique<duplication_add_request>();
         req->app_name = app_name;
         req->remote_cluster_name = remote_cluster;
-        if (specify) {
+        if (specified) {
             req->__set_remote_app_name(remote_app_name);
             req->__set_remote_replica_count(remote_replica_count);
         }
@@ -105,8 +105,8 @@ public:
         return create_dup(app_name, remote_cluster, true, app_name, remote_replica_count);
     }
 
-    duplication_add_response create_dup_without_specify(const std::string &app_name,
-                                                        const std::string &remote_cluster)
+    duplication_add_response create_dup_unspecified(const std::string &app_name,
+                                                    const std::string &remote_cluster)
     {
         return create_dup(app_name, remote_cluster, false, "", 0);
     }
@@ -389,7 +389,7 @@ public:
     {
         static const std::string kTestSameAppName(kTestAppName + "_same");
         static const std::string kTestAnotherAppName(kTestAppName + "_another");
-        static const std::string kTestNoSpecifyAppName(kTestAppName + "_no_specify");
+        static const std::string kTestUnSpecifiedAppName(kTestAppName + "_unspecified");
 
         create_app(kTestAppName);
         create_app(kTestSameAppName);
@@ -400,7 +400,7 @@ public:
             std::string app_name;
             std::string remote;
 
-            bool specify;
+            bool specified;
             std::string remote_app_name;
             int32_t remote_replica_count;
 
@@ -465,21 +465,21 @@ public:
              kTestRemoteReplicaCount,
              ERR_OK},
             // Add a duplication without specifying remote_app_name and remote_replica_count.
-            {kTestNoSpecifyAppName,
+            {kTestUnSpecifiedAppName,
              kTestRemoteClusterName,
              false,
-             kTestNoSpecifyAppName,
+             kTestUnSpecifiedAppName,
              3,
              ERR_OK},
         };
 
         for (auto test : tests) {
             duplication_add_response resp;
-            if (test.specify) {
+            if (test.specified) {
                 resp = create_dup(
                     test.app_name, test.remote, test.remote_app_name, test.remote_replica_count);
             } else {
-                resp = create_dup_without_specify(test.app_name, test.remote);
+                resp = create_dup_unspecified(test.app_name, test.remote);
             }
 
             ASSERT_EQ(test.wec, resp.err);

--- a/src/meta/test/meta_duplication_service_test.cpp
+++ b/src/meta/test/meta_duplication_service_test.cpp
@@ -196,7 +196,7 @@ public:
         int last_dup = 0;
         for (int i = 0; i < 1000; i++) {
             auto dup =
-                dup_svc().new_dup_from_init(kTestRemoteClusterName, kTestRemoteAppName, {}, app);
+                dup_svc().new_dup_from_init(kTestRemoteClusterName, kTestRemoteAppName, 3, {}, app);
 
             ASSERT_GT(dup->id, 0);
             ASSERT_FALSE(dup->is_altering());

--- a/src/meta/test/meta_duplication_service_test.cpp
+++ b/src/meta/test/meta_duplication_service_test.cpp
@@ -856,7 +856,7 @@ TEST_F(meta_duplication_service_test, query_duplication_handler)
     ASSERT_EQ(std::string() + R"({"1":{"create_ts":")" + ts_buf + R"(","dupid":)" +
                   std::to_string(dup->id) +
                   R"(,"fail_mode":"FAIL_SLOW","remote":"slave-cluster")"
-                  R"(,"remote_replica_count":3,"remote_app_name":"remote_test_app")"
+                  R"(,"remote_app_name":"remote_test_app","remote_replica_count":3)"
                   R"(,"status":"DS_PREPARE"},"appid":2})",
               fake_resp.body);
 }

--- a/src/meta/test/meta_duplication_service_test.cpp
+++ b/src/meta/test/meta_duplication_service_test.cpp
@@ -102,7 +102,7 @@ public:
                                         const std::string &remote_app_name,
                                         const int32_t remote_replica_count)
     {
-        return create_dup(app_name, remote_cluster, true, app_name, remote_replica_count);
+        return create_dup(app_name, remote_cluster, true, remote_app_name, remote_replica_count);
     }
 
     duplication_add_response create_dup_unspecified(const std::string &app_name,
@@ -389,11 +389,12 @@ public:
     {
         static const std::string kTestSameAppName(kTestAppName + "_same");
         static const std::string kTestAnotherAppName(kTestAppName + "_another");
-        static const std::string kTestUnSpecifiedAppName(kTestAppName + "_unspecified");
+        static const std::string kTestUnspecifiedAppName(kTestAppName + "_unspecified");
 
         create_app(kTestAppName);
         create_app(kTestSameAppName);
         create_app(kTestAnotherAppName);
+        create_app(kTestUnspecifiedAppName);
 
         struct TestData
         {
@@ -465,10 +466,10 @@ public:
              kTestRemoteReplicaCount,
              ERR_OK},
             // Add a duplication without specifying remote_app_name and remote_replica_count.
-            {kTestUnSpecifiedAppName,
+            {kTestUnspecifiedAppName,
              kTestRemoteClusterName,
              false,
-             kTestUnSpecifiedAppName,
+             kTestUnspecifiedAppName,
              3,
              ERR_OK},
         };

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -925,9 +925,12 @@ private:
 
 // A helper macro to parse an optional command argument, the result is filled in an uint32_t
 // variable 'value'.
-#define PARSE_OPT_UINT(name, value, def_val)                                                       \
+//
+// Variable arguments are `name` or `init_list` of argh::parser::operator(). See argh::parser
+// for details.
+#define PARSE_OPT_UINT(value, def_val, ...)                                                        \
     do {                                                                                           \
-        const auto param = cmd(name, (def_val)).str();                                             \
+        const auto param = cmd(__VA_ARGS__, (def_val)).str();                                      \
         if (!::dsn::buf2uint32(param, value)) {                                                    \
             fmt::print(stderr, "invalid command, '{}' should be an unsigned integer\n", param);    \
             return false;                                                                          \

--- a/src/shell/commands/duplication.cpp
+++ b/src/shell/commands/duplication.cpp
@@ -83,12 +83,11 @@ bool add_dup(command_executor *e, shell_context *sc, arguments args)
 
     // Read the replica count of the remote app, if any.
     const auto &remote_replica_count_ss = cmd({"-r", "--remote_replica_count"});
-    const auto missing_remote_replica_count = static_cast<bool>(remote_replica_count_ss);
 
     // 0 represents that remote_replica_count is missing, which means the remote_replica_count
     // would be set as the replica count of source app.
     int32_t remote_replica_count = 0;
-    if (!missing_remote_replica_count) {
+    if (static_cast<bool>(remote_replica_count_ss)) {
         std::string remote_replica_count_str(remote_replica_count_ss.str());
         if (!dsn::buf2int32(remote_replica_count_str, remote_replica_count) ||
             remote_replica_count < 1) {

--- a/src/shell/commands/duplication.cpp
+++ b/src/shell/commands/duplication.cpp
@@ -89,11 +89,10 @@ bool add_dup(command_executor *e, shell_context *sc, arguments args)
     int32_t remote_replica_count = 0;
     if (static_cast<bool>(remote_replica_count_ss)) {
         std::string remote_replica_count_str(remote_replica_count_ss.str());
-        if (!dsn::buf2int32(remote_replica_count_str, remote_replica_count) ||
-            remote_replica_count < 1) {
-            fmt::print(stderr, "invalid remote_replica_count: {}\n", remote_replica_count_str);
-            return false;
-        }
+        RETURN_FALSE_IF_NOT(dsn::buf2int32(remote_replica_count_str, remote_replica_count) &&
+                                remote_replica_count >= 1,
+                            "invalid remote_replica_count: {}",
+                            remote_replica_count_str);
     }
 
     auto err_resp = sc->ddl_client->add_dup(app_name,

--- a/src/shell/commands/duplication.cpp
+++ b/src/shell/commands/duplication.cpp
@@ -88,19 +88,21 @@ bool add_dup(command_executor *e, shell_context *sc, arguments args)
 
     // 0 represents that remote_replica_count is missing, which means the remote_replica_count
     // would be set as the replica count of source app.
-    int32_t remote_replica_count = 0; 
+    int32_t remote_replica_count = 0;
     if (!missing_remote_replica_count) {
         std::string remote_replica_count_str(remote_replica_count_ss.str());
-        if (!dsn::buf2int32(remote_replica_count_str, remote_replica_count) || remote_replica_count < 1) {
-            fmt::print(stderr,
-                    "invalid remote_replica_count: {}\n",
-                    remote_replica_count_str);
+        if (!dsn::buf2int32(remote_replica_count_str, remote_replica_count) ||
+            remote_replica_count < 1) {
+            fmt::print(stderr, "invalid remote_replica_count: {}\n", remote_replica_count_str);
             return false;
         }
     }
 
-    auto err_resp = sc->ddl_client->add_dup(
-        app_name, remote_cluster_name, is_duplicating_checkpoint, remote_app_name, remote_replica_count);
+    auto err_resp = sc->ddl_client->add_dup(app_name,
+                                            remote_cluster_name,
+                                            is_duplicating_checkpoint,
+                                            remote_app_name,
+                                            remote_replica_count);
     auto err = err_resp.get_error();
     std::string hint;
     if (err) {

--- a/src/shell/commands/duplication.cpp
+++ b/src/shell/commands/duplication.cpp
@@ -76,15 +76,15 @@ bool add_dup(command_executor *e, shell_context *sc, arguments args)
     }
 
     // Check if the boolean option is specified.
-    bool is_duplicating_checkpoint = cmd[{"-s", "--sst"}];
+    const auto is_duplicating_checkpoint = cmd[{"-s", "--sst"}];
 
     // Read the app name of the remote cluster, if any.
     // Otherwise, use app_name as the remote_app_name.
-    std::string remote_app_name(cmd({"-a", "--remote_app_name"}, app_name).str());
+    const std::string remote_app_name(cmd({"-a", "--remote_app_name"}, app_name).str());
 
     // Read the replica count of the remote app, if any.
-    auto remote_replica_count_ss = cmd({"-r", "--remote_replica_count"});
-    bool missing_remote_replica_count = remote_replica_count_ss.fail();
+    const auto &remote_replica_count_ss = cmd({"-r", "--remote_replica_count"});
+    const auto missing_remote_replica_count = static_cast<bool>(remote_replica_count_ss);
 
     // 0 represents that remote_replica_count is missing, which means the remote_replica_count
     // would be set as the replica count of source app.

--- a/src/shell/commands/duplication.cpp
+++ b/src/shell/commands/duplication.cpp
@@ -82,13 +82,10 @@ bool add_dup(command_executor *e, shell_context *sc, arguments args)
     // Otherwise, use app_name as the remote_app_name.
     const std::string remote_app_name(cmd({"-a", "--remote_app_name"}, app_name).str());
 
-    // Read the replica count of the remote app, if any.
-    const auto &remote_replica_count_ss = cmd();
-
-    // 0 represents that remote_replica_count is missing, which means the remote_replica_count
-    // would be set as the replica count of source app.
-    int32_t remote_replica_count = 0;
-    PARSE_OPT_UINT({"-r", "--remote_replica_count"}, remote_replica_count, 0);
+    // 0 represents that remote_replica_count is missing, which means the replica count of
+    // the remote app would be the same as the source app.
+    uint32_t remote_replica_count = 0;
+    PARSE_OPT_UINT(remote_replica_count, 0, {"-r", "--remote_replica_count"});
 
     auto err_resp = sc->ddl_client->add_dup(app_name,
                                             remote_cluster_name,

--- a/src/shell/commands/duplication.cpp
+++ b/src/shell/commands/duplication.cpp
@@ -83,18 +83,12 @@ bool add_dup(command_executor *e, shell_context *sc, arguments args)
     const std::string remote_app_name(cmd({"-a", "--remote_app_name"}, app_name).str());
 
     // Read the replica count of the remote app, if any.
-    const auto &remote_replica_count_ss = cmd({"-r", "--remote_replica_count"});
+    const auto &remote_replica_count_ss = cmd();
 
     // 0 represents that remote_replica_count is missing, which means the remote_replica_count
     // would be set as the replica count of source app.
     int32_t remote_replica_count = 0;
-    if (static_cast<bool>(remote_replica_count_ss)) {
-        std::string remote_replica_count_str(remote_replica_count_ss.str());
-        RETURN_FALSE_IF_NOT(dsn::buf2int32(remote_replica_count_str, remote_replica_count) &&
-                                remote_replica_count >= 1,
-                            "invalid remote_replica_count: {}",
-                            remote_replica_count_str);
-    }
+    PARSE_OPT_UINT({"-r", "--remote_replica_count"}, remote_replica_count, 0);
 
     auto err_resp = sc->ddl_client->add_dup(app_name,
                                             remote_cluster_name,

--- a/src/shell/commands/duplication.cpp
+++ b/src/shell/commands/duplication.cpp
@@ -33,6 +33,7 @@
 #include "duplication_types.h"
 #include "shell/argh.h"
 #include "shell/command_executor.h"
+#include "shell/command_helper.h"
 #include "shell/commands.h"
 #include "shell/sds/sds.h"
 #include "utils/error_code.h"

--- a/src/shell/commands/duplication.cpp
+++ b/src/shell/commands/duplication.cpp
@@ -39,7 +39,6 @@
 #include "utils/errors.h"
 #include "utils/fmt_logging.h"
 #include "utils/output_utils.h"
-#include "utils/ports.h"
 #include "utils/string_conv.h"
 #include "utils/time_utils.h"
 

--- a/src/shell/commands/local_partition_split.cpp
+++ b/src/shell/commands/local_partition_split.cpp
@@ -697,8 +697,8 @@ bool local_partition_split(command_executor *e, shell_context *sc, arguments arg
     PARSE_UINT(lpsc.src_partition_count);
     PARSE_UINT(lpsc.dst_partition_count);
     lpsc.dst_app_name = cmd(param_index++).str();
-    PARSE_OPT_UINT("threads_per_data_dir", lpsc.threads_per_data_dir, 1);
-    PARSE_OPT_UINT("threads_per_partition", lpsc.threads_per_partition, 1);
+    PARSE_OPT_UINT(lpsc.threads_per_data_dir, 1, "threads_per_data_dir");
+    PARSE_OPT_UINT(lpsc.threads_per_partition, 1, "threads_per_partition");
     lpsc.post_full_compact = cmd["--post_full_compact"];
     lpsc.post_count = cmd["--post_count"];
 

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -475,7 +475,8 @@ static command_executor commands[] = {
     },
     {"add_dup",
      "add duplication",
-     "<app_name> <remote_cluster_name> [-s|--sst] [-a|--remote_app_name str]",
+     "<app_name> <remote_cluster_name> [-s|--sst] [-a|--remote_app_name str] "
+     "[-r|--remote_replica_count num]",
      add_dup},
     {"query_dup", "query duplication info", "<app_name> [-d|--detail]", query_dup},
     {"remove_dup", "remove duplication", "<app_name> <dup_id>", remove_dup},


### PR DESCRIPTION
While duplicating from a cluster A only including one node where all tables have
just one replica to another cluster B including at least 3 nodes where all tables have
3 replicas, the target table on B would be also created with one replica. Thus we
should allow a duplication to be created with specified replica count. 