### PR TITLE
fix(backup): Fix the stack overflow when read large sst file

### DIFF
--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -435,8 +435,8 @@ dsn::task_ptr hdfs_file_object::upload(const upload_request &req,
             }
 
             rocksdb::Slice result;
-            char scratch[file_size];
-            s = rfile->Read(file_size, &result, scratch);
+            auto scratch = dsn::utils::make_shared_array<char>(file_size);
+            s = rfile->Read(file_size, &result, scratch.get());
             if (!s.ok()) {
                 LOG_ERROR(
                     "read local file '{}' failed, err = {}", req.input_local_name, s.ToString());

--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -41,6 +41,7 @@
 #include "utils/fmt_logging.h"
 #include "utils/safe_strerror_posix.h"
 #include "utils/strings.h"
+#include "utils/utils.h"
 
 DSN_DEFINE_uint64(replication,
                   hdfs_read_batch_size_bytes,


### PR DESCRIPTION
After refactoring to use RocksDB APIs to read files from local
filesystem, it may cause stack overflow when the file to read
is larger than the stack size (say 8MB).

This patch changes to use heap instead of stack to store the
file content.