### PR TITLE
fix(scripts): fix downgrade_node script doesnt work 

### DIFF
--- a/scripts/downgrade_node.sh
+++ b/scripts/downgrade_node.sh
@@ -16,8 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-
 PID=$$
 
 function usage()
@@ -63,7 +61,7 @@ echo "UID=$UID"
 echo "PID=$PID"
 echo
 
-if [ [ "$cluster" != "" ]; then
+if [ "$cluster" != "" ]; then
   echo "set_meta_level steady" | ./run.sh shell --cluster $cluster &>/tmp/$UID.$PID.pegasus.set_meta_level
   echo ls | ./run.sh shell --cluster $cluster &>/tmp/$UID.$PID.pegasus.ls
 else


### PR DESCRIPTION
The downgrade_node scripts usually used in the scale down replica server. The function of downgrade_node scripts implementation with wildchar of shell output.

- The character matching is not success for everysingle line in shell output. So add "set -e" will exit with 1 and report failed. 
- Fix a shell grammar promblem.
