### PR TITLE
fix(shell): Add PARSE_OPT_STRS marco for shell command execute  flag input mode

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -927,19 +927,7 @@ private:
 #define PARSE_OPT_STRS(container, def_val, ...)                                                    \
     do {                                                                                           \
         const auto param = cmd(__VA_ARGS__, (def_val)).str();                                      \
-        ::dsn::utils::split_args(param.c_str(), container, ',');                                   \
-        if (container.empty()) {                                                                   \
-            fmt::print(stderr,                                                                     \
-                       "invalid command, '{}' should be in the form of 'val1,val2,val3' and "      \
-                       "should not be empty\n",                                                    \
-                       param);                                                                     \
-            return false;                                                                          \
-        }                                                                                          \
-        std::set<std::string> str_set(container.begin(), container.end());                         \
-        if (str_set.size() != container.size()) {                                                  \
-            fmt::print(stderr, "invalid command, '{}' has duplicate values\n", param);             \
-            return false;                                                                          \
-        }                                                                                          \
+        ::dsn::utils::split_args(param.c_str(), container, ',');                                                                                                                            \
     } while (false)
 
 // A helper macro to parse command argument, the result is filled in an uint32_t variable named

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -924,6 +924,24 @@ private:
         }                                                                                          \
     } while (false)
 
+#define PARSE_OPT_STRS(container, def_val, ...)                                                        \
+    do {                                                                                           \
+        const auto param = cmd(__VA_ARGS__, (def_val)).str();                                               \
+        ::dsn::utils::split_args(param.c_str(), container, ',');                                   \
+        if (container.empty()) {                                                                   \
+            fmt::print(stderr,                                                                     \
+                       "invalid command, '{}' should be in the form of 'val1,val2,val3' and "      \
+                       "should not be empty\n",                                                    \
+                       param);                                                                     \
+            return false;                                                                          \
+        }                                                                                          \
+        std::set<std::string> str_set(container.begin(), container.end());                         \
+        if (str_set.size() != container.size()) {                                                  \
+            fmt::print(stderr, "invalid command, '{}' has duplicate values\n", param);             \
+            return false;                                                                          \
+        }                                                                                          \
+    } while (false)
+
 // A helper macro to parse command argument, the result is filled in an uint32_t variable named
 // 'value'.
 #define PARSE_UINT(value)                                                                          \

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -927,7 +927,7 @@ private:
 #define PARSE_OPT_STRS(container, def_val, ...)                                                    \
     do {                                                                                           \
         const auto param = cmd(__VA_ARGS__, (def_val)).str();                                      \
-        ::dsn::utils::split_args(param.c_str(), container, ',');                                                                                                                            \
+        ::dsn::utils::split_args(param.c_str(), container, ',');                                   \
     } while (false)
 
 // A helper macro to parse command argument, the result is filled in an uint32_t variable named

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -924,9 +924,9 @@ private:
         }                                                                                          \
     } while (false)
 
-#define PARSE_OPT_STRS(container, def_val, ...)                                                        \
+#define PARSE_OPT_STRS(container, def_val, ...)                                                    \
     do {                                                                                           \
-        const auto param = cmd(__VA_ARGS__, (def_val)).str();                                               \
+        const auto param = cmd(__VA_ARGS__, (def_val)).str();                                      \
         ::dsn::utils::split_args(param.c_str(), container, ',');                                   \
         if (container.empty()) {                                                                   \
             fmt::print(stderr,                                                                     \

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -39,6 +39,7 @@
 #include "shell/sds/sds.h"
 #include "utils/error_code.h"
 #include "utils/strings.h"
+#include "utils/fmt_logging.h"
 
 bool add_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {
@@ -159,14 +160,14 @@ bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {
     const std::string query_backup_policy_help =
         "<-p|--policy_name> [-b|--backup_info_cnt] [-j|--json]";
-    argh::parser cmd(args.argc, args.argv);
-    RETURN_FALSE_IF_NOT(cmd.pos_args().size() > 1,
+    argh::parser cmd(args.argc, args.argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
+    RETURN_FALSE_IF_NOT(cmd.pos_args().size() <= 1,
                         "invalid command, should be in the form of '{}'",
                         query_backup_policy_help);
 
     int param_index = 1;
     std::vector<std::string> policy_names;
-    PARSE_STRS(policy_names);
+    PARSE_OPT_STRS(policy_names, " ", {"-p", "--policy_name"});
 
     uint32_t backup_info_cnt;
     PARSE_OPT_UINT(backup_info_cnt, 3, {"-b", "--backup_info_cnt"});

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -157,8 +157,8 @@ bool ls_backup_policy(command_executor *e, shell_context *sc, arguments args)
 
 bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {
-    const std::string query_backup_policy_help = "<policy_name> [-b|--backup_info_cnt] [-j|--json]";
-    argh::parser cmd(args.argc, args.argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
+    const std::string query_backup_policy_help = "<-p|--policy_name> [-b|--backup_info_cnt] [-j|--json]";
+    argh::parser cmd(args.argc, args.argv);
     RETURN_FALSE_IF_NOT(cmd.pos_args().size() > 1,
                         "invalid command, should be in the form of '{}'",
                         query_backup_policy_help);

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -157,7 +157,7 @@ bool ls_backup_policy(command_executor *e, shell_context *sc, arguments args)
 
 bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {
-    const std::string query_backup_policy_help = 
+    const std::string query_backup_policy_help =
         "<-p|--policy_name> [-b|--backup_info_cnt] [-j|--json]";
     argh::parser cmd(args.argc, args.argv);
     RETURN_FALSE_IF_NOT(cmd.pos_args().size() > 1,

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -27,7 +27,9 @@
 #include <algorithm>
 #include <cstdint>
 #include <iostream>
+#include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -39,6 +39,7 @@
 #include "shell/sds/sds.h"
 #include "utils/error_code.h"
 #include "utils/strings.h"
+#include "utils/fmt_logging.h"
 
 bool add_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {
@@ -160,13 +161,25 @@ bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
     const std::string query_backup_policy_help =
         "<-p|--policy_name> [-b|--backup_info_cnt] [-j|--json]";
     argh::parser cmd(args.argc, args.argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
-    RETURN_FALSE_IF_NOT(cmd.pos_args().size() <= 1,
+    RETURN_FALSE_IF_NOT(cmd.pos_args().size() >= 1,
                         "invalid command, should be in the form of '{}'",
                         query_backup_policy_help);
 
-    int param_index = 1;
     std::vector<std::string> policy_names;
-    PARSE_OPT_STRS(policy_names, " ", {"-p", "--policy_name"});
+    PARSE_OPT_STRS(policy_names, "", {"-p", "--policy_name"});
+    
+    if (policy_names.empty()) {
+        SHELL_PRINTLN_ERROR(
+                "invalid command, policy_name should be in the form of 'val1,val2,val3' and "
+                "should not be empty");
+        return false;
+    }
+
+    std::set<std::string> str_set(policy_names.begin(), policy_names.end());
+    if (str_set.size() != policy_names.size()) {
+        SHELL_PRINTLN_ERROR("invalid command, policy_name has duplicate values");
+        return false;
+    }
 
     uint32_t backup_info_cnt;
     PARSE_OPT_UINT(backup_info_cnt, 3, {"-b", "--backup_info_cnt"});

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -167,11 +167,11 @@ bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
 
     std::vector<std::string> policy_names;
     PARSE_OPT_STRS(policy_names, "", {"-p", "--policy_name"});
-    
+
     if (policy_names.empty()) {
         SHELL_PRINTLN_ERROR(
-                "invalid command, policy_name should be in the form of 'val1,val2,val3' and "
-                "should not be empty");
+            "invalid command, policy_name should be in the form of 'val1,val2,val3' and "
+            "should not be empty");
         return false;
     }
 

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -157,7 +157,8 @@ bool ls_backup_policy(command_executor *e, shell_context *sc, arguments args)
 
 bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {
-    const std::string query_backup_policy_help = "<-p|--policy_name> [-b|--backup_info_cnt] [-j|--json]";
+    const std::string query_backup_policy_help = 
+        "<-p|--policy_name> [-b|--backup_info_cnt] [-j|--json]";
     argh::parser cmd(args.argc, args.argv);
     RETURN_FALSE_IF_NOT(cmd.pos_args().size() > 1,
                         "invalid command, should be in the form of '{}'",

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -39,7 +39,6 @@
 #include "shell/sds/sds.h"
 #include "utils/error_code.h"
 #include "utils/strings.h"
-#include "utils/fmt_logging.h"
 
 bool add_backup_policy(command_executor *e, shell_context *sc, arguments args)
 {

--- a/src/shell/commands/cold_backup.cpp
+++ b/src/shell/commands/cold_backup.cpp
@@ -161,7 +161,7 @@ bool query_backup_policy(command_executor *e, shell_context *sc, arguments args)
     const std::string query_backup_policy_help =
         "<-p|--policy_name> [-b|--backup_info_cnt] [-j|--json]";
     argh::parser cmd(args.argc, args.argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
-    RETURN_FALSE_IF_NOT(cmd.pos_args().size() >= 1,
+    RETURN_FALSE_IF_NOT(cmd.params().size() >= 1,
                         "invalid command, should be in the form of '{}'",
                         query_backup_policy_help);
 


### PR DESCRIPTION
The marco `PARSE_STRS` execute strs with `param_index`，and it only
execute the number of params_index of input strs.

The marco `PARSE_OPT_STRS` can execute input strs with flag.

The historical flag input mode should be continued.