### PR TITLE
feat: Distinguish log file names

### DIFF
--- a/src/failure_detector/test/run.sh
+++ b/src/failure_detector/test/run.sh
@@ -40,9 +40,9 @@ while read -r -a line; do
         echo "run dsn.failure_detector.tests $test_case failed"
         echo "---- ls ----"
         ls -l
-        if find . -name log.1.txt; then
-            echo "---- tail -n 100 log.1.txt ----"
-            tail -n 100 `find . -name log.1.txt`
+        if [ `find . -name pegasus.log.* | wc -l` -ne 0 ]; then
+            echo "---- tail -n 100 pegasus.log.* ----"
+            tail -n 100 `find . -name pegasus.log.*`
         fi
         if [ -f core ]; then
             echo "---- gdb ./dsn.failure_detector.tests core ----"

--- a/src/meta/test/meta_state/run.sh
+++ b/src/meta/test/meta_state/run.sh
@@ -40,9 +40,9 @@ while read -r -a line; do
         echo "run dsn_meta_state_tests $test_case failed"
         echo "---- ls ----"
         ls -l
-        if find . -name log.1.txt; then
-            echo "---- tail -n 100 log.1.txt ----"
-            tail -n 100 `find . -name log.1.txt`
+        if [ `find . -name pegasus.log.* | wc -l` -ne 0 ]; then
+            echo "---- tail -n 100 pegasus.log.* ----"
+            tail -n 100 `find . -name pegasus.log.*`
         fi
         if [ -f core ]; then
             echo "---- gdb ./dsn_meta_state_tests core ----"

--- a/src/meta/test/run.sh
+++ b/src/meta/test/run.sh
@@ -54,9 +54,9 @@ if [ $? -ne 0 ]; then
     echo "run dsn.meta.test failed"
     echo "---- ls ----"
     ls -l
-    if find . -name log.1.txt; then
-        echo "---- tail -n 100 log.1.txt ----"
-        tail -n 100 `find . -name log.1.txt`
+    if [ `find . -name pegasus.log.* | wc -l` -ne 0 ]; then
+            echo "---- tail -n 100 pegasus.log.* ----"
+            tail -n 100 `find . -name pegasus.log.*`
     fi
     if [ -f core ]; then
         echo "---- gdb ./dsn.meta.test core ----"

--- a/src/replica/backup/test/run.sh
+++ b/src/replica/backup/test/run.sh
@@ -45,7 +45,7 @@ fi
 ./dsn_replica_backup_test
 
 if [ $? -ne 0 ]; then
-    tail -n 100 data/log/log.1.txt
+    tail -n 100 `find . -name pegasus.log.*`
     if [ -f core ]; then
         gdb ./dsn_replica_backup_test core -ex "bt"
     fi

--- a/src/replica/bulk_load/test/run.sh
+++ b/src/replica/bulk_load/test/run.sh
@@ -45,7 +45,7 @@ fi
 ./dsn_replica_bulk_load_test
 
 if [ $? -ne 0 ]; then
-    tail -n 100 data/log/log.1.txt
+    tail -n 100 `find . -name pegasus.log.*`
     if [ -f core ]; then
         gdb ./dsn_replica_bulk_load_test core -ex "bt"
     fi

--- a/src/replica/duplication/test/run.sh
+++ b/src/replica/duplication/test/run.sh
@@ -45,7 +45,7 @@ fi
 ./dsn_replica_dup_test
 
 if [ $? -ne 0 ]; then
-    tail -n 100 data/log/log.1.txt
+    tail -n 100 `find . -name pegasus.log.*`
     if [ -f core ]; then
         gdb ./dsn_replica_dup_test core -ex "bt"
     fi

--- a/src/replica/split/test/run.sh
+++ b/src/replica/split/test/run.sh
@@ -45,7 +45,7 @@ fi
 ./dsn_replica_split_test
 
 if [ $? -ne 0 ]; then
-    tail -n 100 data/log/log.1.txt
+    tail -n 100 `find . -name pegasus.log.*`
     if [ -f core ]; then
         gdb ./dsn_replica_split_test core -ex "bt"
     fi

--- a/src/replica/storage/simple_kv/run.sh
+++ b/src/replica/storage/simple_kv/run.sh
@@ -62,9 +62,9 @@ if [ -f core ] || ! grep ERR_OK out > /dev/null ; then
     ls -l
     echo "---- head -n 100 out ----"
     head -n 100 out
-    if [ -f data/logs/log.1.txt ]; then
-        echo "---- tail -n 100 log.1.txt ----"
-        tail -n 100 data/logs/log.1.txt
+    if [ `find data/logs -name pegasus.log.* | wc -l` -ne 0 ]; then
+        echo "---- tail -n 100 pegasus.log.* ----"
+        tail -n 100 `find data/logs -name pegasus.log.*`
     fi
     if [ -f core ]; then
         echo "---- gdb ./dsn.replication.simple_kv core ----"

--- a/src/replica/storage/simple_kv/test/run.sh
+++ b/src/replica/storage/simple_kv/test/run.sh
@@ -52,8 +52,8 @@ function run_single()
     echo "${bin} ${prefix}.ini ${prefix}.act"
     ${bin} ${prefix}.ini ${prefix}.act
     ret=$?
-    if find . -name log.1.txt &>/dev/null; then
-        log=`find . -name log.1.txt`
+    if [ `find . -name pegasus.log.* | wc -l` -ne 0 ]; then
+        log=`find . -name pegasus.log.*`
         cat ${log} | grep -v FAILURE_DETECT | grep -v BEACON | grep -v beacon | grep -v THREAD_POOL_FD >${prefix}.log
         rm ${log}
     fi

--- a/src/runtime/test/run.sh
+++ b/src/runtime/test/run.sh
@@ -40,9 +40,9 @@ while read -r -a line; do
         echo "run dsn_runtime_tests $test_case failed"
         echo "---- ls ----"
         ls -l
-        if find . -name log.1.txt; then
-            echo "---- tail -n 100 log.1.txt ----"
-            tail -n 100 `find . -name log.1.txt`
+        if [ `find . -name pegasus.log.* | wc -l` -ne 0 ]; then
+            echo "---- tail -n 100 pegasus.log.* ----"
+            tail -n 100 `find . -name pegasus.log.*`
         fi
         if [ -f core ]; then
             echo "---- gdb ./dsn_runtime_tests core ----"

--- a/src/runtime/tracer.cpp
+++ b/src/runtime/tracer.cpp
@@ -408,7 +408,7 @@ void tracer::install(service_spec &spec)
             "tracer.find",
             "Find related logs",
             "[forward|f|backward|b] [rpc|r|task|t] [trace_id|task_id(e.g., a023003920302390)] "
-            "<log_file_name(e.g., log.yyyyMMdd_hhmmss_SSS)>",
+            "<log_file_name(e.g., replica.log.yyyyMMdd_hhmmss_SSS)>",
             tracer_log_flow);
     });
 }

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -28,6 +28,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "runtime/tool_api.h"
 #include "simple_logger.h"
@@ -61,7 +62,7 @@ std::function<std::string()> log_prefixed_message_func = []() -> std::string { r
 
 void set_log_prefixed_message_func(std::function<std::string()> func)
 {
-    log_prefixed_message_func = func;
+    log_prefixed_message_func = std::move(func);
 }
 } // namespace dsn
 
@@ -73,7 +74,8 @@ static void log_on_sys_exit(::dsn::sys_exit_type)
 
 void dsn_log_init(const std::string &logging_factory_name,
                   const std::string &log_dir,
-                  std::function<std::string()> dsn_log_prefixed_message_func)
+                  const std::string &role_name,
+                  const std::function<std::string()> &dsn_log_prefixed_message_func)
 {
     log_start_level = enum_from_string(FLAGS_logging_start_level, LOG_LEVEL_INVALID);
 
@@ -86,7 +88,7 @@ void dsn_log_init(const std::string &logging_factory_name,
     }
 
     dsn::logging_provider *logger = dsn::utils::factory_store<dsn::logging_provider>::create(
-        logging_factory_name.c_str(), dsn::PROVIDER_TYPE_MAIN, log_dir.c_str());
+        logging_factory_name.c_str(), dsn::PROVIDER_TYPE_MAIN, log_dir.c_str(), role_name.c_str());
     dsn::logging_provider::set_logger(logger);
 
     if (dsn_log_prefixed_message_func != nullptr) {
@@ -117,7 +119,7 @@ logging_provider *logging_provider::instance()
 
 logging_provider *logging_provider::create_default_instance()
 {
-    return new tools::screen_logger(true);
+    return new tools::screen_logger(nullptr, nullptr);
 }
 
 void logging_provider::set_logger(logging_provider *logger) { _logger.reset(logger); }

--- a/src/utils/logging_provider.h
+++ b/src/utils/logging_provider.h
@@ -40,12 +40,12 @@ class logging_provider
 {
 public:
     template <typename T>
-    static logging_provider *create(const char *log_dir)
+    static logging_provider *create(const char *log_dir, const char *role_name)
     {
-        return new T(log_dir);
+        return new T(log_dir, role_name);
     }
 
-    typedef logging_provider *(*factory)(const char *);
+    typedef logging_provider *(*factory)(const char *, const char *);
 
 public:
     virtual ~logging_provider() = default;
@@ -88,4 +88,5 @@ bool register_component_provider(const char *name,
 
 extern void dsn_log_init(const std::string &logging_factory_name,
                          const std::string &log_dir,
-                         std::function<std::string()> dsn_log_prefixed_message_func);
+                         const std::string &role_name,
+                         const std::function<std::string()> &dsn_log_prefixed_message_func);

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -44,7 +44,7 @@ namespace tools {
 class screen_logger : public logging_provider
 {
 public:
-    explicit screen_logger(bool short_header);
+    explicit screen_logger(const char *, const char *) : _short_header(true) {}
     ~screen_logger() override = default;
 
     void log(const char *file,
@@ -74,7 +74,9 @@ private:
 class simple_logger : public logging_provider
 {
 public:
-    simple_logger(const char *log_dir);
+    // 'log_dir' is the directory to store log files, 'role_name' is the name of the process,
+    // such as 'replica_server', 'meta_server' in Pegasus.
+    simple_logger(const char *log_dir, const char *role_name);
     ~simple_logger() override;
 
     void log(const char *file,

--- a/src/utils/test/clear.sh
+++ b/src/utils/test/clear.sh
@@ -24,4 +24,4 @@
 # THE SOFTWARE.
 
 
-rm -rf dsn.utils.tests.xml log*.txt
+rm -rf dsn.utils.tests.xml pegasus*.txt

--- a/src/utils/test/logger.cpp
+++ b/src/utils/test/logger.cpp
@@ -81,7 +81,7 @@ public:
         ASSERT_TRUE(utils::filesystem::get_subfiles(test_dir, sub_list, false));
 
         file_names.clear();
-        std::regex pattern(R"(log\.[0-9]{8}_[0-9]{6}_[0-9]{3})");
+        std::regex pattern(R"(SimpleLogger\.log\.[0-9]{8}_[0-9]{6}_[0-9]{3})");
         for (const auto &path : sub_list) {
             std::string name(utils::filesystem::get_file_name(path));
             if (std::regex_match(name, pattern)) {
@@ -147,7 +147,7 @@ public:
 
 TEST_F(logger_test, screen_logger_test)
 {
-    auto logger = std::make_unique<screen_logger>(true);
+    auto logger = std::make_unique<screen_logger>(nullptr, nullptr);
     LOG_PRINT(logger.get(), "{}", "test_print");
     std::thread t([](screen_logger *lg) { LOG_PRINT(lg, "{}", "test_print"); }, logger.get());
     t.join();
@@ -161,7 +161,7 @@ TEST_F(simple_logger_test, redundant_log_test)
         std::set<std::string> before_files;
         NO_FATALS(get_log_files(before_files));
 
-        auto logger = std::make_unique<simple_logger>(test_dir.c_str());
+        auto logger = std::make_unique<simple_logger>(test_dir.c_str(), "SimpleLogger");
         for (unsigned int i = 0; i != 1000; ++i) {
             LOG_PRINT(logger.get(), "{}", "test_print");
         }

--- a/src/utils/test/main.cpp
+++ b/src/utils/test/main.cpp
@@ -25,7 +25,7 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
-    dsn_log_init("dsn::tools::simple_logger", "./", nullptr);
+    dsn_log_init("dsn::tools::simple_logger", "./", "test", nullptr);
 
     dsn::flags_initialize();
 

--- a/src/utils/test/run.sh
+++ b/src/utils/test/run.sh
@@ -36,9 +36,9 @@ if [ $? -ne 0 ]; then
     echo "run dsn_utils_tests failed"
     echo "---- ls ----"
     ls -l
-    if find . -name log.1.txt; then
-        echo "---- tail -n 100 log.1.txt ----"
-        tail -n 100 `find . -name log.1.txt`
+    if [ `find . -name pegasus.log.* | wc -l` -ne 0 ]; then
+        echo "---- tail -n 100 pegasus.log.* ----"
+        tail -n 100 `find . -name pegasus.log.*`
     fi
     if [ -f core ]; then
         echo "---- gdb ./dsn_utils_tests core ----"

--- a/src/zookeeper/test/run.sh
+++ b/src/zookeeper/test/run.sh
@@ -37,9 +37,9 @@ if [ $? -ne 0 ]; then
     echo "run dsn.zookeeper.tests failed"
     echo "---- ls ----"
     ls -l
-    if find . -name log.1.txt; then
-        echo "---- tail -n 100 log.1.txt ----"
-        tail -n 100 `find . -name log.1.txt`
+    if [ `find . -name pegasus.log.* | wc -l` -ne 0 ]; then
+        echo "---- tail -n 100 pegasus.log.* ----"
+        tail -n 100 `find . -name pegasus.log.*`
     fi
     if [ -f core ]; then
         echo "---- gdb ./dsn.zookeeper.tests core ----"


### PR DESCRIPTION
This patch fills the log file name with the role name. For example, the replica
server log file name is in the form of `replica.log.<yyyyMMdd_hhmmss_SSS>`,
while the meta server log file name is in the form of `meta.log.<yyyyMMdd_hhmmss_SSS>`.

If the role name is empty (typically in unit tests), it will fall back to use
a new configudation `base_name` in `tools.simple_logger` section, it's default
as `pegasus`. Then, the log file is in the form of `pegasus.log.<yyyyMMdd_hhmmss_SSS>`.


```diff
[tools.simple_logger]
+base_name = pegasus
```