### PR TITLE
refactor(FQDN): Minor refactor on remove_node()

### DIFF
--- a/src/common/replication_other_types.h
+++ b/src/common/replication_other_types.h
@@ -95,17 +95,6 @@ inline bool is_partition_config_equal(const partition_configuration &pc1,
 class replica_helper
 {
 public:
-    template <typename T>
-    static bool remove_node(const T node,
-                            /*inout*/ std::vector<T> &nodes)
-    {
-        auto it = std::find(nodes.begin(), nodes.end(), node);
-        if (it != nodes.end()) {
-            nodes.erase(it);
-            return true;
-        }
-        return false;
-    }
     static bool get_replica_config(const partition_configuration &pc,
                                    const ::dsn::host_port &node,
                                    /*out*/ replica_configuration &rc);

--- a/src/meta/test/meta_partition_guardian_test.cpp
+++ b/src/meta/test/meta_partition_guardian_test.cpp
@@ -82,7 +82,7 @@ static void apply_update_request(/*in-out*/ configuration_update_request &update
     case config_type::CT_ASSIGN_PRIMARY:
     case config_type::CT_UPGRADE_TO_PRIMARY:
         SET_OBJ_IP_AND_HOST_PORT(pc, primary, update_req, node);
-        REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, update_req, node);
+        REMOVE_IP_AND_HOST_PORT_BY_OBJ(update_req, node, pc, secondaries);
         break;
 
     case config_type::CT_ADD_SECONDARY:
@@ -98,7 +98,7 @@ static void apply_update_request(/*in-out*/ configuration_update_request &update
             RESET_IP_AND_HOST_PORT(pc, primary);
         } else {
             CHECK_NE(update_req.node, pc.primary);
-            REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, update_req, node);
+            REMOVE_IP_AND_HOST_PORT_BY_OBJ(update_req, node, pc, secondaries);
         }
         break;
 

--- a/src/meta/test/meta_partition_guardian_test.cpp
+++ b/src/meta/test/meta_partition_guardian_test.cpp
@@ -82,9 +82,7 @@ static void apply_update_request(/*in-out*/ configuration_update_request &update
     case config_type::CT_ASSIGN_PRIMARY:
     case config_type::CT_UPGRADE_TO_PRIMARY:
         SET_OBJ_IP_AND_HOST_PORT(pc, primary, update_req, node);
-        // TODO(yingchun): optimize the following code
-        replica_helper::remove_node(update_req.node, pc.secondaries);
-        replica_helper::remove_node(update_req.hp_node, pc.hp_secondaries);
+        REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, update_req, node);
         break;
 
     case config_type::CT_ADD_SECONDARY:
@@ -100,8 +98,7 @@ static void apply_update_request(/*in-out*/ configuration_update_request &update
             RESET_IP_AND_HOST_PORT(pc, primary);
         } else {
             CHECK_NE(update_req.node, pc.primary);
-            replica_helper::remove_node(update_req.node, pc.secondaries);
-            replica_helper::remove_node(update_req.hp_node, pc.hp_secondaries);
+            REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, update_req, node);
         }
         break;
 

--- a/src/meta/test/misc/misc.cpp
+++ b/src/meta/test/misc/misc.cpp
@@ -360,7 +360,7 @@ void proposal_action_check_and_apply(const configuration_proposal_action &act,
         CHECK(node != nodes.end(), "");
         ns = &node->second;
         SET_IP_AND_HOST_PORT(pc, primary, act.node, hp_node);
-        CHECK(REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, act, node), "");
+        CHECK(REMOVE_IP_AND_HOST_PORT_BY_OBJ(act, node, pc, secondaries), "");
         ns->put_partition(pc.pid, true);
         break;
     }
@@ -390,7 +390,7 @@ void proposal_action_check_and_apply(const configuration_proposal_action &act,
         CHECK_EQ(pc.primary, act.target);
         CHECK(is_secondary(pc, hp_node), "");
         CHECK(is_secondary(pc, act.node), "");
-        CHECK(REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, act, node), "");
+        CHECK(REMOVE_IP_AND_HOST_PORT_BY_OBJ(act, node, pc, secondaries), "");
         const auto node = nodes.find(hp_node);
         CHECK(node != nodes.end(), "");
         ns = &node->second;

--- a/src/meta/test/misc/misc.cpp
+++ b/src/meta/test/misc/misc.cpp
@@ -360,8 +360,7 @@ void proposal_action_check_and_apply(const configuration_proposal_action &act,
         CHECK(node != nodes.end(), "");
         ns = &node->second;
         SET_IP_AND_HOST_PORT(pc, primary, act.node, hp_node);
-        CHECK(replica_helper::remove_node(hp_node, pc.hp_secondaries), "");
-        CHECK(replica_helper::remove_node(act.node, pc.secondaries), "");
+        CHECK(REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, act, node), "");
         ns->put_partition(pc.pid, true);
         break;
     }
@@ -391,8 +390,7 @@ void proposal_action_check_and_apply(const configuration_proposal_action &act,
         CHECK_EQ(pc.primary, act.target);
         CHECK(is_secondary(pc, hp_node), "");
         CHECK(is_secondary(pc, act.node), "");
-        CHECK(replica_helper::remove_node(hp_node, pc.hp_secondaries), "");
-        CHECK(replica_helper::remove_node(act.node, pc.secondaries), "");
+        CHECK(REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, act, node), "");
         const auto node = nodes.find(hp_node);
         CHECK(node != nodes.end(), "");
         ns = &node->second;

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+// IWYU pragma: no_include <ext/alloc_traits.h>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -105,7 +106,7 @@ public:
         case config_type::CT_ASSIGN_PRIMARY:
         case config_type::CT_UPGRADE_TO_PRIMARY:
             SET_OBJ_IP_AND_HOST_PORT(pc, primary, *update_req, node);
-            REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, *update_req, node);
+            REMOVE_IP_AND_HOST_PORT_BY_OBJ(*update_req, node, pc, secondaries);
             break;
 
         case config_type::CT_ADD_SECONDARY:
@@ -121,7 +122,7 @@ public:
                 RESET_IP_AND_HOST_PORT(pc, primary);
             } else {
                 CHECK_NE(update_req->node, pc.primary);
-                REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, *update_req, node);
+                REMOVE_IP_AND_HOST_PORT_BY_OBJ(*update_req, node, pc, secondaries);
             }
             break;
 

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -24,8 +24,6 @@
  * THE SOFTWARE.
  */
 
-// IWYU pragma: no_include <ext/alloc_traits.h>
-#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -107,8 +105,7 @@ public:
         case config_type::CT_ASSIGN_PRIMARY:
         case config_type::CT_UPGRADE_TO_PRIMARY:
             SET_OBJ_IP_AND_HOST_PORT(pc, primary, *update_req, node);
-            replica_helper::remove_node(update_req->node, pc.secondaries);
-            replica_helper::remove_node(update_req->hp_node, pc.hp_secondaries);
+            REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, *update_req, node);
             break;
 
         case config_type::CT_ADD_SECONDARY:
@@ -124,8 +121,7 @@ public:
                 RESET_IP_AND_HOST_PORT(pc, primary);
             } else {
                 CHECK_NE(update_req->node, pc.primary);
-                replica_helper::remove_node(update_req->node, pc.secondaries);
-                replica_helper::remove_node(update_req->hp_node, pc.hp_secondaries);
+                REMOVE_IP_AND_HOST_PORT_BY_OBJ(pc, secondaries, *update_req, node);
             }
             break;
 

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -175,7 +175,7 @@ void replica::assign_primary(configuration_update_request &proposal)
     SET_IP_AND_HOST_PORT(
         proposal.config, primary, _stub->primary_address(), _stub->primary_host_port());
     REMOVE_IP_AND_HOST_PORT(
-        proposal.config, secondaries, _stub->primary_address(), _stub->primary_host_port());
+        _stub->primary_address(), _stub->primary_host_port(), proposal.config, secondaries);
 
     update_configuration_on_meta_server(proposal.type, node, proposal.config);
 }
@@ -298,7 +298,7 @@ void replica::downgrade_to_inactive_on_primary(configuration_update_request &pro
         RESET_IP_AND_HOST_PORT(proposal.config, primary);
     } else {
         CHECK_NE(proposal.node, proposal.config.primary);
-        CHECK(REMOVE_IP_AND_HOST_PORT_BY_OBJ(proposal.config, secondaries, proposal, node),
+        CHECK(REMOVE_IP_AND_HOST_PORT_BY_OBJ(proposal, node, proposal.config, secondaries),
               "remove node failed, node = {}",
               FMT_HOST_PORT_AND_IP(proposal, node));
     }
@@ -327,7 +327,7 @@ void replica::remove(configuration_update_request &proposal)
         RESET_IP_AND_HOST_PORT(proposal.config, primary);
         break;
     case partition_status::PS_SECONDARY: {
-        CHECK(REMOVE_IP_AND_HOST_PORT_BY_OBJ(proposal.config, secondaries, proposal, node),
+        CHECK(REMOVE_IP_AND_HOST_PORT_BY_OBJ(proposal, node, proposal.config, secondaries),
               "remove node failed, node = {}",
               FMT_HOST_PORT_AND_IP(proposal, node));
     } break;

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1753,7 +1753,7 @@ void replica_stub::remove_replica_on_meta_server(const app_info &info,
     if (_primary_host_port == pc.hp_primary) {
         RESET_IP_AND_HOST_PORT(request->config, primary);
     } else if (REMOVE_IP_AND_HOST_PORT(
-                   request->config, secondaries, primary_address(), _primary_host_port)) {
+                   primary_address(), _primary_host_port, request->config, secondaries)) {
     } else {
         return;
     }

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1752,8 +1752,8 @@ void replica_stub::remove_replica_on_meta_server(const app_info &info,
 
     if (_primary_host_port == pc.hp_primary) {
         RESET_IP_AND_HOST_PORT(request->config, primary);
-    } else if (replica_helper::remove_node(primary_address(), request->config.secondaries) &&
-               replica_helper::remove_node(_primary_host_port, request->config.hp_secondaries)) {
+    } else if (REMOVE_IP_AND_HOST_PORT(
+                   request->config, secondaries, primary_address(), _primary_host_port)) {
     } else {
         return;
     }

--- a/src/rpc/rpc_host_port.cpp
+++ b/src/rpc/rpc_host_port.cpp
@@ -250,19 +250,19 @@ error_s host_port::lookup_hostname(uint32_t ip, std::string *hostname)
     return error_s::ok();
 }
 
-bool remove_node(const rpc_address &addr,
-                 const host_port &hp,
-                 /*inout*/ std::vector<rpc_address> &addrs,
-                 /*inout*/ std::vector<host_port> &hps)
+bool remove_node(const rpc_address &to_rm_addr,
+                 const host_port &to_rm_hp,
+                 /*inout*/ std::vector<rpc_address> &dst_addrs,
+                 /*inout*/ std::vector<host_port> &dst_hps)
 {
-    const auto it_addr = std::find(addrs.begin(), addrs.end(), addr);
-    const auto it_hp = std::find(hps.begin(), hps.end(), hp);
-    bool found_addr = (it_addr != addrs.end());
-    bool found_hp = (it_hp != hps.end());
+    const auto it_addr = std::find(dst_addrs.begin(), dst_addrs.end(), to_rm_addr);
+    const auto it_hp = std::find(dst_hps.begin(), dst_hps.end(), to_rm_hp);
+    bool found_addr = (it_addr != dst_addrs.end());
+    bool found_hp = (it_hp != dst_hps.end());
     DCHECK_EQ(found_addr, found_hp);
     if (found_addr) {
-        addrs.erase(it_addr);
-        hps.erase(it_hp);
+        dst_addrs.erase(it_addr);
+        dst_hps.erase(it_hp);
     }
     return found_addr;
 }

--- a/src/rpc/rpc_host_port.cpp
+++ b/src/rpc/rpc_host_port.cpp
@@ -22,6 +22,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <algorithm>
 #include <cstring>
 #include <memory>
 #include <unordered_set>
@@ -247,6 +248,23 @@ error_s host_port::lookup_hostname(uint32_t ip, std::string *hostname)
 
     *hostname = host;
     return error_s::ok();
+}
+
+bool remove_node(const rpc_address &addr,
+                 const host_port &hp,
+                 /*inout*/ std::vector<rpc_address> &addrs,
+                 /*inout*/ std::vector<host_port> &hps)
+{
+    const auto it_addr = std::find(addrs.begin(), addrs.end(), addr);
+    const auto it_hp = std::find(hps.begin(), hps.end(), hp);
+    bool found_addr = (it_addr != addrs.end());
+    bool found_hp = (it_hp != hps.end());
+    DCHECK_EQ(found_addr, found_hp);
+    if (found_addr) {
+        addrs.erase(it_addr);
+        hps.erase(it_hp);
+    }
+    return found_addr;
 }
 
 } // namespace dsn

--- a/src/rpc/rpc_host_port.h
+++ b/src/rpc/rpc_host_port.h
@@ -232,6 +232,14 @@ class TProtocol;
         DCHECK_EQ(_obj.field.size(), _obj.hp_##field.size());                                      \
     } while (0)
 
+#define REMOVE_IP_AND_HOST_PORT(dst_obj, dst_field, to_rm_addr, to_rm_hp)                          \
+    remove_node(to_rm_addr, to_rm_hp, dst_obj.dst_field, dst_obj.hp_##dst_field)
+#define REMOVE_IP_AND_HOST_PORT_BY_OBJ(dst_obj, dst_field, to_rm_obj, to_rm_field)                 \
+    remove_node((to_rm_obj).to_rm_field,                                                           \
+                (to_rm_obj).hp_##to_rm_field,                                                      \
+                dst_obj.dst_field,                                                                 \
+                dst_obj.hp_##dst_field)
+
 // TODO(yingchun): the 'hp' can be reduced.
 // Set 'value' to the '<field>' map and optional 'hp_<field>' map of 'obj'. The key of the
 // maps are rpc_address and host_port type and indexed by 'addr' and 'hp', respectively.
@@ -368,6 +376,11 @@ inline bool operator<(const host_port &hp1, const host_port &hp2)
         return true;
     }
 }
+
+bool remove_node(const rpc_address &addr,
+                 const host_port &hp,
+                 /*inout*/ std::vector<rpc_address> &addrs,
+                 /*inout*/ std::vector<host_port> &hps);
 } // namespace dsn
 
 USER_DEFINED_STRUCTURE_FORMATTER(::dsn::host_port);

--- a/src/rpc/rpc_host_port.h
+++ b/src/rpc/rpc_host_port.h
@@ -232,9 +232,9 @@ class TProtocol;
         DCHECK_EQ(_obj.field.size(), _obj.hp_##field.size());                                      \
     } while (0)
 
-#define REMOVE_IP_AND_HOST_PORT(dst_obj, dst_field, to_rm_addr, to_rm_hp)                          \
+#define REMOVE_IP_AND_HOST_PORT(to_rm_addr, to_rm_hp, dst_obj, dst_field)                          \
     remove_node(to_rm_addr, to_rm_hp, dst_obj.dst_field, dst_obj.hp_##dst_field)
-#define REMOVE_IP_AND_HOST_PORT_BY_OBJ(dst_obj, dst_field, to_rm_obj, to_rm_field)                 \
+#define REMOVE_IP_AND_HOST_PORT_BY_OBJ(to_rm_obj, to_rm_field, dst_obj, dst_field)                 \
     remove_node((to_rm_obj).to_rm_field,                                                           \
                 (to_rm_obj).hp_##to_rm_field,                                                      \
                 dst_obj.dst_field,                                                                 \
@@ -377,10 +377,10 @@ inline bool operator<(const host_port &hp1, const host_port &hp2)
     }
 }
 
-bool remove_node(const rpc_address &addr,
-                 const host_port &hp,
-                 /*inout*/ std::vector<rpc_address> &addrs,
-                 /*inout*/ std::vector<host_port> &hps);
+bool remove_node(const rpc_address &to_rm_addr,
+                 const host_port &to_rm_hp,
+                 /*inout*/ std::vector<rpc_address> &dst_addrs,
+                 /*inout*/ std::vector<host_port> &dst_hps);
 } // namespace dsn
 
 USER_DEFINED_STRUCTURE_FORMATTER(::dsn::host_port);


### PR DESCRIPTION
This patch unifies the code like
```
remove_node(src.node, dst.nodes);
remove_node(src.hp_node, dst.hp_nodes);
```
and
```
remove_node(node, dst.nodes);
remove_node(hp_node, dst.hp_nodes);
```
to
```
REMOVE_IP_AND_HOST_PORT_BY_OBJ(src, node, dst, nodes);
```
and
```
REMOVE_IP_AND_HOST_PORT(node, hp_node, dst, nodes);
```
to simplify code and ensure nothing missed.