### PR TITLE
chore(pack): Support to pack server binaries separately

### DIFF
--- a/.github/actions/build_pegasus/action.yaml
+++ b/.github/actions/build_pegasus/action.yaml
@@ -38,12 +38,12 @@ runs:
       shell: bash
     - name: Pack Server
       run: |
-        ./run.sh pack_server -j
+        ./run.sh pack_server -j ${PACK_OPTIONS}
         rm -rf pegasus-server-*
       shell: bash
     - name: Pack Tools
       run: |
-        ./run.sh pack_tools -j
+        ./run.sh pack_tools -j ${PACK_OPTIONS}
         rm -rf pegasus-tools-*
       shell: bash
     - name: Clear Build Files

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -418,7 +418,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       USE_JEMALLOC: OFF
-      BUILD_OPTIONS: -t debug --test
+      BUILD_OPTIONS: -t debug --test --separate_servers
+      PACK_OPTIONS: --separate_servers
     container:
       image: apache/pegasus:thirdparties-bin-centos7-${{ github.base_ref }}
     steps:

--- a/scripts/pack_client.sh
+++ b/scripts/pack_client.sh
@@ -39,12 +39,6 @@ then
     exit 1
 fi
 
-if [ ! -f ${BUILD_LATEST_DIR}/output/bin/pegasus_server/pegasus_server ]
-then
-    echo "ERROR: ${BUILD_LATEST_DIR}/output/bin/pegasus_server/pegasus_server not found"
-    exit 1
-fi
-
 if [ ! -f ${BUILD_LATEST_DIR}/CMakeCache.txt ]
 then
     echo "ERROR: ${BUILD_LATEST_DIR}/CMakeCache.txt not found"

--- a/scripts/pack_common.sh
+++ b/scripts/pack_common.sh
@@ -20,7 +20,11 @@ set -e
 
 function get_stdcpp_lib()
 {
-    libname=`ldd ${BUILD_LATEST_DIR}/output/bin/pegasus_server/pegasus_server 2>/dev/null | grep libstdc++`
+    if [[ $2 == "false" ]]; then
+        libname=`ldd ${BUILD_LATEST_DIR}/output/bin/pegasus_server/pegasus_server 2>/dev/null | grep libstdc++`
+    else
+        libname=`ldd ${BUILD_LATEST_DIR}/output/bin/pegasus_meta_server/pegasus_meta_server 2>/dev/null | grep libstdc++`
+    fi
     libname=`echo $libname | cut -f1 -d" "`
     if [ $1 = "true" ]; then
         gcc_path=`which gcc`


### PR DESCRIPTION
This patch adds a new flag `--separate_servers` to indicate whether to pack `pegasus_collector`，`pegasus_meta_server` and `pegasus_replica_server` binaries, otherwise a combined `pegasus_server` binary will be packed in the pegasus_server_xxx.tar. 

When build server in option `--separate_servers`,the corresponding option to use pack command is:
```
./run.sh pack_server -s  or ./run.sh pack_server --separate_servers
./run.sh pack_tools -s   or  ./run.sh pack_tools --separate_servers
```