### PR TITLE
refactor(FQDN): further more refator on idl/dsn.layer2.thrift

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -112,7 +112,6 @@ JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 LambdaBodyIndentation: Signature
-Language:        Cpp
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1

--- a/src/client/partition_resolver_simple.cpp
+++ b/src/client/partition_resolver_simple.cpp
@@ -413,14 +413,18 @@ void partition_resolver_simple::handle_pending_requests(std::deque<request_conte
 host_port partition_resolver_simple::get_host_port(const partition_configuration &pc) const
 {
     if (_app_is_stateful) {
-        return pc.hp_primary;
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        return primary;
     }
 
-    if (pc.hp_last_drops.empty()) {
+    std::vector<host_port> last_drops;
+    GET_HOST_PORTS(pc, last_drops, last_drops);
+    if (last_drops.empty()) {
         return host_port();
     }
 
-    return pc.hp_last_drops[rand::next_u32(0, pc.last_drops.size() - 1)];
+    return last_drops[rand::next_u32(0, last_drops.size() - 1)];
 }
 
 error_code partition_resolver_simple::get_host_port(int partition_index, /*out*/ host_port &hp)

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -168,9 +168,19 @@ dsn::error_code replication_ddl_client::wait_app_ready(const std::string &app_na
         int ready_count = 0;
         for (int i = 0; i < partition_count; i++) {
             const auto &pc = query_resp.partitions[i];
-            if (pc.hp_primary && (pc.hp_secondaries.size() + 1 >= max_replica_count)) {
-                ready_count++;
+            host_port primary;
+            GET_HOST_PORT(pc, primary, primary);
+            if (!primary) {
+                continue;
             }
+
+            std::vector<host_port> secondaries;
+            GET_HOST_PORTS(pc, secondaries, secondaries);
+            if (secondaries.size() + 1 < max_replica_count) {
+                continue;
+            }
+
+            ready_count++;
         }
         if (ready_count == partition_count) {
             std::cout << app_name << " is ready now: (" << ready_count << "/" << partition_count
@@ -429,11 +439,16 @@ error_s replication_ddl_client::list_apps(bool detailed,
             int read_unhealthy = 0;
             for (const auto &pc : pcs) {
                 int replica_count = 0;
-                if (pc.hp_primary) {
+                host_port primary;
+                GET_HOST_PORT(pc, primary, primary);
+                if (primary) {
                     replica_count++;
                 }
-                replica_count += pc.hp_secondaries.size();
-                if (pc.hp_primary) {
+
+                std::vector<host_port> secondaries;
+                GET_HOST_PORTS(pc, secondaries, secondaries);
+                replica_count += secondaries.size();
+                if (primary) {
                     if (replica_count >= pc.max_replica_count) {
                         fully_healthy++;
                     } else if (replica_count < 2) {

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -180,12 +180,16 @@ int32_t replication_options::app_mutation_2pc_min_replica_count(int32_t app_max_
     rc.learner_signature = invalid_signature;
     SET_OBJ_IP_AND_HOST_PORT(rc, primary, pc, primary);
 
-    if (node == pc.hp_primary) {
+    host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
+    if (node == primary) {
         rc.status = partition_status::PS_PRIMARY;
         return true;
     }
 
-    if (utils::contains(pc.hp_secondaries, node)) {
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    if (utils::contains(secondaries, node)) {
         rc.status = partition_status::PS_SECONDARY;
         return true;
     }

--- a/src/meta/cluster_balance_policy.cpp
+++ b/src/meta/cluster_balance_policy.cpp
@@ -229,12 +229,17 @@ bool cluster_balance_policy::get_app_migration_info(std::shared_ptr<app_state> a
     info.partitions.reserve(app->pcs.size());
     for (const auto &pc : app->pcs) {
         std::map<host_port, partition_status::type> pstatus_map;
-        pstatus_map[pc.hp_primary] = partition_status::PS_PRIMARY;
-        if (pc.hp_secondaries.size() != pc.max_replica_count - 1) {
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        pstatus_map[primary] = partition_status::PS_PRIMARY;
+
+        std::vector<host_port> secondaries;
+        GET_HOST_PORTS(pc, secondaries, secondaries);
+        if (secondaries.size() != pc.max_replica_count - 1) {
             // partition is unhealthy
             return false;
         }
-        for (const auto &secondary : pc.hp_secondaries) {
+        for (const auto &secondary : secondaries) {
             pstatus_map[secondary] = partition_status::PS_SECONDARY;
         }
         info.partitions.push_back(std::move(pstatus_map));

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -35,6 +35,7 @@
 #include "meta_admin_types.h"
 #include "rpc/dns_resolver.h" // IWYU pragma: keep
 #include "rpc/rpc_address.h"
+#include "rpc/rpc_host_port.h"
 #include "utils/command_manager.h"
 #include "utils/fail_point.h"
 #include "utils/flags.h"
@@ -172,14 +173,16 @@ generate_balancer_request(const app_mapper &apps,
             new_proposal_action(to, to, config_type::CT_UPGRADE_TO_PRIMARY));
         result.action_list.emplace_back(new_proposal_action(to, from, config_type::CT_REMOVE));
         break;
-    case balance_type::COPY_SECONDARY:
+    case balance_type::COPY_SECONDARY: {
         ans = "copy_secondary";
         result.balance_type = balancer_request_type::copy_secondary;
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
         result.action_list.emplace_back(
-            new_proposal_action(pc.hp_primary, to, config_type::CT_ADD_SECONDARY_FOR_LB));
-        result.action_list.emplace_back(
-            new_proposal_action(pc.hp_primary, from, config_type::CT_REMOVE));
+            new_proposal_action(primary, to, config_type::CT_ADD_SECONDARY_FOR_LB));
+        result.action_list.emplace_back(new_proposal_action(primary, from, config_type::CT_REMOVE));
         break;
+    }
     default:
         CHECK(false, "");
     }
@@ -566,7 +569,9 @@ void ford_fulkerson::update_decree(int node_id, const node_state &ns)
 {
     ns.for_each_primary(_app->app_id, [&, this](const gpid &pid) {
         const auto &pc = _app->pcs[pid.get_partition_index()];
-        for (const auto &secondary : pc.hp_secondaries) {
+        std::vector<host_port> secondaries;
+        GET_HOST_PORTS(pc, secondaries, secondaries);
+        for (const auto &secondary : secondaries) {
             auto i = _host_port_id.find(secondary);
             CHECK(i != _host_port_id.end(), "invalid secondary: {}", secondary);
             _network[node_id][i->second]++;

--- a/src/meta/meta_bulk_load_ingestion_context.cpp
+++ b/src/meta/meta_bulk_load_ingestion_context.cpp
@@ -49,8 +49,12 @@ void ingestion_context::partition_node_info::create(const partition_configuratio
 {
     pid = pc.pid;
     std::unordered_set<host_port> current_nodes;
-    current_nodes.insert(pc.hp_primary);
-    for (const auto &secondary : pc.hp_secondaries) {
+    host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
+    current_nodes.insert(primary);
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    for (const auto &secondary : secondaries) {
         current_nodes.insert(secondary);
     }
     for (const auto &node : current_nodes) {

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -371,7 +371,9 @@ bool bulk_load_service::check_partition_status(
     }
 
     pc = app->pcs[pid.get_partition_index()];
-    if (!pc.hp_primary) {
+    host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
+    if (!primary) {
         LOG_WARNING("app({}) partition({}) primary is invalid, try it later", app_name, pid);
         tasking::enqueue(
             LPC_META_STATE_NORMAL,
@@ -382,7 +384,9 @@ bool bulk_load_service::check_partition_status(
         return false;
     }
 
-    if (pc.hp_secondaries.size() < pc.max_replica_count - 1) {
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    if (secondaries.size() < pc.max_replica_count - 1) {
         bulk_load_status::type p_status;
         {
             zauto_read_lock l(_lock);
@@ -434,7 +438,7 @@ void bulk_load_service::partition_bulk_load(const std::string &app_name, const g
         const app_bulk_load_info &ainfo = _app_bulk_load_info[pid.get_app_id()];
         req->pid = pid;
         req->app_name = app_name;
-        SET_IP_AND_HOST_PORT(*req, primary, pc.primary, pc.hp_primary);
+        SET_OBJ_IP_AND_HOST_PORT(*req, primary, pc, primary);
         req->remote_provider_name = ainfo.file_provider_type;
         req->cluster_name = ainfo.cluster_name;
         req->meta_bulk_load_status = get_partition_bulk_load_status_unlocked(pid);
@@ -1205,8 +1209,12 @@ bool bulk_load_service::check_ever_ingestion_succeed(const partition_configurati
     }
 
     std::vector<host_port> current_nodes;
-    current_nodes.emplace_back(pc.hp_primary);
-    for (const auto &secondary : pc.hp_secondaries) {
+    dsn::host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
+    current_nodes.emplace_back(primary);
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    for (const auto &secondary : secondaries) {
         current_nodes.emplace_back(secondary);
     }
 
@@ -1283,8 +1291,8 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
                                pid,
                                pc.hp_primary,
                                pc.ballot),
-                     0,
-                     std::chrono::milliseconds(bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL));
+                      0,
+                      std::chrono::milliseconds(bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL));
 }
 
 // ThreadPool: THREAD_POOL_DEFAULT

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -134,8 +134,11 @@ bool construct_replica(meta_view view, const gpid &pid, int max_replica_count)
     // we put max_replica_count-1 recent replicas to last_drops, in case of the DDD-state when the
     // only primary dead
     // when add node to pc.last_drops, we don't remove it from our cc.drop_list
-    CHECK(pc.hp_last_drops.empty(), "last_drops of partition({}) must be empty", pid);
+    std::vector<host_port> last_drops;
+    GET_HOST_PORTS(pc, last_drops, last_drops);
+    CHECK(last_drops.empty(), "last_drops of partition({}) must be empty", pid);
     for (auto iter = drop_list.rbegin(); iter != drop_list.rend(); ++iter) {
+        // hp_last_drops is added in the steps bellow.
         if (pc.hp_last_drops.size() + 1 >= max_replica_count) {
             break;
         }
@@ -542,7 +545,6 @@ app_state::app_state(const app_info &info) : app_info(info), helpers(new app_sta
     for (int i = 0; i != app_info::partition_count; ++i) {
         pcs[i].pid.set_partition_index(i);
     }
-
     helpers->on_init_partitions();
 }
 

--- a/src/meta/meta_http_service.cpp
+++ b/src/meta/meta_http_service.cpp
@@ -251,11 +251,15 @@ void meta_http_service::list_app_handler(const http_request &req, http_response 
             int read_unhealthy = 0;
             for (const auto &pc : response.partitions) {
                 int replica_count = 0;
-                if (pc.hp_primary) {
+                host_port primary;
+                GET_HOST_PORT(pc, primary, primary);
+                std::vector<host_port> secondaries;
+                GET_HOST_PORTS(pc, secondaries, secondaries);
+                if (primary) {
                     replica_count++;
                 }
-                replica_count += pc.hp_secondaries.size();
-                if (pc.hp_primary) {
+                replica_count += secondaries.size();
+                if (primary) {
                     if (replica_count >= pc.max_replica_count) {
                         fully_healthy++;
                     } else if (replica_count < 2) {
@@ -340,13 +344,17 @@ void meta_http_service::list_node_handler(const http_request &req, http_response
             CHECK_EQ(app.partition_count, response_app.partition_count);
 
             for (const auto &pc : response_app.partitions) {
-                if (pc.hp_primary) {
-                    auto find = tmp_map.find(pc.hp_primary);
+                host_port primary;
+                GET_HOST_PORT(pc, primary, primary);
+                std::vector<host_port> secondaries;
+                GET_HOST_PORTS(pc, secondaries, secondaries);
+                if (primary) {
+                    auto find = tmp_map.find(primary);
                     if (find != tmp_map.end()) {
                         find->second.primary_count++;
                     }
                 }
-                for (const auto &secondary : pc.hp_secondaries) {
+                for (const auto &secondary : secondaries) {
                     auto find = tmp_map.find(secondary);
                     if (find != tmp_map.end()) {
                         find->second.secondary_count++;

--- a/src/meta/meta_split_service.cpp
+++ b/src/meta/meta_split_service.cpp
@@ -311,7 +311,9 @@ void meta_split_service::on_add_child_on_remote_storage_reply(error_code ec,
     // TODO(yingchun): should use conference?
     auto child_pc = app->pcs[child_gpid.get_partition_index()];
     child_pc.secondaries = request.child_config.secondaries;
-    child_pc.__set_hp_secondaries(request.child_config.hp_secondaries);
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(request.child_config, secondaries, secondaries);
+    child_pc.__set_hp_secondaries(secondaries);
     _state->update_configuration_locally(*app, update_child_request);
 
     if (parent_context.msg) {

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -86,11 +86,15 @@ pc_status partition_guardian::cure(meta_view view,
     CHECK(acts.empty(), "");
 
     pc_status status;
-    if (!pc.hp_primary) {
+    host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    if (!primary) {
         status = on_missing_primary(view, gpid);
-    } else if (static_cast<int>(pc.hp_secondaries.size()) + 1 < pc.max_replica_count) {
+    } else if (static_cast<int>(secondaries.size()) + 1 < pc.max_replica_count) {
         status = on_missing_secondary(view, gpid);
-    } else if (static_cast<int>(pc.hp_secondaries.size()) >= pc.max_replica_count) {
+    } else if (static_cast<int>(secondaries.size()) >= pc.max_replica_count) {
         status = on_redundant_secondary(view, gpid);
     } else {
         status = pc_status::healthy;
@@ -125,8 +129,8 @@ void partition_guardian::reconfig(meta_view view, const configuration_update_req
     // handle the dropped out servers
     if (request.type == config_type::CT_DROP_PARTITION) {
         cc->serving.clear();
-
-        const auto &last_drops = request.config.hp_last_drops;
+        std::vector<host_port> last_drops;
+        GET_HOST_PORTS(request.config, last_drops, last_drops);
         for (const auto &last_drop : last_drops) {
             cc->record_drop_history(last_drop);
         }
@@ -163,6 +167,8 @@ bool partition_guardian::from_proposals(meta_view &view,
     host_port target;
     host_port node;
     GET_HOST_PORT(action, target, target);
+    host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
     std::string reason;
     if (!target) {
         reason = "action target is invalid";
@@ -189,10 +195,10 @@ bool partition_guardian::from_proposals(meta_view &view,
 
     switch (action.type) {
     case config_type::CT_ASSIGN_PRIMARY:
-        is_action_valid = (node == target && !pc.primary && !is_secondary(pc, node));
+        is_action_valid = (node == target && !primary && !is_secondary(pc, node));
         break;
     case config_type::CT_UPGRADE_TO_PRIMARY:
-        is_action_valid = (node == target && !pc.primary && is_secondary(pc, node));
+        is_action_valid = (node == target && !primary && is_secondary(pc, node));
         break;
     case config_type::CT_ADD_SECONDARY:
     case config_type::CT_ADD_SECONDARY_FOR_LB:
@@ -247,9 +253,13 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
 
     action.type = config_type::CT_INVALID;
     // try to upgrade a secondary to primary if the primary is missing
-    if (!pc.hp_secondaries.empty()) {
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    std::vector<host_port> last_drops;
+    GET_HOST_PORTS(pc, last_drops, last_drops);
+    if (!secondaries.empty()) {
         RESET_IP_AND_HOST_PORT(action, node);
-        for (const auto &secondary : pc.hp_secondaries) {
+        for (const auto &secondary : secondaries) {
             const auto ns = get_node_state(*(view.nodes), secondary, false);
             CHECK_NOTNULL(ns, "invalid secondary: {}", secondary);
             if (dsn_unlikely(!ns->alive())) {
@@ -284,7 +294,7 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
     }
     // if nothing in the last_drops, it means that this is a newly created partition, so let's
     // just find a node and assign primary for it.
-    else if (pc.hp_last_drops.empty()) {
+    else if (last_drops.empty()) {
         dsn::host_port min_primary_server;
         newly_partitions *min_primary_server_np = nullptr;
 
@@ -338,10 +348,10 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                      dr.last_prepared_decree);
         }
 
-        for (int i = 0; i < pc.hp_last_drops.size(); ++i) {
+        for (int i = 0; i < last_drops.size(); ++i) {
             int dropped_index = -1;
             for (int k = 0; k < cc.dropped.size(); k++) {
-                if (cc.dropped[k].node == pc.hp_last_drops[i]) {
+                if (cc.dropped[k].node == last_drops[i]) {
                     dropped_index = k;
                     break;
                 }
@@ -353,13 +363,13 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                      dropped_index);
         }
 
-        if (pc.hp_last_drops.size() == 1) {
+        if (last_drops.size() == 1) {
             LOG_WARNING("{}: the only node({}) is dead, waiting it to come back",
                         gpid_name,
                         FMT_HOST_PORT_AND_IP(pc, last_drops.back()));
             SET_OBJ_IP_AND_HOST_PORT(action, node, pc, last_drops.back());
         } else {
-            std::vector<dsn::host_port> nodes(pc.hp_last_drops.end() - 2, pc.hp_last_drops.end());
+            std::vector<dsn::host_port> nodes(last_drops.end() - 2, last_drops.end());
             std::vector<dropped_replica> collected_info(2);
             bool ready = true;
 
@@ -668,9 +678,11 @@ pc_status partition_guardian::on_redundant_secondary(meta_view &view, const dsn:
     const node_mapper &nodes = *(view.nodes);
     const partition_configuration &pc = *get_config(*(view.apps), gpid);
     int target = 0;
-    int load = nodes.find(pc.hp_secondaries.front())->second.partition_count();
-    for (int i = 0; i != pc.hp_secondaries.size(); ++i) {
-        int l = nodes.find(pc.hp_secondaries[i])->second.partition_count();
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    int load = nodes.find(secondaries.front())->second.partition_count();
+    for (int i = 0; i != secondaries.size(); ++i) {
+        int l = nodes.find(secondaries[i])->second.partition_count();
         if (l > load) {
             load = l;
             target = i;

--- a/src/meta/server_load_balancer.cpp
+++ b/src/meta/server_load_balancer.cpp
@@ -179,7 +179,9 @@ void server_load_balancer::register_proposals(meta_view view,
             continue;
         }
 
-        if (!pc.hp_primary) {
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        if (!primary) {
             resp.err = ERR_INVALID_PARAMETERS;
             return;
         }

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -776,12 +776,16 @@ void server_state::initialize_node_state()
     for (auto &app_pair : _all_apps) {
         app_state &app = *(app_pair.second);
         for (const auto &pc : app.pcs) {
-            if (pc.hp_primary) {
-                node_state *ns = get_node_state(_nodes, pc.hp_primary, true);
+            host_port primary;
+            GET_HOST_PORT(pc, primary, primary);
+            if (primary) {
+                node_state *ns = get_node_state(_nodes, primary, true);
                 ns->put_partition(pc.pid, true);
             }
 
-            for (const auto &secondary : pc.hp_secondaries) {
+            std::vector<host_port> secondaries;
+            GET_HOST_PORTS(pc, secondaries, secondaries);
+            for (const auto &secondary : secondaries) {
                 CHECK(secondary, "invalid secondary: {}", secondary);
                 node_state *ns = get_node_state(_nodes, secondary, true);
                 ns->put_partition(pc.pid, false);
@@ -1744,63 +1748,40 @@ void server_state::request_check(const partition_configuration &old_pc,
                                  const configuration_update_request &request)
 {
     const auto &new_pc = request.config;
+    host_port old_primary;
+    GET_HOST_PORT(old_pc, primary, old_primary);
+    host_port req_node;
+    GET_HOST_PORT(request, node, req_node);
+    std::vector<host_port> old_secondaries;
+    GET_HOST_PORTS(old_pc, secondaries, old_secondaries);
     switch (request.type) {
     case config_type::CT_ASSIGN_PRIMARY:
-        if (request.__isset.hp_node) {
-            CHECK_NE(old_pc.hp_primary, request.hp_node);
-            CHECK(!utils::contains(old_pc.hp_secondaries, request.hp_node), "");
-        } else {
-            CHECK_NE(old_pc.primary, request.node);
-            CHECK(!utils::contains(old_pc.secondaries, request.node), "");
-        }
+        CHECK_NE(old_primary, req_node);
+        CHECK(!utils::contains(old_secondaries, req_node), "");
         break;
     case config_type::CT_UPGRADE_TO_PRIMARY:
-        if (request.__isset.hp_node) {
-            CHECK_NE(old_pc.hp_primary, request.hp_node);
-            CHECK(utils::contains(old_pc.hp_secondaries, request.hp_node), "");
-        } else {
-            CHECK_NE(old_pc.primary, request.node);
-            CHECK(utils::contains(old_pc.secondaries, request.node), "");
-        }
+        CHECK_NE(old_primary, req_node);
+        CHECK(utils::contains(old_secondaries, req_node), "");
         break;
     case config_type::CT_DOWNGRADE_TO_SECONDARY:
-        if (request.__isset.hp_node) {
-            CHECK_EQ(old_pc.hp_primary, request.hp_node);
-            CHECK(!utils::contains(old_pc.hp_secondaries, request.hp_node), "");
-        } else {
-            CHECK_EQ(old_pc.primary, request.node);
-            CHECK(!utils::contains(old_pc.secondaries, request.node), "");
-        }
+        CHECK_EQ(old_primary, req_node);
+        CHECK(!utils::contains(old_secondaries, req_node), "");
         break;
     case config_type::CT_DOWNGRADE_TO_INACTIVE:
     case config_type::CT_REMOVE:
-        if (request.__isset.hp_node) {
-            CHECK(old_pc.hp_primary == request.hp_node ||
-                      utils::contains(old_pc.hp_secondaries, request.hp_node),
-                  "");
-        } else {
-            CHECK(old_pc.primary == request.node ||
-                      utils::contains(old_pc.secondaries, request.node),
-                  "");
-        }
+        CHECK(old_primary == req_node || utils::contains(old_secondaries, req_node), "");
         break;
     case config_type::CT_UPGRADE_TO_SECONDARY:
-        if (request.__isset.hp_node) {
-            CHECK_NE(old_pc.hp_primary, request.hp_node);
-            CHECK(!utils::contains(old_pc.hp_secondaries, request.hp_node), "");
-        } else {
-            CHECK_NE(old_pc.primary, request.node);
-            CHECK(!utils::contains(old_pc.secondaries, request.node), "");
-        }
+        CHECK_NE(old_primary, req_node);
+        CHECK(!utils::contains(old_secondaries, req_node), "");
         break;
     case config_type::CT_PRIMARY_FORCE_UPDATE_BALLOT: {
-        if (request.__isset.hp_node) {
-            CHECK_EQ(old_pc.hp_primary, new_pc.hp_primary);
-            CHECK(old_pc.hp_secondaries == new_pc.hp_secondaries, "");
-        } else {
-            CHECK_EQ(old_pc.primary, new_pc.primary);
-            CHECK(old_pc.secondaries == new_pc.secondaries, "");
-        }
+        host_port new_primary;
+        GET_HOST_PORT(new_pc, primary, new_primary);
+        CHECK_EQ(old_primary, new_primary);
+        std::vector<host_port> new_secondaries;
+        GET_HOST_PORTS(new_pc, secondaries, new_secondaries);
+        CHECK(old_secondaries == new_secondaries, "");
         break;
     }
     default:
@@ -1862,7 +1843,9 @@ void server_state::update_configuration_locally(
             break;
 
         case config_type::CT_DROP_PARTITION: {
-            for (const auto &last_drop : new_pc.hp_last_drops) {
+            std::vector<host_port> last_drops;
+            GET_HOST_PORTS(new_pc, last_drops, last_drops);
+            for (const auto &last_drop : last_drops) {
                 ns = get_node_state(_nodes, last_drop, false);
                 if (ns != nullptr) {
                     ns->remove_partition(gpid, false);
@@ -2224,8 +2207,10 @@ void server_state::downgrade_stateless_nodes(std::shared_ptr<app_state> &app,
     partition_configuration &pc = req->config;
 
     unsigned i = 0;
-    for (; i < pc.hp_secondaries.size(); ++i) {
-        if (pc.hp_secondaries[i] == node) {
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    for (; i < secondaries.size(); ++i) {
+        if (secondaries[i] == node) {
             SET_OBJ_IP_AND_HOST_PORT(*req, node, pc, last_drops[i]);
             break;
         }
@@ -2348,7 +2333,9 @@ void server_state::on_partition_node_dead(std::shared_ptr<app_state> &app,
         return;
     }
 
-    if (pc.hp_primary) {
+    host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
+    if (primary) {
         downgrade_secondary_to_inactive(app, pidx, node);
         return;
     }
@@ -2908,7 +2895,9 @@ bool server_state::check_all_partitions()
     for (int i = 0; i < add_secondary_actions.size(); ++i) {
         gpid &pid = add_secondary_gpids[i];
         const auto *pc = get_config(_all_apps, pid);
-        if (!add_secondary_proposed[i] && pc->hp_secondaries.empty()) {
+        std::vector<host_port> secondaries;
+        GET_HOST_PORTS(*pc, secondaries, secondaries);
+        if (!add_secondary_proposed[i] && secondaries.empty()) {
             const auto &action = add_secondary_actions[i];
             CHECK(action.hp_node, "");
             if (_add_secondary_enable_flow_control && add_secondary_running_nodes[action.hp_node] >=
@@ -3029,22 +3018,27 @@ void server_state::check_consistency(const dsn::gpid &gpid)
 
     auto &app = *(iter->second);
     auto &pc = app.pcs[gpid.get_partition_index()];
-
     if (app.is_stateful) {
-        if (pc.hp_primary) {
-            const auto it = _nodes.find(pc.hp_primary);
-            CHECK(it != _nodes.end(), "invalid primary: {}", pc.hp_primary);
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        std::vector<host_port> last_drops;
+        GET_HOST_PORTS(pc, last_drops, last_drops);
+        if (primary) {
+            const auto it = _nodes.find(primary);
+            CHECK(it != _nodes.end(), "invalid primary: {}", primary);
             CHECK_EQ(it->second.served_as(gpid), partition_status::PS_PRIMARY);
-            CHECK(!utils::contains(pc.hp_last_drops, pc.hp_primary),
+            CHECK(!utils::contains(last_drops, primary),
                   "primary({}) shouldn't appear in last_drops",
-                  pc.hp_primary);
+                  primary);
         }
 
-        for (const auto &secondary : pc.hp_secondaries) {
+        std::vector<host_port> secondaries;
+        GET_HOST_PORTS(pc, secondaries, secondaries);
+        for (const auto &secondary : secondaries) {
             const auto it = _nodes.find(secondary);
             CHECK(it != _nodes.end(), "invalid secondary: {}", secondary);
             CHECK_EQ(it->second.served_as(gpid), partition_status::PS_SECONDARY);
-            CHECK(!utils::contains(pc.hp_last_drops, secondary),
+            CHECK(!utils::contains(last_drops, secondary),
                   "secondary({}) shouldn't appear in last_drops",
                   secondary);
         }

--- a/src/meta/test/json_compacity.cpp
+++ b/src/meta/test/json_compacity.cpp
@@ -86,15 +86,20 @@ void meta_service_test_app::json_compacity()
 
     // 4. old pc version
     const char *json3 = "{\"pid\":\"1.1\",\"ballot\":234,\"max_replica_count\":3,"
-                        "\"primary\":\"invalid address\",\"secondaries\":[\"127.0.0.1:6\"],"
-                        "\"hp_primary\":\"invalid host_port\",\"hp_secondaries\":[\"localhost:6\"],"
+                        "\"primary\":\"127.0.0.1:1\",\"secondaries\":[\"127.0.0.1:6\"],"
+                        "\"hp_primary\":\"localhost:1\",\"hp_secondaries\":[\"localhost:6\"],"
                         "\"last_drops\":[],\"last_committed_decree\":157}";
     dsn::partition_configuration pc;
     dsn::json::json_forwarder<dsn::partition_configuration>::decode(
         dsn::blob(json3, 0, strlen(json3)), pc);
     ASSERT_EQ(234, pc.ballot);
-    ASSERT_TRUE(!pc.hp_primary);
-    ASSERT_TRUE(!pc.primary);
+    // As how we do in src/meta/server_state.cpp, we have to set the '__isset' fields manually.
+    ASSERT_FALSE(pc.__isset.hp_primary);
+    ASSERT_TRUE(pc.hp_primary);
+    ASSERT_TRUE(pc.primary);
+    ASSERT_STREQ("127.0.0.1:1", pc.primary.to_string());
+    ASSERT_EQ("localhost:1", pc.hp_primary.to_string());
+    ASSERT_FALSE(pc.__isset.hp_secondaries);
     ASSERT_EQ(1, pc.hp_secondaries.size());
     ASSERT_EQ(1, pc.secondaries.size());
     ASSERT_STREQ("127.0.0.1:6", pc.secondaries[0].to_string());

--- a/src/replica/backup/replica_backup_manager.cpp
+++ b/src/replica/backup/replica_backup_manager.cpp
@@ -240,7 +240,7 @@ void replica_backup_manager::send_clear_request_to_secondaries(const gpid &pid,
     std::vector<dsn::host_port> secondaries;
     GET_HOST_PORTS(_replica->_primary_states.pc, secondaries, secondaries);
     for (const auto &secondary : secondaries) {
-        rpc::call_one_way_typed(dsn::dns_resolver::instance().resolve_address(secondary),
+        rpc::call_one_way_typed(secondary.resolve(),
                                 RPC_CLEAR_COLD_BACKUP,
                                 request,
                                 get_gpid().thread_hash());

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -188,7 +188,9 @@ void replica_bulk_loader::broadcast_group_bulk_load(const bulk_load_request &met
 
     LOG_INFO_PREFIX("start to broadcast group bulk load");
 
-    for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(_replica->_primary_states.pc, secondaries, secondaries);
+    for (const auto &secondary : secondaries) {
         if (secondary == _stub->primary_host_port()) {
             continue;
         }
@@ -748,7 +750,9 @@ void replica_bulk_loader::handle_bulk_load_finish(bulk_load_status::type new_sta
     }
 
     if (status() == partition_status::PS_PRIMARY) {
-        for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
+        std::vector<dsn::host_port> secondaries;
+        GET_HOST_PORTS(_replica->_primary_states.pc, secondaries, secondaries);
+        for (const auto &secondary : secondaries) {
             _replica->_primary_states.reset_node_bulk_load_states(secondary);
         }
     }
@@ -948,7 +952,9 @@ void replica_bulk_loader::report_group_download_progress(/*out*/ bulk_load_respo
                     primary_state.download_status);
 
     int32_t total_progress = primary_state.download_progress;
-    for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(_replica->_primary_states.pc, secondaries, secondaries);
+    for (const auto &secondary : secondaries) {
         const auto &secondary_state =
             _replica->_primary_states.secondary_bulk_load_states[secondary];
         int32_t s_progress =
@@ -990,11 +996,12 @@ void replica_bulk_loader::report_group_ingestion_status(/*out*/ bulk_load_respon
                     FMT_HOST_PORT_AND_IP(_replica->_primary_states.pc, primary),
                     enum_to_string(primary_state.ingest_status));
 
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(_replica->_primary_states.pc, secondaries, secondaries);
     bool is_group_ingestion_finish =
         (primary_state.ingest_status == ingestion_status::IS_SUCCEED) &&
-        (_replica->_primary_states.pc.hp_secondaries.size() + 1 ==
-         _replica->_primary_states.pc.max_replica_count);
-    for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
+        (secondaries.size() + 1 == _replica->_primary_states.pc.max_replica_count);
+    for (const auto &secondary : secondaries) {
         const auto &secondary_state =
             _replica->_primary_states.secondary_bulk_load_states[secondary];
         ingestion_status::type ingest_status = secondary_state.__isset.ingest_status
@@ -1039,10 +1046,11 @@ void replica_bulk_loader::report_group_cleaned_up(bulk_load_response &response)
                     FMT_HOST_PORT_AND_IP(_replica->_primary_states.pc, primary),
                     primary_state.is_cleaned_up);
 
-    bool group_flag =
-        (primary_state.is_cleaned_up) && (_replica->_primary_states.pc.hp_secondaries.size() + 1 ==
-                                          _replica->_primary_states.pc.max_replica_count);
-    for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(_replica->_primary_states.pc, secondaries, secondaries);
+    bool group_flag = primary_state.is_cleaned_up &&
+                      (secondaries.size() + 1 == _replica->_primary_states.pc.max_replica_count);
+    for (const auto &secondary : secondaries) {
         const auto &secondary_state =
             _replica->_primary_states.secondary_bulk_load_states[secondary];
         bool is_cleaned_up = secondary_state.__isset.is_cleaned_up ? secondary_state.is_cleaned_up
@@ -1080,10 +1088,12 @@ void replica_bulk_loader::report_group_is_paused(bulk_load_response &response)
                     FMT_HOST_PORT_AND_IP(_replica->_primary_states.pc, primary),
                     primary_state.is_paused);
 
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(_replica->_primary_states.pc, secondaries, secondaries);
     bool group_is_paused =
-        primary_state.is_paused && (_replica->_primary_states.pc.hp_secondaries.size() + 1 ==
-                                    _replica->_primary_states.pc.max_replica_count);
-    for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
+        primary_state.is_paused &&
+        (secondaries.size() + 1 == _replica->_primary_states.pc.max_replica_count);
+    for (const auto &secondary : secondaries) {
         partition_bulk_load_state secondary_state =
             _replica->_primary_states.secondary_bulk_load_states[secondary];
         bool is_paused = secondary_state.__isset.is_paused ? secondary_state.is_paused : false;

--- a/src/replica/duplication/replica_follower.cpp
+++ b/src/replica/duplication/replica_follower.cpp
@@ -177,7 +177,9 @@ error_code replica_follower::update_master_replica_config(error_code err, query_
         return ERR_INCONSISTENT_STATE;
     }
 
-    if (dsn_unlikely(!resp.partitions[0].hp_primary)) {
+    dsn::host_port primary;
+    GET_HOST_PORT(resp.partitions[0], primary, primary);
+    if (dsn_unlikely(!primary)) {
         LOG_ERROR_PREFIX("master[{}] partition address is invalid", master_replica_name());
         return ERR_INVALID_STATE;
     }
@@ -202,9 +204,14 @@ void replica_follower::copy_master_replica_checkpoint()
     dsn::message_ex *msg =
         dsn::message_ex::create_request(RPC_QUERY_LAST_CHECKPOINT_INFO, 0, _pc.pid.thread_hash());
     dsn::marshall(msg, request);
-    rpc::call(_pc.primary, msg, &_tracker, [&](error_code err, learn_response &&resp) mutable {
-        nfs_copy_checkpoint(err, std::move(resp));
-    });
+    dsn::host_port primary;
+    GET_HOST_PORT(_pc, primary, primary);
+    rpc::call(dsn::dns_resolver::instance().resolve_address(primary),
+              msg,
+              &_tracker,
+              [&](error_code err, learn_response &&resp) mutable {
+                  nfs_copy_checkpoint(err, std::move(resp));
+              });
 }
 
 // ThreadPool: THREAD_POOL_DEFAULT

--- a/src/replica/duplication/replica_follower.cpp
+++ b/src/replica/duplication/replica_follower.cpp
@@ -206,7 +206,7 @@ void replica_follower::copy_master_replica_checkpoint()
     dsn::marshall(msg, request);
     dsn::host_port primary;
     GET_HOST_PORT(_pc, primary, primary);
-    rpc::call(dsn::dns_resolver::instance().resolve_address(primary),
+    rpc::call(primary.resolve(),
               msg,
               &_tracker,
               [&](error_code err, learn_response &&resp) mutable {

--- a/src/replica/duplication/replica_follower.h
+++ b/src/replica/duplication/replica_follower.h
@@ -26,6 +26,7 @@
 #include "common/gpid.h"
 #include "dsn.layer2_types.h"
 #include "replica/replica_base.h"
+#include "rpc/dns_resolver.h" // IWYU pragma: keep
 #include "rpc/rpc_host_port.h"
 #include "task/task_tracker.h"
 #include "utils/error_code.h"
@@ -78,7 +79,9 @@ private:
     std::string master_replica_name()
     {
         std::string app_info = fmt::format("{}.{}", _master_cluster_name, _master_app_name);
-        if (_pc.hp_primary) {
+        dsn::host_port primary;
+        GET_HOST_PORT(_pc, primary, primary);
+        if (primary) {
             return fmt::format("{}({}|{})", app_info, FMT_HOST_PORT_AND_IP(_pc, primary), _pc.pid);
         }
         return app_info;

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -201,7 +201,7 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
     CHECK(_primary_states.pc.__isset.hp_secondaries,
           "The primary partition_configuration must be normalized before using it");
     const auto &secondaries = _primary_states.pc.hp_secondaries;
-    if (static_cast<int32_t>(_primary_states.pc.hp_secondaries.size()) + 1 <
+    if (static_cast<int32_t>(secondaries.size()) + 1 <
         _options->app_mutation_2pc_min_replica_count(_app_info.max_replica_count)) {
         response_client_write(request, ERR_NOT_ENOUGH_MEMBER);
         return;

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -198,6 +198,9 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
         return;
     }
 
+    CHECK(_primary_states.pc.__isset.hp_secondaries,
+          "The primary partition_configuration must be normalized before using it");
+    const auto &secondaries = _primary_states.pc.hp_secondaries;
     if (static_cast<int32_t>(_primary_states.pc.hp_secondaries.size()) + 1 <
         _options->app_mutation_2pc_min_replica_count(_app_info.max_replica_count)) {
         response_client_write(request, ERR_NOT_ENOUGH_MEMBER);
@@ -220,8 +223,7 @@ void replica::on_client_write(dsn::message_ex *request, bool ignore_throttling)
         LOG_INFO_PREFIX("receive bulk load ingestion request");
 
         // bulk load ingestion request requires that all secondaries should be alive
-        if (static_cast<int32_t>(_primary_states.pc.hp_secondaries.size()) + 1 <
-            _primary_states.pc.max_replica_count) {
+        if (static_cast<int32_t>(secondaries.size()) + 1 < _primary_states.pc.max_replica_count) {
             response_client_write(request, ERR_NOT_ENOUGH_MEMBER);
             return;
         }
@@ -363,6 +365,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
     mu->set_is_sync_to_child(_primary_states.sync_send_write_request);
 
     // check bounded staleness
+    const auto &secondaries = _primary_states.pc.hp_secondaries;
     if (mu->data.header.decree > last_committed_decree() + FLAGS_staleness_for_commit) {
         err = ERR_CAPACITY_EXCEEDED;
         reply_with_error(mu, err);
@@ -376,8 +379,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
             break;
         }
         LOG_INFO_PREFIX("try to prepare bulk load mutation({})", mu->name());
-        if (static_cast<int32_t>(_primary_states.pc.hp_secondaries.size()) + 1 <
-            _primary_states.pc.max_replica_count) {
+        if (static_cast<int32_t>(secondaries.size()) + 1 < _primary_states.pc.max_replica_count) {
             err = ERR_NOT_ENOUGH_MEMBER;
             break;
         }
@@ -390,7 +392,7 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
     // stop prepare if there are too few replicas unless it's a reconciliation
     // for reconciliation, we should ensure every prepared mutation to be committed
     // please refer to PacificA paper
-    if (static_cast<int32_t>(_primary_states.pc.hp_secondaries.size()) + 1 <
+    if (static_cast<int32_t>(secondaries.size()) + 1 <
             _options->app_mutation_2pc_min_replica_count(_app_info.max_replica_count) &&
         !reconciliation) {
         err = ERR_NOT_ENOUGH_MEMBER;
@@ -412,9 +414,8 @@ void replica::init_prepare(mutation_ptr &mu, bool reconciliation, bool pop_all_c
 
     // remote prepare
     mu->set_prepare_ts();
-    mu->set_left_secondary_ack_count(
-        static_cast<unsigned int>(_primary_states.pc.hp_secondaries.size()));
-    for (const auto &secondary : _primary_states.pc.hp_secondaries) {
+    mu->set_left_secondary_ack_count(static_cast<unsigned int>(secondaries.size()));
+    for (const auto &secondary : secondaries) {
         send_prepare_message(secondary,
                              partition_status::PS_SECONDARY,
                              mu,

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -46,6 +46,8 @@
 #include "replica/replica_context.h"
 #include "replica/replication_app_base.h"
 #include "replica_stub.h"
+#include "rpc/dns_resolver.h"
+#include "rpc/rpc_host_port.h"
 #include "runtime/api_layer1.h"
 #include "task/async_calls.h"
 #include "utils/autoref_ptr.h"
@@ -256,10 +258,15 @@ void replica::on_cold_backup(const backup_request &request, /*out*/ backup_respo
 
 void replica::send_backup_request_to_secondary(const backup_request &request)
 {
-    for (const auto &secondary : _primary_states.pc.secondaries) {
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(_primary_states.pc, secondaries, secondaries);
+    for (const auto &secondary : secondaries) {
         // primary will send backup_request to secondary periodically
         // so, we shouldn't handle the response
-        rpc::call_one_way_typed(secondary, RPC_COLD_BACKUP, request, get_gpid().thread_hash());
+        rpc::call_one_way_typed(dsn::dns_resolver::instance().resolve_address(secondary),
+                                RPC_COLD_BACKUP,
+                                request,
+                                get_gpid().thread_hash());
     }
 }
 

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -263,7 +263,7 @@ void replica::send_backup_request_to_secondary(const backup_request &request)
     for (const auto &secondary : secondaries) {
         // primary will send backup_request to secondary periodically
         // so, we shouldn't handle the response
-        rpc::call_one_way_typed(dsn::dns_resolver::instance().resolve_address(secondary),
+        rpc::call_one_way_typed(secondary.resolve(),
                                 RPC_COLD_BACKUP,
                                 request,
                                 get_gpid().thread_hash());

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -276,6 +276,7 @@ void replica::downgrade_to_secondary_on_primary(configuration_update_request &pr
     }
 
     CHECK_EQ(proposal.config.pid, _primary_states.pc.pid);
+    CHECK_EQ(proposal.config.primary, _primary_states.pc.primary);
     dsn::host_port primary;
     GET_HOST_PORT(proposal.config, primary, primary);
     // The local host_port type 'hp_primary' field must be set.

--- a/src/replica/replica_config.cpp
+++ b/src/replica/replica_config.cpp
@@ -175,7 +175,6 @@ void replica::assign_primary(configuration_update_request &proposal)
         proposal.config, primary, _stub->primary_address(), _stub->primary_host_port());
     REMOVE_IP_AND_HOST_PORT(
         _stub->primary_address(), _stub->primary_host_port(), proposal.config, secondaries);
-
     update_configuration_on_meta_server(proposal.type, node, proposal.config);
 }
 
@@ -190,15 +189,24 @@ void replica::add_potential_secondary(const configuration_update_request &propos
 
     CHECK_EQ(proposal.config.ballot, get_ballot());
     CHECK_EQ(proposal.config.pid, _primary_states.pc.pid);
-    CHECK_EQ(proposal.config.hp_primary, _primary_states.pc.hp_primary);
-    CHECK(proposal.config.hp_secondaries == _primary_states.pc.hp_secondaries, "");
-
+    CHECK_EQ(proposal.config.primary, _primary_states.pc.primary);
+    CHECK(proposal.config.secondaries == _primary_states.pc.secondaries, "");
+    dsn::host_port primary;
+    GET_HOST_PORT(proposal.config, primary, primary);
+    // The local host_port type 'hp_primary' field must be set.
+    CHECK(_primary_states.pc.__isset.hp_primary, "");
+    CHECK_EQ(primary, _primary_states.pc.hp_primary);
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(proposal.config, secondaries, secondaries);
+    // The local host_port type 'hp_secondaries' field must be set.
+    CHECK(_primary_states.pc.__isset.hp_secondaries, "");
+    CHECK(secondaries == _primary_states.pc.hp_secondaries, "");
     host_port node;
     GET_HOST_PORT(proposal, node, node);
     CHECK(!_primary_states.check_exist(node, partition_status::PS_PRIMARY), "node = {}", node);
     CHECK(!_primary_states.check_exist(node, partition_status::PS_SECONDARY), "node = {}", node);
 
-    int potential_secondaries_count =
+    const int potential_secondaries_count =
         _primary_states.pc.hp_secondaries.size() + _primary_states.learners.size();
     if (potential_secondaries_count >= _primary_states.pc.max_replica_count - 1) {
         if (proposal.type == config_type::CT_ADD_SECONDARY) {
@@ -268,9 +276,19 @@ void replica::downgrade_to_secondary_on_primary(configuration_update_request &pr
     }
 
     CHECK_EQ(proposal.config.pid, _primary_states.pc.pid);
-    CHECK_EQ(proposal.config.hp_primary, _primary_states.pc.hp_primary);
-    CHECK(proposal.config.hp_secondaries == _primary_states.pc.hp_secondaries, "");
-    CHECK_EQ(proposal.hp_node, proposal.config.hp_primary);
+    dsn::host_port primary;
+    GET_HOST_PORT(proposal.config, primary, primary);
+    // The local host_port type 'hp_primary' field must be set.
+    CHECK(_primary_states.pc.__isset.hp_primary, "");
+    CHECK_EQ(primary, _primary_states.pc.hp_primary);
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(proposal.config, secondaries, secondaries);
+    // The local host_port type 'hp_secondaries' field must be set.
+    CHECK(_primary_states.pc.__isset.hp_secondaries, "");
+    CHECK(secondaries == _primary_states.pc.hp_secondaries, "");
+    dsn::host_port node;
+    GET_HOST_PORT(proposal, node, node);
+    CHECK_EQ(node, primary);
     CHECK_EQ(proposal.node, proposal.config.primary);
 
     RESET_IP_AND_HOST_PORT(proposal.config, primary);
@@ -285,12 +303,20 @@ void replica::downgrade_to_inactive_on_primary(configuration_update_request &pro
         return;
 
     CHECK_EQ(proposal.config.pid, _primary_states.pc.pid);
-    CHECK_EQ(proposal.config.hp_primary, _primary_states.pc.hp_primary);
-    CHECK(proposal.config.hp_secondaries == _primary_states.pc.hp_secondaries, "");
+    dsn::host_port primary;
+    GET_HOST_PORT(proposal.config, primary, primary);
+    // The local host_port type 'hp_primary' field must be set.
+    CHECK(_primary_states.pc.__isset.hp_primary, "");
+    CHECK_EQ(primary, _primary_states.pc.hp_primary);
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(proposal.config, secondaries, secondaries);
+    // The local host_port type 'hp_secondaries' field must be set.
+    CHECK(_primary_states.pc.__isset.hp_secondaries, "");
+    CHECK(secondaries == _primary_states.pc.hp_secondaries, "");
 
     host_port node;
     GET_HOST_PORT(proposal, node, node);
-    if (node == proposal.config.hp_primary) {
+    if (node == primary) {
         CHECK_EQ(proposal.node, proposal.config.primary);
         RESET_IP_AND_HOST_PORT(proposal.config, primary);
     } else {
@@ -310,8 +336,18 @@ void replica::remove(configuration_update_request &proposal)
         return;
 
     CHECK_EQ(proposal.config.pid, _primary_states.pc.pid);
-    CHECK_EQ(proposal.config.hp_primary, _primary_states.pc.hp_primary);
-    CHECK(proposal.config.hp_secondaries == _primary_states.pc.hp_secondaries, "");
+    CHECK_EQ(proposal.config.primary, _primary_states.pc.primary);
+    dsn::host_port primary;
+    GET_HOST_PORT(proposal.config, primary, primary);
+    // The local host_port type 'hp_primary' field must be set.
+    CHECK(_primary_states.pc.__isset.hp_primary, "");
+    CHECK_EQ(primary, _primary_states.pc.hp_primary);
+    CHECK(proposal.config.secondaries == _primary_states.pc.secondaries, "");
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(proposal.config, secondaries, secondaries);
+    // The local host_port type 'hp_secondaries' field must be set.
+    CHECK(_primary_states.pc.__isset.hp_secondaries, "");
+    CHECK(secondaries == _primary_states.pc.hp_secondaries, "");
 
     host_port node;
     GET_HOST_PORT(proposal, node, node);
@@ -319,7 +355,7 @@ void replica::remove(configuration_update_request &proposal)
 
     switch (st) {
     case partition_status::PS_PRIMARY:
-        CHECK_EQ(proposal.config.hp_primary, node);
+        CHECK_EQ(primary, node);
         CHECK_EQ(proposal.config.primary, proposal.node);
         RESET_IP_AND_HOST_PORT(proposal.config, primary);
         break;
@@ -379,7 +415,9 @@ void replica::update_configuration_on_meta_server(config_type::type type,
         CHECK(status() == partition_status::PS_INACTIVE && _inactive_is_transient &&
                   _is_initializing,
               "");
-        CHECK_EQ(new_pc.hp_primary, node);
+        dsn::host_port primary;
+        GET_HOST_PORT(new_pc, primary, primary);
+        CHECK_EQ(primary, node);
     } else if (type != config_type::CT_ASSIGN_PRIMARY &&
                type != config_type::CT_UPGRADE_TO_PRIMARY) {
         CHECK_EQ(status(), partition_status::PS_PRIMARY);
@@ -491,8 +529,18 @@ void replica::on_update_configuration_on_meta_server_reply(
     // post-update work items?
     if (resp.err == ERR_OK) {
         CHECK_EQ(req->config.pid, resp.config.pid);
-        CHECK_EQ(req->config.hp_primary, resp.config.hp_primary);
-        CHECK(req->config.hp_secondaries == resp.config.hp_secondaries, "");
+        CHECK_EQ(req->config.primary, resp.config.primary);
+        dsn::host_port req_primary;
+        GET_HOST_PORT(req->config, primary, req_primary);
+        dsn::host_port resp_primary;
+        GET_HOST_PORT(resp.config, primary, resp_primary);
+        CHECK_EQ(req_primary, resp_primary);
+        CHECK(req->config.secondaries == resp.config.secondaries, "");
+        std::vector<dsn::host_port> req_secondaries;
+        GET_HOST_PORTS(req->config, secondaries, req_secondaries);
+        std::vector<dsn::host_port> resp_secondaries;
+        GET_HOST_PORTS(resp.config, secondaries, resp_secondaries);
+        CHECK(req_secondaries == resp_secondaries, "");
 
         switch (req->type) {
         case config_type::CT_UPGRADE_TO_PRIMARY:
@@ -643,7 +691,9 @@ bool replica::update_configuration(const partition_configuration &pc)
 
     if (rconfig.status == partition_status::PS_PRIMARY &&
         (rconfig.ballot > get_ballot() || status() != partition_status::PS_PRIMARY)) {
-        _primary_states.reset_membership(pc, pc.hp_primary != _stub->primary_host_port());
+        dsn::host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        _primary_states.reset_membership(pc, primary != _stub->primary_host_port());
     }
 
     if (pc.ballot > get_ballot() ||
@@ -1031,9 +1081,9 @@ bool replica::update_local_configuration(const replica_configuration &config,
             init_prepare(next, false);
         }
 
-        CHECK(_primary_states.pc.__isset.hp_secondaries, "");
-        if (_primary_states.pc.hp_secondaries.size() + 1 <
-            _options->app_mutation_2pc_min_replica_count(_app_info.max_replica_count)) {
+        if (_primary_states.pc.__isset.hp_secondaries &&
+            _primary_states.pc.hp_secondaries.size() + 1 <
+                _options->app_mutation_2pc_min_replica_count(_app_info.max_replica_count)) {
             std::vector<mutation_ptr> queued;
             _primary_states.write_queue.clear(queued);
             for (auto &m : queued) {
@@ -1075,6 +1125,8 @@ void replica::on_config_sync(const app_info &info,
     update_app_envs(info.envs);
     _is_duplication_master = info.duplicating;
 
+    dsn::host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
     if (status() == partition_status::PS_PRIMARY) {
         if (nullptr != _primary_states.reconfiguration_task) {
             // already under reconfiguration, skip configuration sync
@@ -1084,10 +1136,10 @@ void replica::on_config_sync(const app_info &info,
     } else {
         if (_is_initializing) {
             // in initializing, when replica still primary, need to inc ballot
-            if (pc.hp_primary == _stub->primary_host_port() &&
+            if (primary == _stub->primary_host_port() &&
                 status() == partition_status::PS_INACTIVE && _inactive_is_transient) {
                 update_configuration_on_meta_server(config_type::CT_PRIMARY_FORCE_UPDATE_BALLOT,
-                                                    pc.hp_primary,
+                                                    primary,
                                                     const_cast<partition_configuration &>(pc));
                 return;
             }
@@ -1097,8 +1149,8 @@ void replica::on_config_sync(const app_info &info,
         update_configuration(pc);
 
         if (status() == partition_status::PS_INACTIVE && !_inactive_is_transient) {
-            if (pc.hp_primary == _stub->primary_host_port() // dead primary
-                || !pc.hp_primary // primary is dead (otherwise let primary remove this)
+            if (primary == _stub->primary_host_port() // dead primary
+                || !primary // primary is dead (otherwise let primary remove this)
             ) {
                 LOG_INFO_PREFIX("downgrade myself as inactive is not transient, remote_config({})",
                                 boost::lexical_cast<std::string>(pc));

--- a/src/replica/replica_context.cpp
+++ b/src/replica/replica_context.cpp
@@ -106,17 +106,30 @@ void primary_context::reset_membership(const partition_configuration &new_pc, bo
 
     pc = new_pc;
 
-    if (pc.hp_primary) {
-        statuses[pc.hp_primary] = partition_status::PS_PRIMARY;
+    // Normalize the partition_configuration type 'pc' before using it.
+    dsn::host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
+    if (primary) {
+        statuses[primary] = partition_status::PS_PRIMARY;
+        // Normalize 'hp_primary'.
+        if (!pc.__isset.hp_primary) {
+            pc.__set_hp_primary(primary);
+        }
     }
 
-    for (auto it = new_pc.hp_secondaries.begin(); it != new_pc.hp_secondaries.end(); ++it) {
-        statuses[*it] = partition_status::PS_SECONDARY;
-        learners.erase(*it);
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(new_pc, secondaries, secondaries);
+    for (const auto &secondary : secondaries) {
+        statuses[secondary] = partition_status::PS_SECONDARY;
+        learners.erase(secondary);
+    }
+    // Normalize 'hp_secondaries'.
+    if (!pc.__isset.hp_secondaries) {
+        pc.__set_hp_secondaries(secondaries);
     }
 
-    for (auto it = learners.begin(); it != learners.end(); ++it) {
-        statuses[it->first] = partition_status::PS_POTENTIAL_SECONDARY;
+    for (const auto &[learner, _] : learners) {
+        statuses[learner] = partition_status::PS_POTENTIAL_SECONDARY;
     }
 }
 

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1200,19 +1200,32 @@ void replica_stub::on_config_proposal(const configuration_update_request &propos
              enum_to_string(proposal.type),
              FMT_HOST_PORT_AND_IP(proposal, node));
 
-    replica_ptr rep = get_replica(proposal.config.pid);
+    // Normalize the partition_configuration type 'config' before using it.
+    configuration_update_request normalized_proposal = proposal;
+    if (!normalized_proposal.config.__isset.hp_primary) {
+        dsn::host_port primary;
+        GET_HOST_PORT(normalized_proposal.config, primary, primary);
+        normalized_proposal.config.__set_hp_primary(primary);
+    }
+    if (!normalized_proposal.config.__isset.hp_secondaries) {
+        std::vector<dsn::host_port> secondaries;
+        GET_HOST_PORTS(normalized_proposal.config, secondaries, secondaries);
+        normalized_proposal.config.__set_hp_secondaries(secondaries);
+    }
+
+    replica_ptr rep = get_replica(normalized_proposal.config.pid);
     if (rep == nullptr) {
-        if (proposal.type == config_type::CT_ASSIGN_PRIMARY) {
-            std::shared_ptr<configuration_update_request> req2(new configuration_update_request);
-            *req2 = proposal;
-            begin_open_replica(proposal.info, proposal.config.pid, nullptr, req2);
-        } else if (proposal.type == config_type::CT_UPGRADE_TO_PRIMARY) {
-            remove_replica_on_meta_server(proposal.info, proposal.config);
+        if (normalized_proposal.type == config_type::CT_ASSIGN_PRIMARY) {
+            auto cu_req = std::make_shared<configuration_update_request>(normalized_proposal);
+            begin_open_replica(
+                normalized_proposal.info, normalized_proposal.config.pid, nullptr, cu_req);
+        } else if (normalized_proposal.type == config_type::CT_UPGRADE_TO_PRIMARY) {
+            remove_replica_on_meta_server(normalized_proposal.info, normalized_proposal.config);
         }
     }
 
     if (rep != nullptr) {
-        rep->on_config_proposal((configuration_update_request &)proposal);
+        rep->on_config_proposal(normalized_proposal);
     }
 }
 

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -771,14 +771,18 @@ void replica_split_manager::update_child_group_partition_count(
         return;
     }
 
-    if (!_replica->_primary_states.learners.empty() ||
-        _replica->_primary_states.pc.hp_secondaries.size() + 1 <
-            _replica->_primary_states.pc.max_replica_count) {
-        LOG_ERROR_PREFIX("there are {} learners or not have enough secondaries(count is {})",
-                         _replica->_primary_states.learners.size(),
-                         _replica->_primary_states.pc.hp_secondaries.size());
-        parent_handle_split_error(
-            "update_child_group_partition_count failed, have learner or lack of secondary", true);
+    if (!_replica->_primary_states.learners.empty()) {
+        LOG_ERROR_PREFIX("there are {} learners", _replica->_primary_states.learners.size());
+        parent_handle_split_error("update_child_group_partition_count failed, have learner", true);
+        return;
+    }
+
+    std::vector<dsn::host_port> secondaries;
+    GET_HOST_PORTS(_replica->_primary_states.pc, secondaries, secondaries);
+    if (secondaries.size() + 1 < _replica->_primary_states.pc.max_replica_count) {
+        LOG_ERROR_PREFIX("there are not enough secondaries(count is {})", secondaries.size());
+        parent_handle_split_error("update_child_group_partition_count failed, lack of secondary",
+                                  true);
         return;
     }
 
@@ -1220,14 +1224,17 @@ void replica_split_manager::trigger_primary_parent_split(
 
     _meta_split_status = meta_split_status;
     if (meta_split_status == split_status::SPLITTING) {
-        if (!_replica->_primary_states.learners.empty() ||
-            _replica->_primary_states.pc.hp_secondaries.size() + 1 <
-                _replica->_primary_states.pc.max_replica_count) {
-            LOG_WARNING_PREFIX(
-                "there are {} learners or not have enough secondaries(count is {}), wait for "
-                "next round",
-                _replica->_primary_states.learners.size(),
-                _replica->_primary_states.pc.hp_secondaries.size());
+        if (!_replica->_primary_states.learners.empty()) {
+            LOG_WARNING_PREFIX("there are {} learners, wait for next round",
+                               _replica->_primary_states.learners.size());
+            return;
+        }
+
+        std::vector<dsn::host_port> secondaries;
+        GET_HOST_PORTS(_replica->_primary_states.pc, secondaries, secondaries);
+        if (secondaries.size() + 1 < _replica->_primary_states.pc.max_replica_count) {
+            LOG_WARNING_PREFIX("there are not enough secondaries(count is {}), wait for next round",
+                               secondaries.size());
             return;
         }
 

--- a/src/rpc/rpc_host_port.h
+++ b/src/rpc/rpc_host_port.h
@@ -73,7 +73,7 @@ class TProtocol;
         } else {                                                                                   \
             _target.reserve(_obj.field.size());                                                    \
             for (const auto &addr : _obj.field) {                                                  \
-                _target.emplace_back(host_port::from_address(addr));                               \
+                _target.emplace_back(dsn::host_port::from_address(addr));                          \
             }                                                                                      \
         }                                                                                          \
     } while (0)
@@ -131,6 +131,7 @@ class TProtocol;
         auto &_obj = (obj);                                                                        \
         _obj.field.set_invalid();                                                                  \
         _obj.hp_##field.reset();                                                                   \
+        _obj.__isset.hp_##field = false;                                                           \
     } while (0)
 
 // Clear the '<field>' and optional 'hp_<field>' of 'obj'. The types of the fields are std::vector
@@ -139,7 +140,8 @@ class TProtocol;
     do {                                                                                           \
         auto &_obj = (obj);                                                                        \
         _obj.field.clear();                                                                        \
-        _obj.__set_hp_##field({});                                                                 \
+        _obj.hp_##field.clear();                                                                   \
+        _obj.__isset.hp_##field = false;                                                           \
     } while (0)
 
 // Add 'addr' and 'hp' to the vector '<field>' and optional vector 'hp_<field>' of 'obj'. The types

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -224,9 +224,9 @@ void hotspot_partition_calculator::send_detect_hotkey_request(
     req.type = hotkey_type;
     req.action = action;
     req.pid = dsn::gpid(app_id, partition_index);
-    auto error =
-        _shell_context->ddl_client->detect_hotkey(pcs[partition_index].hp_primary, req, resp);
-
+    dsn::host_port primary;
+    GET_HOST_PORT(pcs[partition_index], primary, primary);
+    auto error = _shell_context->ddl_client->detect_hotkey(primary, req, resp);
     LOG_INFO("{} {} hotkey detection in {}.{}, server: {}",
              (action == dsn::replication::detect_action::STOP) ? "Stop" : "Start",
              (hotkey_type == dsn::replication::hotkey_type::WRITE) ? "write" : "read",

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -1744,7 +1744,9 @@ inline std::unique_ptr<aggregate_stats_calcs> create_table_aggregate_stats_calcs
               row.app_id);
 
         for (const auto &pc : iter->second) {
-            if (pc.hp_primary != node) {
+            dsn::host_port primary;
+            GET_HOST_PORT(pc, primary, primary);
+            if (primary != node) {
                 // Ignore once the replica of the metrics is not the primary of the partition.
                 continue;
             }
@@ -1775,7 +1777,9 @@ create_partition_aggregate_stats_calcs(const int32_t table_id,
     partition_stat_map increases;
     partition_stat_map rates;
     for (size_t i = 0; i < rows.size(); ++i) {
-        if (pcs[i].hp_primary != node) {
+        dsn::host_port primary;
+        GET_HOST_PORT(pcs[i], primary, primary);
+        if (primary != node) {
             // Ignore once the replica of the metrics is not the primary of the partition.
             continue;
         }
@@ -2031,12 +2035,15 @@ inline bool get_app_partition_stat(shell_context *sc,
                     m.name, app_id_x, partition_index_x, counter_name)) {
                 // only primary partition will be counted
                 const auto find = pcs_by_appid.find(app_id_x);
-                if (find != pcs_by_appid.end() &&
-                    find->second[partition_index_x].hp_primary == nodes[i].hp) {
-                    row_data &row = rows[app_id_name[app_id_x]][partition_index_x];
-                    row.row_name = std::to_string(partition_index_x);
-                    row.app_id = app_id_x;
-                    update_app_pegasus_perf_counter(row, counter_name, m.value);
+                if (find != pcs_by_appid.end()) {
+                    dsn::host_port primary;
+                    GET_HOST_PORT(find->second[partition_index_x], primary, primary);
+                    if (primary == nodes[i].hp) {
+                        row_data &row = rows[app_id_name[app_id_x]][partition_index_x];
+                        row.row_name = std::to_string(partition_index_x);
+                        row.app_id = app_id_x;
+                        update_app_pegasus_perf_counter(row, counter_name, m.value);
+                    }
                 }
             } else if (parse_app_perf_counter_name(m.name, app_name, counter_name)) {
                 // if the app_name from perf-counter isn't existed(maybe the app was dropped), it
@@ -2285,7 +2292,9 @@ inline bool get_storage_size_stat(shell_context *sc, app_storage_size_stat &st_s
             if (find == pcs_by_appid.end()) // app id not found
                 continue;
             auto &pc = find->second[partition_index_x];
-            if (pc.hp_primary != nodes[i].hp) // not primary replica
+            dsn::host_port primary;
+            GET_HOST_PORT(pc, primary, primary);
+            if (primary != nodes[i].hp) // not primary replica
                 continue;
             if (pc.partition_flags != 0) // already calculated
                 continue;

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -2240,7 +2240,9 @@ create_rdb_estimated_keys_stats_calcs(const int32_t table_id,
 
     partition_stat_map sums;
     for (size_t i = 0; i < rows.size(); ++i) {
-        if (pcs[i].hp_primary != node) {
+        dsn::host_port primary;
+        GET_HOST_PORT(pcs[i], primary, primary);
+        if (primary != node) {
             // Ignore once the replica of the metrics is not the primary of the partition.
             continue;
         }
@@ -2885,9 +2887,12 @@ bool calculate_hash_value(command_executor *e, shell_context *sc, arguments args
         tp.add_row_name_and_data("partition_index", partition_index);
         if (pcs.size() > partition_index) {
             const auto &pc = pcs[partition_index];
-            tp.add_row_name_and_data("primary", pc.hp_primary.to_string());
-            tp.add_row_name_and_data("secondaries",
-                                     fmt::format("{}", fmt::join(pc.hp_secondaries, ",")));
+            dsn::host_port primary;
+            GET_HOST_PORT(pc, primary, primary);
+            std::vector<dsn::host_port> secondaries;
+            GET_HOST_PORTS(pc, secondaries, secondaries);
+            tp.add_row_name_and_data("primary", primary);
+            tp.add_row_name_and_data("secondaries", fmt::format("{}", fmt::join(secondaries, ",")));
         }
     }
     tp.output(std::cout);

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -682,13 +682,17 @@ bool ls_nodes(command_executor *, shell_context *sc, arguments args)
             }
 
             for (const auto &pc : pcs) {
-                if (pc.hp_primary) {
-                    auto find = tmp_map.find(pc.hp_primary);
+                dsn::host_port primary;
+                GET_HOST_PORT(pc, primary, primary);
+                if (primary) {
+                    auto find = tmp_map.find(primary);
                     if (find != tmp_map.end()) {
                         find->second.primary_count++;
                     }
                 }
-                for (const auto &secondary : pc.hp_secondaries) {
+                std::vector<dsn::host_port> secondaries;
+                GET_HOST_PORTS(pc, secondaries, secondaries);
+                for (const auto &secondary : secondaries) {
                     auto find = tmp_map.find(secondary);
                     if (find != tmp_map.end()) {
                         find->second.secondary_count++;

--- a/src/shell/commands/recovery.cpp
+++ b/src/shell/commands/recovery.cpp
@@ -166,12 +166,13 @@ bool recover(command_executor *e, shell_context *sc, arguments args)
 
 dsn::host_port diagnose_recommend(const dsn::replication::ddd_partition_info &pinfo)
 {
-    if (pinfo.config.hp_last_drops.size() < 2) {
+    std::vector<dsn::host_port> last_drops;
+    GET_HOST_PORTS(pinfo.config, last_drops, last_drops);
+    if (last_drops.size() < 2) {
         return dsn::host_port();
     }
 
-    std::vector<dsn::host_port> last_two_nodes(pinfo.config.hp_last_drops.end() - 2,
-                                               pinfo.config.hp_last_drops.end());
+    std::vector<dsn::host_port> last_two_nodes(last_drops.end() - 2, last_drops.end());
     std::vector<dsn::replication::ddd_node_info> last_dropped;
     for (const auto &node : last_two_nodes) {
         const auto it = std::find_if(
@@ -294,12 +295,13 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
             << "last_committed(" << pinfo.config.last_committed_decree << ")" << std::endl;
         out << "    ----" << std::endl;
         dsn::host_port latest_dropped, secondary_latest_dropped;
-        if (pinfo.config.hp_last_drops.size() > 0) {
-            latest_dropped = pinfo.config.hp_last_drops[pinfo.config.hp_last_drops.size() - 1];
+        std::vector<dsn::host_port> last_drops;
+        GET_HOST_PORTS(pinfo.config, last_drops, last_drops);
+        if (last_drops.size() > 0) {
+            latest_dropped = last_drops[last_drops.size() - 1];
         }
-        if (pinfo.config.hp_last_drops.size() > 1) {
-            secondary_latest_dropped =
-                pinfo.config.hp_last_drops[pinfo.config.hp_last_drops.size() - 2];
+        if (last_drops.size() > 1) {
+            secondary_latest_dropped = last_drops[last_drops.size() - 2];
         }
         int j = 0;
         for (const dsn::replication::ddd_node_info &n : pinfo.dropped) {
@@ -323,12 +325,12 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
         }
         out << "    ----" << std::endl;
         j = 0;
-        for (const auto &r : pinfo.config.hp_last_drops) {
+        for (const auto &r : last_drops) {
             out << "    last_drops[" << j++ << "]: "
                 << "node(" << r.to_string() << ")";
-            if (j == (int)pinfo.config.hp_last_drops.size() - 1)
+            if (j == (int)last_drops.size() - 1)
                 out << "  <== the secondary latest";
-            else if (j == (int)pinfo.config.hp_last_drops.size())
+            else if (j == (int)last_drops.size())
                 out << "  <== the latest";
             out << std::endl;
         }

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -341,11 +341,15 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
     double disk_used_for_all_replicas = 0;
     int all_replicas_count = 0;
     for (const auto &pc : pcs) {
+        dsn::host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        std::vector<dsn::host_port> secondaries;
+        GET_HOST_PORTS(pc, secondaries, secondaries);
         std::string primary_str("-");
-        if (pc.hp_primary) {
+        if (primary) {
             bool disk_found = false;
             double disk_value = 0;
-            auto f1 = disk_map.find(pc.hp_primary);
+            auto f1 = disk_map.find(primary);
             if (f1 != disk_map.end()) {
                 auto &sub_map = f1->second;
                 auto f2 = sub_map.find(pc.pid.get_partition_index());
@@ -360,7 +364,7 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
             }
             bool count_found = false;
             double count_value = 0;
-            auto f3 = count_map.find(pc.hp_primary);
+            auto f3 = count_map.find(primary);
             if (f3 != count_map.end()) {
                 auto &sub_map = f3->second;
                 auto f4 = sub_map.find(pc.pid.get_partition_index());
@@ -372,7 +376,7 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
 
             // TODO(wangdan): refactor as format style.
             std::stringstream oss;
-            oss << pc.hp_primary.resolve(resolve_ip) << "(";
+            oss << primary.resolve(resolve_ip) << "(";
             if (disk_found) {
                 oss << disk_value;
             } else {
@@ -391,12 +395,12 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
         {
             std::stringstream oss;
             oss << "[";
-            for (int j = 0; j < pc.hp_secondaries.size(); j++) {
+            for (int j = 0; j < secondaries.size(); j++) {
                 if (j != 0)
                     oss << ",";
                 bool found = false;
                 double value = 0;
-                auto f1 = disk_map.find(pc.hp_secondaries[j]);
+                auto f1 = disk_map.find(secondaries[j]);
                 if (f1 != disk_map.end()) {
                     auto &sub_map = f1->second;
                     auto f2 = sub_map.find(pc.pid.get_partition_index());
@@ -409,7 +413,7 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
                 }
                 bool count_found = false;
                 double count_value = 0;
-                auto f3 = count_map.find(pc.hp_secondaries[j]);
+                auto f3 = count_map.find(secondaries[j]);
                 if (f3 != count_map.end()) {
                     auto &sub_map = f3->second;
                     auto f3 = sub_map.find(pc.pid.get_partition_index());
@@ -420,7 +424,7 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
                 }
 
                 // TODO(wangdan): refactor as format style.
-                oss << pc.hp_secondaries[j].resolve(resolve_ip) << "(";
+                oss << secondaries[j].resolve(resolve_ip) << "(";
                 if (found) {
                     oss << value;
                 } else {
@@ -441,8 +445,8 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
         if (detailed) {
             tp_details.add_row(std::to_string(pc.pid.get_partition_index()));
             tp_details.append_data(pc.ballot);
-            tp_details.append_data(fmt::format(
-                "{}/{}", pc.hp_secondaries.size() + (pc.hp_primary ? 1 : 0), pc.max_replica_count));
+            tp_details.append_data(
+                fmt::format("{}/{}", secondaries.size() + (primary ? 1 : 0), pc.max_replica_count));
             tp_details.append_data(primary_str);
             tp_details.append_data(secondary_str);
         }

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -172,8 +172,12 @@ void test_util::wait_table_healthy(const std::string &table_name) const
             std::vector<dsn::partition_configuration> pcs;
             ASSERT_EQ(dsn::ERR_OK, ddl_client_->list_app(table_name, table_id, pcount, pcs));
             for (const auto &pc : pcs) {
-                ASSERT_TRUE(pc.primary);
-                ASSERT_EQ(1 + pc.secondaries.size(), pc.max_replica_count);
+                dsn::host_port primary;
+                GET_HOST_PORT(pc, primary, primary);
+                ASSERT_TRUE(primary);
+                std::vector<dsn::host_port> secondaries;
+                GET_HOST_PORTS(pc, secondaries, secondaries);
+                ASSERT_EQ(1 + secondaries.size(), pc.max_replica_count);
             }
         },
         180);

--- a/src/test/kill_test/partition_kill_testor.cpp
+++ b/src/test/kill_test/partition_kill_testor.cpp
@@ -93,7 +93,7 @@ void partition_kill_testor::run()
         dsn::host_port primary;
         GET_HOST_PORT(pc, primary, primary);
         tasks[i] = dsn::dist::cmd::async_call_remote(
-            dsn::dns_resolver::instance().resolve_address(primary),
+            primary.resolve(),
             "replica.kill_partition",
             arguments,
             callback,


### PR DESCRIPTION
This is a further refactor on idl/dsn.layer2.thrift, the main effects are on
partition_configuration structure.

To keep compatible and support rolling update, it should be accepted that partial
servers or clients with the FQDN supporting feature and partial of them without
the feature. In this patch, macros like `GET_HOST_PORT` and `GET_HOST_PORTS` are
used in almost all places where partition_configuration objects appear. (Unit
tests don't require this because the tests must in the latest version which has
this feature).

When invoking a RPC, it's preferred to use host_port because we suppose that the
IP address is possible to be changed, but the hostname is permanent.

When received a proposol request, the optional `hp_primary` and `hp_secondaries`
will be filled by the related host_ports of the `primary` and `secondaries` and
fields. Then we can simplily deal with the logic.