### PR TITLE
fix(aarch64): Fix build failure on ARM architecture chips

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -234,6 +234,7 @@ ExternalProject_Add(fmt
 )
 
 set(CURL_OPTIONS
+        --enable-shared
         --disable-dict
         --disable-file
         --disable-ftp
@@ -245,11 +246,12 @@ set(CURL_OPTIONS
         --disable-manual
         --disable-pop3
         --disable-rtsp
-        --disable-shared
         --disable-smtp
         --disable-telnet
         --disable-tftp
+        --without-brotli
         --without-libidn
+        --without-libidn2
         --without-librtmp
         --without-libssh2
         --without-ssl
@@ -261,8 +263,6 @@ if (APPLE)
     set(CURL_OPTIONS
             ${CURL_OPTIONS}
             --without-nghttp2
-            --without-libidn2
-            --without-brotli
             )
 endif ()
 ExternalProject_Add(curl


### PR DESCRIPTION
Fix build failures like:

1.
```
/bin/ld: /.../thirdparty/output/lib/libcurl.a(libcurl_la-content_encoding.o): in function `brotli_close_writer':
content_encoding.c:(.text+0x2c): undefined reference to `BrotliDecoderDestroyInstance'
```

2.
```
/bin/ld: /.../thirdparty/output/lib/libcurl.a(libcurl_la-easy.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `malloc' which may bind externally can not be used when making a shared object; recompile with -fPIC
/bin/ld: /.../thirdparty/output/lib/libcurl.a(libcurl_la-easy.o)(.text+0x30): unresolvable R_AARCH64_ADR_PREL_PG_HI21 relocation against symbol `malloc'
```

3.
```
/bin/ld: idn.c:(.text+0x34): undefined reference to `idn2_lookup_ul'
```