### PR TITLE
feat(remote_command): change some  remote_command shell output to JSON format

### DIFF
--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -34,6 +34,7 @@
 #include "fmt/core.h"
 #include "nfs/nfs_code_definition.h"
 #include "nfs/nfs_node.h"
+#include "nlohmann/json.hpp"
 #include "runtime/rpc/dns_resolver.h" // IWYU pragma: keep
 #include "runtime/rpc/rpc_host_port.h"
 #include "utils/blob.h"

--- a/src/nfs/nfs_client_impl.cpp
+++ b/src/nfs/nfs_client_impl.cpp
@@ -26,6 +26,7 @@
 
 #include "nfs_client_impl.h"
 
+#include <cstdint>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <mutex>
 

--- a/src/nfs/nfs_server_impl.cpp
+++ b/src/nfs/nfs_server_impl.cpp
@@ -35,6 +35,7 @@
 
 #include "absl/strings/string_view.h"
 #include "nfs/nfs_code_definition.h"
+#include "nlohmann/json.hpp"
 #include "runtime/api_layer1.h"
 #include "runtime/task/async_calls.h"
 #include "utils/TokenBucket.h"

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -129,27 +129,32 @@ std::string command_manager::set_bool(bool &value,
                                       const std::string &name,
                                       const std::vector<std::string> &args)
 {
+    nlohmann::json msg;
+    msg["error"] = "ok";
     // Query.
     if (args.empty()) {
-        return value ? "true" : "false";
+        msg[name] = value ? "true" : "false";
+        return msg.dump(2);
     }
 
     // Invalid arguments size.
     if (args.size() > 1) {
-        return fmt::format("ERR: invalid arguments, only one boolean argument is acceptable");
+        msg["error"] = "ERR: invalid arguments, only one boolean argument is acceptable";
+        return msg.dump(2);
     }
 
     // Invalid argument.
     bool new_value;
     if (!dsn::buf2bool(args[0], new_value, /* ignore_case */ true)) {
-        return fmt::format("ERR: invalid arguments, '{}' is not a boolean", args[0]);
+        msg["error"] = fmt::format("ERR: invalid arguments, '{}' is not a boolean", args[0]);
+        return msg.dump(2);
     }
 
     // Set to a new value.
     value = new_value;
     LOG_INFO("set {} to {} by remote command", name, new_value);
 
-    return "OK";
+    return msg.dump(2);
 }
 
 command_manager::command_manager()


### PR DESCRIPTION
Some remote commands shell output are format by json. And some remote command are not.

- Changes the output of register_int_command、register_bool_command to JSON format to improve readability
  by programs (e.g., Python scripts)
