### PR TITLE
refactor(logging): Minor refactor on logging module

### DIFF
--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -44,6 +44,7 @@
 #include <gperftools/malloc_extension.h>
 #endif
 
+#include "fmt/core.h"
 #include "perf_counter/perf_counters.h"
 #include "runtime/api_layer1.h"
 #include "runtime/api_task.h"
@@ -53,8 +54,6 @@
 #include "runtime/rpc/rpc_engine.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "runtime/rpc/rpc_message.h"
-#include "security/init.h"
-#include "security/negotiation_manager.h"
 #include "runtime/service_app.h"
 #include "runtime/service_engine.h"
 #include "runtime/task/task.h"
@@ -63,6 +62,8 @@
 #include "runtime/task/task_spec.h"
 #include "runtime/task/task_worker.h"
 #include "runtime/tool_api.h"
+#include "security/init.h"
+#include "security/negotiation_manager.h"
 #include "utils/api_utilities.h"
 #include "utils/command_manager.h"
 #include "utils/config_api.h"
@@ -75,6 +76,7 @@
 #include "utils/join_point.h"
 #include "utils/logging_provider.h"
 #include "utils/process_utils.h"
+#include "utils/string_conv.h"
 #include "utils/strings.h"
 #include "utils/sys_exit_hook.h"
 #include "utils/threadpool_spec.h"
@@ -342,45 +344,29 @@ inline void dsn_global_init()
 
 static std::string dsn_log_prefixed_message_func()
 {
-    std::string res;
-    res.resize(100);
-    char *prefixed_message = const_cast<char *>(res.c_str());
-
-    int tid = dsn::utils::get_current_tid();
-    auto t = dsn::task::get_current_task_id();
+    const int tid = dsn::utils::get_current_tid();
+    const auto t = dsn::task::get_current_task_id();
     if (t) {
         if (nullptr != dsn::task::get_current_worker2()) {
-            sprintf(prefixed_message,
-                    "%6s.%7s%d.%016" PRIx64 ": ",
-                    dsn::task::get_current_node_name(),
-                    dsn::task::get_current_worker2()->pool_spec().name.c_str(),
-                    dsn::task::get_current_worker2()->index(),
-                    t);
+            return fmt::format("{}.{}{}.{:016}: ",
+                               dsn::task::get_current_node_name(),
+                               dsn::task::get_current_worker2()->pool_spec().name,
+                               dsn::task::get_current_worker2()->index(),
+                               t);
         } else {
-            sprintf(prefixed_message,
-                    "%6s.%7s.%05d.%016" PRIx64 ": ",
-                    dsn::task::get_current_node_name(),
-                    "io-thrd",
-                    tid,
-                    t);
+            return fmt::format(
+                "{}.io-thrd.{}.{:016}: ", dsn::task::get_current_node_name(), tid, t);
         }
     } else {
         if (nullptr != dsn::task::get_current_worker2()) {
-            sprintf(prefixed_message,
-                    "%6s.%7s%u: ",
-                    dsn::task::get_current_node_name(),
-                    dsn::task::get_current_worker2()->pool_spec().name.c_str(),
-                    dsn::task::get_current_worker2()->index());
+            return fmt::format("{}.{}{}: ",
+                               dsn::task::get_current_node_name(),
+                               dsn::task::get_current_worker2()->pool_spec().name,
+                               dsn::task::get_current_worker2()->index());
         } else {
-            sprintf(prefixed_message,
-                    "%6s.%7s.%05d: ",
-                    dsn::task::get_current_node_name(),
-                    "io-thrd",
-                    tid);
+            return fmt::format("{}.io-thrd.{}: ", dsn::task::get_current_node_name(), tid);
         }
     }
-
-    return res;
 }
 
 bool run(const char *config_file,
@@ -447,14 +433,14 @@ bool run(const char *config_file,
     spec.dir_log = ::dsn::utils::filesystem::path_combine(cdir, "log");
     dsn::utils::filesystem::create_directory(spec.dir_log);
 
-    // init tools
+    // Initialize tools.
     dsn_all.tool.reset(::dsn::utils::factory_store<::dsn::tools::tool_app>::create(
         spec.tool.c_str(), ::dsn::PROVIDER_TYPE_MAIN, spec.tool.c_str()));
     dsn_all.tool->install(spec);
 
-    // init app specs
+    // Initialize app specs.
     if (!spec.init_app_specs()) {
-        printf("error in config file %s, exit ...\n", config_file);
+        fmt::print(stderr, "error in config file {}, exit ...\n", config_file);
         return false;
     }
 
@@ -465,7 +451,7 @@ bool run(const char *config_file,
     // init logging
     dsn_log_init(spec.logging_factory_name, spec.dir_log, dsn_log_prefixed_message_func);
 
-    // prepare minimum necessary
+    // Prepare the minimum necessary.
     ::dsn::service_engine::instance().init_before_toollets(spec);
 
     LOG_INFO("process({}) start: {}, date: {}",
@@ -473,10 +459,10 @@ bool run(const char *config_file,
              dsn::utils::process_start_millis(),
              dsn::utils::process_start_date_time_mills());
 
-    // init toollets
-    for (auto it = spec.toollets.begin(); it != spec.toollets.end(); ++it) {
-        auto tlet =
-            dsn::tools::internal_use_only::get_toollet(it->c_str(), ::dsn::PROVIDER_TYPE_MAIN);
+    // Initialize toollets.
+    for (const auto &toollet_name : spec.toollets) {
+        auto tlet = dsn::tools::internal_use_only::get_toollet(toollet_name.c_str(),
+                                                               ::dsn::PROVIDER_TYPE_MAIN);
         CHECK_NOTNULL(tlet, "toolet not found");
         tlet->install(spec);
     }
@@ -507,29 +493,37 @@ bool run(const char *config_file,
         }
     }
 
-    // split app_name and app_index
-    std::list<std::string> applistkvs;
-    ::dsn::utils::split_args(app_list.c_str(), applistkvs, ';');
-
     // init apps
     for (auto &sp : spec.app_specs) {
-        if (!sp.run)
+        if (!sp.run) {
             continue;
+        }
 
         bool create_it = false;
-
         // create all apps
-        if (app_list == "") {
+        if (app_list.empty()) {
             create_it = true;
         } else {
-            for (auto &kv : applistkvs) {
-                std::list<std::string> argskvs;
-                ::dsn::utils::split_args(kv.c_str(), argskvs, '@');
-                if (std::string("apps.") + argskvs.front() == sp.config_section) {
-                    if (argskvs.size() < 2)
+            // Extract app_names.
+            std::list<std::string> app_names_and_indexes;
+            ::dsn::utils::split_args(app_list.c_str(), app_names_and_indexes, ';');
+            for (const auto &app_name_and_index : app_names_and_indexes) {
+                std::vector<std::string> name_and_index;
+                ::dsn::utils::split_args(app_name_and_index.c_str(), name_and_index, '@');
+                CHECK(!name_and_index.empty(),
+                      "app_name should be specified in '{}'",
+                      app_name_and_index);
+                if (std::string("apps.") + name_and_index.front() == sp.config_section) {
+                    if (name_and_index.size() < 2) {
                         create_it = true;
-                    else
-                        create_it = (std::stoi(argskvs.back()) == sp.index);
+                    } else {
+                        int32_t index = 0;
+                        const auto index_str = name_and_index.back();
+                        CHECK(dsn::buf2int32(index_str, index),
+                              "'{}' is not a valid index",
+                              index_str);
+                        create_it = (index == sp.index);
+                    }
                     break;
                 }
             }
@@ -540,10 +534,11 @@ bool run(const char *config_file,
         }
     }
 
-    if (dsn::service_engine::instance().get_all_nodes().size() == 0) {
-        printf("no app are created, usually because \n"
-               "app_name is not specified correctly, should be 'xxx' in [apps.xxx]\n"
-               "or app_index (1-based) is greater than specified count in config file\n");
+    if (dsn::service_engine::instance().get_all_nodes().empty()) {
+        fmt::print(stderr,
+                   "no app are created, usually because \n"
+                   "app_name is not specified correctly, should be 'xxx' in [apps.xxx]\n"
+                   "or app_index (1-based) is greater than specified count in config file\n");
         exit(1);
     }
 

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -43,7 +43,7 @@ class screen_logger : public logging_provider
 {
 public:
     explicit screen_logger(bool short_header);
-    ~screen_logger() override;
+    ~screen_logger() override = default;
 
     void log(const char *file,
              const char *function,
@@ -54,6 +54,13 @@ public:
     virtual void flush();
 
 private:
+    static void print_header(log_level_t log_level);
+    void print_long_header(const char *file,
+                           const char *function,
+                           const int line,
+                           log_level_t log_level);
+    static void print_body(const char *body, log_level_t log_level);
+
     ::dsn::utils::ex_lock_nr _lock;
     const bool _short_header;
 };
@@ -77,17 +84,25 @@ public:
     void flush() override;
 
 private:
+    void print_header(log_level_t log_level);
+    void print_long_header(const char *file,
+                           const char *function,
+                           const int line,
+                           log_level_t log_level);
+    void print_body(const char *body, log_level_t log_level);
+
     void create_log_file();
 
 private:
     ::dsn::utils::ex_lock _lock; // use recursive lock to avoid dead lock when flush() is called
                                  // in signal handler if cored for bad logging format reason.
+    // The directory to store log files.
     const std::string _log_dir;
     FILE *_log;
     int _start_index;
     int _index;
     int _lines;
-    log_level_t _stderr_start_level;
+    const log_level_t _stderr_start_level;
 };
 } // namespace tools
 } // namespace dsn


### PR DESCRIPTION
Mainly including:
- Using fmt::format/print instead of sprintf/printf, which is more convenient
  and faster
- Add some configuration validators
- Encapsulate print_header(), print_long_header() and print_body() for
  screen_logger and simple_logger
- Add more comments
- Naming improvment