### PR TITLE
chore(CI): Add envs in build_debug_on_centos7 to ensure job can be run on centOS 7

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -418,6 +418,8 @@ jobs:
       USE_JEMALLOC: OFF
       BUILD_OPTIONS: -t debug --test --separate_servers
       PACK_OPTIONS: --separate_servers
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container:
       image: apache/pegasus:thirdparties-bin-centos7-${{ github.base_ref }}
     steps:


### PR DESCRIPTION
https://github.com/actions/runner/issues/2906