### PR TITLE
fix(backup): validate backup policy name

### DIFF
--- a/src/meta/CMakeLists.txt
+++ b/src/meta/CMakeLists.txt
@@ -39,6 +39,7 @@ set(MY_PROJ_LIBS
         dsn_http
         dsn_runtime
         dsn_aio
+        prometheus-cpp-core
         zookeeper
         hashtable
         hdfs

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1473,9 +1473,17 @@ bool backup_service::is_valid_policy_name_unlocked(const std::string &policy_nam
         return false;
     }
 
-    // Because the policy name is used as a metric name in prometheus, it must match the regex.
-    if (!prometheus::CheckLabelName(policy_name)) {
-        hint_message = "policy name should match regex '[a-zA-Z_][a-zA-Z0-9_]*'";
+    // Validate the policy name as a metric name in prometheus.
+    if (!prometheus::CheckMetricName(policy_name)) {
+        hint_message = "policy name should match regex '[a-zA-Z_:][a-zA-Z0-9_:]*' when act as a "
+                       "metric name in prometheus";
+        return false;
+    }
+
+    // Validate the policy name as a metric label in prometheus.
+    if (!prometheus::CheckLabelName(policy_name, prometheus::MetricType::Gauge)) {
+        hint_message = "policy name should match regex '[a-zA-Z_][a-zA-Z0-9_]*' when act as a "
+                       "metric label in prometheus";
         return false;
     }
 

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1465,8 +1465,8 @@ bool backup_service::is_valid_policy_name_unlocked(const std::string &policy_nam
                                                    std::string &hint_message)
 {
     // BACKUP_INFO and policy_name should not be the same, because they are in the same level in the
-    // output
-    // when query the policy details, use different names to distinguish the respective contents.
+    // output when query the policy details, use different names to distinguish the respective
+    // contents.
     static const std::set<std::string> kReservedNames = {cold_backup_constant::BACKUP_INFO};
     if (kReservedNames.count(policy_name) == 1) {
         hint_message = "policy name is reserved";

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1474,8 +1474,8 @@ bool backup_service::is_valid_policy_name_unlocked(const std::string &policy_nam
     }
 
     // Because the policy name is used as a metric name in prometheus, it must match the regex.
-    if (!prometheus::CheckMetricName(policy_name)) {
-        hint_message = "policy name should match regex '[a-zA-Z_:][a-zA-Z0-9_:]*'";
+    if (!prometheus::CheckLabelName(policy_name)) {
+        hint_message = "policy name should match regex '[a-zA-Z_][a-zA-Z0-9_]*'";
         return false;
     }
 

--- a/src/meta/meta_backup_service.h
+++ b/src/meta/meta_backup_service.h
@@ -407,6 +407,7 @@ private:
 
     FRIEND_TEST(backup_service_test, test_init_backup);
     FRIEND_TEST(backup_service_test, test_query_backup_status);
+    FRIEND_TEST(backup_service_test, test_valid_policy_name);
     FRIEND_TEST(meta_backup_service_test, test_add_backup_policy);
 
     void start_create_policy_meta_root(dsn::task_ptr callback);
@@ -420,7 +421,7 @@ private:
                                             const policy &p,
                                             std::shared_ptr<policy_context> &p_context_ptr);
 
-    bool is_valid_policy_name_unlocked(const std::string &policy_name);
+    bool is_valid_policy_name_unlocked(const std::string &policy_name, std::string &hint_message);
 
     policy_factory _factory;
     meta_service *_meta_svc;

--- a/src/meta/test/meta_backup_test.cpp
+++ b/src/meta/test/meta_backup_test.cpp
@@ -204,6 +204,24 @@ TEST_F(backup_service_test, test_query_backup_status)
     ASSERT_EQ(1, resp.backup_items.size());
 }
 
+TEST_F(backup_service_test, test_valid_policy_name)
+{
+    std::string hint_message;
+    ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked(cold_backup_constant::BACKUP_INFO,
+                                                                hint_message));
+    ASSERT_EQ("policy_name is reserved", hint_message);
+
+    ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("bad-policy-name", hint_message));
+    ASSERT_EQ("policy_name should match regex '[a-zA-Z_:][a-zA-Z0-9_:]*'", hint_message);
+
+    _backup_service->_policy_states.insert(std::make_pair("exist_policy_name", nullptr));
+    ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("exist_policy_name", hint_message));
+    ASSERT_EQ("policy_name is already exist", hint_message);
+
+    ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("new_policy_name0", hint_message));
+    ASSERT_TRUE(hint_message.empty());
+}
+
 class backup_engine_test : public meta_test_base
 {
 public:

--- a/src/meta/test/meta_backup_test.cpp
+++ b/src/meta/test/meta_backup_test.cpp
@@ -213,7 +213,7 @@ TEST_F(backup_service_test, test_valid_policy_name)
     ASSERT_EQ("policy name is reserved", hint_message);
 
     ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("bad-policy-name", hint_message));
-    ASSERT_EQ("policy name should match regex '[a-zA-Z_:][a-zA-Z0-9_:]*'", hint_message);
+    ASSERT_EQ("policy name should match regex '[a-zA-Z_][a-zA-Z0-9_]*'", hint_message);
 
     _backup_service->_policy_states.insert(std::make_pair("exist_policy_name", nullptr));
     ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("exist_policy_name", hint_message));

--- a/src/meta/test/meta_backup_test.cpp
+++ b/src/meta/test/meta_backup_test.cpp
@@ -19,6 +19,7 @@
 #include <map>
 #include <memory>
 #include <string>
+// IWYU pragma: no_include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/src/meta/test/meta_backup_test.cpp
+++ b/src/meta/test/meta_backup_test.cpp
@@ -213,7 +213,14 @@ TEST_F(backup_service_test, test_valid_policy_name)
     ASSERT_EQ("policy name is reserved", hint_message);
 
     ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("bad-policy-name", hint_message));
-    ASSERT_EQ("policy name should match regex '[a-zA-Z_][a-zA-Z0-9_]*'", hint_message);
+    ASSERT_EQ("policy name should match regex '[a-zA-Z_:][a-zA-Z0-9_:]*' when act as a metric name "
+              "in prometheus",
+              hint_message);
+
+    ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("bad_policy_name:", hint_message));
+    ASSERT_EQ("policy name should match regex '[a-zA-Z_][a-zA-Z0-9_]*' when act as a metric label "
+              "in prometheus",
+              hint_message);
 
     _backup_service->_policy_states.insert(std::make_pair("exist_policy_name", nullptr));
     ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("exist_policy_name", hint_message));

--- a/src/meta/test/meta_backup_test.cpp
+++ b/src/meta/test/meta_backup_test.cpp
@@ -209,16 +209,16 @@ TEST_F(backup_service_test, test_valid_policy_name)
     std::string hint_message;
     ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked(cold_backup_constant::BACKUP_INFO,
                                                                 hint_message));
-    ASSERT_EQ("policy_name is reserved", hint_message);
+    ASSERT_EQ("policy name is reserved", hint_message);
 
     ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("bad-policy-name", hint_message));
-    ASSERT_EQ("policy_name should match regex '[a-zA-Z_:][a-zA-Z0-9_:]*'", hint_message);
+    ASSERT_EQ("policy name should match regex '[a-zA-Z_:][a-zA-Z0-9_:]*'", hint_message);
 
     _backup_service->_policy_states.insert(std::make_pair("exist_policy_name", nullptr));
     ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("exist_policy_name", hint_message));
-    ASSERT_EQ("policy_name is already exist", hint_message);
+    ASSERT_EQ("policy name is already exist", hint_message);
 
-    ASSERT_FALSE(_backup_service->is_valid_policy_name_unlocked("new_policy_name0", hint_message));
+    ASSERT_TRUE(_backup_service->is_valid_policy_name_unlocked("new_policy_name0", hint_message));
     ASSERT_TRUE(hint_message.empty());
 }
 


### PR DESCRIPTION
Because the backup policy name will be used as a metric name and label, it
should not contain any invalid character (e.g. `-`), otherwise, it lead crash.

This patch adds a validator to ensure there are only allowed characters in
backup policy name.