### PR TITLE
refactor(shell): Refactor on 'remote_command' command

### DIFF
--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -24,11 +24,11 @@
 #include <nlohmann/json_fwd.hpp>
 #include <stdint.h>
 #include <stdio.h>
-#include <string.h>
 #include <algorithm>
 // IWYU pragma: no_include <bits/getopt_core.h>
 #include <chrono>
 #include <fstream>
+#include <initializer_list>
 #include <iostream>
 #include <map>
 #include <memory>

--- a/src/utils/command_manager.h
+++ b/src/utils/command_manager.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <stdint.h>
 #include <functional>
@@ -147,7 +148,9 @@ private:
 
         // Invalid arguments size.
         if (args.size() > 1) {
-            msg["error"] = "ERR: invalid arguments, only one integer argument is acceptable";
+            msg["error"] =
+                fmt::format("ERR: invalid arguments '{}', only one argument is acceptable",
+                            fmt::join(args, " "));
             return msg.dump(2);
         }
 
@@ -162,7 +165,8 @@ private:
         T new_value = 0;
         if (!internal::buf2signed(args[0], new_value) ||
             !validator(static_cast<int64_t>(new_value))) {
-            msg["error"] = "ERR: invalid arguments";
+            msg["error"] =
+                fmt::format("ERR: invalid argument '{}', the value is not acceptable", args[0]);
             return msg.dump(2);
         }
 


### PR DESCRIPTION
This patch refactors the code for the `remote_command` shell CLI tool,
now uses `argh::parser` instead of `getopt_long`. And now the error
output is colored to notice the administors.
The effected commands are `server_info`, `server_stat`, `flush_log` and
`remote_command`.

To keep compatible, `remote_command server-info`, `remote_command server_info`
and `server_info` are equal. The same to `server_stat` and `flush_log`.

Behavior changes:
- If there are some errors, the tool return false instead of true, then
  the USAGE can be output for hint.
- The output is organized as JSON format, and the embeded structures are
  also in JSON format. (This is very useful for thirdparty tools to parse
  the output.)

Example:
```
>>> remote_command server-info -l b334667ddf87:34801
{
  "command": "server-info ",
  "details": {
    "b334667ddf87:34801": {
      "acked": true,
      "message": {
        "build_type": "Debug",
        "git_SHA": "cbdca43302c36f5e03b0f96d0dbd6a59149f2ce6",
        "start_time": "2024-07-15 07:25:50",
        "version": "2.6.0-SNAPSHOT"
      },
      "role": "user-specified"
    }
  },
  "failed_count": 0,
  "succeed_count": 1
}

>>> server_stat -l b334667ddf87:34801
{
  "command": "server-stat ",
  "details": {
    "b334667ddf87:34801": {
      "acked": true,
      "message": "replica*app.pegasus*manual.compact.enqueue.count=not_found, replica*app.pegasus*manual.compact.running.count=not_found, replica*app.pegasus*rdb.block_cache.memory_usage=not_found, replica*eon.replica_stub*closing.replica(Count)=not_found, replica*eon.replica_stub*disk.available.max.ratio=not_found, replica*eon.replica_stub*disk.available.min.ratio=not_found, replica*eon.replica_stub*disk.available.total.ratio=not_found, replica*eon.replica_stub*disk.capacity.total(MB)=not_found, replica*eon.replica_stub*opening.replica(Count)=not_found, replica*eon.replica_stub*replica(Count)=not_found, replica*eon.replica_stub*replicas.commit.qps=not_found, replica*eon.replica_stub*replicas.learning.count=not_found, replica*server*memused.res(MB)=not_found, replica*server*memused.virt(MB)=not_found, zion*profiler*RPC_RRDB_RRDB_BATCH_GET.latency.server=not_found, zion*profiler*RPC_RRDB_RRDB_BATCH_GET.qps=not_found, zion*profiler*RPC_RRDB_RRDB_GET.latency.server=not_found, zion*profiler*RPC_RRDB_RRDB_GET.qps=not_found, zion*profiler*RPC_RRDB_RRDB_MULTI_GET.latency.server=not_found, zion*profiler*RPC_RRDB_RRDB_MULTI_GET.qps=not_found, zion*profiler*RPC_RRDB_RRDB_MULTI_PUT.latency.server=not_found, zion*profiler*RPC_RRDB_RRDB_MULTI_PUT.qps=not_found, zion*profiler*RPC_RRDB_RRDB_PUT.latency.server=not_found, zion*profiler*RPC_RRDB_RRDB_PUT.qps=not_found",
      "role": "user-specified"
    }
  },
  "failed_count": 0,
  "succeed_count": 1
}

>>> remote_command meta.lb.add_secondary_max_count_for_one_node -l b334667ddf87:34601
{
  "command": "meta.lb.add_secondary_max_count_for_one_node ",
  "details": {
    "b334667ddf87:34601": {
      "acked": true,
      "message": {
        "error": "ok",
        "meta.lb.add_secondary_max_count_for_one_node": "10"
      },
      "role": "user-specified"
    }
  },
  "failed_count": 0,
  "succeed_count": 1
}
```