### PR TITLE
fix(duplication): create checkpoint for the replica with 0 or 1 record

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -49,19 +49,20 @@ env:
   TEST_OPTS: disk_min_available_space_ratio=5;throttle_test_medium_value_kb=10;throttle_test_large_value_kb=25
 
 jobs:
-  #cpp_clang_format_linter:
-  #  name: Lint
-  #  runs-on: ubuntu-latest
-  #  container:
-  #    image: apache/pegasus:clang-format-3.9
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - name: clang-format
-  #      run: ./scripts/run-clang-format.py --clang-format-executable clang-format-3.9 -e ./src/shell/linenoise -e ./src/shell/sds -e ./thirdparty -r .
+  cpp_clang_format_linter:
+    name: Lint
+    runs-on: ubuntu-latest
+    container:
+      image: apache/pegasus:clang-format-3.9
+    steps:
+      - uses: actions/checkout@v3
+      - name: clang-format
+        #run: ./scripts/run-clang-format.py --clang-format-executable clang-format-3.9 -e ./src/shell/linenoise -e ./src/shell/sds -e ./thirdparty -r .
+        run: ls
 
   iwyu:
     name: IWYU
-    #  needs: cpp_clang_format_linter
+      needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     env:
       USE_JEMALLOC: OFF

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -53,7 +53,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:clang-format-3.9
+      #image: apache/pegasus:clang-format-3.9
+      image: apache/pegasus:thirdparties-bin-ubuntu2204-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
       - name: clang-format

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -49,19 +49,19 @@ env:
   TEST_OPTS: disk_min_available_space_ratio=5;throttle_test_medium_value_kb=10;throttle_test_large_value_kb=25
 
 jobs:
-  cpp_clang_format_linter:
-    name: Lint
-    runs-on: ubuntu-latest
-    container:
-      image: apache/pegasus:clang-format-3.9
-    steps:
-      - uses: actions/checkout@v3
-      - name: clang-format
-        run: ./scripts/run-clang-format.py --clang-format-executable clang-format-3.9 -e ./src/shell/linenoise -e ./src/shell/sds -e ./thirdparty -r .
+  #cpp_clang_format_linter:
+  #  name: Lint
+  #  runs-on: ubuntu-latest
+  #  container:
+  #    image: apache/pegasus:clang-format-3.9
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - name: clang-format
+  #      run: ./scripts/run-clang-format.py --clang-format-executable clang-format-3.9 -e ./src/shell/linenoise -e ./src/shell/sds -e ./thirdparty -r .
 
   iwyu:
     name: IWYU
-    needs: cpp_clang_format_linter
+    #  needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     env:
       USE_JEMALLOC: OFF

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -53,13 +53,12 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     container:
-      #image: apache/pegasus:clang-format-3.9
+      image: apache/pegasus:clang-format-3.9
       image: apache/pegasus:thirdparties-bin-ubuntu2204-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
       - name: clang-format
-        #run: ./scripts/run-clang-format.py --clang-format-executable clang-format-3.9 -e ./src/shell/linenoise -e ./src/shell/sds -e ./thirdparty -r .
-        run: ls
+        run: ./scripts/run-clang-format.py --clang-format-executable clang-format-3.9 -e ./src/shell/linenoise -e ./src/shell/sds -e ./thirdparty -r .
 
   iwyu:
     name: IWYU

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -62,7 +62,7 @@ jobs:
 
   iwyu:
     name: IWYU
-      needs: cpp_clang_format_linter
+    needs: cpp_clang_format_linter
     runs-on: ubuntu-latest
     env:
       USE_JEMALLOC: OFF

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -54,7 +54,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: apache/pegasus:clang-format-3.9
-      image: apache/pegasus:thirdparties-bin-ubuntu2204-${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v3
       - name: clang-format

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -35,7 +35,6 @@
 #include "load_from_private_log.h"
 #include "replica/mutation_log.h"
 #include "replica/replica.h"
-#include "runtime/task/async_calls.h"
 #include "utils/autoref_ptr.h"
 #include "utils/error_code.h"
 #include "utils/fmt_logging.h"

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -67,7 +67,8 @@ replica_duplicator::replica_duplicator(const duplication_entry &ent, replica *r)
         // keep current max committed_decree as start point.
         // todo(jiashuo1) _checkpoint_decree hasn't be ready to persist zk, so if master restart,
         // the value will be reset 0
-        _checkpoint_decree = _progress.last_decree = std::max(_replica->last_applied_decree(), 1);
+        _checkpoint_decree = _progress.last_decree =
+            std::max(_replica->last_applied_decree(), static_cast<decree>(1));
     } else {
         _progress.last_decree = _progress.confirmed_decree = it->second;
     }

--- a/src/replica/duplication/replica_duplicator.h
+++ b/src/replica/duplication/replica_duplicator.h
@@ -187,7 +187,7 @@ private:
 
     // The min decree that should be covered by the checkpoint which is triggered by the
     // newly added duplication.
-    decree _min_checkpoint_decree = invalid_decree;
+    decree _min_checkpoint_decree{invalid_decree};
 
     duplication_status::type _status{duplication_status::DS_INIT};
     std::atomic<duplication_fail_mode::type> _fail_mode{duplication_fail_mode::FAIL_SLOW};

--- a/src/replica/duplication/replica_duplicator.h
+++ b/src/replica/duplication/replica_duplicator.h
@@ -39,7 +39,7 @@ namespace replication {
 class duplication_progress
 {
 public:
-    // check if checkpoint has catch up with `_start_point_decree`
+    // check if checkpoint has catch up with `_checkpoint_decree`
     bool checkpoint_has_prepared{false};
     // the maximum decree that's been persisted in meta server
     decree confirmed_decree{invalid_decree};
@@ -184,7 +184,7 @@ private:
     replica_stub *_stub;
     dsn::task_tracker _tracker;
 
-    decree _start_point_decree = invalid_decree;
+    decree _checkpoint_decree = invalid_decree;
     duplication_status::type _status{duplication_status::DS_INIT};
     std::atomic<duplication_fail_mode::type> _fail_mode{duplication_fail_mode::FAIL_SLOW};
 

--- a/src/replica/duplication/replica_duplicator.h
+++ b/src/replica/duplication/replica_duplicator.h
@@ -39,12 +39,13 @@ namespace replication {
 class duplication_progress
 {
 public:
-    // check if checkpoint has catch up with `_checkpoint_decree`
+    // Check if checkpoint has covered `_min_checkpoint_decree`.
     bool checkpoint_has_prepared{false};
-    // the maximum decree that's been persisted in meta server
+
+    // The max decree that has been persisted in the meta server.
     decree confirmed_decree{invalid_decree};
 
-    // the maximum decree that's been duplicated to remote.
+    // The max decree that has been duplicated to the remote cluster.
     decree last_decree{invalid_decree};
 
     duplication_progress &set_last_decree(decree d)
@@ -184,7 +185,10 @@ private:
     replica_stub *_stub;
     dsn::task_tracker _tracker;
 
-    decree _checkpoint_decree = invalid_decree;
+    // The min decree that should be covered by the checkpoint which is triggered by the
+    // newly added duplication.
+    decree _min_checkpoint_decree = invalid_decree;
+
     duplication_status::type _status{duplication_status::DS_INIT};
     std::atomic<duplication_fail_mode::type> _fail_mode{duplication_fail_mode::FAIL_SLOW};
 

--- a/src/replica/duplication/test/duplication_test_base.h
+++ b/src/replica/duplication/test/duplication_test_base.h
@@ -54,13 +54,13 @@ public:
         return dup_entities[dupid].get();
     }
 
-    std::unique_ptr<replica_duplicator> create_test_duplicator(decree confirmed = invalid_decree)
+    std::unique_ptr<replica_duplicator> create_test_duplicator(decree confirmed_decree = invalid_decree)
     {
         duplication_entry dup_ent;
         dup_ent.dupid = 1;
         dup_ent.remote = "remote_address";
         dup_ent.status = duplication_status::DS_PAUSE;
-        dup_ent.progress[_replica->get_gpid().get_partition_index()] = confirmed;
+        dup_ent.progress[_replica->get_gpid().get_partition_index()] = confirmed_decree;
 
         auto duplicator = std::make_unique<replica_duplicator>(dup_ent, _replica.get());
         return duplicator;

--- a/src/replica/duplication/test/duplication_test_base.h
+++ b/src/replica/duplication/test/duplication_test_base.h
@@ -54,9 +54,7 @@ public:
         return dup_entities[dupid].get();
     }
 
-    std::unique_ptr<replica_duplicator>
-    create_test_duplicator(decree confirmed = invalid_decree,
-                           decree checkpoint_decree = invalid_decree)
+    std::unique_ptr<replica_duplicator> create_test_duplicator(decree confirmed = invalid_decree)
     {
         duplication_entry dup_ent;
         dup_ent.dupid = 1;
@@ -65,7 +63,6 @@ public:
         dup_ent.progress[_replica->get_gpid().get_partition_index()] = confirmed;
 
         auto duplicator = std::make_unique<replica_duplicator>(dup_ent, _replica.get());
-        duplicator->_checkpoint_decree = checkpoint_decree;
         return duplicator;
     }
 
@@ -93,7 +90,7 @@ public:
 
     void wait_all(const std::unique_ptr<replica_duplicator> &dup)
     {
-        // dup->tracker()->wait_outstanding_tasks();
+        dup->tracker()->wait_outstanding_tasks();
         dup->_replica->tracker()->wait_outstanding_tasks();
     }
 };

--- a/src/replica/duplication/test/duplication_test_base.h
+++ b/src/replica/duplication/test/duplication_test_base.h
@@ -54,7 +54,8 @@ public:
         return dup_entities[dupid].get();
     }
 
-    std::unique_ptr<replica_duplicator> create_test_duplicator(decree confirmed_decree = invalid_decree)
+    std::unique_ptr<replica_duplicator>
+    create_test_duplicator(decree confirmed_decree = invalid_decree)
     {
         duplication_entry dup_ent;
         dup_ent.dupid = 1;

--- a/src/replica/duplication/test/duplication_test_base.h
+++ b/src/replica/duplication/test/duplication_test_base.h
@@ -54,8 +54,9 @@ public:
         return dup_entities[dupid].get();
     }
 
-    std::unique_ptr<replica_duplicator> create_test_duplicator(decree confirmed = invalid_decree,
-                                                               decree start = invalid_decree)
+    std::unique_ptr<replica_duplicator>
+    create_test_duplicator(decree confirmed = invalid_decree,
+                           decree checkpoint_decree = invalid_decree)
     {
         duplication_entry dup_ent;
         dup_ent.dupid = 1;
@@ -64,7 +65,7 @@ public:
         dup_ent.progress[_replica->get_gpid().get_partition_index()] = confirmed;
 
         auto duplicator = std::make_unique<replica_duplicator>(dup_ent, _replica.get());
-        duplicator->_start_point_decree = start;
+        duplicator->_checkpoint_decree = checkpoint_decree;
         return duplicator;
     }
 
@@ -92,7 +93,7 @@ public:
 
     void wait_all(const std::unique_ptr<replica_duplicator> &dup)
     {
-        dup->tracker()->wait_outstanding_tasks();
+        // dup->tracker()->wait_outstanding_tasks();
         dup->_replica->tracker()->wait_outstanding_tasks();
     }
 };

--- a/src/replica/duplication/test/replica_duplicator_test.cpp
+++ b/src/replica/duplication/test/replica_duplicator_test.cpp
@@ -159,7 +159,7 @@ TEST_P(replica_duplicator_test, duplication_progress)
     auto duplicator = create_test_duplicator();
 
     // Start duplication from empty replica.
-    ASSERT_EQ(1, duplicator->progress().last_decree);
+    ASSERT_EQ(0, duplicator->progress().last_decree);
     ASSERT_EQ(invalid_decree, duplicator->progress().confirmed_decree);
 
     duplicator->update_progress(duplicator->progress().set_last_decree(10));

--- a/src/replica/duplication/test/replica_duplicator_test.cpp
+++ b/src/replica/duplication/test/replica_duplicator_test.cpp
@@ -157,7 +157,7 @@ TEST_P(replica_duplicator_test, pause_start_duplication) { test_pause_start_dupl
 TEST_P(replica_duplicator_test, duplication_progress)
 {
     auto duplicator = create_test_duplicator();
-    ASSERT_EQ(duplicator->progress().last_decree, 0); // start duplication from empty plog
+    ASSERT_EQ(1, duplicator->progress().last_decree); // start duplication from empty plog
     ASSERT_EQ(duplicator->progress().confirmed_decree, invalid_decree);
 
     duplicator->update_progress(duplicator->progress().set_last_decree(10));

--- a/src/replica/duplication/test/replica_duplicator_test.cpp
+++ b/src/replica/duplication/test/replica_duplicator_test.cpp
@@ -64,9 +64,9 @@ public:
 
     decree last_durable_decree() const { return _replica->last_durable_decree(); }
 
-    decree log_dup_start_decree(const std::unique_ptr<replica_duplicator> &dup) const
+    decree checkpoint_decree(const std::unique_ptr<replica_duplicator> &dup) const
     {
-        return dup->_start_point_decree;
+        return dup->_checkpoint_decree;
     }
 
     void test_new_duplicator(const std::string &remote_app_name, bool specify_remote_app_name)
@@ -183,13 +183,16 @@ TEST_P(replica_duplicator_test, duplication_progress)
     ASSERT_TRUE(duplicator_for_checkpoint->progress().checkpoint_has_prepared);
 }
 
-TEST_P(replica_duplicator_test, prapre_dup)
+TEST_P(replica_duplicator_test, prepare_dup)
 {
     auto duplicator = create_test_duplicator(invalid_decree, 100);
+    replica()->update_last_applied_decree(100);
     replica()->update_expect_last_durable_decree(100);
     duplicator->prepare_dup();
     wait_all(duplicator);
-    ASSERT_EQ(last_durable_decree(), log_dup_start_decree(duplicator));
+
+    ASSERT_EQ(100, checkpoint_decree(duplicator));
+    ASSERT_EQ(100, last_durable_decree());
 }
 
 } // namespace replication

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -269,11 +269,24 @@ public:
     //
     // Duplication
     //
+
     using trigger_checkpoint_callback = std::function<void(error_code)>;
-    void async_trigger_manual_emergency_checkpoint(decree checkpoint_decree,
+
+    // Choose a fixed thread from pool to trigger an emergency checkpoint asynchronously.
+    // A new checkpoint would still be created even if the replica is empty (hasn't received
+    // any write operation).
+    //
+    // Parameters:
+    // - `min_checkpoint_decree`: the min decree that should be covered by the triggered
+    // checkpoint. Should be a number greater than 0 which means a new checkpoint must be
+    // created.
+    // - `delay_ms`: the delayed time in milliseconds that the triggering task is put into
+    // the thread pool.
+    // - `callback`: the callback processor handling the error code of triggering checkpoint.
+    void async_trigger_manual_emergency_checkpoint(decree min_checkpoint_decree,
                                                    uint32_t delay_ms,
                                                    trigger_checkpoint_callback callback = {});
-    error_code trigger_manual_emergency_checkpoint(decree checkpoint_decree);
+
     void on_query_last_checkpoint(learn_response &response);
     std::shared_ptr<replica_duplicator_manager> get_duplication_manager() const
     {
@@ -475,6 +488,10 @@ private:
     void update_plog_gc_enabled(bool enabled);
     bool is_plog_gc_enabled() const;
     std::string get_plog_gc_enabled_message() const;
+
+    // Trigger an emergency checkpoint for duplication. Once the replica is empty (hasn't
+    // received any write operation), there would be no checkpoint created.
+    error_code trigger_manual_emergency_checkpoint(decree min_checkpoint_decree);
 
     /////////////////////////////////////////////////////////////////
     // cold backup

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -268,7 +268,11 @@ public:
     //
     // Duplication
     //
-    error_code trigger_manual_emergency_checkpoint(decree old_decree);
+    using trigger_checkpoint_callback = std::function<void(error_code)>;
+    void async_trigger_manual_emergency_checkpoint(decree checkpoint_decree,
+                                                   uint32_t delay_ms,
+                                                   trigger_checkpoint_callback callback = {});
+    error_code trigger_manual_emergency_checkpoint(decree checkpoint_decree);
     void on_query_last_checkpoint(learn_response &response);
     std::shared_ptr<replica_duplicator_manager> get_duplication_manager() const
     {

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -30,6 +30,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <atomic>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -198,8 +198,10 @@ void replica::async_trigger_manual_emergency_checkpoint(decree min_checkpoint_de
                                                         uint32_t delay_ms,
                                                         trigger_checkpoint_callback callback)
 {
-    CHECK_GT_PREFIX_MSG(min_checkpoint_decree, 0, "min_checkpoint_decree should be a number "
-            "greater than 0 which means a new checkpoint must be created");
+    CHECK_GT_PREFIX_MSG(min_checkpoint_decree,
+                        0,
+                        "min_checkpoint_decree should be a number greater than 0 "
+                        "which means a new checkpoint must be created");
 
     tasking::enqueue(
         LPC_REPLICATION_COMMON,

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -42,6 +42,7 @@
 #include "metadata_types.h"
 #include "mutation_log.h"
 #include "replica.h"
+#include "replica/mutation.h"
 #include "replica/prepare_list.h"
 #include "replica/replica_context.h"
 #include "replica/replication_app_base.h"

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -223,6 +223,9 @@ void replica::async_trigger_manual_emergency_checkpoint(decree min_checkpoint_de
                                 last_applied_decree,
                                 last_durable_decree());
 
+                // For the empty replica, here we commit an empty write would be to increase
+                // the decree to at least 1, to ensure that the checkpoint would inevitably
+                // be created even if the replica is empty.
                 mutation_ptr mu = new_mutation(invalid_decree);
                 mu->add_client_request(RPC_REPLICATION_WRITE_EMPTY, nullptr);
                 init_prepare(mu, false);

--- a/src/replica/test/mock_utils.h
+++ b/src/replica/test/mock_utils.h
@@ -100,6 +100,8 @@ public:
         return manual_compaction_status::IDLE;
     }
 
+    void set_last_applied_decree(decree d) { _last_committed_decree.store(d); }
+
     void set_last_durable_decree(decree d) { _last_durable_decree = d; }
 
     void set_expect_last_durable_decree(decree d) { _expect_last_durable_decree = d; }
@@ -216,6 +218,11 @@ public:
             return;
         }
         backup_context->complete_checkpoint();
+    }
+
+    void update_last_applied_decree(decree decree)
+    {
+        dynamic_cast<mock_replication_app_base *>(_app.get())->set_last_applied_decree(decree);
     }
 
     void update_last_durable_decree(decree decree)

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -18,6 +18,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <atomic>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <memory>

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -56,6 +56,7 @@
 #include "runtime/rpc/rpc_message.h"
 #include "runtime/task/task_code.h"
 #include "runtime/task/task_tracker.h"
+#include "test_util/test_util.h"
 #include "utils/autoref_ptr.h"
 #include "utils/defer.h"
 #include "utils/env.h"
@@ -65,10 +66,14 @@
 #include "utils/fmt_logging.h"
 #include "utils/metrics.h"
 #include "utils/string_conv.h"
+#include "utils/synchronize.h"
 #include "utils/test_macros.h"
 
 DSN_DECLARE_bool(fd_disabled);
 DSN_DECLARE_string(cold_backup_root);
+DSN_DECLARE_uint32(mutation_2pc_min_replica_count);
+
+using pegasus::AssertEventually;
 
 namespace dsn {
 namespace replication {
@@ -90,6 +95,7 @@ public:
         mock_app_info();
         _mock_replica =
             stub->generate_replica_ptr(_app_info, _pid, partition_status::PS_PRIMARY, 1);
+        _mock_replica->init_private_log(_log_dir);
 
         // set FLAGS_cold_backup_root manually.
         // FLAGS_cold_backup_root is set by configuration "replication.cold_backup_root",
@@ -203,6 +209,25 @@ public:
     }
 
     bool is_checkpointing() { return _mock_replica->_is_manual_emergency_checkpointing; }
+
+    void test_trigger_manual_emergency_checkpoint(const decree checkpoint_decree,
+                                                  const error_code expected_err,
+                                                  std::function<void()> callback = {})
+    {
+        dsn::utils::notify_event op_completed;
+        _mock_replica->async_trigger_manual_emergency_checkpoint(
+            checkpoint_decree, 0, [&](error_code actual_err) {
+                ASSERT_EQ(expected_err, actual_err);
+
+                if (callback) {
+                    callback();
+                }
+
+                op_completed.notify();
+            });
+
+        op_completed.wait();
+    }
 
     bool has_gpid(gpid &pid) const
     {
@@ -426,28 +451,54 @@ TEST_P(replica_test, test_replica_backup_and_restore_with_specific_path)
 
 TEST_P(replica_test, test_trigger_manual_emergency_checkpoint)
 {
-    ASSERT_EQ(_mock_replica->trigger_manual_emergency_checkpoint(100), ERR_OK);
-    ASSERT_TRUE(is_checkpointing());
+    // There is only one replica for the unit test.
+    PRESERVE_FLAG(mutation_2pc_min_replica_count);
+    FLAGS_mutation_2pc_min_replica_count = 1;
+
+    // Initially the mutation log is empty.
+    ASSERT_EQ(0, _mock_replica->last_applied_decree());
+    ASSERT_EQ(0, _mock_replica->last_durable_decree());
+
+    _mock_replica->update_expect_last_durable_decree(1);
+    test_trigger_manual_emergency_checkpoint(1, ERR_OK);
+    _mock_replica->tracker()->wait_outstanding_tasks();
+
+    // ASSERT_IN_TIME([&] { ASSERT_LE(1, _mock_replica->last_applied_decree()); }, 60);
+
+    // ASSERT_IN_TIME([&] { ASSERT_EQ(1, _mock_replica->last_durable_decree()); }, 60);
+
+    ASSERT_LE(1, _mock_replica->last_applied_decree());
+
+    ASSERT_EQ(1, _mock_replica->last_durable_decree());
+
+    _mock_replica->update_last_applied_decree(100);
+    test_trigger_manual_emergency_checkpoint(
+        100, ERR_OK, [this]() { ASSERT_TRUE(is_checkpointing()); });
     _mock_replica->update_last_durable_decree(100);
 
-    // test no need start checkpoint because `old_decree` < `last_durable`
-    ASSERT_EQ(_mock_replica->trigger_manual_emergency_checkpoint(100), ERR_OK);
-    ASSERT_FALSE(is_checkpointing());
+    // test no need start checkpoint because `old_decree` <= `last_durable`
+    test_trigger_manual_emergency_checkpoint(
+        100, ERR_OK, [this]() { ASSERT_FALSE(is_checkpointing()); });
 
-    // test has existed running task
+    // Test existing running task.
     force_update_checkpointing(true);
-    ASSERT_EQ(_mock_replica->trigger_manual_emergency_checkpoint(101), ERR_BUSY);
-    ASSERT_TRUE(is_checkpointing());
+    _mock_replica->update_last_applied_decree(101);
+    test_trigger_manual_emergency_checkpoint(
+        101, ERR_BUSY, [this]() { ASSERT_TRUE(is_checkpointing()); });
+
     // test running task completed
     _mock_replica->tracker()->wait_outstanding_tasks();
     ASSERT_FALSE(is_checkpointing());
 
     // test exceed max concurrent count
-    ASSERT_EQ(_mock_replica->trigger_manual_emergency_checkpoint(101), ERR_OK);
+    test_trigger_manual_emergency_checkpoint(101, ERR_OK);
     force_update_checkpointing(false);
+
+    PRESERVE_FLAG(max_concurrent_manual_emergency_checkpointing_count);
     FLAGS_max_concurrent_manual_emergency_checkpointing_count = 1;
-    ASSERT_EQ(_mock_replica->trigger_manual_emergency_checkpoint(101), ERR_TRY_AGAIN);
-    ASSERT_FALSE(is_checkpointing());
+
+    test_trigger_manual_emergency_checkpoint(
+        101, ERR_TRY_AGAIN, [this]() { ASSERT_FALSE(is_checkpointing()); });
     _mock_replica->tracker()->wait_outstanding_tasks();
 }
 

--- a/src/utils/errors.h
+++ b/src/utils/errors.h
@@ -136,7 +136,7 @@ public:
         return os << s.description();
     }
 
-    friend bool operator==(const error_s lhs, const error_s &rhs)
+    friend bool operator==(const error_s &lhs, const error_s &rhs)
     {
         if (lhs._info && rhs._info) {
             return lhs._info->code == rhs._info->code && lhs._info->msg == rhs._info->msg;


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2069

To create the checkpoint of the replica with 0 or 1 record immediately:

- set the min decree for checkpoint to at least 1, which means the checkpoint
would inevitably be created even if the replica is empty.
- for the empty replica, an empty write would be committed to increase the
decree to at least 1 to ensure that the checkpoint would be created.
- the max decree in rocksdb memtable (the last applied decree) is considered
as the min decree that should be covered by the checkpoint, which means
currently all of the data in current rocksdb should be included into the created
checkpoint.

The following configuration is added to control the retry interval for triggering
checkpoint:

```diff
[replication]
+ trigger_checkpoint_retry_interval_ms = 100
```