### PR TITLE
chore(CI): Add building debug version job on CentOS 7 and fix link errors

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -378,8 +378,8 @@ jobs:
       - name: Run server tests
         uses: "./.github/actions/run_server_tests"
 
-  build_pegasus_on_macos:
-    name: macOS
+  build_release_on_macos:
+    name: Build Release on macOS
     needs: cpp_clang_format_linter
     runs-on: macos-12
     steps:
@@ -411,3 +411,20 @@ jobs:
           ccache -z
           ./run.sh build --test --skip_thirdparty -j $(sysctl -n hw.physicalcpu)
           ccache -s
+
+  build_debug_on_centos7:
+    name: Build Debug on CentOS 7
+    needs: cpp_clang_format_linter
+    runs-on: ubuntu-latest
+    env:
+      USE_JEMALLOC: OFF
+      BUILD_OPTIONS: -t debug --test
+    container:
+      image: apache/pegasus:thirdparties-bin-centos7-${{ github.base_ref }}
+    steps:
+      - name: Clone code
+        uses: actions/checkout@v3
+      - name: Rebuild thirdparty if needed
+        uses: "./.github/actions/rebuild_thirdparty_if_needed"
+      - name: Build Pegasus
+        uses: "./.github/actions/build_pegasus"

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -234,7 +234,6 @@ ExternalProject_Add(fmt
 )
 
 set(CURL_OPTIONS
-        --enable-shared
         --disable-dict
         --disable-file
         --disable-ftp
@@ -246,11 +245,11 @@ set(CURL_OPTIONS
         --disable-manual
         --disable-pop3
         --disable-rtsp
+        --disable-shared
         --disable-smtp
         --disable-telnet
         --disable-tftp
         --without-brotli
-        --without-libidn
         --without-libidn2
         --without-librtmp
         --without-libssh2
@@ -269,7 +268,7 @@ ExternalProject_Add(curl
         URL ${OSS_URL_PREFIX}/curl-8.4.0.tar.gz
         http://curl.haxx.se/download/curl-8.4.0.tar.gz
         URL_MD5 533e8a3b1228d5945a6a512537bea4c7
-        CONFIGURE_COMMAND ./configure --prefix=${TP_OUTPUT}
+        CONFIGURE_COMMAND CFLAGS=-fPIC CPPFLAGS=-fPIC ./configure --prefix=${TP_OUTPUT}
         ${CURL_OPTIONS}
         BUILD_IN_SOURCE 1
         DOWNLOAD_EXTRACT_TIMESTAMP true
@@ -282,6 +281,8 @@ ExternalProject_Add(prometheus-cpp
         URL_MD5 cdb515e802aa9aaaf1f6dde1271a20a2
         DEPENDS curl
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
+        -DCMAKE_C_FLAGS=-fPIC
+        -DCMAKE_CXX_FLAGS=-fPIC
         -DENABLE_TESTING=OFF
         -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}


### PR DESCRIPTION
- Add a new job `Build Debug on CentOS 7`
- Rename the `macOS` job to `Build Release on macOS`
- Fix the link error on CentOS 7 and revert some modification of commit d00b25136aeb04c70eb62ba4ea8b0250804483a8