### PR TITLE
feat(encryption): add a new security configuration for encryption key 

### DIFF
--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -234,8 +234,8 @@ DSN_DECLARE_int32(fd_check_interval_seconds);
 DSN_DECLARE_int32(fd_grace_seconds);
 DSN_DECLARE_int32(fd_lease_seconds);
 DSN_DECLARE_int32(gc_interval_ms);
-DSN_DECLARE_string(encryption_cluster_key_name);
 DSN_DECLARE_string(data_dirs);
+DSN_DECLARE_string(encryption_cluster_key_name);
 DSN_DECLARE_string(server_key);
 
 DSN_DEFINE_bool(replication,

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -234,7 +234,7 @@ DSN_DECLARE_int32(fd_check_interval_seconds);
 DSN_DECLARE_int32(fd_grace_seconds);
 DSN_DECLARE_int32(fd_lease_seconds);
 DSN_DECLARE_int32(gc_interval_ms);
-DSN_DECLARE_string(cluster_name);
+DSN_DECLARE_string(encryption_cluster_key_name);
 DSN_DECLARE_string(data_dirs);
 DSN_DECLARE_string(server_key);
 
@@ -448,7 +448,7 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     dsn::replication::kms_info kms_info;
     if (FLAGS_encrypt_data_at_rest && !utils::is_empty(FLAGS_hadoop_kms_url)) {
         _key_provider.reset(new dsn::security::kms_key_provider(
-            ::absl::StrSplit(FLAGS_hadoop_kms_url, ",", ::absl::SkipEmpty()), FLAGS_cluster_name));
+            ::absl::StrSplit(FLAGS_hadoop_kms_url, ",", ::absl::SkipEmpty()), FLAGS_encryption_cluster_key_name));
         const auto &ec = dsn::utils::load_rjobj_from_file(
             kms_path, dsn::utils::FileDataType::kNonSensitive, &kms_info);
         if (ec != dsn::ERR_PATH_NOT_FOUND && ec != dsn::ERR_OK) {

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -448,7 +448,8 @@ void replica_stub::initialize(const replication_options &opts, bool clear /* = f
     dsn::replication::kms_info kms_info;
     if (FLAGS_encrypt_data_at_rest && !utils::is_empty(FLAGS_hadoop_kms_url)) {
         _key_provider.reset(new dsn::security::kms_key_provider(
-            ::absl::StrSplit(FLAGS_hadoop_kms_url, ",", ::absl::SkipEmpty()), FLAGS_encryption_cluster_key_name));
+            ::absl::StrSplit(FLAGS_hadoop_kms_url, ",", ::absl::SkipEmpty()),
+            FLAGS_encryption_cluster_key_name));
         const auto &ec = dsn::utils::load_rjobj_from_file(
             kms_path, dsn::utils::FileDataType::kNonSensitive, &kms_info);
         if (ec != dsn::ERR_PATH_NOT_FOUND && ec != dsn::ERR_OK) {

--- a/src/security/access_controller.cpp
+++ b/src/security/access_controller.cpp
@@ -32,6 +32,11 @@ DSN_DEFINE_string(security,
                   super_users,
                   "",
                   "super users for access controller, comma-separated list of user names");
+DSN_DEFINE_string(security,
+                  encryption_cluster_key_name,
+                  "pegasus_cluster_key",
+                  "Name of the cluster key that is used to encrypt server encryption keys as"
+                  "stored in Ranger KMS.");
 
 namespace dsn {
 namespace security {


### PR DESCRIPTION
Separate the cluster_name and encryption key configurations for clearer usage.

A new config [security] encryption_cluster_key_name has been introduced for managing kms key:

```diff
[security]
+encryption_cluster_key_name
```