### PR TITLE
refactor: Simplify code on partition_configuration

### DIFF
--- a/src/client/partition_resolver_simple.h
+++ b/src/client/partition_resolver_simple.h
@@ -65,7 +65,7 @@ private:
     struct partition_info
     {
         int timeout_count;
-        ::dsn::partition_configuration config;
+        ::dsn::partition_configuration pc;
     };
     mutable dsn::zrwlock_nr _config_lock;
     std::unordered_map<int, std::unique_ptr<partition_info>> _config_cache;
@@ -107,7 +107,7 @@ private:
 
 private:
     // local routines
-    host_port get_host_port(const partition_configuration &config) const;
+    host_port get_host_port(const partition_configuration &pc) const;
     error_code get_host_port(int partition_index, /*out*/ host_port &hp);
     void handle_pending_requests(std::deque<request_context_ptr> &reqs, error_code err);
     void clear_all_pending_requests();

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -166,7 +166,7 @@ dsn::error_code replication_ddl_client::wait_app_ready(const std::string &app_na
         CHECK_EQ(partition_count, query_resp.partition_count);
         int ready_count = 0;
         for (int i = 0; i < partition_count; i++) {
-            const partition_configuration &pc = query_resp.partitions[i];
+            const auto &pc = query_resp.partitions[i];
             if (pc.hp_primary && (pc.hp_secondaries.size() + 1 >= max_replica_count)) {
                 ready_count++;
             }
@@ -422,8 +422,8 @@ dsn::error_code replication_ddl_client::list_apps(const dsn::app_status::type st
             }
             int32_t app_id;
             int32_t partition_count;
-            std::vector<partition_configuration> partitions;
-            r = list_app(info.app_name, app_id, partition_count, partitions);
+            std::vector<partition_configuration> pcs;
+            r = list_app(info.app_name, app_id, partition_count, pcs);
             if (r != dsn::ERR_OK) {
                 LOG_ERROR("list app({}) failed, err = {}", info.app_name, r);
                 return r;
@@ -433,18 +433,18 @@ dsn::error_code replication_ddl_client::list_apps(const dsn::app_status::type st
             int fully_healthy = 0;
             int write_unhealthy = 0;
             int read_unhealthy = 0;
-            for (int i = 0; i < partitions.size(); i++) {
-                const dsn::partition_configuration &p = partitions[i];
+            for (const auto &pc : pcs) {
                 int replica_count = 0;
-                if (p.hp_primary) {
+                if (pc.hp_primary) {
                     replica_count++;
                 }
-                replica_count += p.hp_secondaries.size();
-                if (p.hp_primary) {
-                    if (replica_count >= p.max_replica_count)
+                replica_count += pc.hp_secondaries.size();
+                if (pc.hp_primary) {
+                    if (replica_count >= pc.max_replica_count) {
                         fully_healthy++;
-                    else if (replica_count < 2)
+                    } else if (replica_count < 2) {
                         write_unhealthy++;
+                    }
                 } else {
                     write_unhealthy++;
                     read_unhealthy++;
@@ -566,22 +566,21 @@ dsn::error_code replication_ddl_client::list_nodes(const dsn::replication::node_
         for (auto &app : apps) {
             int32_t app_id;
             int32_t partition_count;
-            std::vector<partition_configuration> partitions;
-            r = list_app(app.app_name, app_id, partition_count, partitions);
+            std::vector<partition_configuration> pcs;
+            r = list_app(app.app_name, app_id, partition_count, pcs);
             if (r != dsn::ERR_OK) {
                 return r;
             }
 
-            for (int i = 0; i < partitions.size(); i++) {
-                const dsn::partition_configuration &p = partitions[i];
-                if (p.hp_primary) {
-                    auto find = tmp_map.find(p.hp_primary);
+            for (const auto &pc : pcs) {
+                if (pc.hp_primary) {
+                    auto find = tmp_map.find(pc.hp_primary);
                     if (find != tmp_map.end()) {
                         find->second.primary_count++;
                     }
                 }
-                for (int j = 0; j < p.hp_secondaries.size(); j++) {
-                    auto find = tmp_map.find(p.hp_secondaries[j]);
+                for (const auto &secondary : pc.hp_secondaries) {
+                    auto find = tmp_map.find(secondary);
                     if (find != tmp_map.end()) {
                         find->second.secondary_count++;
                     }
@@ -723,13 +722,13 @@ dsn::error_code replication_ddl_client::list_app(const std::string &app_name,
     int32_t app_id = 0;
     int32_t partition_count = 0;
     int32_t max_replica_count = 0;
-    std::vector<partition_configuration> partitions;
-    dsn::error_code err = list_app(app_name, app_id, partition_count, partitions);
+    std::vector<partition_configuration> pcs;
+    dsn::error_code err = list_app(app_name, app_id, partition_count, pcs);
     if (err != dsn::ERR_OK) {
         return err;
     }
-    if (!partitions.empty()) {
-        max_replica_count = partitions[0].max_replica_count;
+    if (!pcs.empty()) {
+        max_replica_count = pcs[0].max_replica_count;
     }
 
     // print query_cfg_response
@@ -765,41 +764,33 @@ dsn::error_code replication_ddl_client::list_app(const std::string &app_name,
         int fully_healthy = 0;
         int write_unhealthy = 0;
         int read_unhealthy = 0;
-        for (const auto &p : partitions) {
+        for (const auto &pc : pcs) {
             int replica_count = 0;
-            if (p.hp_primary) {
+            if (pc.hp_primary) {
                 replica_count++;
-                node_stat[p.hp_primary].first++;
+                node_stat[pc.hp_primary].first++;
                 total_prim_count++;
             }
-            replica_count += p.hp_secondaries.size();
-            total_sec_count += p.hp_secondaries.size();
-            if (p.hp_primary) {
-                if (replica_count >= p.max_replica_count)
+            replica_count += pc.hp_secondaries.size();
+            total_sec_count += pc.hp_secondaries.size();
+            if (pc.hp_primary) {
+                if (replica_count >= pc.max_replica_count) {
                     fully_healthy++;
-                else if (replica_count < 2)
+                } else if (replica_count < 2) {
                     write_unhealthy++;
+                }
             } else {
                 write_unhealthy++;
                 read_unhealthy++;
             }
-            tp_details.add_row(p.pid.get_partition_index());
-            tp_details.append_data(p.ballot);
-            std::stringstream oss;
-            oss << replica_count << "/" << p.max_replica_count;
-            tp_details.append_data(oss.str());
-            tp_details.append_data(p.hp_primary ? p.hp_primary.to_string() : "-");
-            oss.str("");
-            oss << "[";
-            // TODO (yingchun) join
-            for (int j = 0; j < p.hp_secondaries.size(); j++) {
-                if (j != 0)
-                    oss << ",";
-                oss << p.hp_secondaries[j];
-                node_stat[p.hp_secondaries[j]].second++;
+            for (const auto &secondary : pc.hp_secondaries) {
+                node_stat[secondary].second++;
             }
-            oss << "]";
-            tp_details.append_data(oss.str());
+            tp_details.add_row(pc.pid.get_partition_index());
+            tp_details.append_data(pc.ballot);
+            tp_details.append_data(fmt::format("{}/{}", replica_count, pc.max_replica_count));
+            tp_details.append_data(pc.hp_primary ? pc.hp_primary.to_string() : "-");
+            tp_details.append_data(fmt::format("[{}]", fmt::join(pc.hp_secondaries, ",")));
         }
         mtp.add(std::move(tp_details));
 
@@ -837,7 +828,7 @@ dsn::error_code replication_ddl_client::list_app(const std::string &app_name,
 dsn::error_code replication_ddl_client::list_app(const std::string &app_name,
                                                  int32_t &app_id,
                                                  int32_t &partition_count,
-                                                 std::vector<partition_configuration> &partitions)
+                                                 std::vector<partition_configuration> &pcs)
 {
     RETURN_EC_NOT_OK_MSG(validate_app_name(app_name), "invalid app_name: '{}'", app_name);
 
@@ -859,7 +850,7 @@ dsn::error_code replication_ddl_client::list_app(const std::string &app_name,
 
     app_id = resp.app_id;
     partition_count = resp.partition_count;
-    partitions = resp.partitions;
+    pcs = resp.partitions;
 
     return dsn::ERR_OK;
 }
@@ -1322,8 +1313,8 @@ dsn::error_code replication_ddl_client::query_restore(int32_t restore_app_id, bo
     ::dsn::unmarshall(resp_task->get_response(), response);
     if (response.err == ERR_OK) {
         int overall_progress = 0;
-        for (const auto &p : response.restore_progress) {
-            overall_progress += p;
+        for (const auto &progress : response.restore_progress) {
+            overall_progress += progress;
         }
         overall_progress = overall_progress / response.restore_progress.size();
         overall_progress = overall_progress / 10;

--- a/src/client/replication_ddl_client.h
+++ b/src/client/replication_ddl_client.h
@@ -125,7 +125,7 @@ public:
     dsn::error_code list_app(const std::string &app_name,
                              int32_t &app_id,
                              int32_t &partition_count,
-                             std::vector<partition_configuration> &partitions);
+                             std::vector<partition_configuration> &pcs);
 
     dsn::replication::configuration_meta_control_response
     control_meta_function_level(meta_function_level::type level);

--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -448,8 +448,8 @@ inline bool json_decode(const dsn::json::JsonObject &in, dsn::host_port &hp)
     return static_cast<bool>(hp);
 }
 
-inline void json_encode(JsonWriter &out, const dsn::partition_configuration &config);
-inline bool json_decode(const JsonObject &in, dsn::partition_configuration &config);
+inline void json_encode(JsonWriter &out, const dsn::partition_configuration &pc);
+inline bool json_decode(const JsonObject &in, dsn::partition_configuration &pc);
 inline void json_encode(JsonWriter &out, const dsn::app_info &info);
 inline bool json_decode(const JsonObject &in, dsn::app_info &info);
 inline void json_encode(JsonWriter &out, const dsn::replication::file_meta &f_meta);

--- a/src/common/replication_common.cpp
+++ b/src/common/replication_common.cpp
@@ -166,26 +166,26 @@ int32_t replication_options::app_mutation_2pc_min_replica_count(int32_t app_max_
     }
 }
 
-/*static*/ bool replica_helper::get_replica_config(const partition_configuration &partition_config,
+/*static*/ bool replica_helper::get_replica_config(const partition_configuration &pc,
                                                    const ::dsn::host_port &node,
-                                                   /*out*/ replica_configuration &replica_config)
+                                                   /*out*/ replica_configuration &rc)
 {
-    replica_config.pid = partition_config.pid;
-    replica_config.ballot = partition_config.ballot;
-    replica_config.learner_signature = invalid_signature;
-    SET_OBJ_IP_AND_HOST_PORT(replica_config, primary, partition_config, primary);
+    rc.pid = pc.pid;
+    rc.ballot = pc.ballot;
+    rc.learner_signature = invalid_signature;
+    SET_OBJ_IP_AND_HOST_PORT(rc, primary, pc, primary);
 
-    if (node == partition_config.hp_primary) {
-        replica_config.status = partition_status::PS_PRIMARY;
+    if (node == pc.hp_primary) {
+        rc.status = partition_status::PS_PRIMARY;
         return true;
     }
 
-    if (utils::contains(partition_config.hp_secondaries, node)) {
-        replica_config.status = partition_status::PS_SECONDARY;
+    if (utils::contains(pc.hp_secondaries, node)) {
+        rc.status = partition_status::PS_SECONDARY;
         return true;
     }
 
-    replica_config.status = partition_status::PS_INACTIVE;
+    rc.status = partition_status::PS_INACTIVE;
     return false;
 }
 

--- a/src/common/replication_other_types.h
+++ b/src/common/replication_other_types.h
@@ -79,8 +79,8 @@ inline bool is_partition_config_equal(const partition_configuration &pc1,
                                       const partition_configuration &pc2)
 {
     // secondaries no need to be same order
-    for (const auto &hp : pc1.hp_secondaries) {
-        if (!is_secondary(pc2, hp)) {
+    for (const auto &pc1_secondary : pc1.hp_secondaries) {
+        if (!is_secondary(pc2, pc1_secondary)) {
             return false;
         }
     }
@@ -106,9 +106,9 @@ public:
         }
         return false;
     }
-    static bool get_replica_config(const partition_configuration &partition_config,
+    static bool get_replica_config(const partition_configuration &pc,
                                    const ::dsn::host_port &node,
-                                   /*out*/ replica_configuration &replica_config);
+                                   /*out*/ replica_configuration &rc);
 
     // Return true if 'server_list' is a valid comma-separated list of servers, otherwise return
     // false. The result is filled into 'servers' if success.

--- a/src/meta/backup_engine.cpp
+++ b/src/meta/backup_engine.cpp
@@ -182,7 +182,7 @@ void backup_engine::backup_app_partition(const gpid &pid)
             _is_backup_failed = true;
             return;
         }
-        partition_primary = app->partitions[pid.get_partition_index()].hp_primary;
+        partition_primary = app->pcs[pid.get_partition_index()].hp_primary;
     }
 
     if (!partition_primary) {

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -547,10 +547,10 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                           const host_port secondary1("localhost", 34802);
                           const host_port secondary2("localhost", 34803);
 
-                          partition_configuration p;
-                          SET_IP_AND_HOST_PORT_BY_DNS(p, primary, primary);
-                          SET_IPS_AND_HOST_PORTS_BY_DNS(p, secondaries, secondary1, secondary2);
-                          resp.partitions.emplace_back(p);
+                          partition_configuration pc;
+                          SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, primary);
+                          SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, secondary1, secondary2);
+                          resp.partitions.emplace_back(pc);
                       }
                   });
 
@@ -561,18 +561,18 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                       if (resp.partitions.size() != dup->partition_count) {
                           query_err = ERR_INCONSISTENT_STATE;
                       } else {
-                          for (const auto &partition : resp.partitions) {
-                              if (!partition.hp_primary) {
+                          for (const auto &pc : resp.partitions) {
+                              if (!pc.hp_primary) {
                                   query_err = ERR_INACTIVE_STATE;
                                   break;
                               }
 
-                              if (partition.hp_secondaries.empty()) {
+                              if (pc.hp_secondaries.empty()) {
                                   query_err = ERR_NOT_ENOUGH_MEMBER;
                                   break;
                               }
 
-                              for (const auto &secondary : partition.hp_secondaries) {
+                              for (const auto &secondary : pc.hp_secondaries) {
                                   if (!secondary) {
                                       query_err = ERR_INACTIVE_STATE;
                                       break;

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -320,7 +320,7 @@ void load_balance_policy::start_moving_primary(const std::shared_ptr<app_state> 
     while (plan_moving-- > 0) {
         dsn::gpid selected = select_moving(potential_moving, prev_load, current_load, from, to);
 
-        const partition_configuration &pc = app->partitions[selected.get_partition_index()];
+        const auto &pc = app->pcs[selected.get_partition_index()];
         auto balancer_result = _migration_result->emplace(
             selected,
             generate_balancer_request(
@@ -338,7 +338,7 @@ std::list<dsn::gpid> load_balance_policy::calc_potential_moving(
     std::list<dsn::gpid> potential_moving;
     const node_state &ns = _global_view->nodes->find(from)->second;
     ns.for_each_primary(app->app_id, [&](const gpid &pid) {
-        const partition_configuration &pc = app->partitions[pid.get_partition_index()];
+        const auto &pc = app->pcs[pid.get_partition_index()];
         if (is_secondary(pc, to)) {
             potential_moving.push_back(pid);
         }
@@ -566,10 +566,10 @@ void ford_fulkerson::add_edge(int node_id, const node_state &ns)
 void ford_fulkerson::update_decree(int node_id, const node_state &ns)
 {
     ns.for_each_primary(_app->app_id, [&, this](const gpid &pid) {
-        const partition_configuration &pc = _app->partitions[pid.get_partition_index()];
+        const auto &pc = _app->pcs[pid.get_partition_index()];
         for (const auto &secondary : pc.hp_secondaries) {
             auto i = _host_port_id.find(secondary);
-            CHECK(i != _host_port_id.end(), "invalid secondary address, address = {}", secondary);
+            CHECK(i != _host_port_id.end(), "invalid secondary: {}", secondary);
             _network[node_id][i->second]++;
         }
         return true;
@@ -709,7 +709,7 @@ void copy_replica_operation::copy_once(gpid selected_pid, migration_list *result
     const auto &from = _host_port_vec[*_ordered_host_port_ids.rbegin()];
     const auto &to = _host_port_vec[*_ordered_host_port_ids.begin()];
 
-    auto pc = _app->partitions[selected_pid.get_partition_index()];
+    auto pc = _app->pcs[selected_pid.get_partition_index()];
     auto request = generate_balancer_request(_apps, pc, get_balance_type(), from, to);
     result->emplace(selected_pid, request);
 }

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -532,7 +532,7 @@ void policy_context::start_backup_partition_unlocked(gpid pid)
                 pid, cold_backup_constant::PROGRESS_FINISHED, dsn::host_port());
             return;
         }
-        partition_primary = app->partitions[pid.get_partition_index()].hp_primary;
+        partition_primary = app->pcs[pid.get_partition_index()].hp_primary;
     }
     if (!partition_primary) {
         LOG_WARNING("{}: partition {} doesn't have a primary now, retry to backup it later",
@@ -670,7 +670,7 @@ void policy_context::initialize_backup_progress_unlocked()
             // unfinished_partitions_per_app & partition_progress & app_chkpt_size
             _progress.unfinished_partitions_per_app[app_id] = app->partition_count;
             std::map<int, int64_t> partition_chkpt_size;
-            for (const partition_configuration &pc : app->partitions) {
+            for (const auto &pc : app->pcs) {
                 _progress.partition_progress[pc.pid] = 0;
                 partition_chkpt_size[pc.pid.get_app_id()] = 0;
             }

--- a/src/meta/meta_bulk_load_ingestion_context.cpp
+++ b/src/meta/meta_bulk_load_ingestion_context.cpp
@@ -44,13 +44,13 @@ ingestion_context::ingestion_context() { reset_all(); }
 
 ingestion_context::~ingestion_context() { reset_all(); }
 
-void ingestion_context::partition_node_info::create(const partition_configuration &config,
+void ingestion_context::partition_node_info::create(const partition_configuration &pc,
                                                     const config_context &cc)
 {
-    pid = config.pid;
+    pid = pc.pid;
     std::unordered_set<host_port> current_nodes;
-    current_nodes.insert(config.hp_primary);
-    for (const auto &secondary : config.hp_secondaries) {
+    current_nodes.insert(pc.hp_primary);
+    for (const auto &secondary : pc.hp_secondaries) {
         current_nodes.insert(secondary);
     }
     for (const auto &node : current_nodes) {
@@ -120,16 +120,16 @@ void ingestion_context::node_context::decrease(const std::string &disk_tag)
     disk_ingesting_counts[disk_tag]--;
 }
 
-bool ingestion_context::try_partition_ingestion(const partition_configuration &config,
+bool ingestion_context::try_partition_ingestion(const partition_configuration &pc,
                                                 const config_context &cc)
 {
     FAIL_POINT_INJECT_F("ingestion_try_partition_ingestion", [=](absl::string_view) -> bool {
         auto info = partition_node_info();
-        info.pid = config.pid;
-        _running_partitions[config.pid] = info;
+        info.pid = pc.pid;
+        _running_partitions[pc.pid] = info;
         return true;
     });
-    partition_node_info info(config, cc);
+    partition_node_info info(pc, cc);
     for (const auto &kv : info.node_disk) {
         if (!check_node_ingestion(kv.first, kv.second)) {
             return false;

--- a/src/meta/meta_bulk_load_ingestion_context.h
+++ b/src/meta/meta_bulk_load_ingestion_context.h
@@ -49,11 +49,11 @@ private:
         std::unordered_map<host_port, std::string> node_disk;
 
         partition_node_info() {}
-        partition_node_info(const partition_configuration &config, const config_context &cc)
+        partition_node_info(const partition_configuration &pc, const config_context &cc)
         {
-            create(config, cc);
+            create(pc, cc);
         }
-        void create(const partition_configuration &config, const config_context &cc);
+        void create(const partition_configuration &pc, const config_context &cc);
     };
 
     struct node_context
@@ -77,7 +77,7 @@ private:
         void decrease(const std::string &disk_tag);
     };
 
-    bool try_partition_ingestion(const partition_configuration &config, const config_context &cc);
+    bool try_partition_ingestion(const partition_configuration &pc, const config_context &cc);
     bool check_node_ingestion(const host_port &node, const std::string &disk_tag);
     void add_partition(const partition_node_info &info);
     void remove_partition(const gpid &pid);

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -357,7 +357,7 @@ bool bulk_load_service::check_partition_status(
     const gpid &pid,
     bool always_unhealthy_check,
     const std::function<void(const std::string &, const gpid &)> &retry_function,
-    /*out*/ partition_configuration &pconfig)
+    /*out*/ partition_configuration &pc)
 {
     std::shared_ptr<app_state> app = get_app(pid.get_app_id());
     if (app == nullptr || app->status != app_status::AS_AVAILABLE) {
@@ -370,8 +370,8 @@ bool bulk_load_service::check_partition_status(
         return false;
     }
 
-    pconfig = app->partitions[pid.get_partition_index()];
-    if (!pconfig.hp_primary) {
+    pc = app->pcs[pid.get_partition_index()];
+    if (!pc.hp_primary) {
         LOG_WARNING("app({}) partition({}) primary is invalid, try it later", app_name, pid);
         tasking::enqueue(
             LPC_META_STATE_NORMAL,
@@ -382,7 +382,7 @@ bool bulk_load_service::check_partition_status(
         return false;
     }
 
-    if (pconfig.hp_secondaries.size() < pconfig.max_replica_count - 1) {
+    if (pc.hp_secondaries.size() < pc.max_replica_count - 1) {
         bulk_load_status::type p_status;
         {
             zauto_read_lock l(_lock);
@@ -416,7 +416,7 @@ void bulk_load_service::partition_bulk_load(const std::string &app_name, const g
 {
     FAIL_POINT_INJECT_F("meta_bulk_load_partition_bulk_load", [](absl::string_view) {});
 
-    partition_configuration pconfig;
+    partition_configuration pc;
     if (!check_partition_status(app_name,
                                 pid,
                                 false,
@@ -424,7 +424,7 @@ void bulk_load_service::partition_bulk_load(const std::string &app_name, const g
                                           this,
                                           std::placeholders::_1,
                                           std::placeholders::_2),
-                                pconfig)) {
+                                pc)) {
         return;
     }
 
@@ -434,18 +434,18 @@ void bulk_load_service::partition_bulk_load(const std::string &app_name, const g
         const app_bulk_load_info &ainfo = _app_bulk_load_info[pid.get_app_id()];
         req->pid = pid;
         req->app_name = app_name;
-        SET_IP_AND_HOST_PORT(*req, primary, pconfig.primary, pconfig.hp_primary);
+        SET_IP_AND_HOST_PORT(*req, primary, pc.primary, pc.hp_primary);
         req->remote_provider_name = ainfo.file_provider_type;
         req->cluster_name = ainfo.cluster_name;
         req->meta_bulk_load_status = get_partition_bulk_load_status_unlocked(pid);
-        req->ballot = pconfig.ballot;
+        req->ballot = pc.ballot;
         req->query_bulk_load_metadata = is_partition_metadata_not_updated_unlocked(pid);
         req->remote_root_path = ainfo.remote_root_path;
     }
 
     LOG_INFO("send bulk load request to node({}), app({}), partition({}), partition "
              "status = {}, remote provider = {}, cluster_name = {}, remote_root_path = {}",
-             FMT_HOST_PORT_AND_IP(pconfig, primary),
+             FMT_HOST_PORT_AND_IP(pc, primary),
              app_name,
              pid,
              dsn::enum_to_string(req->meta_bulk_load_status),
@@ -454,17 +454,16 @@ void bulk_load_service::partition_bulk_load(const std::string &app_name, const g
              req->remote_root_path);
 
     bulk_load_rpc rpc(std::move(req), RPC_BULK_LOAD, 0_ms, 0, pid.thread_hash());
-    rpc.call(
-        pconfig.primary, _meta_svc->tracker(), [this, pid, rpc, pconfig](error_code err) mutable {
-            // The remote server may not support FQDN, but do not try to reverse resolve the
-            // IP addresses because they may be unresolved. Just warning and ignore this.
-            LOG_WARNING_IF(!rpc.response().__isset.hp_group_bulk_load_state,
-                           "The {} primary {} doesn't support FQDN, the response "
-                           "hp_group_bulk_load_state field is not set",
-                           pid,
-                           FMT_HOST_PORT_AND_IP(pconfig, primary));
-            on_partition_bulk_load_reply(err, rpc.request(), rpc.response());
-        });
+    rpc.call(pc.primary, _meta_svc->tracker(), [this, pid, rpc, pc](error_code err) mutable {
+        // The remote server may not support FQDN, but do not try to reverse resolve the
+        // IP addresses because they may be unresolved. Just warning and ignore this.
+        LOG_WARNING_IF(!rpc.response().__isset.hp_group_bulk_load_state,
+                       "The {} primary {} doesn't support FQDN, the response "
+                       "hp_group_bulk_load_state field is not set",
+                       pid,
+                       FMT_HOST_PORT_AND_IP(pc, primary));
+        on_partition_bulk_load_reply(err, rpc.request(), rpc.response());
+    });
 }
 
 // ThreadPool: THREAD_POOL_META_STATE
@@ -533,7 +532,7 @@ void bulk_load_service::on_partition_bulk_load_reply(error_code err,
         handle_app_unavailable(pid.get_app_id(), app_name);
         return;
     }
-    ballot current_ballot = app->partitions[pid.get_partition_index()].ballot;
+    ballot current_ballot = app->pcs[pid.get_partition_index()].ballot;
     if (request.ballot < current_ballot) {
         LOG_WARNING(
             "receive out-date response from node({}), app({}), partition({}), request ballot = "
@@ -597,7 +596,7 @@ void bulk_load_service::try_resend_bulk_load_request(const std::string &app_name
 
 // ThreadPool: THREAD_POOL_META_STATE
 void bulk_load_service::handle_app_downloading(const bulk_load_response &response,
-                                               const host_port &primary_addr)
+                                               const host_port &primary)
 {
     const std::string &app_name = response.app_name;
     const gpid &pid = response.pid;
@@ -606,7 +605,7 @@ void bulk_load_service::handle_app_downloading(const bulk_load_response &respons
         LOG_WARNING(
             "receive bulk load response from node({}) app({}), partition({}), primary_status({}), "
             "but total_download_progress is not set",
-            primary_addr,
+            primary,
             app_name,
             pid,
             dsn::enum_to_string(response.primary_bulk_load_status));
@@ -619,7 +618,7 @@ void bulk_load_service::handle_app_downloading(const bulk_load_response &respons
             !bulk_load_states.__isset.download_status) {
             LOG_WARNING("receive bulk load response from node({}) app({}), partition({}), "
                         "primary_status({}), but node({}) progress or status is not set",
-                        primary_addr,
+                        primary,
                         app_name,
                         pid,
                         dsn::enum_to_string(response.primary_bulk_load_status),
@@ -658,7 +657,7 @@ void bulk_load_service::handle_app_downloading(const bulk_load_response &respons
     int32_t total_progress = response.total_download_progress;
     LOG_INFO("receive bulk load response from node({}) app({}) partition({}), primary_status({}), "
              "total_download_progress = {}",
-             primary_addr,
+             primary,
              app_name,
              pid,
              dsn::enum_to_string(response.primary_bulk_load_status),
@@ -679,7 +678,7 @@ void bulk_load_service::handle_app_downloading(const bulk_load_response &respons
 
 // ThreadPool: THREAD_POOL_META_STATE
 void bulk_load_service::handle_app_ingestion(const bulk_load_response &response,
-                                             const host_port &primary_addr)
+                                             const host_port &primary)
 {
     const std::string &app_name = response.app_name;
     const gpid &pid = response.pid;
@@ -687,7 +686,7 @@ void bulk_load_service::handle_app_ingestion(const bulk_load_response &response,
     if (!response.__isset.is_group_ingestion_finished) {
         LOG_WARNING("receive bulk load response from node({}) app({}) partition({}), "
                     "primary_status({}), but is_group_ingestion_finished is not set",
-                    primary_addr,
+                    primary,
                     app_name,
                     pid,
                     dsn::enum_to_string(response.primary_bulk_load_status));
@@ -699,7 +698,7 @@ void bulk_load_service::handle_app_ingestion(const bulk_load_response &response,
         if (!bulk_load_states.__isset.ingest_status) {
             LOG_WARNING("receive bulk load response from node({}) app({}) partition({}), "
                         "primary_status({}), but node({}) ingestion_status is not set",
-                        primary_addr,
+                        primary,
                         app_name,
                         pid,
                         dsn::enum_to_string(response.primary_bulk_load_status),
@@ -718,7 +717,7 @@ void bulk_load_service::handle_app_ingestion(const bulk_load_response &response,
 
     LOG_INFO("receive bulk load response from node({}) app({}) partition({}), primary_status({}), "
              "is_group_ingestion_finished = {}",
-             primary_addr,
+             primary,
              app_name,
              pid,
              dsn::enum_to_string(response.primary_bulk_load_status),
@@ -737,7 +736,7 @@ void bulk_load_service::handle_app_ingestion(const bulk_load_response &response,
 
 // ThreadPool: THREAD_POOL_META_STATE
 void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &response,
-                                                const host_port &primary_addr)
+                                                const host_port &primary)
 {
     const std::string &app_name = response.app_name;
     const gpid &pid = response.pid;
@@ -745,7 +744,7 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
     if (!response.__isset.is_group_bulk_load_context_cleaned_up) {
         LOG_WARNING("receive bulk load response from node({}) app({}) partition({}), "
                     "primary_status({}), but is_group_bulk_load_context_cleaned_up is not set",
-                    primary_addr,
+                    primary,
                     app_name,
                     pid,
                     dsn::enum_to_string(response.primary_bulk_load_status));
@@ -756,7 +755,7 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
         if (!kv.second.__isset.is_cleaned_up) {
             LOG_WARNING("receive bulk load response from node({}) app({}), partition({}), "
                         "primary_status({}), but node({}) is_cleaned_up is not set",
-                        primary_addr,
+                        primary,
                         app_name,
                         pid,
                         dsn::enum_to_string(response.primary_bulk_load_status),
@@ -771,7 +770,7 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
             LOG_WARNING(
                 "receive bulk load response from node({}) app({}) partition({}), current partition "
                 "has already been cleaned up",
-                primary_addr,
+                primary,
                 app_name,
                 pid);
             return;
@@ -782,7 +781,7 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
     bool group_cleaned_up = response.is_group_bulk_load_context_cleaned_up;
     LOG_INFO("receive bulk load response from node({}) app({}) partition({}), primary status = {}, "
              "is_group_bulk_load_context_cleaned_up = {}",
-             primary_addr,
+             primary,
              app_name,
              pid,
              dsn::enum_to_string(response.primary_bulk_load_status),
@@ -818,7 +817,7 @@ void bulk_load_service::handle_bulk_load_finish(const bulk_load_response &respon
 
 // ThreadPool: THREAD_POOL_META_STATE
 void bulk_load_service::handle_app_pausing(const bulk_load_response &response,
-                                           const host_port &primary_addr)
+                                           const host_port &primary)
 {
     const std::string &app_name = response.app_name;
     const gpid &pid = response.pid;
@@ -826,7 +825,7 @@ void bulk_load_service::handle_app_pausing(const bulk_load_response &response,
     if (!response.__isset.is_group_bulk_load_paused) {
         LOG_WARNING("receive bulk load response from node({}) app({}) partition({}), "
                     "primary_status({}), but is_group_bulk_load_paused is not set",
-                    primary_addr,
+                    primary,
                     app_name,
                     pid,
                     dsn::enum_to_string(response.primary_bulk_load_status));
@@ -837,7 +836,7 @@ void bulk_load_service::handle_app_pausing(const bulk_load_response &response,
         if (!kv.second.__isset.is_paused) {
             LOG_WARNING("receive bulk load response from node({}) app({}), partition({}), "
                         "primary_status({}), but node({}) is_paused is not set",
-                        primary_addr,
+                        primary,
                         app_name,
                         pid,
                         dsn::enum_to_string(response.primary_bulk_load_status),
@@ -849,7 +848,7 @@ void bulk_load_service::handle_app_pausing(const bulk_load_response &response,
     bool is_group_paused = response.is_group_bulk_load_paused;
     LOG_INFO("receive bulk load response from node({}) app({}) partition({}), primary status = {}, "
              "is_group_bulk_load_paused = {}",
-             primary_addr,
+             primary,
              app_name,
              pid,
              dsn::enum_to_string(response.primary_bulk_load_status),
@@ -1187,7 +1186,7 @@ void bulk_load_service::update_app_status_on_remote_storage_reply(const app_bulk
 }
 
 // ThreadPool: THREAD_POOL_META_STATE
-bool bulk_load_service::check_ever_ingestion_succeed(const partition_configuration &config,
+bool bulk_load_service::check_ever_ingestion_succeed(const partition_configuration &pc,
                                                      const std::string &app_name,
                                                      const gpid &pid)
 {
@@ -1202,8 +1201,8 @@ bool bulk_load_service::check_ever_ingestion_succeed(const partition_configurati
     }
 
     std::vector<host_port> current_nodes;
-    current_nodes.emplace_back(config.hp_primary);
-    for (const auto &secondary : config.hp_secondaries) {
+    current_nodes.emplace_back(pc.hp_primary);
+    for (const auto &secondary : pc.hp_secondaries) {
         current_nodes.emplace_back(secondary);
     }
 
@@ -1243,7 +1242,7 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
         return;
     }
 
-    partition_configuration pconfig;
+    partition_configuration pc;
     if (!check_partition_status(app_name,
                                 pid,
                                 true,
@@ -1251,16 +1250,16 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
                                           this,
                                           std::placeholders::_1,
                                           std::placeholders::_2),
-                                pconfig)) {
+                                pc)) {
         return;
     }
 
-    if (check_ever_ingestion_succeed(pconfig, app_name, pid)) {
+    if (check_ever_ingestion_succeed(pc, app_name, pid)) {
         return;
     }
 
     auto app = get_app(pid.get_app_id());
-    if (!try_partition_ingestion(pconfig, app->helpers->contexts[pid.get_partition_index()])) {
+    if (!try_partition_ingestion(pc, app->helpers->contexts[pid.get_partition_index()])) {
         LOG_WARNING(
             "app({}) partition({}) couldn't execute ingestion, wait and try later", app_name, pid);
         tasking::enqueue(LPC_META_STATE_NORMAL,
@@ -1271,24 +1270,21 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
         return;
     }
 
-    const auto &primary_addr = pconfig.hp_primary;
-    ballot meta_ballot = pconfig.ballot;
-    tasking::enqueue(LPC_BULK_LOAD_INGESTION,
-                     _meta_svc->tracker(),
-                     std::bind(&bulk_load_service::send_ingestion_request,
-                               this,
-                               app_name,
-                               pid,
-                               primary_addr,
-                               meta_ballot),
-                     0,
-                     std::chrono::seconds(bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL));
+    const auto &primary = pc.hp_primary;
+    ballot meta_ballot = pc.ballot;
+    tasking::enqueue(
+        LPC_BULK_LOAD_INGESTION,
+        _meta_svc->tracker(),
+        std::bind(
+            &bulk_load_service::send_ingestion_request, this, app_name, pid, primary, meta_ballot),
+        0,
+        std::chrono::seconds(bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL));
 }
 
 // ThreadPool: THREAD_POOL_DEFAULT
 void bulk_load_service::send_ingestion_request(const std::string &app_name,
                                                const gpid &pid,
-                                               const host_port &primary_addr,
+                                               const host_port &primary,
                                                const ballot &meta_ballot)
 {
     ingestion_request req;
@@ -1311,11 +1307,11 @@ void bulk_load_service::send_ingestion_request(const std::string &app_name,
     dsn::rpc_response_task_ptr rpc_callback = rpc::create_rpc_response_task(
         msg,
         _meta_svc->tracker(),
-        [this, app_name, pid, primary_addr](error_code err, ingestion_response &&resp) {
-            on_partition_ingestion_reply(err, std::move(resp), app_name, pid, primary_addr);
+        [this, app_name, pid, primary](error_code err, ingestion_response &&resp) {
+            on_partition_ingestion_reply(err, std::move(resp), app_name, pid, primary);
         });
-    _meta_svc->send_request(msg, primary_addr, rpc_callback);
-    LOG_INFO("send ingest_request to node({}), app({}) partition({})", primary_addr, app_name, pid);
+    _meta_svc->send_request(msg, primary, rpc_callback);
+    LOG_INFO("send ingest_request to node({}), app({}) partition({})", primary, app_name, pid);
 }
 
 // ThreadPool: THREAD_POOL_DEFAULT
@@ -1323,7 +1319,7 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
                                                      const ingestion_response &&resp,
                                                      const std::string &app_name,
                                                      const gpid &pid,
-                                                     const host_port &primary_addr)
+                                                     const host_port &primary)
 {
     if (err != ERR_OK || resp.err != ERR_OK || resp.rocksdb_error != ERR_OK) {
         finish_ingestion(pid);
@@ -1335,7 +1331,7 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
             "repeated request",
             app_name,
             pid,
-            primary_addr);
+            primary);
         return;
     }
 
@@ -1344,7 +1340,7 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
         LOG_ERROR("app({}) partition({}) on node({}) ingestion files failed, error = {}",
                   app_name,
                   pid,
-                  primary_addr,
+                  primary,
                   err);
         tasking::enqueue(
             LPC_META_STATE_NORMAL,
@@ -1359,7 +1355,7 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
                   "{}, retry it later",
                   app_name,
                   pid,
-                  primary_addr,
+                  primary,
                   resp.rocksdb_error);
         tasking::enqueue(LPC_BULK_LOAD_INGESTION,
                          _meta_svc->tracker(),
@@ -1377,7 +1373,7 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
             "error = {}",
             app_name,
             pid,
-            primary_addr,
+            primary,
             resp.err,
             resp.rocksdb_error);
 
@@ -1393,7 +1389,7 @@ void bulk_load_service::on_partition_ingestion_reply(error_code err,
     LOG_INFO("app({}) partition({}) receive ingestion response from node({}) succeed",
              app_name,
              pid,
-             primary_addr);
+             primary);
 }
 
 // ThreadPool: THREAD_POOL_META_STATE

--- a/src/meta/meta_bulk_load_service.h
+++ b/src/meta/meta_bulk_load_service.h
@@ -189,7 +189,7 @@ private:
         const gpid &pid,
         bool always_unhealthy_check,
         const std::function<void(const std::string &, const gpid &)> &retry_function,
-        /*out*/ partition_configuration &pconfig);
+        /*out*/ partition_configuration &pc);
 
     void partition_bulk_load(const std::string &app_name, const gpid &pid);
 
@@ -200,15 +200,15 @@ private:
     // if app is still in bulk load, resend bulk_load_request to primary after interval seconds
     void try_resend_bulk_load_request(const std::string &app_name, const gpid &pid);
 
-    void handle_app_downloading(const bulk_load_response &response, const host_port &primary_addr);
+    void handle_app_downloading(const bulk_load_response &response, const host_port &primary);
 
-    void handle_app_ingestion(const bulk_load_response &response, const host_port &primary_addr);
+    void handle_app_ingestion(const bulk_load_response &response, const host_port &primary);
 
     // when app status is `succeed, `failed`, `canceled`, meta and replica should cleanup bulk load
     // states
-    void handle_bulk_load_finish(const bulk_load_response &response, const host_port &primary_addr);
+    void handle_bulk_load_finish(const bulk_load_response &response, const host_port &primary);
 
-    void handle_app_pausing(const bulk_load_response &response, const host_port &primary_addr);
+    void handle_app_pausing(const bulk_load_response &response, const host_port &primary);
 
     // app not existed or not available during bulk load
     void handle_app_unavailable(int32_t app_id, const std::string &app_name);
@@ -223,20 +223,20 @@ private:
 
     void send_ingestion_request(const std::string &app_name,
                                 const gpid &pid,
-                                const host_port &primary_addr,
+                                const host_port &primary,
                                 const ballot &meta_ballot);
 
     void on_partition_ingestion_reply(error_code err,
                                       const ingestion_response &&resp,
                                       const std::string &app_name,
                                       const gpid &pid,
-                                      const host_port &primary_addr);
+                                      const host_port &primary);
 
     // Called by `partition_ingestion`
     // - true : this partition has ever executed ingestion succeed, no need to send ingestion
     // request
     // - false: this partition has not executed ingestion or executed ingestion failed
-    bool check_ever_ingestion_succeed(const partition_configuration &config,
+    bool check_ever_ingestion_succeed(const partition_configuration &pc,
                                       const std::string &app_name,
                                       const gpid &pid);
 
@@ -252,9 +252,9 @@ private:
     ///
     /// ingestion_context functions
     ///
-    bool try_partition_ingestion(const partition_configuration &config, const config_context &cc)
+    bool try_partition_ingestion(const partition_configuration &pc, const config_context &cc)
     {
-        return _ingestion_context->try_partition_ingestion(config, cc);
+        return _ingestion_context->try_partition_ingestion(pc, cc);
     }
 
     void finish_ingestion(const gpid &pid) { _ingestion_context->remove_partition(pid); }

--- a/src/meta/meta_data.h
+++ b/src/meta/meta_data.h
@@ -196,7 +196,7 @@ struct serving_replica
 class config_context
 {
 public:
-    partition_configuration *config_owner;
+    partition_configuration *pc;
     config_status stage;
     // for server state's update config management
     //[
@@ -264,18 +264,12 @@ public:
 
 struct partition_configuration_stateless
 {
-    partition_configuration &config;
-    partition_configuration_stateless(partition_configuration &pc) : config(pc) {}
-    std::vector<dsn::host_port> &workers() { return config.hp_last_drops; }
-    std::vector<dsn::host_port> &hosts() { return config.hp_secondaries; }
-    bool is_host(const host_port &node) const
-    {
-        return utils::contains(config.hp_secondaries, node);
-    }
-    bool is_worker(const host_port &node) const
-    {
-        return utils::contains(config.hp_last_drops, node);
-    }
+    partition_configuration &pc;
+    partition_configuration_stateless(partition_configuration &_pc) : pc(_pc) {}
+    std::vector<dsn::host_port> &workers() { return pc.hp_last_drops; }
+    std::vector<dsn::host_port> &hosts() { return pc.hp_secondaries; }
+    bool is_host(const host_port &node) const { return utils::contains(pc.hp_secondaries, node); }
+    bool is_worker(const host_port &node) const { return utils::contains(pc.hp_last_drops, node); }
     bool is_member(const host_port &node) const { return is_host(node) || is_worker(node); }
 };
 
@@ -362,7 +356,7 @@ public:
 public:
     const char *get_logname() const { return log_name.c_str(); }
     std::shared_ptr<app_state_helper> helpers;
-    std::vector<partition_configuration> partitions;
+    std::vector<partition_configuration> pcs;
     std::map<dupid_t, duplication_info_s_ptr> duplications;
 
     static std::shared_ptr<app_state> create(const app_info &info);
@@ -462,7 +456,7 @@ inline const partition_configuration *get_config(const app_mapper &apps, const d
     auto iter = apps.find(gpid.get_app_id());
     if (iter == apps.end() || iter->second->status == app_status::AS_DROPPED)
         return nullptr;
-    return &(iter->second->partitions[gpid.get_partition_index()]);
+    return &(iter->second->pcs[gpid.get_partition_index()]);
 }
 
 inline partition_configuration *get_config(app_mapper &apps, const dsn::gpid &gpid)
@@ -470,7 +464,7 @@ inline partition_configuration *get_config(app_mapper &apps, const dsn::gpid &gp
     auto iter = apps.find(gpid.get_app_id());
     if (iter == apps.end() || iter->second->status == app_status::AS_DROPPED)
         return nullptr;
-    return &(iter->second->partitions[gpid.get_partition_index()]);
+    return &(iter->second->pcs[gpid.get_partition_index()]);
 }
 
 inline const config_context *get_config_context(const app_mapper &apps, const dsn::gpid &gpid)
@@ -510,29 +504,30 @@ inline health_status partition_health_status(const partition_configuration &pc,
                                              int mutation_2pc_min_replica_count)
 {
     if (!pc.hp_primary) {
-        if (pc.hp_secondaries.empty())
+        if (pc.hp_secondaries.empty()) {
             return HS_DEAD;
-        else
-            return HS_UNREADABLE;
-    } else {
-        int n = pc.hp_secondaries.size() + 1;
-        if (n < mutation_2pc_min_replica_count)
-            return HS_UNWRITABLE;
-        else if (n < pc.max_replica_count)
-            return HS_WRITABLE_ILL;
-        else
-            return HS_HEALTHY;
+        }
+        return HS_UNREADABLE;
     }
+
+    const auto replica_count = pc.hp_secondaries.size() + 1;
+    if (replica_count < mutation_2pc_min_replica_count) {
+        return HS_UNWRITABLE;
+    }
+
+    if (replica_count < pc.max_replica_count) {
+        return HS_WRITABLE_ILL;
+    }
+    return HS_HEALTHY;
 }
 
 inline void
 for_each_available_app(const app_mapper &apps,
                        const std::function<bool(const std::shared_ptr<app_state> &)> &action)
 {
-    for (const auto &p : apps) {
-        if (p.second->status == app_status::AS_AVAILABLE) {
-            if (!action(p.second))
-                break;
+    for (const auto &[_, as] : apps) {
+        if (as->status == app_status::AS_AVAILABLE && !action(as)) {
+            break;
         }
     }
 }
@@ -548,6 +543,7 @@ inline int count_partitions(const app_mapper &apps)
 
 void when_update_replicas(config_type::type t, const std::function<void(bool)> &func);
 
+// TODO(yingchun): refactor to deal both rpc_address and host_port
 template <typename T>
 void maintain_drops(/*inout*/ std::vector<T> &drops, const T &node, config_type::type t)
 {

--- a/src/meta/meta_http_service.cpp
+++ b/src/meta/meta_http_service.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <rapidjson/ostreamwrapper.h>
 #include <algorithm>
 #include <map>
@@ -141,40 +142,33 @@ void meta_http_service::get_app_handler(const http_request &req, http_response &
         int fully_healthy = 0;
         int write_unhealthy = 0;
         int read_unhealthy = 0;
-        for (const auto &p : response.partitions) {
+        for (const auto &pc : response.partitions) {
             int replica_count = 0;
-            if (p.hp_primary) {
+            if (pc.hp_primary) {
                 replica_count++;
-                node_stat[p.hp_primary].first++;
+                node_stat[pc.hp_primary].first++;
                 total_prim_count++;
             }
-            replica_count += p.hp_secondaries.size();
-            total_sec_count += p.hp_secondaries.size();
-            if (p.hp_primary) {
-                if (replica_count >= p.max_replica_count)
+            replica_count += pc.hp_secondaries.size();
+            total_sec_count += pc.hp_secondaries.size();
+            if (pc.hp_primary) {
+                if (replica_count >= pc.max_replica_count) {
                     fully_healthy++;
-                else if (replica_count < 2)
+                } else if (replica_count < 2) {
                     write_unhealthy++;
+                }
             } else {
                 write_unhealthy++;
                 read_unhealthy++;
             }
-            tp_details.add_row(p.pid.get_partition_index());
-            tp_details.append_data(p.ballot);
-            std::stringstream oss;
-            oss << replica_count << "/" << p.max_replica_count;
-            tp_details.append_data(oss.str());
-            tp_details.append_data(p.hp_primary ? p.hp_primary.to_string() : "-");
-            oss.str("");
-            oss << "[";
-            for (int j = 0; j < p.hp_secondaries.size(); j++) {
-                if (j != 0)
-                    oss << ",";
-                oss << p.hp_secondaries[j];
-                node_stat[p.hp_secondaries[j]].second++;
+            tp_details.add_row(pc.pid.get_partition_index());
+            tp_details.append_data(pc.ballot);
+            tp_details.append_data(fmt::format("{}/{}", replica_count, pc.max_replica_count));
+            tp_details.append_data(pc.hp_primary ? pc.hp_primary.to_string() : "-");
+            tp_details.append_data(fmt::format("[{}]", fmt::join(pc.hp_secondaries, ",")));
+            for (const auto &secondary : pc.hp_secondaries) {
+                node_stat[secondary].second++;
             }
-            oss << "]";
-            tp_details.append_data(oss.str());
         }
         mtp.add(std::move(tp_details));
 
@@ -322,18 +316,18 @@ void meta_http_service::list_app_handler(const http_request &req, http_response 
             int fully_healthy = 0;
             int write_unhealthy = 0;
             int read_unhealthy = 0;
-            for (int i = 0; i < response.partitions.size(); i++) {
-                const dsn::partition_configuration &p = response.partitions[i];
+            for (const auto &pc : response.partitions) {
                 int replica_count = 0;
-                if (p.hp_primary) {
+                if (pc.hp_primary) {
                     replica_count++;
                 }
-                replica_count += p.hp_secondaries.size();
-                if (p.hp_primary) {
-                    if (replica_count >= p.max_replica_count)
+                replica_count += pc.hp_secondaries.size();
+                if (pc.hp_primary) {
+                    if (replica_count >= pc.max_replica_count) {
                         fully_healthy++;
-                    else if (replica_count < 2)
+                    } else if (replica_count < 2) {
                         write_unhealthy++;
+                    }
                 } else {
                     write_unhealthy++;
                     read_unhealthy++;
@@ -413,16 +407,15 @@ void meta_http_service::list_node_handler(const http_request &req, http_response
             CHECK_EQ(app.app_id, response_app.app_id);
             CHECK_EQ(app.partition_count, response_app.partition_count);
 
-            for (int i = 0; i < response_app.partitions.size(); i++) {
-                const dsn::partition_configuration &p = response_app.partitions[i];
-                if (p.hp_primary) {
-                    auto find = tmp_map.find(p.hp_primary);
+            for (const auto &pc : response_app.partitions) {
+                if (pc.hp_primary) {
+                    auto find = tmp_map.find(pc.hp_primary);
                     if (find != tmp_map.end()) {
                         find->second.primary_count++;
                     }
                 }
-                for (int j = 0; j < p.hp_secondaries.size(); j++) {
-                    auto find = tmp_map.find(p.hp_secondaries[j]);
+                for (const auto &secondary : pc.hp_secondaries) {
+                    auto find = tmp_map.find(secondary);
                     if (find != tmp_map.end()) {
                         find->second.secondary_count++;
                     }

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -756,9 +756,9 @@ void meta_service::on_query_configuration_by_index(configuration_query_by_index_
     host_port forward_hp;
     if (!check_status_and_authz(rpc, &forward_hp)) {
         if (forward_hp) {
-            partition_configuration config;
-            SET_IP_AND_HOST_PORT_BY_DNS(config, primary, forward_hp);
-            response.partitions.push_back(std::move(config));
+            partition_configuration pc;
+            SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, forward_hp);
+            response.partitions.push_back(std::move(pc));
         }
         return;
     }

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -86,14 +86,15 @@ pc_status partition_guardian::cure(meta_view view,
     CHECK(acts.empty(), "");
 
     pc_status status;
-    if (!pc.hp_primary)
+    if (!pc.hp_primary) {
         status = on_missing_primary(view, gpid);
-    else if (static_cast<int>(pc.hp_secondaries.size()) + 1 < pc.max_replica_count)
+    } else if (static_cast<int>(pc.hp_secondaries.size()) + 1 < pc.max_replica_count) {
         status = on_missing_secondary(view, gpid);
-    else if (static_cast<int>(pc.hp_secondaries.size()) >= pc.max_replica_count)
+    } else if (static_cast<int>(pc.hp_secondaries.size()) >= pc.max_replica_count) {
         status = on_redundant_secondary(view, gpid);
-    else
+    } else {
         status = pc_status::healthy;
+    }
 
     if (!acts.empty()) {
         action = *acts.front();
@@ -125,9 +126,9 @@ void partition_guardian::reconfig(meta_view view, const configuration_update_req
     if (request.type == config_type::CT_DROP_PARTITION) {
         cc->serving.clear();
 
-        const std::vector<host_port> &config_dropped = request.config.hp_last_drops;
-        for (const auto &drop_node : config_dropped) {
-            cc->record_drop_history(drop_node);
+        const auto &last_drops = request.config.hp_last_drops;
+        for (const auto &last_drop : last_drops) {
+            cc->record_drop_history(last_drop);
         }
     } else {
         when_update_replicas(request.type, [cc, &request](bool is_adding) {
@@ -248,9 +249,9 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
     // try to upgrade a secondary to primary if the primary is missing
     if (!pc.hp_secondaries.empty()) {
         RESET_IP_AND_HOST_PORT(action, node);
-        for (const auto &hp_secondary : pc.hp_secondaries) {
-            const auto ns = get_node_state(*(view.nodes), hp_secondary, false);
-            CHECK_NOTNULL(ns, "invalid secondary: {}", hp_secondary);
+        for (const auto &secondary : pc.hp_secondaries) {
+            const auto ns = get_node_state(*(view.nodes), secondary, false);
+            CHECK_NOTNULL(ns, "invalid secondary: {}", secondary);
             if (dsn_unlikely(!ns->alive())) {
                 continue;
             }
@@ -515,7 +516,7 @@ pc_status partition_guardian::on_missing_secondary(meta_view &view, const dsn::g
 
     configuration_proposal_action action;
     bool is_emergency = false;
-    if (cc.config_owner->max_replica_count >
+    if (cc.pc->max_replica_count >
             _svc->get_options().app_mutation_2pc_min_replica_count(pc.max_replica_count) &&
         replica_count(pc) <
             _svc->get_options().app_mutation_2pc_min_replica_count(pc.max_replica_count)) {

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -157,7 +157,7 @@ public:
 
     void query_configuration_by_index(const query_cfg_request &request,
                                       /*out*/ query_cfg_response &response);
-    bool query_configuration_by_gpid(const dsn::gpid id, /*out*/ partition_configuration &config);
+    bool query_configuration_by_gpid(const dsn::gpid id, /*out*/ partition_configuration &pc);
 
     // app options
     void create_app(dsn::message_ex *msg);
@@ -276,7 +276,7 @@ private:
     void
     update_configuration_locally(app_state &app,
                                  std::shared_ptr<configuration_update_request> &config_request);
-    void request_check(const partition_configuration &old,
+    void request_check(const partition_configuration &old_pc,
                        const configuration_update_request &request);
     void recall_partition(std::shared_ptr<app_state> &app, int pidx);
     void drop_partition(std::shared_ptr<app_state> &app, int pidx);
@@ -285,11 +285,9 @@ private:
                                          int pidx,
                                          const host_port &node);
     void
-    downgrade_stateless_nodes(std::shared_ptr<app_state> &app, int pidx, const host_port &address);
-
-    void on_partition_node_dead(std::shared_ptr<app_state> &app,
-                                int pidx,
-                                const dsn::host_port &address);
+    downgrade_stateless_nodes(std::shared_ptr<app_state> &app, int pidx, const host_port &node);
+    void
+    on_partition_node_dead(std::shared_ptr<app_state> &app, int pidx, const dsn::host_port &node);
     void send_proposal(const host_port &target, const configuration_update_request &proposal);
     void send_proposal(const configuration_proposal_action &action,
                        const partition_configuration &pc,
@@ -347,18 +345,16 @@ private:
                                             int32_t partition_index,
                                             int32_t new_max_replica_count,
                                             partition_callback on_partition_updated);
-    task_ptr update_partition_max_replica_count_on_remote(
-        std::shared_ptr<app_state> &app,
-        const partition_configuration &new_partition_config,
-        partition_callback on_partition_updated);
-    void on_update_partition_max_replica_count_on_remote_reply(
-        error_code ec,
-        std::shared_ptr<app_state> &app,
-        const partition_configuration &new_partition_config,
-        partition_callback on_partition_updated);
+    task_ptr update_partition_max_replica_count_on_remote(std::shared_ptr<app_state> &app,
+                                                          const partition_configuration &new_pc,
+                                                          partition_callback on_partition_updated);
     void
-    update_partition_max_replica_count_locally(std::shared_ptr<app_state> &app,
-                                               const partition_configuration &new_partition_config);
+    on_update_partition_max_replica_count_on_remote_reply(error_code ec,
+                                                          std::shared_ptr<app_state> &app,
+                                                          const partition_configuration &new_pc,
+                                                          partition_callback on_partition_updated);
+    void update_partition_max_replica_count_locally(std::shared_ptr<app_state> &app,
+                                                    const partition_configuration &new_pc);
 
     void recover_all_partitions_max_replica_count(std::shared_ptr<app_state> &app,
                                                   int32_t max_replica_count,

--- a/src/meta/server_state_restore.cpp
+++ b/src/meta/server_state_restore.cpp
@@ -250,8 +250,8 @@ void server_state::on_query_restore_status(configuration_query_restore_rpc rpc)
     response.restore_status.resize(app->partition_count, ERR_OK);
     for (int32_t i = 0; i < app->partition_count; i++) {
         const auto &r_state = app->helpers->restore_states[i];
-        const auto &p = app->partitions[i];
-        if (p.hp_primary || !p.hp_secondaries.empty()) {
+        const auto &pc = app->pcs[i];
+        if (pc.hp_primary || !pc.hp_secondaries.empty()) {
             // already have primary, restore succeed
             continue;
         }

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -504,7 +504,7 @@ TEST_F(policy_context_test, test_app_dropped_during_backup)
 
             app_state *app = state->_all_apps[3].get();
             app->status = dsn::app_status::AS_AVAILABLE;
-            for (partition_configuration &pc : app->partitions) {
+            for (auto &pc : app->pcs) {
                 SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, node_list[0]);
                 SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, node_list[1], node_list[2]);
             }

--- a/src/meta/test/balancer_simulator/balancer_simulator.cpp
+++ b/src/meta/test/balancer_simulator/balancer_simulator.cpp
@@ -96,11 +96,11 @@ void generate_balanced_apps(/*out*/ app_mapper &apps,
     info.partition_count = partitions_per_node * node_list.size();
     info.max_replica_count = 3;
 
-    std::shared_ptr<app_state> the_app = app_state::create(info);
+    std::shared_ptr<app_state> app = app_state::create(info);
 
     simple_priority_queue pq1(node_list, server_load_balancer::primary_comparator(nodes));
     // generate balanced primary
-    for (dsn::partition_configuration &pc : the_app->partitions) {
+    for (auto &pc : app->pcs) {
         const auto &n = pq1.pop();
         nodes[n].put_partition(pc.pid, true);
         SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, n);
@@ -111,7 +111,7 @@ void generate_balanced_apps(/*out*/ app_mapper &apps,
     simple_priority_queue pq2(node_list, server_load_balancer::partition_comparator(nodes));
     std::vector<dsn::host_port> temp;
 
-    for (dsn::partition_configuration &pc : the_app->partitions) {
+    for (auto &pc : app->pcs) {
         temp.clear();
         while (pc.hp_secondaries.size() + 1 < pc.max_replica_count) {
             const auto &n = pq2.pop();
@@ -127,7 +127,7 @@ void generate_balanced_apps(/*out*/ app_mapper &apps,
 
     // check if balanced
     int pri_min, part_min;
-    pri_min = part_min = the_app->partition_count + 1;
+    pri_min = part_min = app->partition_count + 1;
     int pri_max, part_max;
     pri_max = part_max = -1;
 
@@ -142,7 +142,7 @@ void generate_balanced_apps(/*out*/ app_mapper &apps,
             part_min = kv.second.partition_count();
     }
 
-    apps.emplace(the_app->app_id, the_app);
+    apps.emplace(app->app_id, app);
 
     CHECK_LE(pri_max - pri_min, 1);
     CHECK_LE(part_max - part_min, 1);
@@ -150,9 +150,9 @@ void generate_balanced_apps(/*out*/ app_mapper &apps,
 
 void random_move_primary(app_mapper &apps, node_mapper &nodes, int primary_move_ratio)
 {
-    app_state &the_app = *(apps[0]);
-    int space_size = the_app.partition_count * 100;
-    for (dsn::partition_configuration &pc : the_app.partitions) {
+    app_state &app = *(apps[0]);
+    int space_size = app.partition_count * 100;
+    for (auto &pc : app.pcs) {
         int n = random32(1, space_size) / 100;
         if (n < primary_move_ratio) {
             int indice = random32(0, 1);

--- a/src/meta/test/balancer_validator.cpp
+++ b/src/meta/test/balancer_validator.cpp
@@ -165,14 +165,14 @@ void meta_service_test_app::balancer_validator()
                   iter.second.partition_count());
     }
 
-    std::shared_ptr<app_state> &the_app = apps[1];
-    for (::dsn::partition_configuration &pc : the_app->partitions) {
+    const auto &app = apps[1];
+    for (const auto &pc : app->pcs) {
         CHECK(pc.hp_primary, "");
         CHECK_GE(pc.secondaries.size(), pc.max_replica_count - 1);
     }
 
     // now test the cure
-    ::dsn::partition_configuration &pc = the_app->partitions[0];
+    auto &pc = app->pcs[0];
     nodes[pc.hp_primary].remove_partition(pc.pid, false);
     for (const auto &hp : pc.hp_secondaries) {
         nodes[hp].remove_partition(pc.pid, false);
@@ -218,11 +218,11 @@ static void load_apps_and_nodes(const char *file, app_mapper &apps, node_mapper 
             infile >> n;
             infile >> ip_port;
             const auto primary = host_port::from_string(ip_port);
-            SET_IP_AND_HOST_PORT_BY_DNS(app->partitions[j], primary, primary);
+            SET_IP_AND_HOST_PORT_BY_DNS(app->pcs[j], primary, primary);
             for (int k = 1; k < n; ++k) {
                 infile >> ip_port;
                 const auto secondary = host_port::from_string(ip_port);
-                ADD_IP_AND_HOST_PORT_BY_DNS(app->partitions[j], secondaries, secondary);
+                ADD_IP_AND_HOST_PORT_BY_DNS(app->pcs[j], secondaries, secondary);
             }
         }
     }

--- a/src/meta/test/cluster_balance_policy_test.cpp
+++ b/src/meta/test/cluster_balance_policy_test.cpp
@@ -119,7 +119,7 @@ TEST(cluster_balance_policy, get_app_migration_info)
     info.app_name = appname;
     info.partition_count = 1;
     auto app = std::make_shared<app_state>(info);
-    SET_IP_AND_HOST_PORT_BY_DNS(app->partitions[0], primary, hp);
+    SET_IP_AND_HOST_PORT_BY_DNS(app->pcs[0], primary, hp);
 
     node_state ns;
     ns.set_hp(hp);
@@ -129,14 +129,14 @@ TEST(cluster_balance_policy, get_app_migration_info)
 
     cluster_balance_policy::app_migration_info migration_info;
     {
-        app->partitions[0].max_replica_count = 100;
+        app->pcs[0].max_replica_count = 100;
         auto res =
             policy.get_app_migration_info(app, nodes, balance_type::COPY_PRIMARY, migration_info);
         ASSERT_FALSE(res);
     }
 
     {
-        app->partitions[0].max_replica_count = 1;
+        app->pcs[0].max_replica_count = 1;
         auto res =
             policy.get_app_migration_info(app, nodes, balance_type::COPY_PRIMARY, migration_info);
         ASSERT_TRUE(res);
@@ -162,15 +162,15 @@ TEST(cluster_balance_policy, get_node_migration_info)
     info.app_name = appname;
     info.partition_count = 1;
     auto app = std::make_shared<app_state>(info);
-    SET_IP_AND_HOST_PORT_BY_DNS(app->partitions[0], primary, hp);
+    SET_IP_AND_HOST_PORT_BY_DNS(app->pcs[0], primary, hp);
     serving_replica sr;
     sr.node = hp;
     std::string disk_tag = "disk1";
     sr.disk_tag = disk_tag;
     config_context context;
-    context.config_owner = new partition_configuration();
-    auto cleanup = dsn::defer([&context]() { delete context.config_owner; });
-    context.config_owner->pid = gpid(appid, 0);
+    context.pc = new partition_configuration();
+    auto cleanup = dsn::defer([&context]() { delete context.pc; });
+    context.pc->pid = gpid(appid, 0);
     context.serving.emplace_back(std::move(sr));
     app->helpers->contexts.emplace_back(std::move(context));
 
@@ -517,8 +517,8 @@ TEST(cluster_balance_policy, calc_potential_moving)
     partition_configuration pc;
     SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, hp1);
     SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, hp2, hp3);
-    app->partitions[0] = pc;
-    app->partitions[1] = pc;
+    app->pcs[0] = pc;
+    app->pcs[1] = pc;
 
     app_mapper apps;
     apps[app_id] = app;

--- a/src/meta/test/ford_fulkerson_test.cpp
+++ b/src/meta/test/ford_fulkerson_test.cpp
@@ -99,8 +99,8 @@ TEST(ford_fulkerson, update_decree)
     std::shared_ptr<app_state> app = app_state::create(info);
     partition_configuration pc;
     SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, hp2, hp3);
-    app->partitions.push_back(pc);
-    app->partitions.push_back(pc);
+    app->pcs.push_back(pc);
+    app->pcs.push_back(pc);
 
     node_mapper nodes;
     node_state ns;
@@ -137,8 +137,8 @@ TEST(ford_fulkerson, find_shortest_path)
     partition_configuration pc;
     SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, hp1);
     SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, hp2, hp3);
-    app->partitions[0] = pc;
-    app->partitions[1] = pc;
+    app->pcs[0] = pc;
+    app->pcs[1] = pc;
 
     node_mapper nodes;
     node_state ns1;

--- a/src/meta/test/meta_bulk_load_ingestion_test.cpp
+++ b/src/meta/test/meta_bulk_load_ingestion_test.cpp
@@ -199,39 +199,27 @@ public:
         ainfo.app_id = APP_ID;
         ainfo.partition_count = PARTITION_COUNT;
         _app = std::make_shared<app_state>(ainfo);
-        _app->partitions.reserve(PARTITION_COUNT);
+        _app->pcs.reserve(PARTITION_COUNT);
         _app->helpers->contexts.reserve(PARTITION_COUNT);
-        mock_partition(0,
-                       {NODE1, NODE2, NODE3},
-                       {TAG1, TAG1, TAG2},
-                       _app->partitions[0],
-                       _app->helpers->contexts[0]);
-        mock_partition(1,
-                       {NODE4, NODE1, NODE2},
-                       {TAG2, TAG1, TAG2},
-                       _app->partitions[1],
-                       _app->helpers->contexts[1]);
-        mock_partition(2,
-                       {NODE3, NODE1, NODE4},
-                       {TAG1, TAG2, TAG1},
-                       _app->partitions[2],
-                       _app->helpers->contexts[2]);
-        mock_partition(3,
-                       {NODE2, NODE3, NODE4},
-                       {TAG1, TAG1, TAG2},
-                       _app->partitions[3],
-                       _app->helpers->contexts[3]);
+        mock_partition(
+            0, {NODE1, NODE2, NODE3}, {TAG1, TAG1, TAG2}, _app->pcs[0], _app->helpers->contexts[0]);
+        mock_partition(
+            1, {NODE4, NODE1, NODE2}, {TAG2, TAG1, TAG2}, _app->pcs[1], _app->helpers->contexts[1]);
+        mock_partition(
+            2, {NODE3, NODE1, NODE4}, {TAG1, TAG2, TAG1}, _app->pcs[2], _app->helpers->contexts[2]);
+        mock_partition(
+            3, {NODE2, NODE3, NODE4}, {TAG1, TAG1, TAG2}, _app->pcs[3], _app->helpers->contexts[3]);
     }
 
     void mock_partition(const uint32_t pidx,
                         std::vector<host_port> nodes,
                         const std::vector<std::string> tags,
-                        partition_configuration &config,
+                        partition_configuration &pc,
                         config_context &cc)
     {
-        config.pid = gpid(APP_ID, pidx);
-        SET_IP_AND_HOST_PORT_BY_DNS(config, primary, nodes[0]);
-        SET_IPS_AND_HOST_PORTS_BY_DNS(config, secondaries, nodes[1], nodes[2]);
+        pc.pid = gpid(APP_ID, pidx);
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, nodes[0]);
+        SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, nodes[1], nodes[2]);
 
         auto count = nodes.size();
         for (auto i = 0; i < count; i++) {
@@ -253,14 +241,13 @@ public:
 
     bool try_partition_ingestion(const uint32_t pidx)
     {
-        return _context->try_partition_ingestion(_app->partitions[pidx],
-                                                 _app->helpers->contexts[pidx]);
+        return _context->try_partition_ingestion(_app->pcs[pidx], _app->helpers->contexts[pidx]);
     }
 
     void add_partition(const uint32_t pidx)
     {
-        auto pinfo = ingestion_context::partition_node_info(_app->partitions[pidx],
-                                                            _app->helpers->contexts[pidx]);
+        const auto pinfo =
+            ingestion_context::partition_node_info(_app->pcs[pidx], _app->helpers->contexts[pidx]);
         _context->add_partition(pinfo);
     }
 

--- a/src/meta/test/meta_bulk_load_service_test.cpp
+++ b/src/meta/test/meta_bulk_load_service_test.cpp
@@ -174,16 +174,16 @@ public:
     gpid before_check_partition_status(bulk_load_status::type status)
     {
         std::shared_ptr<app_state> app = find_app(APP_NAME);
-        partition_configuration config;
-        config.pid = gpid(app->app_id, 0);
-        config.max_replica_count = 3;
-        config.ballot = BALLOT;
-        SET_IP_AND_HOST_PORT_BY_DNS(config, primary, PRIMARY_HP);
-        SET_IPS_AND_HOST_PORTS_BY_DNS(config, secondaries, SECONDARY1_HP, SECONDARY2_HP);
-        app->partitions.clear();
-        app->partitions.emplace_back(config);
+        partition_configuration pc;
+        pc.pid = gpid(app->app_id, 0);
+        pc.max_replica_count = 3;
+        pc.ballot = BALLOT;
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, PRIMARY_HP);
+        SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, SECONDARY1_HP, SECONDARY2_HP);
+        app->pcs.clear();
+        app->pcs.emplace_back(pc);
         mock_meta_bulk_load_context(app->app_id, app->partition_count, status);
-        return config.pid;
+        return pc.pid;
     }
 
     bool check_partition_status(const std::string name,
@@ -194,18 +194,18 @@ public:
     {
         std::shared_ptr<app_state> app = find_app(name);
         if (mock_primary_invalid) {
-            RESET_IP_AND_HOST_PORT(app->partitions[pid.get_partition_index()], primary);
+            RESET_IP_AND_HOST_PORT(app->pcs[pid.get_partition_index()], primary);
         }
         if (mock_lack_secondary) {
-            CLEAR_IP_AND_HOST_PORT(app->partitions[pid.get_partition_index()], secondaries);
+            CLEAR_IP_AND_HOST_PORT(app->pcs[pid.get_partition_index()], secondaries);
         }
-        partition_configuration pconfig;
+        partition_configuration pc;
         bool flag = bulk_svc().check_partition_status(
             name,
             pid,
             always_unhealthy_check,
             std::bind(&bulk_load_service_test::mock_partition_bulk_load, this, name, pid),
-            pconfig);
+            pc);
         wait_all();
         return flag;
     }
@@ -233,22 +233,22 @@ public:
                                    bool same)
     {
         set_partition_bulk_load_info(pid, ever_ingest_succeed);
-        partition_configuration config;
-        config.pid = pid;
-        SET_IP_AND_HOST_PORT_BY_DNS(config, primary, PRIMARY_HP);
+        partition_configuration pc;
+        pc.pid = pid;
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, PRIMARY_HP);
         if (same) {
-            ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY1_HP);
-            ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY2_HP);
+            ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, SECONDARY1_HP);
+            ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, SECONDARY2_HP);
         } else {
-            ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY1_HP);
+            ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, SECONDARY1_HP);
             if (secondary_count == 2) {
-                ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY3_HP);
+                ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, SECONDARY3_HP);
             } else if (secondary_count >= 3) {
-                ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY2_HP);
-                ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY3_HP);
+                ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, SECONDARY2_HP);
+                ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, SECONDARY3_HP);
             }
         }
-        auto flag = bulk_svc().check_ever_ingestion_succeed(config, APP_NAME, pid);
+        auto flag = bulk_svc().check_ever_ingestion_succeed(pc, APP_NAME, pid);
         wait_all();
         return flag;
     }
@@ -315,9 +315,9 @@ public:
         fail::cfg("ingestion_try_partition_ingestion", "return()");
         config_context cc;
         for (auto i = 0; i < count; i++) {
-            partition_configuration config;
-            config.pid = gpid(app_id, i);
-            bulk_svc().try_partition_ingestion(config, cc);
+            partition_configuration pc;
+            pc.pid = gpid(app_id, i);
+            bulk_svc().try_partition_ingestion(pc, cc);
         }
     }
 
@@ -452,11 +452,11 @@ public:
             [this, &info]() {
                 LOG_INFO("create app({}) app_id={}, dir succeed", info.app_name, info.app_id);
                 for (int i = 0; i < info.partition_count; ++i) {
-                    partition_configuration config;
-                    config.max_replica_count = 3;
-                    config.pid = gpid(info.app_id, i);
-                    config.ballot = BALLOT;
-                    blob v = json::json_forwarder<partition_configuration>::encode(config);
+                    partition_configuration pc;
+                    pc.max_replica_count = 3;
+                    pc.pid = gpid(info.app_id, i);
+                    pc.ballot = BALLOT;
+                    blob v = json::json_forwarder<partition_configuration>::encode(pc);
                     _ms->get_meta_storage()->create_node(
                         _app_root + "/" + boost::lexical_cast<std::string>(info.app_id) + "/" +
                             boost::lexical_cast<std::string>(i),

--- a/src/meta/test/meta_data.cpp
+++ b/src/meta/test/meta_data.cpp
@@ -109,7 +109,7 @@ static bool vec_equal(const std::vector<dropped_replica> &vec1,
 
 TEST(meta_data, collect_replica)
 {
-    app_mapper app;
+    app_mapper apps;
     node_mapper nodes;
 
     dsn::app_info info;
@@ -120,16 +120,16 @@ TEST(meta_data, collect_replica)
     info.app_type = "test";
     info.max_replica_count = 3;
     info.partition_count = 1024;
-    std::shared_ptr<app_state> the_app = app_state::create(info);
-    app.emplace(the_app->app_id, the_app);
-    meta_view view = {&app, &nodes};
+    std::shared_ptr<app_state> app = app_state::create(info);
+    apps.emplace(app->app_id, app);
+    meta_view view = {&apps, &nodes};
 
     replica_info rep;
     rep.app_type = "test";
     rep.pid = dsn::gpid(1, 0);
 
-    dsn::partition_configuration &pc = *get_config(app, rep.pid);
-    config_context &cc = *get_config_context(app, rep.pid);
+    auto &pc = *get_config(apps, rep.pid);
+    auto &cc = *get_config_context(apps, rep.pid);
 
     std::vector<dsn::host_port> node_list;
     generate_node_list(node_list, 10, 10);
@@ -352,7 +352,7 @@ TEST(meta_data, collect_replica)
 
 TEST(meta_data, construct_replica)
 {
-    app_mapper app;
+    app_mapper apps;
     node_mapper nodes;
 
     dsn::app_info info;
@@ -363,16 +363,16 @@ TEST(meta_data, construct_replica)
     info.app_type = "test";
     info.max_replica_count = 3;
     info.partition_count = 1024;
-    std::shared_ptr<app_state> the_app = app_state::create(info);
-    app.emplace(the_app->app_id, the_app);
-    meta_view view = {&app, &nodes};
+    std::shared_ptr<app_state> app = app_state::create(info);
+    apps.emplace(app->app_id, app);
+    meta_view view = {&apps, &nodes};
 
     replica_info rep;
     rep.app_type = "test";
     rep.pid = dsn::gpid(1, 0);
 
-    dsn::partition_configuration &pc = *get_config(app, rep.pid);
-    config_context &cc = *get_config_context(app, rep.pid);
+    dsn::partition_configuration &pc = *get_config(apps, rep.pid);
+    config_context &cc = *get_config_context(apps, rep.pid);
 
     std::vector<dsn::host_port> node_list;
     generate_node_list(node_list, 10, 10);

--- a/src/meta/test/meta_duplication_service_test.cpp
+++ b/src/meta/test/meta_duplication_service_test.cpp
@@ -674,7 +674,7 @@ TEST_F(meta_duplication_service_test, duplication_sync)
     auto app = find_app(test_app);
 
     // generate all primaries on node[0]
-    for (partition_configuration &pc : app->partitions) {
+    for (auto &pc : app->pcs) {
         pc.ballot = random32(1, 10000);
         SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, server_nodes[0]);
         SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, server_nodes[1], server_nodes[2]);
@@ -897,7 +897,7 @@ TEST_F(meta_duplication_service_test, fail_mode)
 
     // ensure dup_sync will synchronize fail_mode
     const auto hp = generate_node_list(3)[0];
-    for (partition_configuration &pc : app->partitions) {
+    for (auto &pc : app->pcs) {
         SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, hp);
     }
     initialize_node_state();

--- a/src/meta/test/meta_mauanl_compaction_test.cpp
+++ b/src/meta/test/meta_mauanl_compaction_test.cpp
@@ -51,7 +51,7 @@ public:
     {
         create_app(APP_NAME, PARTITION_COUNT);
         auto app = find_app(APP_NAME);
-        app->partitions.resize(PARTITION_COUNT);
+        app->pcs.resize(PARTITION_COUNT);
         app->helpers->contexts.resize(PARTITION_COUNT);
         for (auto i = 0; i < PARTITION_COUNT; ++i) {
             serving_replica rep;

--- a/src/meta/test/meta_partition_guardian_test.cpp
+++ b/src/meta/test/meta_partition_guardian_test.cpp
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+// IWYU pragma: no_include <ext/alloc_traits.h>
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -207,8 +208,8 @@ void meta_partition_guardian_test::cure_test()
     std::vector<dsn::host_port> nodes;
     generate_node_list(nodes, 4, 4);
 
-    dsn::partition_configuration &pc = app->partitions[0];
-    config_context &cc = *get_config_context(state->_all_apps, dsn::gpid(1, 0));
+    auto &pc = app->pcs[0];
+    auto &cc = *get_config_context(state->_all_apps, dsn::gpid(1, 0));
 
 #define PROPOSAL_FLAG_CHECK                                                                        \
     ASSERT_TRUE(proposal_sent);                                                                    \
@@ -797,7 +798,7 @@ void meta_partition_guardian_test::cure()
     std::vector<dsn::host_port> nodes_list;
     generate_node_list(nodes_list, 20, 100);
 
-    app_mapper app;
+    app_mapper apps;
     node_mapper nodes;
     meta_service svc;
     partition_guardian guardian(&svc);
@@ -810,9 +811,9 @@ void meta_partition_guardian_test::cure()
     info.app_type = "test";
     info.max_replica_count = 3;
     info.partition_count = 1024;
-    std::shared_ptr<app_state> the_app = app_state::create(info);
+    std::shared_ptr<app_state> app = app_state::create(info);
 
-    app.emplace(the_app->app_id, the_app);
+    apps.emplace(app->app_id, app);
     for (const auto &hp : nodes_list) {
         get_node_state(nodes, hp, true)->set_alive(true);
     }
@@ -823,21 +824,21 @@ void meta_partition_guardian_test::cure()
         pc_status status;
         all_partitions_healthy = true;
 
-        for (int i = 0; i != the_app->partition_count; ++i) {
-            dsn::gpid &pid = the_app->partitions[i].pid;
-            status = guardian.cure({&app, &nodes}, pid, action);
+        CHECK_EQ(app->partition_count, app->pcs.size());
+        for (const auto &pc : app->pcs) {
+            status = guardian.cure({&apps, &nodes}, pc.pid, action);
             if (status != pc_status::healthy) {
                 all_partitions_healthy = false;
-                proposal_action_check_and_apply(action, pid, app, nodes, nullptr);
+                proposal_action_check_and_apply(action, pc.pid, apps, nodes, nullptr);
 
                 configuration_update_request fake_request;
-                fake_request.info = *the_app;
-                fake_request.config = the_app->partitions[i];
+                fake_request.info = *app;
+                fake_request.config = pc;
                 fake_request.type = action.type;
                 SET_OBJ_IP_AND_HOST_PORT(fake_request, node, action, node);
                 fake_request.host_node = action.node;
 
-                guardian.reconfig({&app, &nodes}, fake_request);
+                guardian.reconfig({&apps, &nodes}, fake_request);
                 check_nodes_loads(nodes);
             }
         }
@@ -849,7 +850,7 @@ void meta_partition_guardian_test::from_proposal_test()
     std::vector<dsn::host_port> nodes_list;
     generate_node_list(nodes_list, 3, 3);
 
-    app_mapper app;
+    app_mapper apps;
     node_mapper nodes;
     meta_service svc;
 
@@ -863,20 +864,20 @@ void meta_partition_guardian_test::from_proposal_test()
     info.app_type = "test";
     info.max_replica_count = 3;
     info.partition_count = 1;
-    std::shared_ptr<app_state> the_app = app_state::create(info);
+    std::shared_ptr<app_state> app = app_state::create(info);
 
-    app.emplace(the_app->app_id, the_app);
+    apps.emplace(app->app_id, app);
     for (const auto &hp : nodes_list) {
         get_node_state(nodes, hp, true)->set_alive(true);
     }
 
-    meta_view mv{&app, &nodes};
+    meta_view mv{&apps, &nodes};
     dsn::gpid p(1, 0);
     configuration_proposal_action cpa;
     configuration_proposal_action cpa2;
 
-    dsn::partition_configuration &pc = *get_config(app, p);
-    config_context &cc = *get_config_context(app, p);
+    dsn::partition_configuration &pc = *get_config(apps, p);
+    config_context &cc = *get_config_context(apps, p);
 
     std::cerr << "Case 1: test no proposals in config_context" << std::endl;
     ASSERT_FALSE(guardian.from_proposals(mv, p, cpa));

--- a/src/meta/test/meta_split_service_test.cpp
+++ b/src/meta/test/meta_split_service_test.cpp
@@ -128,16 +128,16 @@ public:
 
     error_code register_child(int32_t parent_index, ballot req_parent_ballot, bool wait_zk)
     {
-        partition_configuration parent_config;
-        parent_config.ballot = req_parent_ballot;
-        parent_config.last_committed_decree = 5;
-        parent_config.max_replica_count = 3;
-        parent_config.pid = gpid(app->app_id, parent_index);
+        partition_configuration parent_pc;
+        parent_pc.ballot = req_parent_ballot;
+        parent_pc.last_committed_decree = 5;
+        parent_pc.max_replica_count = 3;
+        parent_pc.pid = gpid(app->app_id, parent_index);
 
-        partition_configuration child_config;
-        child_config.ballot = PARENT_BALLOT + 1;
-        child_config.last_committed_decree = 5;
-        child_config.pid = gpid(app->app_id, parent_index + PARTITION_COUNT);
+        partition_configuration child_pc;
+        child_pc.ballot = PARENT_BALLOT + 1;
+        child_pc.last_committed_decree = 5;
+        child_pc.pid = gpid(app->app_id, parent_index + PARTITION_COUNT);
 
         // mock node state
         node_state node;
@@ -147,8 +147,8 @@ public:
         auto request = std::make_unique<register_child_request>();
         request->app.app_name = app->app_name;
         request->app.app_id = app->app_id;
-        request->parent_config = parent_config;
-        request->child_config = child_config;
+        request->parent_config = parent_pc;
+        request->child_config = child_pc;
         SET_IP_AND_HOST_PORT_BY_DNS(*request, primary, NODE);
 
         register_child_rpc rpc(std::move(request), RPC_CM_REGISTER_CHILD_REPLICA);
@@ -207,17 +207,17 @@ public:
     void mock_app_partition_split_context()
     {
         app->partition_count = NEW_PARTITION_COUNT;
-        app->partitions.resize(app->partition_count);
+        app->pcs.resize(app->partition_count);
         _ss->get_table_metric_entities().resize_partitions(app->app_id, app->partition_count);
         app->helpers->contexts.resize(app->partition_count);
         app->helpers->split_states.splitting_count = app->partition_count / 2;
         for (int i = 0; i < app->partition_count; ++i) {
-            app->helpers->contexts[i].config_owner = &app->partitions[i];
-            app->partitions[i].pid = gpid(app->app_id, i);
+            app->helpers->contexts[i].pc = &app->pcs[i];
+            app->pcs[i].pid = gpid(app->app_id, i);
             if (i >= app->partition_count / 2) {
-                app->partitions[i].ballot = invalid_ballot;
+                app->pcs[i].ballot = invalid_ballot;
             } else {
-                app->partitions[i].ballot = PARENT_BALLOT;
+                app->pcs[i].ballot = PARENT_BALLOT;
                 app->helpers->contexts[i].stage = config_status::not_pending;
                 app->helpers->split_states.status[i] = split_status::SPLITTING;
             }
@@ -227,7 +227,7 @@ public:
     void clear_app_partition_split_context()
     {
         app->partition_count = PARTITION_COUNT;
-        app->partitions.resize(app->partition_count);
+        app->pcs.resize(app->partition_count);
         _ss->get_table_metric_entities().resize_partitions(app->app_id, app->partition_count);
         app->helpers->contexts.resize(app->partition_count);
         app->helpers->split_states.splitting_count = 0;
@@ -237,16 +237,16 @@ public:
     void mock_only_one_partition_split(split_status::type split_status)
     {
         app->partition_count = NEW_PARTITION_COUNT;
-        app->partitions.resize(app->partition_count);
+        app->pcs.resize(app->partition_count);
         _ss->get_table_metric_entities().resize_partitions(app->app_id, app->partition_count);
         app->helpers->contexts.resize(app->partition_count);
         for (int i = 0; i < app->partition_count; ++i) {
-            app->helpers->contexts[i].config_owner = &app->partitions[i];
-            app->partitions[i].pid = dsn::gpid(app->app_id, i);
+            app->helpers->contexts[i].pc = &app->pcs[i];
+            app->pcs[i].pid = dsn::gpid(app->app_id, i);
             if (i >= app->partition_count / 2) {
-                app->partitions[i].ballot = invalid_ballot;
+                app->pcs[i].ballot = invalid_ballot;
             } else {
-                app->partitions[i].ballot = PARENT_BALLOT;
+                app->pcs[i].ballot = PARENT_BALLOT;
                 app->helpers->contexts[i].stage = config_status::not_pending;
             }
         }
@@ -256,7 +256,7 @@ public:
 
     void mock_child_registered()
     {
-        app->partitions[CHILD_INDEX].ballot = PARENT_BALLOT;
+        app->pcs[CHILD_INDEX].ballot = PARENT_BALLOT;
         app->helpers->split_states.splitting_count--;
         app->helpers->split_states.status.erase(PARENT_INDEX);
     }
@@ -358,11 +358,11 @@ public:
                                                           const int32_t app_id,
                                                           const int32_t pidx)
     {
-        partition_configuration config;
-        config.max_replica_count = 3;
-        config.pid = gpid(app_id, pidx);
-        config.ballot = PARENT_BALLOT;
-        blob value = json::json_forwarder<partition_configuration>::encode(config);
+        partition_configuration pc;
+        pc.max_replica_count = 3;
+        pc.pid = gpid(app_id, pidx);
+        pc.ballot = PARENT_BALLOT;
+        blob value = json::json_forwarder<partition_configuration>::encode(pc);
         _ms->get_meta_storage()->create_node(
             app_root + "/" + boost::lexical_cast<std::string>(app_id) + "/" +
                 boost::lexical_cast<std::string>(pidx),
@@ -846,7 +846,7 @@ TEST_F(meta_split_service_failover_test, half_split_test)
     ASSERT_EQ(split_states.splitting_count, PARTITION_COUNT - 1);
     ASSERT_EQ(split_states.status.find(PARENT_INDEX), split_states.status.end());
     ASSERT_EQ(app->partition_count, NEW_PARTITION_COUNT);
-    ASSERT_EQ(app->partitions.size(), NEW_PARTITION_COUNT);
+    ASSERT_EQ(app->pcs.size(), NEW_PARTITION_COUNT);
 }
 
 } // namespace replication

--- a/src/meta/test/misc/misc.h
+++ b/src/meta/test/misc/misc.h
@@ -111,7 +111,7 @@ void generate_apps(/*out*/ dsn::replication::app_mapper &apps,
 void migration_check_and_apply(
     /*in-out*/ dsn::replication::app_mapper &apps,
     /*in-out*/ dsn::replication::node_mapper &nodes,
-    /*in-out*/ dsn::replication::migration_list &ml,
+    /*in*/ const dsn::replication::migration_list &ml,
     /*in-out*/ nodes_fs_manager *manager);
 
 // when the test need to track the disk info, please input the fs_manager of all disks,

--- a/src/meta/test/state_sync_test.cpp
+++ b/src/meta/test/state_sync_test.cpp
@@ -75,7 +75,7 @@ static void random_assign_partition_config(std::shared_ptr<app_state> &app,
     };
 
     int max_servers = (server_list.size() - 1) * 2 - 1;
-    for (dsn::partition_configuration &pc : app->partitions) {
+    for (auto &pc : app->pcs) {
         int start = 0;
         std::vector<int> indices;
         for (int i = 0; i < max_replica_count && start <= max_servers; ++i) {
@@ -169,7 +169,7 @@ void meta_service_test_app::state_sync_test()
             random_assign_partition_config(app, server_list, 3);
             if (app->status == dsn::app_status::AS_DROPPING) {
                 for (int j = 0; j < app->partition_count; ++j) {
-                    app->partitions[j].partition_flags = pc_flags::dropped;
+                    app->pcs[j].partition_flags = pc_flags::dropped;
                 }
             }
         }
@@ -281,7 +281,7 @@ void meta_service_test_app::state_sync_test()
         dsn::gpid gpid = {15, 0};
         dsn::partition_configuration pc;
         ASSERT_TRUE(ss2->query_configuration_by_gpid(gpid, pc));
-        ASSERT_EQ(ss1->_all_apps[15]->partitions[0], pc);
+        ASSERT_EQ(ss1->_all_apps[15]->pcs[0], pc);
         // 1.2 dropped app
         if (!drop_set.empty()) {
             gpid.set_app_id(drop_set[0]);
@@ -301,7 +301,7 @@ void meta_service_test_app::state_sync_test()
         ASSERT_EQ(app_created->partition_count, resp.partition_count);
         ASSERT_EQ(resp.partitions.size(), 3);
         for (int i = 1; i <= 3; ++i)
-            ASSERT_EQ(resp.partitions[i - 1], app_created->partitions[i]);
+            ASSERT_EQ(resp.partitions[i - 1], app_created->pcs[i]);
 
         // 2.2 no exist app
         req.app_name = "make_no_sense";

--- a/src/replica/backup/replica_backup_manager.cpp
+++ b/src/replica/backup/replica_backup_manager.cpp
@@ -235,9 +235,9 @@ void replica_backup_manager::send_clear_request_to_secondaries(const gpid &pid,
     request.__set_pid(pid);
     request.__set_policy_name(policy_name);
 
-    for (const auto &target_address : _replica->_primary_states.membership.secondaries) {
+    for (const auto &secondary : _replica->_primary_states.pc.secondaries) {
         rpc::call_one_way_typed(
-            target_address, RPC_CLEAR_COLD_BACKUP, request, get_gpid().thread_hash());
+            secondary, RPC_CLEAR_COLD_BACKUP, request, get_gpid().thread_hash());
     }
 }
 

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -188,14 +188,15 @@ void replica_bulk_loader::broadcast_group_bulk_load(const bulk_load_request &met
 
     LOG_INFO_PREFIX("start to broadcast group bulk load");
 
-    for (const auto &hp : _replica->_primary_states.membership.hp_secondaries) {
-        if (hp == _stub->primary_host_port())
+    for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
+        if (secondary == _stub->primary_host_port()) {
             continue;
+        }
 
         auto request = std::make_unique<group_bulk_load_request>();
         request->app_name = _replica->_app_info.app_name;
-        const auto &addr = dsn::dns_resolver::instance().resolve_address(hp);
-        SET_IP_AND_HOST_PORT(*request, target, addr, hp);
+        const auto &addr = dsn::dns_resolver::instance().resolve_address(secondary);
+        SET_IP_AND_HOST_PORT(*request, target, addr, secondary);
         _replica->_primary_states.get_replica_config(partition_status::PS_SECONDARY,
                                                      request->config);
         request->cluster_name = meta_req.cluster_name;
@@ -203,14 +204,14 @@ void replica_bulk_loader::broadcast_group_bulk_load(const bulk_load_request &met
         request->meta_bulk_load_status = meta_req.meta_bulk_load_status;
         request->remote_root_path = meta_req.remote_root_path;
 
-        LOG_INFO_PREFIX("send group_bulk_load_request to {}({})", hp, addr);
+        LOG_INFO_PREFIX("send group_bulk_load_request to {}({})", secondary, addr);
 
         group_bulk_load_rpc rpc(
             std::move(request), RPC_GROUP_BULK_LOAD, 0_ms, 0, get_gpid().thread_hash());
         auto callback_task = rpc.call(addr, tracker(), [this, rpc](error_code err) mutable {
             on_group_bulk_load_reply(err, rpc.request(), rpc.response());
         });
-        _replica->_primary_states.group_bulk_load_pending_replies[hp] = callback_task;
+        _replica->_primary_states.group_bulk_load_pending_replies[secondary] = callback_task;
     }
 }
 
@@ -740,8 +741,8 @@ void replica_bulk_loader::handle_bulk_load_finish(bulk_load_status::type new_sta
     }
 
     if (status() == partition_status::PS_PRIMARY) {
-        for (const auto &target_hp : _replica->_primary_states.membership.hp_secondaries) {
-            _replica->_primary_states.reset_node_bulk_load_states(target_hp);
+        for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
+            _replica->_primary_states.reset_node_bulk_load_states(secondary);
         }
     }
 
@@ -929,29 +930,29 @@ void replica_bulk_loader::report_group_download_progress(/*out*/ bulk_load_respo
     }
     SET_VALUE_FROM_IP_AND_HOST_PORT(response,
                                     group_bulk_load_state,
-                                    _replica->_primary_states.membership.primary,
-                                    _replica->_primary_states.membership.hp_primary,
+                                    _replica->_primary_states.pc.primary,
+                                    _replica->_primary_states.pc.hp_primary,
                                     primary_state);
     LOG_INFO_PREFIX("primary = {}, download progress = {}%, status = {}",
-                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.membership, primary),
+                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.pc, primary),
                     primary_state.download_progress,
                     primary_state.download_status);
 
     int32_t total_progress = primary_state.download_progress;
-    for (const auto &target_hp : _replica->_primary_states.membership.hp_secondaries) {
+    for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
         const auto &secondary_state =
-            _replica->_primary_states.secondary_bulk_load_states[target_hp];
+            _replica->_primary_states.secondary_bulk_load_states[secondary];
         int32_t s_progress =
             secondary_state.__isset.download_progress ? secondary_state.download_progress : 0;
         error_code s_status =
             secondary_state.__isset.download_status ? secondary_state.download_status : ERR_OK;
         LOG_INFO_PREFIX(
-            "secondary = {}, download progress = {}%, status={}", target_hp, s_progress, s_status);
-        SET_VALUE_FROM_HOST_PORT(response, group_bulk_load_state, target_hp, secondary_state);
+            "secondary = {}, download progress = {}%, status={}", secondary, s_progress, s_status);
+        SET_VALUE_FROM_HOST_PORT(response, group_bulk_load_state, secondary, secondary_state);
         total_progress += s_progress;
     }
 
-    total_progress /= _replica->_primary_states.membership.max_replica_count;
+    total_progress /= _replica->_primary_states.pc.max_replica_count;
     LOG_INFO_PREFIX("total download progress = {}%", total_progress);
     response.__set_total_download_progress(total_progress);
 }
@@ -971,26 +972,26 @@ void replica_bulk_loader::report_group_ingestion_status(/*out*/ bulk_load_respon
     primary_state.__set_ingest_status(_replica->_app->get_ingestion_status());
     SET_VALUE_FROM_IP_AND_HOST_PORT(response,
                                     group_bulk_load_state,
-                                    _replica->_primary_states.membership.primary,
-                                    _replica->_primary_states.membership.hp_primary,
+                                    _replica->_primary_states.pc.primary,
+                                    _replica->_primary_states.pc.hp_primary,
                                     primary_state);
     LOG_INFO_PREFIX("primary = {}, ingestion status = {}",
-                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.membership, primary),
+                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.pc, primary),
                     enum_to_string(primary_state.ingest_status));
 
     bool is_group_ingestion_finish =
         (primary_state.ingest_status == ingestion_status::IS_SUCCEED) &&
-        (_replica->_primary_states.membership.hp_secondaries.size() + 1 ==
-         _replica->_primary_states.membership.max_replica_count);
-    for (const auto &target_hp : _replica->_primary_states.membership.hp_secondaries) {
+        (_replica->_primary_states.pc.hp_secondaries.size() + 1 ==
+         _replica->_primary_states.pc.max_replica_count);
+    for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
         const auto &secondary_state =
-            _replica->_primary_states.secondary_bulk_load_states[target_hp];
+            _replica->_primary_states.secondary_bulk_load_states[secondary];
         ingestion_status::type ingest_status = secondary_state.__isset.ingest_status
                                                    ? secondary_state.ingest_status
                                                    : ingestion_status::IS_INVALID;
         LOG_INFO_PREFIX(
-            "secondary = {}, ingestion status={}", target_hp, enum_to_string(ingest_status));
-        SET_VALUE_FROM_HOST_PORT(response, group_bulk_load_state, target_hp, secondary_state);
+            "secondary = {}, ingestion status={}", secondary, enum_to_string(ingest_status));
+        SET_VALUE_FROM_HOST_PORT(response, group_bulk_load_state, secondary, secondary_state);
         is_group_ingestion_finish &= (ingest_status == ingestion_status::IS_SUCCEED);
     }
     response.__set_is_group_ingestion_finished(is_group_ingestion_finish);
@@ -1018,24 +1019,24 @@ void replica_bulk_loader::report_group_cleaned_up(bulk_load_response &response)
     primary_state.__set_is_cleaned_up(is_cleaned_up());
     SET_VALUE_FROM_IP_AND_HOST_PORT(response,
                                     group_bulk_load_state,
-                                    _replica->_primary_states.membership.primary,
-                                    _replica->_primary_states.membership.hp_primary,
+                                    _replica->_primary_states.pc.primary,
+                                    _replica->_primary_states.pc.hp_primary,
                                     primary_state);
     LOG_INFO_PREFIX("primary = {}, bulk load states cleaned_up = {}",
-                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.membership, primary),
+                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.pc, primary),
                     primary_state.is_cleaned_up);
 
-    bool group_flag = (primary_state.is_cleaned_up) &&
-                      (_replica->_primary_states.membership.hp_secondaries.size() + 1 ==
-                       _replica->_primary_states.membership.max_replica_count);
-    for (const auto &target_hp : _replica->_primary_states.membership.hp_secondaries) {
+    bool group_flag =
+        (primary_state.is_cleaned_up) && (_replica->_primary_states.pc.hp_secondaries.size() + 1 ==
+                                          _replica->_primary_states.pc.max_replica_count);
+    for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
         const auto &secondary_state =
-            _replica->_primary_states.secondary_bulk_load_states[target_hp];
+            _replica->_primary_states.secondary_bulk_load_states[secondary];
         bool is_cleaned_up = secondary_state.__isset.is_cleaned_up ? secondary_state.is_cleaned_up
                                                                    : false;
         LOG_INFO_PREFIX(
-            "secondary = {}, bulk load states cleaned_up = {}", target_hp, is_cleaned_up);
-        SET_VALUE_FROM_HOST_PORT(response, group_bulk_load_state, target_hp, secondary_state);
+            "secondary = {}, bulk load states cleaned_up = {}", secondary, is_cleaned_up);
+        SET_VALUE_FROM_HOST_PORT(response, group_bulk_load_state, secondary, secondary_state);
         group_flag &= is_cleaned_up;
     }
     LOG_INFO_PREFIX("group bulk load states cleaned_up = {}", group_flag);
@@ -1057,22 +1058,22 @@ void replica_bulk_loader::report_group_is_paused(bulk_load_response &response)
     primary_state.__set_is_paused(_status == bulk_load_status::BLS_PAUSED);
     SET_VALUE_FROM_IP_AND_HOST_PORT(response,
                                     group_bulk_load_state,
-                                    _replica->_primary_states.membership.primary,
-                                    _replica->_primary_states.membership.hp_primary,
+                                    _replica->_primary_states.pc.primary,
+                                    _replica->_primary_states.pc.hp_primary,
                                     primary_state);
     LOG_INFO_PREFIX("primary = {}, bulk_load is_paused = {}",
-                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.membership, primary),
+                    FMT_HOST_PORT_AND_IP(_replica->_primary_states.pc, primary),
                     primary_state.is_paused);
 
-    bool group_is_paused = primary_state.is_paused &&
-                           (_replica->_primary_states.membership.hp_secondaries.size() + 1 ==
-                            _replica->_primary_states.membership.max_replica_count);
-    for (const auto &target_hp : _replica->_primary_states.membership.hp_secondaries) {
+    bool group_is_paused =
+        primary_state.is_paused && (_replica->_primary_states.pc.hp_secondaries.size() + 1 ==
+                                    _replica->_primary_states.pc.max_replica_count);
+    for (const auto &secondary : _replica->_primary_states.pc.hp_secondaries) {
         partition_bulk_load_state secondary_state =
-            _replica->_primary_states.secondary_bulk_load_states[target_hp];
+            _replica->_primary_states.secondary_bulk_load_states[secondary];
         bool is_paused = secondary_state.__isset.is_paused ? secondary_state.is_paused : false;
-        LOG_INFO_PREFIX("secondary = {}, bulk_load is_paused = {}", target_hp, is_paused);
-        SET_VALUE_FROM_HOST_PORT(response, group_bulk_load_state, target_hp, secondary_state);
+        LOG_INFO_PREFIX("secondary = {}, bulk_load is_paused = {}", secondary, is_paused);
+        SET_VALUE_FROM_HOST_PORT(response, group_bulk_load_state, secondary, secondary_state);
         group_is_paused &= is_paused;
     }
     LOG_INFO_PREFIX("group bulk load is_paused = {}", group_is_paused);

--- a/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
+++ b/src/replica/bulk_load/test/replica_bulk_loader_test.cpp
@@ -236,13 +236,13 @@ public:
     void mock_primary_states()
     {
         mock_replica_config(partition_status::PS_PRIMARY);
-        partition_configuration config;
-        config.max_replica_count = 3;
-        config.pid = PID;
-        config.ballot = BALLOT;
-        SET_IP_AND_HOST_PORT_BY_DNS(config, primary, PRIMARY_HP);
-        SET_IPS_AND_HOST_PORTS_BY_DNS(config, secondaries, SECONDARY_HP, SECONDARY_HP2);
-        _replica->set_primary_partition_configuration(config);
+        partition_configuration pc;
+        pc.max_replica_count = 3;
+        pc.pid = PID;
+        pc.ballot = BALLOT;
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, PRIMARY_HP);
+        SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, SECONDARY_HP, SECONDARY_HP2);
+        _replica->set_primary_partition_configuration(pc);
     }
 
     void create_local_metadata_file()
@@ -773,7 +773,7 @@ TEST_P(replica_bulk_loader_test, report_group_ingestion_status_test)
 // report_group_context_clean_flag unit tests
 TEST_P(replica_bulk_loader_test, report_group_cleanup_flag_in_unhealthy_state)
 {
-    // _primary_states.membership.secondaries is empty
+    // _primary_states.pc.secondaries is empty
     mock_replica_config(partition_status::PS_PRIMARY);
     ASSERT_FALSE(test_report_group_cleaned_up());
 }

--- a/src/replica/duplication/replica_follower.h
+++ b/src/replica/duplication/replica_follower.h
@@ -60,7 +60,7 @@ private:
     std::string _master_cluster_name;
     std::string _master_app_name;
     std::vector<host_port> _master_meta_list;
-    partition_configuration _master_replica_config;
+    partition_configuration _pc;
 
     bool need_duplicate{false};
 
@@ -78,11 +78,8 @@ private:
     std::string master_replica_name()
     {
         std::string app_info = fmt::format("{}.{}", _master_cluster_name, _master_app_name);
-        if (_master_replica_config.hp_primary) {
-            return fmt::format("{}({}|{})",
-                               app_info,
-                               FMT_HOST_PORT_AND_IP(_master_replica_config, primary),
-                               _master_replica_config.pid);
+        if (_pc.hp_primary) {
+            return fmt::format("{}({}|{})", app_info, FMT_HOST_PORT_AND_IP(_pc, primary), _pc.pid);
         }
         return app_info;
     }

--- a/src/replica/duplication/test/replica_follower_test.cpp
+++ b/src/replica/duplication/test/replica_follower_test.cpp
@@ -99,7 +99,7 @@ public:
 
     const partition_configuration &master_replica_config(replica_follower *follower) const
     {
-        return follower->_master_replica_config;
+        return follower->_pc;
     }
 
     error_code nfs_copy_checkpoint(replica_follower *follower, error_code err, learn_response resp)
@@ -225,42 +225,42 @@ TEST_P(replica_follower_test, test_update_master_replica_config)
     ASSERT_FALSE(master_replica_config(follower).hp_primary);
 
     resp.partition_count = _app_info.partition_count;
-    partition_configuration p;
-    resp.partitions.emplace_back(p);
-    resp.partitions.emplace_back(p);
+    partition_configuration pc;
+    resp.partitions.emplace_back(pc);
+    resp.partitions.emplace_back(pc);
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_INVALID_DATA);
     ASSERT_FALSE(master_replica_config(follower).primary);
     ASSERT_FALSE(master_replica_config(follower).hp_primary);
 
     resp.partitions.clear();
-    p.pid = gpid(2, 100);
-    resp.partitions.emplace_back(p);
+    pc.pid = gpid(2, 100);
+    resp.partitions.emplace_back(pc);
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_INCONSISTENT_STATE);
     ASSERT_FALSE(master_replica_config(follower).primary);
     ASSERT_FALSE(master_replica_config(follower).hp_primary);
 
     resp.partitions.clear();
-    RESET_IP_AND_HOST_PORT(p, primary);
-    p.pid = gpid(2, 1);
-    resp.partitions.emplace_back(p);
+    RESET_IP_AND_HOST_PORT(pc, primary);
+    pc.pid = gpid(2, 1);
+    resp.partitions.emplace_back(pc);
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_INVALID_STATE);
     ASSERT_FALSE(master_replica_config(follower).primary);
     ASSERT_FALSE(master_replica_config(follower).hp_primary);
 
     resp.partitions.clear();
-    p.pid = gpid(2, 1);
+    pc.pid = gpid(2, 1);
 
     const host_port primary("localhost", 34801);
     const host_port secondary1("localhost", 34802);
     const host_port secondary2("localhost", 34803);
 
-    SET_IP_AND_HOST_PORT_BY_DNS(p, primary, primary);
-    SET_IPS_AND_HOST_PORTS_BY_DNS(p, secondaries, secondary1, secondary2);
-    resp.partitions.emplace_back(p);
+    SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, primary);
+    SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, secondary1, secondary2);
+    resp.partitions.emplace_back(pc);
     ASSERT_EQ(update_master_replica_config(follower, resp), ERR_OK);
-    ASSERT_EQ(master_replica_config(follower).primary, p.primary);
-    ASSERT_EQ(master_replica_config(follower).hp_primary, p.hp_primary);
-    ASSERT_EQ(master_replica_config(follower).pid, p.pid);
+    ASSERT_EQ(master_replica_config(follower).primary, pc.primary);
+    ASSERT_EQ(master_replica_config(follower).hp_primary, pc.hp_primary);
+    ASSERT_EQ(master_replica_config(follower).pid, pc.pid);
 }
 
 TEST_P(replica_follower_test, test_nfs_copy_checkpoint)

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -369,7 +369,7 @@ void replica::init_state()
     _config.pid.set_app_id(0);
     _config.pid.set_partition_index(0);
     _config.status = partition_status::PS_INACTIVE;
-    _primary_states.membership.ballot = 0;
+    _primary_states.pc.ballot = 0;
     _create_time_ms = dsn_now_ms();
     _last_config_change_time_ms = _create_time_ms;
     update_last_checkpoint_generate_time();

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -188,7 +188,7 @@ public:
     //
     void on_config_proposal(configuration_update_request &proposal);
     void on_config_sync(const app_info &info,
-                        const partition_configuration &config,
+                        const partition_configuration &pc,
                         split_status::type meta_split_status);
     void on_cold_backup(const backup_request &request, /*out*/ backup_response &response);
 
@@ -444,7 +444,7 @@ private:
     void remove(configuration_update_request &proposal);
     void update_configuration_on_meta_server(config_type::type type,
                                              const host_port &node,
-                                             partition_configuration &new_config);
+                                             partition_configuration &new_pc);
     void
     on_update_configuration_on_meta_server_reply(error_code err,
                                                  dsn::message_ex *request,
@@ -458,7 +458,7 @@ private:
     void update_app_envs_internal(const std::map<std::string, std::string> &envs);
     void query_app_envs(/*out*/ std::map<std::string, std::string> &envs);
 
-    bool update_configuration(const partition_configuration &config);
+    bool update_configuration(const partition_configuration &pc);
     bool update_local_configuration(const replica_configuration &config, bool same_ballot = false);
     error_code update_init_info_ballot_and_decree();
 

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -256,10 +256,10 @@ void replica::on_cold_backup(const backup_request &request, /*out*/ backup_respo
 
 void replica::send_backup_request_to_secondary(const backup_request &request)
 {
-    for (const auto &target_address : _primary_states.membership.secondaries) {
+    for (const auto &secondary : _primary_states.pc.secondaries) {
         // primary will send backup_request to secondary periodically
         // so, we shouldn't handle the response
-        rpc::call_one_way_typed(target_address, RPC_COLD_BACKUP, request, get_gpid().thread_hash());
+        rpc::call_one_way_typed(secondary, RPC_COLD_BACKUP, request, get_gpid().thread_hash());
     }
 }
 

--- a/src/replica/replica_context.cpp
+++ b/src/replica/replica_context.cpp
@@ -67,7 +67,7 @@ void primary_context::cleanup(bool clean_pending_mutations)
     }
     group_bulk_load_pending_replies.clear();
 
-    membership.ballot = 0;
+    pc.ballot = 0;
 
     cleanup_bulk_load_states();
 
@@ -91,25 +91,26 @@ void primary_context::do_cleanup_pending_mutations(bool clean_pending_mutations)
     }
 }
 
-void primary_context::reset_membership(const partition_configuration &config, bool clear_learners)
+void primary_context::reset_membership(const partition_configuration &new_pc, bool clear_learners)
 {
     statuses.clear();
     if (clear_learners) {
         learners.clear();
     }
 
-    if (config.ballot > membership.ballot)
-        next_learning_version = (((uint64_t)config.ballot) << 32) + 1;
-    else
+    if (new_pc.ballot > pc.ballot) {
+        next_learning_version = (((uint64_t)new_pc.ballot) << 32) + 1;
+    } else {
         ++next_learning_version;
-
-    membership = config;
-
-    if (membership.hp_primary) {
-        statuses[membership.hp_primary] = partition_status::PS_PRIMARY;
     }
 
-    for (auto it = config.hp_secondaries.begin(); it != config.hp_secondaries.end(); ++it) {
+    pc = new_pc;
+
+    if (pc.hp_primary) {
+        statuses[pc.hp_primary] = partition_status::PS_PRIMARY;
+    }
+
+    for (auto it = new_pc.hp_secondaries.begin(); it != new_pc.hp_secondaries.end(); ++it) {
         statuses[*it] = partition_status::PS_SECONDARY;
         learners.erase(*it);
     }
@@ -123,9 +124,9 @@ void primary_context::get_replica_config(partition_status::type st,
                                          /*out*/ replica_configuration &config,
                                          uint64_t learner_signature /*= invalid_signature*/)
 {
-    config.pid = membership.pid;
-    SET_OBJ_IP_AND_HOST_PORT(config, primary, membership, primary);
-    config.ballot = membership.ballot;
+    config.pid = pc.pid;
+    SET_OBJ_IP_AND_HOST_PORT(config, primary, pc, primary);
+    config.ballot = pc.ballot;
     config.status = st;
     config.learner_signature = learner_signature;
 }
@@ -134,9 +135,9 @@ bool primary_context::check_exist(const ::dsn::host_port &node, partition_status
 {
     switch (st) {
     case partition_status::PS_PRIMARY:
-        return membership.hp_primary == node;
+        return pc.hp_primary == node;
     case partition_status::PS_SECONDARY:
-        return utils::contains(membership.hp_secondaries, node);
+        return utils::contains(pc.hp_secondaries, node);
     case partition_status::PS_POTENTIAL_SECONDARY:
         return learners.find(node) != learners.end();
     default:
@@ -176,7 +177,7 @@ bool primary_context::secondary_disk_abnormal() const
     for (const auto &kv : secondary_disk_status) {
         if (kv.second != disk_status::NORMAL) {
             LOG_INFO("partition[{}] secondary[{}] disk space is {}",
-                     membership.pid,
+                     pc.pid,
                      kv.first,
                      enum_to_string(kv.second));
             return true;

--- a/src/replica/replica_context.h
+++ b/src/replica/replica_context.h
@@ -100,7 +100,7 @@ public:
     void cleanup(bool clean_pending_mutations = true);
     bool is_cleaned();
 
-    void reset_membership(const partition_configuration &config, bool clear_learners);
+    void reset_membership(const partition_configuration &new_pc, bool clear_learners);
     void get_replica_config(partition_status::type status,
                             /*out*/ replica_configuration &config,
                             uint64_t learner_signature = invalid_signature);
@@ -120,7 +120,7 @@ public:
 
 public:
     // membership mgr, including learners
-    partition_configuration membership;
+    partition_configuration pc;
     node_statuses statuses;
     learner_map learners;
     uint64_t next_learning_version;

--- a/src/replica/replica_failover.cpp
+++ b/src/replica/replica_failover.cpp
@@ -58,7 +58,7 @@ void replica::handle_local_failure(error_code error)
     }
 
     if (status() == partition_status::PS_PRIMARY) {
-        _stub->remove_replica_on_meta_server(_app_info, _primary_states.membership);
+        _stub->remove_replica_on_meta_server(_app_info, _primary_states.pc);
     }
 
     update_local_configuration_with_no_ballot_change(partition_status::PS_ERROR);
@@ -88,7 +88,7 @@ void replica::handle_remote_failure(partition_status::type st,
             configuration_update_request request;
             SET_IP_AND_HOST_PORT_BY_DNS(request, node, node);
             request.type = config_type::CT_DOWNGRADE_TO_INACTIVE;
-            request.config = _primary_states.membership;
+            request.config = _primary_states.pc;
             downgrade_to_inactive_on_primary(request);
         }
         break;

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1454,7 +1454,7 @@ void replica_stub::on_node_query_reply_scatter2(replica_stub_ptr this_, gpid id)
 }
 
 void replica_stub::remove_replica_on_meta_server(const app_info &info,
-                                                 const partition_configuration &config)
+                                                 const partition_configuration &pc)
 {
     if (FLAGS_fd_disabled) {
         return;
@@ -1464,12 +1464,12 @@ void replica_stub::remove_replica_on_meta_server(const app_info &info,
 
     std::shared_ptr<configuration_update_request> request(new configuration_update_request);
     request->info = info;
-    request->config = config;
+    request->config = pc;
     request->config.ballot++;
     SET_IP_AND_HOST_PORT(*request, node, primary_address(), _primary_host_port);
     request->type = config_type::CT_DOWNGRADE_TO_INACTIVE;
 
-    if (_primary_host_port == config.hp_primary) {
+    if (_primary_host_port == pc.hp_primary) {
         RESET_IP_AND_HOST_PORT(request->config, primary);
     } else if (replica_helper::remove_node(primary_address(), request->config.secondaries) &&
                replica_helper::remove_node(_primary_host_port, request->config.hp_secondaries)) {

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -341,7 +341,7 @@ private:
     void on_node_query_reply_scatter(replica_stub_ptr this_,
                                      const configuration_update_request &config);
     void on_node_query_reply_scatter2(replica_stub_ptr this_, gpid id);
-    void remove_replica_on_meta_server(const app_info &info, const partition_configuration &config);
+    void remove_replica_on_meta_server(const app_info &info, const partition_configuration &pc);
     task_ptr begin_open_replica(const app_info &app,
                                 gpid id,
                                 const std::shared_ptr<group_check_request> &req,

--- a/src/replica/split/replica_split_manager.h
+++ b/src/replica/split/replica_split_manager.h
@@ -150,7 +150,7 @@ private:
     void parent_send_register_request(const register_child_request &request);
 
     // child partition has been registered on meta_server, could be active
-    void child_partition_active(const partition_configuration &config);
+    void child_partition_active(const partition_configuration &pc);
 
     // return true if parent status is valid
     bool parent_check_states();

--- a/src/replica/split/test/replica_split_test.cpp
+++ b/src/replica/split/test/replica_split_test.cpp
@@ -186,16 +186,16 @@ public:
 
     void mock_parent_primary_configuration(bool lack_of_secondary = false)
     {
-        partition_configuration config;
-        config.max_replica_count = 3;
-        config.pid = PARENT_GPID;
-        config.ballot = INIT_BALLOT;
-        SET_IP_AND_HOST_PORT_BY_DNS(config, primary, PRIMARY);
-        ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY);
+        partition_configuration pc;
+        pc.max_replica_count = 3;
+        pc.pid = PARENT_GPID;
+        pc.ballot = INIT_BALLOT;
+        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, PRIMARY);
+        ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, SECONDARY);
         if (!lack_of_secondary) {
-            ADD_IP_AND_HOST_PORT_BY_DNS(config, secondaries, SECONDARY2);
+            ADD_IP_AND_HOST_PORT_BY_DNS(pc, secondaries, SECONDARY2);
         }
-        _parent_replica->set_primary_partition_configuration(config);
+        _parent_replica->set_primary_partition_configuration(pc);
     }
 
     void mock_update_child_partition_count_request(update_child_group_partition_count_request &req,
@@ -453,15 +453,15 @@ public:
         req.partition_count = OLD_PARTITION_COUNT;
         req.pid = PARENT_GPID;
 
-        partition_configuration child_config;
-        child_config.pid = CHILD_GPID;
-        child_config.ballot = INIT_BALLOT + 1;
-        child_config.last_committed_decree = 0;
+        partition_configuration child_pc;
+        child_pc.pid = CHILD_GPID;
+        child_pc.ballot = INIT_BALLOT + 1;
+        child_pc.last_committed_decree = 0;
 
         query_child_state_response resp;
         resp.err = ERR_OK;
         resp.__set_partition_count(NEW_PARTITION_COUNT);
-        resp.__set_child_config(child_config);
+        resp.__set_child_config(child_pc);
 
         _parent_split_mgr->on_query_child_state_reply(ERR_OK, req, resp);
         _parent_split_mgr->tracker()->wait_outstanding_tasks();

--- a/src/replica/storage/simple_kv/test/checker.cpp
+++ b/src/replica/storage/simple_kv/test/checker.cpp
@@ -323,7 +323,7 @@ bool test_checker::get_current_config(parti_config &config)
     meta_service_app *meta = meta_leader();
     if (meta == nullptr)
         return false;
-    partition_configuration c;
+    partition_configuration pc;
 
     // we should never try to acquire lock when we are in checker. Because we are the only
     // thread that is running.
@@ -332,11 +332,8 @@ bool test_checker::get_current_config(parti_config &config)
     // the rDSN's
     //"enqueue,dequeue and lock..."
 
-    // meta->_service->_state->query_configuration_by_gpid(g_default_gpid, c);
     const meta_view view = meta->_service->_state->get_meta_view();
-    const partition_configuration *pc = get_config(*(view.apps), g_default_gpid);
-    c = *pc;
-    config.convert_from(c);
+    config.convert_from(*get_config(*(view.apps), g_default_gpid));
     return true;
 }
 

--- a/src/replica/storage/simple_kv/test/common.cpp
+++ b/src/replica/storage/simple_kv/test/common.cpp
@@ -315,13 +315,13 @@ bool parti_config::from_string(const std::string &str)
     return true;
 }
 
-void parti_config::convert_from(const partition_configuration &c)
+void parti_config::convert_from(const partition_configuration &pc)
 {
-    pid = c.pid;
-    ballot = c.ballot;
-    primary = address_to_node(c.hp_primary);
-    for (auto &s : c.hp_secondaries) {
-        secondaries.push_back(address_to_node(s));
+    pid = pc.pid;
+    ballot = pc.ballot;
+    primary = address_to_node(pc.hp_primary);
+    for (const auto &secondary : pc.hp_secondaries) {
+        secondaries.push_back(address_to_node(secondary));
     }
     std::sort(secondaries.begin(), secondaries.end());
 }

--- a/src/replica/storage/simple_kv/test/common.h
+++ b/src/replica/storage/simple_kv/test/common.h
@@ -198,7 +198,7 @@ struct parti_config
     bool operator<(const parti_config &o) const { return pid == o.pid && ballot < o.ballot; }
     std::string to_string() const;
     bool from_string(const std::string &str);
-    void convert_from(const partition_configuration &c);
+    void convert_from(const partition_configuration &pc);
 
     friend std::ostream &operator<<(std::ostream &os, const parti_config &pc)
     {

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -180,9 +180,9 @@ public:
     void prepare_list_commit_hard(decree d) { _prepare_list->commit(d, COMMIT_TO_DECREE_HARD); }
     decree get_app_last_committed_decree() { return _app->last_committed_decree(); }
     void set_app_last_committed_decree(decree d) { _app->_last_committed_decree = d; }
-    void set_primary_partition_configuration(partition_configuration &pconfig)
+    void set_primary_partition_configuration(partition_configuration &pc)
     {
-        _primary_states.membership = pconfig;
+        _primary_states.pc = pc;
     }
     partition_bulk_load_state get_secondary_bulk_load_state(const host_port &node)
     {

--- a/src/replica/test/open_replica_test.cpp
+++ b/src/replica/test/open_replica_test.cpp
@@ -72,15 +72,15 @@ TEST_P(open_replica_test, open_replica_add_decree_and_ballot_check)
 
         _replica->register_service();
 
-        partition_configuration config;
-        config.pid = pid;
-        config.ballot = test.b;
-        config.last_committed_decree = test.last_committed_decree;
+        partition_configuration pc;
+        pc.pid = pid;
+        pc.ballot = test.b;
+        pc.last_committed_decree = test.last_committed_decree;
         auto as = app_state::create(ai);
 
         auto req = std::make_shared<configuration_update_request>();
         req->info = *as;
-        req->config = config;
+        req->config = pc;
         req->type = config_type::CT_ASSIGN_PRIMARY;
         SET_IP_AND_HOST_PORT_BY_DNS(*req, node, node);
         if (test.expect_crash) {

--- a/src/server/available_detector.cpp
+++ b/src/server/available_detector.cpp
@@ -266,8 +266,8 @@ void available_detector::report_availability_info()
 bool available_detector::generate_hash_keys()
 {
     // get app_id and partition_count.
-    auto err =
-        _ddl_client->list_app(FLAGS_available_detect_app, _app_id, _partition_count, partitions);
+    std::vector<::dsn::partition_configuration> pcs;
+    auto err = _ddl_client->list_app(FLAGS_available_detect_app, _app_id, _partition_count, pcs);
     if (err == ::dsn::ERR_OK && _app_id >= 0) {
         _hash_keys.clear();
         for (auto pidx = 0; pidx < _partition_count; pidx++) {

--- a/src/server/available_detector.cpp
+++ b/src/server/available_detector.cpp
@@ -20,6 +20,7 @@
 #include "available_detector.h"
 
 #include <fmt/core.h>
+#include <fmt/std.h> // IWYU pragma: keep
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <pegasus/error.h>
 #include <stdlib.h>
@@ -31,12 +32,11 @@
 #include <type_traits>
 #include <utility>
 
-#include <fmt/std.h> // IWYU pragma: keep
-
 #include "base/pegasus_key_schema.h"
 #include "client/replication_ddl_client.h"
 #include "common/common.h"
 #include "common/replication_other_types.h"
+#include "dsn.layer2_types.h"
 #include "pegasus/client.h"
 #include "perf_counter/perf_counter.h"
 #include "result_writer.h"

--- a/src/server/available_detector.h
+++ b/src/server/available_detector.h
@@ -25,7 +25,6 @@
 #include <string>
 #include <vector>
 
-#include "dsn.layer2_types.h"
 #include "perf_counter/perf_counter_wrapper.h"
 #include "runtime/rpc/rpc_host_port.h"
 #include "runtime/task/task.h"

--- a/src/server/available_detector.h
+++ b/src/server/available_detector.h
@@ -86,7 +86,6 @@ private:
     std::vector<::dsn::task_ptr> _detect_tasks;
     int32_t _app_id;
     int32_t _partition_count;
-    std::vector<::dsn::partition_configuration> partitions;
 
     std::string _send_alert_email_cmd;
     std::string _send_availability_info_email_cmd;

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -216,24 +216,23 @@ void hotspot_partition_calculator::send_detect_hotkey_request(
 
     int app_id = -1;
     int partition_count = -1;
-    std::vector<dsn::partition_configuration> partitions;
-    _shell_context->ddl_client->list_app(app_name, app_id, partition_count, partitions);
+    std::vector<dsn::partition_configuration> pcs;
+    _shell_context->ddl_client->list_app(app_name, app_id, partition_count, pcs);
 
     dsn::replication::detect_hotkey_response resp;
     dsn::replication::detect_hotkey_request req;
     req.type = hotkey_type;
     req.action = action;
     req.pid = dsn::gpid(app_id, partition_index);
-    auto error = _shell_context->ddl_client->detect_hotkey(
-        partitions[partition_index].hp_primary, req, resp);
+    auto error =
+        _shell_context->ddl_client->detect_hotkey(pcs[partition_index].hp_primary, req, resp);
 
     LOG_INFO("{} {} hotkey detection in {}.{}, server: {}",
              (action == dsn::replication::detect_action::STOP) ? "Stop" : "Start",
              (hotkey_type == dsn::replication::hotkey_type::WRITE) ? "write" : "read",
              app_name,
              partition_index,
-             FMT_HOST_PORT_AND_IP(partitions[partition_index], primary));
-
+             FMT_HOST_PORT_AND_IP(pcs[partition_index], primary));
     if (error != dsn::ERR_OK) {
         LOG_ERROR("Hotkey detect rpc sending failed, in {}.{}, error_hint:{}",
                   app_name,

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -21,6 +21,7 @@
 #include <boost/cstdint.hpp>
 #include <boost/lexical_cast.hpp>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/printf.h>
 #include <getopt.h>
 #include <inttypes.h>
@@ -2231,16 +2232,16 @@ inline dsn::metric_filters rdb_estimated_keys_filters(int32_t table_id)
 // All selected partitions should have their primary replicas on this node.
 std::unique_ptr<aggregate_stats_calcs>
 create_rdb_estimated_keys_stats_calcs(const int32_t table_id,
-                                      const std::vector<dsn::partition_configuration> &partitions,
+                                      const std::vector<dsn::partition_configuration> &pcs,
                                       const dsn::host_port &node,
                                       const std::string &entity_type,
                                       std::vector<row_data> &rows)
 {
-    CHECK_EQ(rows.size(), partitions.size());
+    CHECK_EQ(rows.size(), pcs.size());
 
     partition_stat_map sums;
     for (size_t i = 0; i < rows.size(); ++i) {
-        if (partitions[i].hp_primary != node) {
+        if (pcs[i].hp_primary != node) {
             // Ignore once the replica of the metrics is not the primary of the partition.
             continue;
         }
@@ -2268,13 +2269,13 @@ bool get_rdb_estimated_keys_stats(shell_context *sc,
 
     int32_t table_id = 0;
     int32_t partition_count = 0;
-    std::vector<dsn::partition_configuration> partitions;
-    const auto &err = sc->ddl_client->list_app(table_name, table_id, partition_count, partitions);
+    std::vector<dsn::partition_configuration> pcs;
+    const auto &err = sc->ddl_client->list_app(table_name, table_id, partition_count, pcs);
     if (err != ::dsn::ERR_OK) {
         LOG_ERROR("list app {} failed, error = {}", table_name, err);
         return false;
     }
-    CHECK_EQ(partitions.size(), partition_count);
+    CHECK_EQ(pcs.size(), partition_count);
 
     const auto &results =
         get_metrics(nodes, rdb_estimated_keys_filters(table_id).to_query_string());
@@ -2289,8 +2290,8 @@ bool get_rdb_estimated_keys_stats(shell_context *sc,
         RETURN_SHELL_IF_GET_METRICS_FAILED(
             results[i], nodes[i], "rdb_estimated_keys for table(id={})", table_id);
 
-        auto calcs = create_rdb_estimated_keys_stats_calcs(
-            table_id, partitions, nodes[i].hp, "replica", rows);
+        auto calcs =
+            create_rdb_estimated_keys_stats_calcs(table_id, pcs, nodes[i].hp, "replica", rows);
         RETURN_SHELL_IF_PARSE_METRICS_FAILED(calcs->aggregate_metrics(results[i].body()),
                                              nodes[i],
                                              "rdb_estimated_keys for table(id={})",
@@ -2870,9 +2871,9 @@ bool calculate_hash_value(command_executor *e, shell_context *sc, arguments args
     if (!sc->current_app_name.empty()) {
         int32_t app_id;
         int32_t partition_count;
-        std::vector<::dsn::partition_configuration> partitions;
+        std::vector<::dsn::partition_configuration> pcs;
         ::dsn::error_code err =
-            sc->ddl_client->list_app(sc->current_app_name, app_id, partition_count, partitions);
+            sc->ddl_client->list_app(sc->current_app_name, app_id, partition_count, pcs);
         if (err != ::dsn::ERR_OK) {
             std::cout << "list app [" << sc->current_app_name << "] failed, error=" << err
                       << std::endl;
@@ -2883,17 +2884,11 @@ bool calculate_hash_value(command_executor *e, shell_context *sc, arguments args
         tp.add_row_name_and_data("app_id", app_id);
         tp.add_row_name_and_data("partition_count", partition_count);
         tp.add_row_name_and_data("partition_index", partition_index);
-        if (partitions.size() > partition_index) {
-            ::dsn::partition_configuration &pc = partitions[partition_index];
+        if (pcs.size() > partition_index) {
+            const auto &pc = pcs[partition_index];
             tp.add_row_name_and_data("primary", pc.hp_primary.to_string());
-
-            std::ostringstream oss;
-            for (int i = 0; i < pc.hp_secondaries.size(); ++i) {
-                if (i != 0)
-                    oss << ",";
-                oss << pc.hp_secondaries[i];
-            }
-            tp.add_row_name_and_data("secondaries", oss.str());
+            tp.add_row_name_and_data("secondaries",
+                                     fmt::format("{}", fmt::join(pc.hp_secondaries, ",")));
         }
     }
     tp.output(std::cout);

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -340,22 +340,22 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
         for (auto &app : apps) {
             int32_t app_id;
             int32_t partition_count;
-            std::vector<dsn::partition_configuration> partitions;
-            r = sc->ddl_client->list_app(app.app_name, app_id, partition_count, partitions);
+            std::vector<dsn::partition_configuration> pcs;
+            r = sc->ddl_client->list_app(app.app_name, app_id, partition_count, pcs);
             if (r != dsn::ERR_OK) {
                 std::cout << "list app " << app.app_name << " failed, error=" << r << std::endl;
                 return true;
             }
 
-            for (const dsn::partition_configuration &p : partitions) {
-                if (p.hp_primary) {
-                    auto find = tmp_map.find(p.hp_primary);
+            for (const auto &pc : pcs) {
+                if (pc.hp_primary) {
+                    auto find = tmp_map.find(pc.hp_primary);
                     if (find != tmp_map.end()) {
                         find->second.primary_count++;
                     }
                 }
-                for (const auto &hp : p.hp_secondaries) {
-                    auto find = tmp_map.find(hp);
+                for (const auto &secondary : pc.hp_secondaries) {
+                    auto find = tmp_map.find(secondary);
                     if (find != tmp_map.end()) {
                         find->second.secondary_count++;
                     }

--- a/src/shell/commands/recovery.cpp
+++ b/src/shell/commands/recovery.cpp
@@ -165,8 +165,9 @@ bool recover(command_executor *e, shell_context *sc, arguments args)
 
 dsn::host_port diagnose_recommend(const ddd_partition_info &pinfo)
 {
-    if (pinfo.config.hp_last_drops.size() < 2)
+    if (pinfo.config.hp_last_drops.size() < 2) {
         return dsn::host_port();
+    }
 
     std::vector<dsn::host_port> last_two_nodes(pinfo.config.hp_last_drops.end() - 2,
                                                pinfo.config.hp_last_drops.end());
@@ -290,11 +291,13 @@ bool ddd_diagnose(command_executor *e, shell_context *sc, arguments args)
             << "last_committed(" << pinfo.config.last_committed_decree << ")" << std::endl;
         out << "    ----" << std::endl;
         dsn::host_port latest_dropped, secondary_latest_dropped;
-        if (pinfo.config.hp_last_drops.size() > 0)
+        if (pinfo.config.hp_last_drops.size() > 0) {
             latest_dropped = pinfo.config.hp_last_drops[pinfo.config.hp_last_drops.size() - 1];
-        if (pinfo.config.hp_last_drops.size() > 1)
+        }
+        if (pinfo.config.hp_last_drops.size() > 1) {
             secondary_latest_dropped =
                 pinfo.config.hp_last_drops[pinfo.config.hp_last_drops.size() - 2];
+        }
         int j = 0;
         for (const ddd_node_info &n : pinfo.dropped) {
             dsn::host_port hp_node;

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -285,15 +285,15 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
     int32_t app_id = 0;
     int32_t partition_count = 0;
     int32_t max_replica_count = 0;
-    std::vector<dsn::partition_configuration> partitions;
+    std::vector<dsn::partition_configuration> pcs;
 
-    dsn::error_code err = sc->ddl_client->list_app(app_name, app_id, partition_count, partitions);
+    dsn::error_code err = sc->ddl_client->list_app(app_name, app_id, partition_count, pcs);
     if (err != ::dsn::ERR_OK) {
         std::cout << "ERROR: list app " << app_name << " failed, error=" << err << std::endl;
         return true;
     }
-    if (!partitions.empty()) {
-        max_replica_count = partitions[0].max_replica_count;
+    if (!pcs.empty()) {
+        max_replica_count = pcs[0].max_replica_count;
     }
 
     std::vector<node_desc> nodes;
@@ -333,27 +333,15 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
     int primary_replicas_count = 0;
     double disk_used_for_all_replicas = 0;
     int all_replicas_count = 0;
-    for (int i = 0; i < partitions.size(); i++) {
-        const dsn::partition_configuration &p = partitions[i];
-        int replica_count = 0;
-        if (p.hp_primary) {
-            replica_count++;
-        }
-        replica_count += p.hp_secondaries.size();
-        std::string replica_count_str;
-        {
-            std::stringstream oss;
-            oss << replica_count << "/" << p.max_replica_count;
-            replica_count_str = oss.str();
-        }
+    for (const auto &pc : pcs) {
         std::string primary_str("-");
-        if (p.hp_primary) {
+        if (pc.hp_primary) {
             bool disk_found = false;
             double disk_value = 0;
-            auto f1 = disk_map.find(p.hp_primary);
+            auto f1 = disk_map.find(pc.hp_primary);
             if (f1 != disk_map.end()) {
                 auto &sub_map = f1->second;
-                auto f2 = sub_map.find(p.pid.get_partition_index());
+                auto f2 = sub_map.find(pc.pid.get_partition_index());
                 if (f2 != sub_map.end()) {
                     disk_found = true;
                     disk_value = f2->second;
@@ -365,17 +353,17 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
             }
             bool count_found = false;
             double count_value = 0;
-            auto f3 = count_map.find(p.hp_primary);
+            auto f3 = count_map.find(pc.hp_primary);
             if (f3 != count_map.end()) {
                 auto &sub_map = f3->second;
-                auto f4 = sub_map.find(p.pid.get_partition_index());
+                auto f4 = sub_map.find(pc.pid.get_partition_index());
                 if (f4 != sub_map.end()) {
                     count_found = true;
                     count_value = f4->second;
                 }
             }
             std::stringstream oss;
-            oss << replication_ddl_client::node_name(p.hp_primary, resolve_ip) << "(";
+            oss << replication_ddl_client::node_name(pc.hp_primary, resolve_ip) << "(";
             if (disk_found)
                 oss << disk_value;
             else
@@ -392,15 +380,15 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
         {
             std::stringstream oss;
             oss << "[";
-            for (int j = 0; j < p.hp_secondaries.size(); j++) {
+            for (int j = 0; j < pc.hp_secondaries.size(); j++) {
                 if (j != 0)
                     oss << ",";
                 bool found = false;
                 double value = 0;
-                auto f1 = disk_map.find(p.hp_secondaries[j]);
+                auto f1 = disk_map.find(pc.hp_secondaries[j]);
                 if (f1 != disk_map.end()) {
                     auto &sub_map = f1->second;
-                    auto f2 = sub_map.find(p.pid.get_partition_index());
+                    auto f2 = sub_map.find(pc.pid.get_partition_index());
                     if (f2 != sub_map.end()) {
                         found = true;
                         value = f2->second;
@@ -410,17 +398,17 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
                 }
                 bool count_found = false;
                 double count_value = 0;
-                auto f3 = count_map.find(p.hp_secondaries[j]);
+                auto f3 = count_map.find(pc.hp_secondaries[j]);
                 if (f3 != count_map.end()) {
                     auto &sub_map = f3->second;
-                    auto f3 = sub_map.find(p.pid.get_partition_index());
+                    auto f3 = sub_map.find(pc.pid.get_partition_index());
                     if (f3 != sub_map.end()) {
                         count_found = true;
                         count_value = f3->second;
                     }
                 }
 
-                oss << replication_ddl_client::node_name(p.hp_secondaries[j], resolve_ip) << "(";
+                oss << replication_ddl_client::node_name(pc.hp_secondaries[j], resolve_ip) << "(";
                 if (found)
                     oss << value;
                 else
@@ -437,9 +425,10 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
         }
 
         if (detailed) {
-            tp_details.add_row(std::to_string(p.pid.get_partition_index()));
-            tp_details.append_data(p.ballot);
-            tp_details.append_data(replica_count_str);
+            tp_details.add_row(std::to_string(pc.pid.get_partition_index()));
+            tp_details.append_data(pc.ballot);
+            tp_details.append_data(fmt::format(
+                "{}/{}", pc.hp_secondaries.size() + (pc.hp_primary ? 1 : 0), pc.max_replica_count));
             tp_details.append_data(primary_str);
             tp_details.append_data(secondary_str);
         }

--- a/src/test/function_test/detect_hotspot/test_detect_hotspot.cpp
+++ b/src/test/function_test/detect_hotspot/test_detect_hotspot.cpp
@@ -26,6 +26,7 @@
 
 #include "client/replication_ddl_client.h"
 #include "common/gpid.h"
+#include "dsn.layer2_types.h"
 #include "gtest/gtest.h"
 #include "include/pegasus/client.h"
 #include "include/pegasus/error.h"
@@ -96,11 +97,9 @@ protected:
 
         bool find_hotkey = false;
         dsn::replication::detect_hotkey_response resp;
-        for (int partition_index = 0; partition_index < partitions_.size(); partition_index++) {
-            req.pid = dsn::gpid(table_id_, partition_index);
-            ASSERT_EQ(
-                dsn::ERR_OK,
-                ddl_client_->detect_hotkey(partitions_[partition_index].hp_primary, req, resp));
+        for (const auto &pc : pcs_) {
+            req.pid = pc.pid;
+            ASSERT_EQ(dsn::ERR_OK, ddl_client_->detect_hotkey(pc.hp_primary, req, resp));
             if (!resp.hotkey_result.empty()) {
                 find_hotkey = true;
                 break;
@@ -118,19 +117,15 @@ protected:
         sleep(15);
 
         req.action = dsn::replication::detect_action::STOP;
-        for (int partition_index = 0; partition_index < partitions_.size(); partition_index++) {
-            ASSERT_EQ(
-                dsn::ERR_OK,
-                ddl_client_->detect_hotkey(partitions_[partition_index].hp_primary, req, resp));
+        for (const auto &pc : pcs_) {
+            ASSERT_EQ(dsn::ERR_OK, ddl_client_->detect_hotkey(pc.hp_primary, req, resp));
             ASSERT_EQ(dsn::ERR_OK, resp.err);
         }
 
         req.action = dsn::replication::detect_action::QUERY;
-        for (int partition_index = 0; partition_index < partitions_.size(); partition_index++) {
-            req.pid = dsn::gpid(table_id_, partition_index);
-            ASSERT_EQ(
-                dsn::ERR_OK,
-                ddl_client_->detect_hotkey(partitions_[partition_index].hp_primary, req, resp));
+        for (const auto &pc : pcs_) {
+            req.pid = pc.pid;
+            ASSERT_EQ(dsn::ERR_OK, ddl_client_->detect_hotkey(pc.hp_primary, req, resp));
             ASSERT_EQ("Can't get hotkey now, now state: hotkey_collector_state::STOPPED",
                       resp.err_hint);
         }
@@ -162,12 +157,12 @@ protected:
 
         dsn::replication::detect_hotkey_response resp;
         ASSERT_EQ(dsn::ERR_OK,
-                  ddl_client_->detect_hotkey(partitions_[target_partition].hp_primary, req, resp));
+                  ddl_client_->detect_hotkey(pcs_[target_partition].hp_primary, req, resp));
         ASSERT_EQ(dsn::ERR_OK, resp.err);
 
         req.action = dsn::replication::detect_action::QUERY;
         ASSERT_EQ(dsn::ERR_OK,
-                  ddl_client_->detect_hotkey(partitions_[target_partition].hp_primary, req, resp));
+                  ddl_client_->detect_hotkey(pcs_[target_partition].hp_primary, req, resp));
         ASSERT_EQ("Can't get hotkey now, now state: hotkey_collector_state::COARSE_DETECTING",
                   resp.err_hint);
 
@@ -178,7 +173,7 @@ protected:
 
         req.action = dsn::replication::detect_action::QUERY;
         ASSERT_EQ(dsn::ERR_OK,
-                  ddl_client_->detect_hotkey(partitions_[target_partition].hp_primary, req, resp));
+                  ddl_client_->detect_hotkey(pcs_[target_partition].hp_primary, req, resp));
         ASSERT_EQ("Can't get hotkey now, now state: hotkey_collector_state::STOPPED",
                   resp.err_hint);
     }

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -108,11 +108,10 @@ void test_util::SetUp()
     ASSERT_TRUE(client_ != nullptr);
 
     int32_t partition_count;
-    ASSERT_EQ(dsn::ERR_OK,
-              ddl_client_->list_app(table_name_, table_id_, partition_count, partitions_));
+    ASSERT_EQ(dsn::ERR_OK, ddl_client_->list_app(table_name_, table_id_, partition_count, pcs_));
     ASSERT_NE(0, table_id_);
     ASSERT_EQ(partition_count_, partition_count);
-    ASSERT_EQ(partition_count_, partitions_.size());
+    ASSERT_EQ(partition_count_, pcs_.size());
 }
 
 void test_util::run_cmd_from_project_root(const string &cmd)

--- a/src/test/function_test/utils/test_util.h
+++ b/src/test/function_test/utils/test_util.h
@@ -115,7 +115,7 @@ protected:
     std::string table_name_;
     int32_t table_id_;
     int32_t partition_count_ = 8;
-    std::vector<dsn::partition_configuration> partitions_;
+    std::vector<dsn::partition_configuration> pcs_;
     pegasus_client *client_ = nullptr;
     std::vector<dsn::host_port> meta_list_;
     std::shared_ptr<dsn::replication::replication_ddl_client> ddl_client_;

--- a/src/test/kill_test/kill_testor.h
+++ b/src/test/kill_test/kill_testor.h
@@ -66,7 +66,7 @@ protected:
     shared_ptr<replication_ddl_client> ddl_client;
     vector<dsn::host_port> meta_list;
 
-    std::vector<partition_configuration> partitions;
+    std::vector<partition_configuration> pcs;
 };
 } // namespace test
 } // namespace pegasus

--- a/src/test/kill_test/partition_kill_testor.cpp
+++ b/src/test/kill_test/partition_kill_testor.cpp
@@ -59,14 +59,14 @@ void partition_kill_testor::Run()
 
 void partition_kill_testor::run()
 {
-    if (partitions.size() == 0) {
+    if (pcs.empty()) {
         LOG_INFO("partitions empty");
         return;
     }
 
-    int random_num = generate_one_number(0, partitions.size() - 1);
+    int random_num = generate_one_number(0, pcs.size() - 1);
     std::vector<int> random_indexs;
-    generate_random(random_indexs, random_num, 0, partitions.size() - 1);
+    generate_random(random_indexs, random_num, 0, pcs.size() - 1);
 
     std::vector<dsn::task_ptr> tasks(random_num);
     std::vector<std::pair<bool, std::string>> results(random_num);
@@ -74,10 +74,10 @@ void partition_kill_testor::run()
     std::vector<std::string> arguments(2);
     for (int i = 0; i < random_indexs.size(); ++i) {
         int index = random_indexs[i];
-        const auto &p = partitions[index];
+        const auto &pc = pcs[index];
 
-        arguments[0] = to_string(p.pid.get_app_id());
-        arguments[1] = to_string(p.pid.get_partition_index());
+        arguments[0] = to_string(pc.pid.get_app_id());
+        arguments[1] = to_string(pc.pid.get_partition_index());
 
         auto callback = [&results, i](::dsn::error_code err, const std::string &resp) {
             if (err == ::dsn::ERR_OK) {
@@ -88,7 +88,7 @@ void partition_kill_testor::run()
                 results[i].second = err.to_string();
             }
         };
-        tasks[i] = dsn::dist::cmd::async_call_remote(p.primary,
+        tasks[i] = dsn::dist::cmd::async_call_remote(pc.primary,
                                                      "replica.kill_partition",
                                                      arguments,
                                                      callback,


### PR DESCRIPTION
There is no functional changes, but only refactoring, includes:
- Use range-based loop
- Unify the naming of partition_configuration variables to `pc` (or `pcs`)
- Use `fmt::join` for simplify container formating
- Reduce some if-else statements depth

This patch dosen't change the names in thrift IDL which leads more changes on
client drivers, we can do that in following patches.