### PR TITLE
feat(shell): Add JSON format data output to some backup_policy commands

### DIFF
--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1194,7 +1194,8 @@ dsn::error_code replication_ddl_client::ls_backup_policy(bool json)
     } else {
         dsn::utils::multi_table_printer mtp;
         for (int32_t idx = 0; idx < resp.policys.size(); idx++) {
-            mtp.add(std::move(print_policy_entry(resp.policys[idx])));
+            dsn::utils::table_printer tp = print_policy_entry(resp.policys[idx]);
+            mtp.add(std::move(tp));
         }
         mtp.output(out, json ? tp_output_format::kJsonPretty : tp_output_format::kTabular);
     }
@@ -1232,7 +1233,8 @@ dsn::error_code replication_ddl_client::query_backup_policy(
                 std::cout << "************************" << std::endl;
             }
             const policy_entry &pentry = resp.policys[idx];
-            mtp.add(std::move(print_policy_entry(pentry)));
+            dsn::utils::table_printer tp_policy = print_policy_entry(pentry);
+            mtp.add(std::move(tp_policy));
             const std::vector<backup_entry> &backup_infos = resp.backup_infos[idx];
             dsn::utils::table_printer tp_backup("backup_infos");
             tp_backup.add_title("id");

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -38,6 +38,7 @@
 
 #include "backup_types.h"
 #include "common//duplication_common.h"
+#include "common/backup_common.h"
 #include "common/bulk_load_common.h"
 #include "common/gpid.h"
 #include "common/manual_compact.h"
@@ -1236,7 +1237,7 @@ dsn::error_code replication_ddl_client::query_backup_policy(
             dsn::utils::table_printer tp_policy = print_policy_entry(pentry);
             mtp.add(std::move(tp_policy));
             const std::vector<backup_entry> &backup_infos = resp.backup_infos[idx];
-            dsn::utils::table_printer tp_backup("backup_infos");
+            dsn::utils::table_printer tp_backup(cold_backup_constant::BACKUP_INFO);
             tp_backup.add_title("id");
             tp_backup.add_column("start_time");
             tp_backup.add_column("end_time");

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1206,7 +1206,7 @@ dsn::error_code replication_ddl_client::ls_backup_policy(bool json)
 dsn::error_code replication_ddl_client::query_backup_policy(
     const std::vector<std::string> &policy_names, int backup_info_cnt, bool json)
 {
-    // Output example by JSON format     
+    // Output example by JSON format
     // {
     //     "p1": {
     //         "backup_provider_type": "xxxx_service",

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1206,41 +1206,6 @@ dsn::error_code replication_ddl_client::ls_backup_policy(bool json)
 dsn::error_code replication_ddl_client::query_backup_policy(
     const std::vector<std::string> &policy_names, int backup_info_cnt, bool json)
 {
-    // Output example by JSON format
-    // {
-    //     "p1": {
-    //         "backup_provider_type": "xxxx_service",
-    //         "backup_interval": "86400s",
-    //         "app_ids": "{3}",
-    //         "start_time": "03:36",
-    //         "status": "enabled",
-    //         "backup_history_count": "1"
-    //     },
-    //     "p1_backup_info": {
-    //         "1716781003199": {
-    //             "id": "1716781003199",
-    //             "start_time": "2024-05-27 03:36:43",
-    //             "end_time": "-",
-    //             "app_ids": "{3}"
-    //         }
-    //     },
-    //     "p2": {
-    //         "backup_provider_type": "xxxx_service",
-    //         "backup_interval": "86400s",
-    //         "app_ids": "{3}",
-    //         "start_time": "20:25",
-    //         "status": "enabled",
-    //         "backup_history_count": "1"
-    //     },
-    //     "p2_backup_info": {
-    //         "1716840160297": {
-    //             "id": "1716840160297",
-    //             "start_time": "2024-05-27 20:02:40",
-    //             "end_time": "-",
-    //             "app_ids": "{3}"
-    //         }
-    //     }
-    // }
     auto req = std::make_shared<configuration_query_backup_policy_request>();
     req->policy_names = policy_names;
     req->backup_info_count = backup_info_cnt;

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1201,10 +1201,8 @@ dsn::error_code replication_ddl_client::ls_backup_policy(bool json)
     return ERR_OK;
 }
 
-dsn::error_code
-replication_ddl_client::query_backup_policy(const std::vector<std::string> &policy_names,
-                                            int backup_info_cnt,
-                                            bool json)
+dsn::error_code replication_ddl_client::query_backup_policy(
+    const std::vector<std::string> &policy_names, int backup_info_cnt, bool json)
 {
     auto req = std::make_shared<configuration_query_backup_policy_request>();
     req->policy_names = policy_names;

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1206,6 +1206,41 @@ dsn::error_code replication_ddl_client::ls_backup_policy(bool json)
 dsn::error_code replication_ddl_client::query_backup_policy(
     const std::vector<std::string> &policy_names, int backup_info_cnt, bool json)
 {
+// Output example by JSON format     
+// {
+//     "p1": {
+//         "backup_provider_type": "xxxx_service",
+//         "backup_interval": "86400s",
+//         "app_ids": "{3}",
+//         "start_time": "03:36",
+//         "status": "enabled",
+//         "backup_history_count": "1"
+//     },
+//     "p1_backup_info": {
+//         "1716781003199": {
+//             "id": "1716781003199",
+//             "start_time": "2024-05-27 03:36:43",
+//             "end_time": "-",
+//             "app_ids": "{3}"
+//         }
+//     },
+//     "p2": {
+//         "backup_provider_type": "xxxx_service",
+//         "backup_interval": "86400s",
+//         "app_ids": "{3}",
+//         "start_time": "20:25",
+//         "status": "enabled",
+//         "backup_history_count": "1"
+//     },
+//     "p2_backup_info": {
+//         "1716840160297": {
+//             "id": "1716840160297",
+//             "start_time": "2024-05-27 20:02:40",
+//             "end_time": "-",
+//             "app_ids": "{3}"
+//         }
+//     }
+// }
     auto req = std::make_shared<configuration_query_backup_policy_request>();
     req->policy_names = policy_names;
     req->backup_info_count = backup_info_cnt;
@@ -1234,7 +1269,8 @@ dsn::error_code replication_ddl_client::query_backup_policy(
             dsn::utils::table_printer tp_policy = print_policy_entry(pentry);
             mtp.add(std::move(tp_policy));
             const std::vector<backup_entry> &backup_infos = resp.backup_infos[idx];
-            dsn::utils::table_printer tp_backup(pentry.policy_name + "_" + cold_backup_constant::BACKUP_INFO);
+            dsn::utils::table_printer tp_backup(pentry.policy_name + "_" +
+                                                cold_backup_constant::BACKUP_INFO);
             tp_backup.add_title("id");
             tp_backup.add_column("start_time");
             tp_backup.add_column("end_time");

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1206,41 +1206,41 @@ dsn::error_code replication_ddl_client::ls_backup_policy(bool json)
 dsn::error_code replication_ddl_client::query_backup_policy(
     const std::vector<std::string> &policy_names, int backup_info_cnt, bool json)
 {
-// Output example by JSON format     
-// {
-//     "p1": {
-//         "backup_provider_type": "xxxx_service",
-//         "backup_interval": "86400s",
-//         "app_ids": "{3}",
-//         "start_time": "03:36",
-//         "status": "enabled",
-//         "backup_history_count": "1"
-//     },
-//     "p1_backup_info": {
-//         "1716781003199": {
-//             "id": "1716781003199",
-//             "start_time": "2024-05-27 03:36:43",
-//             "end_time": "-",
-//             "app_ids": "{3}"
-//         }
-//     },
-//     "p2": {
-//         "backup_provider_type": "xxxx_service",
-//         "backup_interval": "86400s",
-//         "app_ids": "{3}",
-//         "start_time": "20:25",
-//         "status": "enabled",
-//         "backup_history_count": "1"
-//     },
-//     "p2_backup_info": {
-//         "1716840160297": {
-//             "id": "1716840160297",
-//             "start_time": "2024-05-27 20:02:40",
-//             "end_time": "-",
-//             "app_ids": "{3}"
-//         }
-//     }
-// }
+    // Output example by JSON format     
+    // {
+    //     "p1": {
+    //         "backup_provider_type": "xxxx_service",
+    //         "backup_interval": "86400s",
+    //         "app_ids": "{3}",
+    //         "start_time": "03:36",
+    //         "status": "enabled",
+    //         "backup_history_count": "1"
+    //     },
+    //     "p1_backup_info": {
+    //         "1716781003199": {
+    //             "id": "1716781003199",
+    //             "start_time": "2024-05-27 03:36:43",
+    //             "end_time": "-",
+    //             "app_ids": "{3}"
+    //         }
+    //     },
+    //     "p2": {
+    //         "backup_provider_type": "xxxx_service",
+    //         "backup_interval": "86400s",
+    //         "app_ids": "{3}",
+    //         "start_time": "20:25",
+    //         "status": "enabled",
+    //         "backup_history_count": "1"
+    //     },
+    //     "p2_backup_info": {
+    //         "1716840160297": {
+    //             "id": "1716840160297",
+    //             "start_time": "2024-05-27 20:02:40",
+    //             "end_time": "-",
+    //             "app_ids": "{3}"
+    //         }
+    //     }
+    // }
     auto req = std::make_shared<configuration_query_backup_policy_request>();
     req->policy_names = policy_names;
     req->backup_info_count = backup_info_cnt;

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1230,14 +1230,11 @@ dsn::error_code replication_ddl_client::query_backup_policy(
     } else {
         dsn::utils::multi_table_printer mtp;
         for (int32_t idx = 0; idx < resp.policys.size(); idx++) {
-            if (idx != 0) {
-                std::cout << "************************" << std::endl;
-            }
             const policy_entry &pentry = resp.policys[idx];
             dsn::utils::table_printer tp_policy = print_policy_entry(pentry);
             mtp.add(std::move(tp_policy));
             const std::vector<backup_entry> &backup_infos = resp.backup_infos[idx];
-            dsn::utils::table_printer tp_backup(cold_backup_constant::BACKUP_INFO);
+            dsn::utils::table_printer tp_backup(pentry.policy_name + "_" + cold_backup_constant::BACKUP_INFO);
             tp_backup.add_title("id");
             tp_backup.add_column("start_time");
             tp_backup.add_column("end_time");

--- a/src/client/replication_ddl_client.h
+++ b/src/client/replication_ddl_client.h
@@ -179,14 +179,15 @@ public:
 
     error_with<query_backup_status_response> query_backup(int32_t app_id, int64_t backup_id);
 
-    dsn::error_code ls_backup_policy();
+    dsn::error_code ls_backup_policy(bool json);
 
     dsn::error_code disable_backup_policy(const std::string &policy_name);
 
     dsn::error_code enable_backup_policy(const std::string &policy_name);
 
     dsn::error_code query_backup_policy(const std::vector<std::string> &policy_names,
-                                        int backup_info_cnt);
+                                        int backup_info_cnt,
+                                        bool json);
 
     dsn::error_code update_backup_policy(const std::string &policy_name,
                                          const std::vector<int32_t> &add_appids,

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1468,7 +1468,6 @@ bool backup_service::is_valid_policy_name_unlocked(const std::string &policy_nam
     // BACKUP_INFO and policy_name should not be the same, because they are in the same level in the
     // output when query the policy details, use different names to distinguish the respective
     // contents.
-    static const std::set<std::string> kReservedNames = {cold_backup_constant::BACKUP_INFO};
     if (policy_name.find(cold_backup_constant::BACKUP_INFO) != std::string::npos) {
         hint_message = "policy name is reserved";
         return false;

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1469,7 +1469,7 @@ bool backup_service::is_valid_policy_name_unlocked(const std::string &policy_nam
     // output when query the policy details, use different names to distinguish the respective
     // contents.
     static const std::set<std::string> kReservedNames = {cold_backup_constant::BACKUP_INFO};
-    if (kReservedNames.count(policy_name) == 1) {
+    if (policy_name.find(cold_backup_constant::BACKUP_INFO) != std::string::npos) {
         hint_message = "policy name is reserved";
         return false;
     }

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -158,7 +158,7 @@ bool ls_backup_policy(command_executor *e, shell_context *sc, arguments args)
 bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {
     const std::string query_backup_policy_help = "<policy_name> [-b|--backup_info_cnt] [-j|--json]";
-    argh::parser cmd(args.argc, args.argv);
+    argh::parser cmd(args.argc, args.argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
     RETURN_FALSE_IF_NOT(cmd.pos_args().size() > 1,
                         "invalid command, should be in the form of '{}'",
                         query_backup_policy_help);

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include "client/replication_ddl_client.h"
+#include "shell/argh.h"
 #include "shell/command_executor.h"
 #include "shell/command_helper.h"
 #include "shell/commands.h"

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -172,10 +172,6 @@ bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
 
     const bool json = cmd[{"-j", "--json"}];
 
-    if (policy_names.empty()) {
-        fprintf(stderr, "empty policy_name, please assign policy_name you want to query\n");
-        return false;
-    }
     ::dsn::error_code ret =
         sc->ddl_client->query_backup_policy(policy_names, backup_info_cnt, json);
     if (ret != ::dsn::ERR_OK) {

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -33,6 +33,7 @@
 
 #include "client/replication_ddl_client.h"
 #include "shell/command_executor.h"
+#include "shell/command_helper.h"
 #include "shell/commands.h"
 #include "shell/sds/sds.h"
 #include "utils/error_code.h"
@@ -143,25 +144,8 @@ bool add_backup_policy(command_executor *e, shell_context *sc, arguments args)
 
 bool ls_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {
-    static struct option long_options[] = {{"json", no_argument, 0, 'j'}, {0, 0, 0, 0}};
-
-    bool json = false;
-
-    optind = 0;
-    while (true) {
-        int option_index = 0;
-        int c;
-        c = getopt_long(args.argc, args.argv, "j", long_options, &option_index);
-        if (c == -1)
-            break;
-        switch (c) {
-        case 'j':
-            json = true;
-            break;
-        default:
-            return false;
-        }
-    }
+    argh::parser cmd(args.argc, args.argv);
+    const bool json = cmd[{"-j", "--json"}];
 
     ::dsn::error_code err = sc->ddl_client->ls_backup_policy(json);
     if (err != ::dsn::ERR_OK) {
@@ -172,48 +156,29 @@ bool ls_backup_policy(command_executor *e, shell_context *sc, arguments args)
 
 bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {
-    static struct option long_options[] = {{"json", no_argument, 0, 'j'},
-                                           {"policy_name", required_argument, 0, 'p'},
-                                           {"backup_info_cnt", required_argument, 0, 'b'},
-                                           {0, 0, 0, 0}};
-    std::vector<std::string> policy_names;
-    int backup_info_cnt = 3;
-    bool json = false;
+    const std::string query_backup_policy_help = "<policy_name> [-b|--backup_info_cnt] [-j|--json]";
+    argh::parser cmd(args.argc, args.argv);
+    RETURN_FALSE_IF_NOT(cmd.pos_args().size() > 1,
+                        "invalid command, should be in the form of '{}'",
+                        query_backup_policy_help);
 
-    optind = 0;
-    while (true) {
-        int option_index = 0;
-        int c;
-        c = getopt_long(args.argc, args.argv, "jp:b:", long_options, &option_index);
-        if (c == -1)
-            break;
-        switch (c) {
-        case 'j':
-            json = true;
-            break;
-        case 'p': {
-            std::vector<std::string> names;
-            ::dsn::utils::split_args(optarg, names, ',');
-            for (const auto &policy_name : names) {
-                if (policy_name.empty()) {
-                    fprintf(stderr, "invalid, empty policy_name, just ignore\n");
-                    continue;
-                } else {
-                    policy_names.emplace_back(policy_name);
-                }
-            }
-        } break;
-        case 'b':
-            backup_info_cnt = atoi(optarg);
-            if (backup_info_cnt <= 0) {
-                fprintf(stderr, "invalid backup_info_cnt %s\n", optarg);
-                return false;
-            }
-            break;
-        default:
-            return false;
+    std::vector<std::string> policy_names;
+    std::vector<std::string> names;
+    ::dsn::utils::split_args(cmd(1).str().c_str(), names, ',');
+    for (const auto &policy_name : names) {
+        if (policy_name.empty()) {
+            fprintf(stderr, "invalid, empty policy_name, just ignore\n");
+            continue;
+        } else {
+            policy_names.emplace_back(policy_name);
         }
     }
+
+    uint32_t backup_info_cnt;
+    PARSE_OPT_UINT(backup_info_cnt, 3, {"-b", "--backup_info_cnt"});
+
+    const bool json = cmd[{"-j", "--json"}];
+
     if (policy_names.empty()) {
         fprintf(stderr, "empty policy_name, please assign policy_name you want to query\n");
         return false;

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -143,8 +143,7 @@ bool add_backup_policy(command_executor *e, shell_context *sc, arguments args)
 
 bool ls_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {
-    static struct option long_options[] = {{"json", no_argument, 0, 'j'},
-                                           {0, 0, 0, 0}};
+    static struct option long_options[] = {{"json", no_argument, 0, 'j'}, {0, 0, 0, 0}};
 
     bool json = false;
 
@@ -219,7 +218,8 @@ bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
         fprintf(stderr, "empty policy_name, please assign policy_name you want to query\n");
         return false;
     }
-    ::dsn::error_code ret = sc->ddl_client->query_backup_policy(policy_names, backup_info_cnt, json);
+    ::dsn::error_code ret =
+        sc->ddl_client->query_backup_policy(policy_names, backup_info_cnt, json);
     if (ret != ::dsn::ERR_OK) {
         fprintf(stderr, "query backup policy failed, err = %s\n", ret.to_string());
     }

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -163,6 +163,7 @@ bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
                         "invalid command, should be in the form of '{}'",
                         query_backup_policy_help);
 
+    int param_index = 1;
     std::vector<std::string> policy_names;
     PARSE_STRS(policy_names);
 

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -164,16 +164,7 @@ bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
                         query_backup_policy_help);
 
     std::vector<std::string> policy_names;
-    std::vector<std::string> names;
-    ::dsn::utils::split_args(cmd(1).str().c_str(), names, ',');
-    for (const auto &policy_name : names) {
-        if (policy_name.empty()) {
-            fprintf(stderr, "invalid, empty policy_name, just ignore\n");
-            continue;
-        } else {
-            policy_names.emplace_back(policy_name);
-        }
-    }
+    PARSE_STRS(policy_names);
 
     uint32_t backup_info_cnt;
     PARSE_OPT_UINT(backup_info_cnt, 3, {"-b", "--backup_info_cnt"});

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -413,11 +413,16 @@ static command_executor commands[] = {
         "<-c|--backup_history_cnt num>",
         add_backup_policy,
     },
-    {"ls_backup_policy", "list the names of the subsistent backup policies", "", ls_backup_policy},
+    {
+        "ls_backup_policy",
+        "list the names of the subsistent backup policies",
+        "[-j|--json]",
+        ls_backup_policy,
+    },
     {
         "query_backup_policy",
         "query subsistent backup policy and last backup infos",
-        "<-p|--policy_name p1,p2...> [-b|--backup_info_cnt num]",
+        "<-p|--policy_name p1,p2...> [-b|--backup_info_cnt num] [-j|--json]",
         query_backup_policy,
     },
     {


### PR DESCRIPTION
Add JSON output to some backup policy commands to facilitate the writing of automation scripts.

Backup policy commands including:
- ls_backup_policy
- query_backup_policy

ls_backup_policy Output example by Tabler format
```
[p1]
backup_provider_type  : hdfs_service
backup_interval       : 86400s
app_ids               : {3}
start_time            : 03:36
status                : enabled
backup_history_count  : 1

[p2]
backup_provider_type  : hdfs_service
backup_interval       : 86400s
app_ids               : {3}
start_time            : 20:25
status                : enabled
backup_history_count  : 1
```
ls_backup_policy Output example by JSON format
```
{
    "p1": {
        "backup_provider_type": "hdfs_service",
        "backup_interval": "86400s",
        "app_ids": "{3}",
        "start_time": "03:36",
        "status": "enabled",
        "backup_history_count": "1"
    },
    "p2": {
        "backup_provider_type": "hdfs_service",
        "backup_interval": "86400s",
        "app_ids": "{3}",
        "start_time": "20:25",
        "status": "enabled",
        "backup_history_count": "1"
    }
}
```

query_backup_policy Output example by Tabler format
```
[p1]
backup_provider_type  : hdfs_service
backup_interval       : 86400s
app_ids               : {3}
start_time            : 03:36
status                : enabled
backup_history_count  : 1

[backup_info]
id             start_time           end_time  app_ids
1716781003199  2024-05-27 03:36:43  -         {3}

[p2]
backup_provider_type  : hdfs_service
backup_interval       : 86400s
app_ids               : {3}
start_time            : 20:25
status                : enabled
backup_history_count  : 1

[backup_info]
id             start_time           end_time  app_ids
1716840160297  2024-05-27 20:02:40  -         {3}
```
query_backup_policy Output example by JSON format
   ```
   {
        "p1": {
            "backup_provider_type": "hdfs_service",
            "backup_interval": "86400s",
            "app_ids": "{3}",
            "start_time": "03:36",
            "status": "enabled",
            "backup_history_count": "1"
        },
        "p1_backup_info": {
            "1716781003199": {
                "id": "1716781003199",
                "start_time": "2024-05-27 03:36:43",
                "end_time": "-",
                "app_ids": "{3}"
            }
        },
        "p2": {
            "backup_provider_type": "hdfs_service",
            "backup_interval": "86400s",
            "app_ids": "{3}",
            "start_time": "20:25",
            "status": "enabled",
            "backup_history_count": "1"
        },
        "p2_backup_info": {
            "1716840160297": {
                "id": "1716840160297",
                "start_time": "2024-05-27 20:02:40",
                "end_time": "-",
                "app_ids": "{3}"
            }
        }
    }
```