### PR TITLE
chore: fix dead link open-falcon.org

### DIFF
--- a/java-client/README.md
+++ b/java-client/README.md
@@ -108,7 +108,7 @@ For each type of request(get, set, multiset, etc.), we collect 8 metrics:
 
 We use io.dropwizard.metrics library to calculate the request count.
 
-Currently, metrics are integrated with open-falcon(https://open-falcon.org/),
+Currently, metrics are integrated with open-falcon(https://github.com/open-falcon),
 <!-- markdown-link-check-disable -->
 which push counters to local http agent http://127.0.0.1:1988/push/v1.
 <!-- markdown-link-check-enable-->

--- a/rfcs/2020-08-27-metric-api.md
+++ b/rfcs/2020-08-27-metric-api.md
@@ -25,7 +25,7 @@ This RFC proposes a new metric API in replace of the old perf-counter API.
 
 ## Motivation
 
-The perf-counter API has bad naming convention to be parsed and queried over the external monitoring system like [Prometheus](https://prometheus.io/), or [open-falcon](http://open-falcon.org/).
+The perf-counter API has bad naming convention to be parsed and queried over the external monitoring system like [Prometheus](https://prometheus.io/), or [open-falcon](https://github.com/open-falcon).
 
 Here are some examples of the perf-counter it exposes:
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2047

Use "github.com/open-falcon" instead of dead link "open-falcon.org".