### PR TITLE
fix(duplication): reduce the delay before last mutation is duplicated to the remote cluster

### DIFF
--- a/src/common/consensus.thrift
+++ b/src/common/consensus.thrift
@@ -32,11 +32,24 @@ namespace cpp dsn.replication
 
 struct mutation_header
 {
+    // The partition that this mutation belongs to.
     1:dsn.gpid             pid;
+
+    // The ID of the membership configuration that this mutation belongs to,
+    // increasing monotonically.
     2:i64                  ballot;
+
+    // The decree of this mutation.
     3:i64                  decree;
+
+    // The start offset of this mutation in the whole mutation log.
     4:i64                  log_offset;
+
+    // The max of the decrees that have been committed before this mutation
+    // is prepared.
     5:i64                  last_committed_decree;
+
+    // The unique timestamp that increases monotonically in microsecond.
     6:i64                  timestamp;
 }
 

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -59,9 +59,10 @@ void load_mutation::run()
     decree last_decree = _duplicator->progress().last_decree;
     _start_decree = last_decree + 1;
 
+    // Load the mutations from plog that have been committed recently, if any.
     const auto max_plog_committed_decree =
         std::min(_replica->private_log()->max_decree_on_disk(), _replica->last_applied_decree());
-    if (max_plog_committed_decree < _start_decree) {
+    if (_start_decree > max_plog_committed_decree) {
         // wait 100ms for next try if no mutation was added.
         repeat(100_ms);
         return;

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -57,7 +57,10 @@ void load_mutation::run()
 {
     decree last_decree = _duplicator->progress().last_decree;
     _start_decree = last_decree + 1;
-    if (_replica->private_log()->max_commit_on_disk() < _start_decree) {
+
+    const auto max_plog_committed_decree =
+        std::min(_replica->private_log()->max_decree_on_disk(), _replica->last_applied_decree());
+    if (max_plog_committed_decree < _start_decree) {
         // wait 100ms for next try if no mutation was added.
         repeat(100_ms);
         return;

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -19,6 +19,7 @@
 
 #include <absl/strings/string_view.h>
 #include <stddef.h>
+#include <algorithm>
 #include <functional>
 #include <string>
 #include <utility>

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -131,7 +131,8 @@ error_s mutation_batch::add(mutation_ptr mu)
         // otherwise, this mutation would be delayed at least several minutes to be duplicated to
         // the remote cluster. It would not be duplicated until some new mutations (such as empty
         // writes) enter, since the last decree that is committed for this replica is NOT
-        // mu->data.header.decree but rather mu->data.header.last_committed_decree.
+        // mu->data.header.decree but rather mu->data.header.last_committed_decree. See also
+        // `mutation_header` in src/common/consensus.thrift.
         _mutation_buffer->commit(mu->get_decree(), COMMIT_TO_DECREE_HARD);
     }
 

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -57,6 +57,7 @@ mutation_buffer::mutation_buffer(replica_base *r,
 void mutation_buffer::commit(decree d, commit_type ct)
 {
     if (d <= last_committed_decree()) {
+        // Ignore the decrees that have been committed.
         return;
     }
 

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -31,7 +31,7 @@
 
 namespace dsn {
 namespace replication {
-
+class replica;
 class replica_duplicator;
 
 class mutation_buffer : public prepare_list
@@ -68,6 +68,8 @@ public:
     // mutations with decree < d will be ignored.
     void set_start_decree(decree d);
 
+    void set_last_committed_decree(decree d);
+
     void reset_mutation_buffer(decree d);
 
     size_t size() const { return _loaded_mutations.size(); }
@@ -77,6 +79,8 @@ public:
 private:
     friend class replica_duplicator_test;
     friend class mutation_batch_test;
+
+    replica *_replica;
 
     std::unique_ptr<prepare_list> _mutation_buffer;
     mutation_tuple_set _loaded_mutations;

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -68,8 +68,6 @@ public:
     // mutations with decree < d will be ignored.
     void set_start_decree(decree d);
 
-    void set_last_committed_decree(decree d);
-
     void reset_mutation_buffer(decree d);
 
     size_t size() const { return _loaded_mutations.size(); }

--- a/src/replica/duplication/mutation_batch.h
+++ b/src/replica/duplication/mutation_batch.h
@@ -57,15 +57,19 @@ public:
 
     explicit mutation_batch(replica_duplicator *r);
 
+    // Add mutations to prepare list. Only those who have been committed would be
+    // duplicated to the remote cluster.
     error_s add(mutation_ptr mu);
 
+    // Add the committed mutation to the loading list, which would be shipped to
+    // the remote cluster later.
     void add_mutation_if_valid(mutation_ptr &, decree start_decree);
 
     mutation_tuple_set move_all_mutations();
 
     decree last_decree() const;
 
-    // mutations with decree < d will be ignored.
+    // Mutations with decree < d will be ignored.
     void set_start_decree(decree d);
 
     void reset_mutation_buffer(decree d);

--- a/src/replica/duplication/replica_duplicator.h
+++ b/src/replica/duplication/replica_duplicator.h
@@ -170,6 +170,7 @@ private:
     friend class load_from_private_log_test;
     friend class ship_mutation_test;
 
+    friend class mutation_batch;
     friend class load_mutation;
     friend class ship_mutation;
 

--- a/src/replica/duplication/test/duplication_test_base.h
+++ b/src/replica/duplication/test/duplication_test_base.h
@@ -76,11 +76,18 @@ public:
         return log_file_map;
     }
 
-    mutation_ptr create_test_mutation(int64_t decree, const std::string &data) override
+    mutation_ptr create_test_mutation(int64_t decree,
+                                      int64_t last_committed_decree,
+                                      const std::string &data) override
     {
-        auto mut = replica_test_base::create_test_mutation(decree, data);
+        auto mut = replica_test_base::create_test_mutation(decree, last_committed_decree, data);
         mut->data.updates[0].code = RPC_DUPLICATION_IDEMPOTENT_WRITE; // must be idempotent write
         return mut;
+    }
+
+    mutation_ptr create_test_mutation(int64_t decree, const std::string &data) override
+    {
+        return duplication_test_base::create_test_mutation(decree, decree - 1, data);
     }
 
     void wait_all(const std::unique_ptr<replica_duplicator> &dup)

--- a/src/replica/duplication/test/mutation_batch_test.cpp
+++ b/src/replica/duplication/test/mutation_batch_test.cpp
@@ -15,9 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <algorithm>
 #include <atomic>
-#include <map>
+#include <iterator>
 #include <memory>
+#include <set>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -397,8 +397,8 @@ private:
     decree _plog_max_decree_on_disk;
 
     // The max decree of the committed mutations that have ever been written onto the disk
-    // for plog. Since it is set with mutation.data.header.last_committed_decree, usually
-    // it equals to _plog_max_decree_on_disk - 1.
+    // for plog. Since it is set with mutation.data.header.last_committed_decree, it must
+    // be less than _plog_max_decree_on_disk.
     decree _plog_max_commit_on_disk;
 };
 

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -243,6 +243,7 @@ public:
 
         JSON_ENCODE_OBJ(writer, max_prepared_decree, max_prepared_decree());
         JSON_ENCODE_OBJ(writer, max_plog_decree, _private_log->max_decree(get_gpid()));
+        JSON_ENCODE_OBJ(writer, max_plog_decree_on_disk, _private_log->max_decree_on_disk());
         JSON_ENCODE_OBJ(writer, max_plog_commit_on_disk, _private_log->max_commit_on_disk());
         JSON_ENCODE_OBJ(writer, last_committed_decree, last_committed_decree());
         JSON_ENCODE_OBJ(writer, last_applied_decree, last_applied_decree());

--- a/src/replica/test/mutation_log_test.cpp
+++ b/src/replica/test/mutation_log_test.cpp
@@ -291,13 +291,15 @@ public:
 
     void TearDown() override { utils::filesystem::remove_path(_log_dir); }
 
-    mutation_ptr create_test_mutation(decree d, const std::string &data) override
+    mutation_ptr create_test_mutation(int64_t decree,
+                                      int64_t last_committed_decree,
+                                      const std::string &data) override
     {
         mutation_ptr mu(new mutation());
         mu->data.header.ballot = 1;
-        mu->data.header.decree = d;
+        mu->data.header.decree = decree;
         mu->data.header.pid = get_gpid();
-        mu->data.header.last_committed_decree = d - 1;
+        mu->data.header.last_committed_decree = last_committed_decree;
         mu->data.header.log_offset = 0;
 
         binary_writer writer;
@@ -311,6 +313,11 @@ public:
         mu->client_requests.push_back(nullptr);
 
         return mu;
+    }
+
+    mutation_ptr create_test_mutation(int64_t decree, const std::string &data) override
+    {
+        return mutation_log_test::create_test_mutation(decree, decree - 1, data);
     }
 
     static void ASSERT_BLOB_EQ(const blob &lhs, const blob &rhs)

--- a/src/replica/test/replica_test_base.h
+++ b/src/replica/test/replica_test_base.h
@@ -61,13 +61,14 @@ public:
         _log_dir = _replica->dir();
     }
 
-    virtual mutation_ptr create_test_mutation(int64_t decree, const std::string &data)
+    virtual mutation_ptr
+    create_test_mutation(int64_t decree, int64_t last_committed_decree, const std::string &data)
     {
         mutation_ptr mu(new mutation());
         mu->data.header.ballot = 1;
         mu->data.header.decree = decree;
         mu->data.header.pid = _replica->get_gpid();
-        mu->data.header.last_committed_decree = decree - 1;
+        mu->data.header.last_committed_decree = last_committed_decree;
         mu->data.header.log_offset = 0;
         mu->data.header.timestamp = decree;
 
@@ -84,7 +85,14 @@ public:
         return mu;
     }
 
+    virtual mutation_ptr create_test_mutation(int64_t decree, const std::string &data)
+    {
+        return replica_test_base::create_test_mutation(decree, decree - 1, data);
+    }
+
     gpid get_gpid() const { return _replica->get_gpid(); }
+
+    void set_last_applied_decree(decree d) { _replica->set_app_last_committed_decree(d); }
 };
 
 } // namespace replication


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2050

As is described by the issue, the problem is that we have to waits 2 ~ 3 minutes
(until some empty write gets in) before the last mutation is duplicated to the remote
cluster.

The reason is that the last committed decree of the last mutation (i.e.
`mutation.data.header.last_committed_decree`), rather than the decree of the
last mutation (i.e. `mutation.data.header.decree`), is chosen as the max decree
that is duplicated to the remote cluster. Instead, the max committed decree should
be chosen as the max decree that is duplicated to the remote cluster.

After the optimization, the delay has been reduced from 2 ~ 3 minutes to about
0.1 seconds.