### PR TITLE
feat(logging): Fill timestamp in log file name and limit single file size and total count

### DIFF
--- a/src/runtime/tracer.cpp
+++ b/src/runtime/tracer.cpp
@@ -408,7 +408,7 @@ void tracer::install(service_spec &spec)
             "tracer.find",
             "Find related logs",
             "[forward|f|backward|b] [rpc|r|task|t] [trace_id|task_id(e.g., a023003920302390)] "
-            "<log_file_name(e.g., log.xx.txt)>",
+            "<log_file_name(e.g., log.yyyyMMdd_hhmmss_SSS)>",
             tracer_log_flow);
     });
 }

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -26,13 +26,14 @@
 
 #include "utils/simple_logger.h"
 
-#include <cstdint>
 #include <errno.h>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <fmt/core.h>
 #include <fmt/printf.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include <algorithm>
+#include <cstdint>
 #include <ctime>
 #include <functional>
 #include <memory>

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -26,11 +26,13 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstdio>
 #include <string>
 
 #include "utils/api_utilities.h"
 #include "utils/logging_provider.h"
+#include "utils/ports.h"
 #include "utils/synchronize.h"
 
 namespace dsn {
@@ -91,17 +93,30 @@ private:
                            log_level_t log_level);
     void print_body(const char *body, log_level_t log_level);
 
+    inline void add_bytes_if_valid(int bytes)
+    {
+        if (dsn_likely(bytes > 0)) {
+            _file_bytes += static_cast<uint64_t>(bytes);
+        }
+    }
+
     void create_log_file();
+    void remove_redundant_files();
 
 private:
     ::dsn::utils::ex_lock _lock; // use recursive lock to avoid dead lock when flush() is called
                                  // in signal handler if cored for bad logging format reason.
     // The directory to store log files.
     const std::string _log_dir;
+    // The path of the symlink to the latest log file.
+    std::string _symlink_path;
+    // The prefix of the log file names. The actual log files are prefixed by '_file_name_prefix'
+    // and postfixed by timestamp.
+    std::string _file_name_prefix;
+    // The current log file descriptor.
     FILE *_log;
-    int _start_index;
-    int _index;
-    int _lines;
+    // The byte size of the current log file.
+    uint64_t _file_bytes;
     const log_level_t _stderr_start_level;
 };
 } // namespace tools

--- a/src/utils/test/logger.cpp
+++ b/src/utils/test/logger.cpp
@@ -81,7 +81,7 @@ public:
         ASSERT_TRUE(utils::filesystem::get_subfiles(test_dir, sub_list, false));
 
         file_names.clear();
-        std::regex pattern(R"(log\.log\.[0-9]{8}_[0-9]{6}_[0-9]{3})");
+        std::regex pattern(R"(log\.[0-9]{8}_[0-9]{6}_[0-9]{3})");
         for (const auto &path : sub_list) {
             std::string name(utils::filesystem::get_file_name(path));
             if (std::regex_match(name, pattern)) {

--- a/src/utils/test/logger.cpp
+++ b/src/utils/test/logger.cpp
@@ -24,15 +24,14 @@
  * THE SOFTWARE.
  */
 
-#include <boost/algorithm/string/predicate.hpp>
-#include <errno.h>
 #include <fmt/core.h>
-#include <stdio.h>
 #include <unistd.h>
-#include <algorithm>
 #include <memory>
+#include <regex>
+#include <set>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -40,91 +39,144 @@
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/logging_provider.h"
-#include "utils/safe_strerror_posix.h"
 #include "utils/simple_logger.h"
+#include "utils/test_macros.h"
 
 DSN_DECLARE_uint64(max_number_of_log_files_on_disk);
 
 namespace dsn {
 namespace tools {
-
-namespace {
-
-void get_log_file_index(std::vector<int> &log_index)
+class logger_test : public testing::Test
 {
-    std::vector<std::string> sub_list;
-    ASSERT_TRUE(dsn::utils::filesystem::get_subfiles("./", sub_list, false));
-
-    for (const auto &path : sub_list) {
-        const auto &name = dsn::utils::filesystem::get_file_name(path);
-        if (!boost::algorithm::starts_with(name, "log.")) {
-            continue;
-        }
-        if (!boost::algorithm::ends_with(name, ".txt")) {
-            continue;
-        }
-
-        int index;
-        if (1 != sscanf(name.c_str(), "log.%d.txt", &index)) {
-            continue;
-        }
-        log_index.push_back(index);
+public:
+    void SetUp() override
+    {
+        // Deregister commands to avoid re-register error.
+        dsn::logging_provider::instance()->deregister_commands();
     }
-}
+};
 
-// Don't name the dir with "./test", otherwise the whole utils test dir would be removed.
-const std::string kTestDir("./test_logger");
-
-void prepare_test_dir()
+class simple_logger_test : public logger_test
 {
-    ASSERT_TRUE(dsn::utils::filesystem::create_directory(kTestDir));
-    ASSERT_EQ(0, ::chdir(kTestDir.c_str()));
-}
+public:
+    void SetUp() override
+    {
+        logger_test::SetUp();
 
-void remove_test_dir()
-{
-    ASSERT_EQ(0, ::chdir("..")) << "chdir failed, err = " << dsn::utils::safe_strerror(errno);
-    ASSERT_TRUE(dsn::utils::filesystem::remove_path(kTestDir)) << "remove_directory " << kTestDir
-                                                               << " failed";
-}
+        std::string cwd;
+        ASSERT_TRUE(dsn::utils::filesystem::get_current_directory(cwd));
+        // NOTE: Don't name the dir with "test", otherwise the whole utils test dir would be
+        // removed.
+        test_dir = dsn::utils::filesystem::path_combine(cwd, "simple_logger_test");
 
-} // anonymous namespace
+        NO_FATALS(prepare_test_dir());
+        std::set<std::string> files;
+        NO_FATALS(get_log_files(files));
+        NO_FATALS(clear_files(files));
+    }
+
+    void get_log_files(std::set<std::string> &file_names)
+    {
+        std::vector<std::string> sub_list;
+        ASSERT_TRUE(utils::filesystem::get_subfiles(test_dir, sub_list, false));
+
+        file_names.clear();
+        std::regex pattern(R"(log\.log\.[0-9]{8}_[0-9]{6}_[0-9]{3})");
+        for (const auto &path : sub_list) {
+            std::string name(utils::filesystem::get_file_name(path));
+            if (std::regex_match(name, pattern)) {
+                ASSERT_TRUE(file_names.insert(name).second);
+            }
+        }
+    }
+
+    void compare_log_files(const std::set<std::string> &before_files,
+                           const std::set<std::string> &after_files)
+    {
+        ASSERT_FALSE(after_files.empty());
+
+        // One new log file is created.
+        if (after_files.size() == before_files.size() + 1) {
+            // All the file names are the same.
+            for (auto it1 = before_files.begin(), it2 = after_files.begin();
+                 it1 != before_files.end();
+                 ++it1, ++it2) {
+                ASSERT_EQ(*it1, *it2);
+            }
+            // The number of log files is the same, but they have rolled.
+        } else if (after_files.size() == before_files.size()) {
+            auto it1 = before_files.begin();
+            auto it2 = after_files.begin();
+            // The first file is different, the one in 'before_files' is older.
+            ASSERT_NE(*it1, *it2);
+
+            // The rest of the files are the same.
+            for (++it1; it1 != before_files.end(); ++it1, ++it2) {
+                ASSERT_EQ(*it1, *it2);
+            }
+        } else {
+            ASSERT_TRUE(false) << "Invalid number of log files, before=" << before_files.size()
+                               << ", after=" << after_files.size();
+        }
+    }
+
+    void clear_files(const std::set<std::string> &file_names)
+    {
+        for (const auto &file_name : file_names) {
+            ASSERT_TRUE(dsn::utils::filesystem::remove_path(file_name));
+        }
+    }
+
+    void prepare_test_dir()
+    {
+        ASSERT_TRUE(dsn::utils::filesystem::create_directory(test_dir)) << test_dir;
+    }
+
+    void remove_test_dir()
+    {
+        ASSERT_TRUE(dsn::utils::filesystem::remove_path(test_dir)) << test_dir;
+    }
+
+public:
+    std::string test_dir;
+};
 
 #define LOG_PRINT(logger, ...)                                                                     \
     (logger)->log(                                                                                 \
         __FILE__, __FUNCTION__, __LINE__, LOG_LEVEL_DEBUG, fmt::format(__VA_ARGS__).c_str())
 
-TEST(LoggerTest, SimpleLogger)
+TEST_F(logger_test, screen_logger_test)
 {
-    // Deregister commands to avoid re-register error.
-    dsn::logging_provider::instance()->deregister_commands();
+    auto logger = std::make_unique<screen_logger>(true);
+    LOG_PRINT(logger.get(), "{}", "test_print");
+    std::thread t([](screen_logger *lg) { LOG_PRINT(lg, "{}", "test_print"); }, logger.get());
+    t.join();
+    logger->flush();
+}
 
-    {
-        auto logger = std::make_unique<screen_logger>(true);
-        LOG_PRINT(logger.get(), "{}", "test_print");
-        std::thread t([](screen_logger *lg) { LOG_PRINT(lg, "{}", "test_print"); }, logger.get());
-        t.join();
-
-        logger->flush();
-    }
-
-    prepare_test_dir();
-
+TEST_F(simple_logger_test, redundant_log_test)
+{
     // Create redundant log files to test if their number could be restricted.
     for (unsigned int i = 0; i < FLAGS_max_number_of_log_files_on_disk + 10; ++i) {
-        auto logger = std::make_unique<simple_logger>("./");
+        std::set<std::string> before_files;
+        NO_FATALS(get_log_files(before_files));
+
+        auto logger = std::make_unique<simple_logger>(test_dir.c_str());
         for (unsigned int i = 0; i != 1000; ++i) {
             LOG_PRINT(logger.get(), "{}", "test_print");
         }
         logger->flush();
+
+        std::set<std::string> after_files;
+        NO_FATALS(get_log_files(after_files));
+        NO_FATALS(compare_log_files(before_files, after_files));
+        ::usleep(2000);
     }
 
-    std::vector<int> index;
-    get_log_file_index(index);
-    ASSERT_FALSE(index.empty());
-    ASSERT_EQ(FLAGS_max_number_of_log_files_on_disk, index.size());
-
-    remove_test_dir();
+    std::set<std::string> files;
+    NO_FATALS(get_log_files(files));
+    ASSERT_FALSE(files.empty());
+    ASSERT_EQ(FLAGS_max_number_of_log_files_on_disk, files.size());
 }
 
 } // namespace tools


### PR DESCRIPTION
- A new symlink is added to point to the latest log file, the symlink is in
  the same directory as the log files.

**Behavior change:**
- Log file is rolled by `max_log_file_bytes` configuration (64MB by default)
  instead of the fixed line count, i.e. 200000.
- Log files are named as `log.<yyyyMMdd_hhmmss_SSS>`, e.g. log.20240524_1806_235
  instead of `log.<index>.txt`, e.g. log.123.txt

```diff
[tools.simple_logger]
+max_log_file_bytes =
```