### PR TITLE
feat(logging): Support to specify log directory

### DIFF
--- a/src/runtime/global_config.h
+++ b/src/runtime/global_config.h
@@ -169,8 +169,7 @@ struct service_spec
     std::vector<threadpool_spec> threadpool_specs;
     std::vector<service_app_spec> app_specs;
 
-    // auto-set
-    std::string dir_log;
+    std::string log_dir;
 
     service_spec() {}
     bool init();
@@ -186,6 +185,11 @@ CONFIG_FLD_STRING_LIST(toollets,
 CONFIG_FLD_STRING(data_dir,
                   "./data",
                   "The default directory to place the all the data, logs, coredump files, and etc.")
+CONFIG_FLD_STRING_BY_KEY(
+    log_dir,
+    "log_dir",
+    "",
+    "The directory to place the logs especially. 'data_dir' will be used if it's empty.")
 CONFIG_FLD(
     bool,
     bool,

--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -45,7 +45,6 @@
 #endif
 
 #include "fmt/core.h"
-#include "fmt/format.h"
 #include "perf_counter/perf_counters.h"
 #include "runtime/api_layer1.h"
 #include "runtime/api_task.h"

--- a/src/utils/config_helper.h
+++ b/src/utils/config_helper.h
@@ -49,9 +49,12 @@
         section, #fld, default_value ? default_value->fld : default_fld_value, dsptr);
 
 #define CONFIG_FLD_STRING(fld, default_fld_value, dsptr)                                           \
+    CONFIG_FLD_STRING_BY_KEY(fld, #fld, default_fld_value, dsptr)
+
+#define CONFIG_FLD_STRING_BY_KEY(fld, key, default_fld_value, dsptr)                               \
     val.fld = dsn_config_get_value_string(                                                         \
         section,                                                                                   \
-        #fld,                                                                                      \
+        key,                                                                                       \
         (val.fld.length() > 0 && val.fld != std::string(default_fld_value))                        \
             ? val.fld.c_str()                                                                      \
             : (default_value ? default_value->fld.c_str() : default_fld_value),                    \

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -72,7 +72,7 @@ static void log_on_sys_exit(::dsn::sys_exit_type)
 }
 
 void dsn_log_init(const std::string &logging_factory_name,
-                  const std::string &dir_log,
+                  const std::string &log_dir,
                   std::function<std::string()> dsn_log_prefixed_message_func)
 {
     log_start_level = enum_from_string(FLAGS_logging_start_level, LOG_LEVEL_INVALID);
@@ -86,7 +86,7 @@ void dsn_log_init(const std::string &logging_factory_name,
     }
 
     dsn::logging_provider *logger = dsn::utils::factory_store<dsn::logging_provider>::create(
-        logging_factory_name.c_str(), dsn::PROVIDER_TYPE_MAIN, dir_log.c_str());
+        logging_factory_name.c_str(), dsn::PROVIDER_TYPE_MAIN, log_dir.c_str());
     dsn::logging_provider::set_logger(logger);
 
     if (dsn_log_prefixed_message_func != nullptr) {

--- a/src/utils/logging_provider.h
+++ b/src/utils/logging_provider.h
@@ -87,5 +87,5 @@ bool register_component_provider(const char *name,
 } // namespace dsn
 
 extern void dsn_log_init(const std::string &logging_factory_name,
-                         const std::string &dir_log,
+                         const std::string &log_dir,
                          std::function<std::string()> dsn_log_prefixed_message_func);


### PR DESCRIPTION
Add a new configuration 'log_dir' to indicate the directory to place the
logs especially. 'data_dir' will be used if it's empty.

```diff
[core]
+log_dir = 
```