### PR TITLE
fix(duplication): deal with plog concurrent problem

### DIFF
--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -158,9 +158,11 @@ void load_from_private_log::find_log_file_to_start()
     // is cleared once WAL replay finished. They are unable to read.
     mutation_log::log_file_map_by_index new_file_map;
     decree cleanable_decree = _private_log->get_cleanable_decree();
-    decree max_decree_gpid =  _private_log->max_decree(get_gpid());
-    if(max_decree_gpid <= cleanable_decree){
-        LOG_ERROR_PREFIX("plog_file all error: max_decree_gpid {} , cleanable_decree {}", max_decree_gpid, cleanable_decree);
+    decree max_decree_gpid = _private_log->max_decree(get_gpid());
+    if (max_decree_gpid <= cleanable_decree) {
+        LOG_ERROR_PREFIX("plog_file all error: max_decree_gpid {} , cleanable_decree {}",
+                         max_decree_gpid,
+                         cleanable_decree);
         return;
     }
 
@@ -176,9 +178,10 @@ void load_from_private_log::find_log_file_to_start()
         // next file map may can not open
         gpid pid = get_gpid();
         decree previous_log_max_decree = file->previous_log_max_decree(pid);
-        // these plog_file has possible be deleted do not open_read next plog_file , otherwise it may coredump
-        if(previous_log_max_decree <= cleanable_decree){
-            break ;
+        // these plog_file has possible be deleted do not open_read next plog_file , otherwise it
+        // may coredump
+        if (previous_log_max_decree <= cleanable_decree) {
+            break;
         }
     }
 

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -156,14 +156,29 @@ void load_from_private_log::find_log_file_to_start()
     // Reopen the files. Because the internal file handle of `file_map`
     // is cleared once WAL replay finished. They are unable to read.
     mutation_log::log_file_map_by_index new_file_map;
-    for (const auto &pr : file_map) {
+    decree cleanable_decree = _private_log->get_cleanable_decree();
+    decree max_decree_gpid =  _private_log->max_decree(get_gpid());
+    if(max_decree_gpid <= cleanable_decree){
+        LOG_ERROR_PREFIX("plog_file all error: max_decree_gpid {} , cleanable_decree {}", max_decree_gpid, cleanable_decree);
+        return;
+    }
+
+    for (auto it = file_map.rbegin(); it != file_map.rend(); ++it) {
         log_file_ptr file;
-        error_s es = log_utils::open_read(pr.second->path(), file);
+        error_s es = log_utils::open_read(it->second->path(), file);
         if (!es.is_ok()) {
             LOG_ERROR_PREFIX("{}", es);
             return;
         }
         new_file_map.emplace(pr.first, file);
+
+        // next file map may can not open
+        gpid pid = get_gpid();
+        decree previous_log_max_decree = file->previous_log_max_decree(pid);
+        // these plog_file has possible be deleted do not open_read next plog_file , otherwise it may coredump
+        if(previous_log_max_decree <= cleanable_decree){
+            break ;
+        }
     }
 
     find_log_file_to_start(std::move(new_file_map));

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -22,6 +22,7 @@
 
 #include "absl/strings/string_view.h"
 #include "common/duplication_common.h"
+#include "common/gpid.h"
 #include "duplication_types.h"
 #include "load_from_private_log.h"
 #include "replica/duplication/mutation_batch.h"
@@ -170,7 +171,7 @@ void load_from_private_log::find_log_file_to_start()
             LOG_ERROR_PREFIX("{}", es);
             return;
         }
-        new_file_map.emplace(pr.first, file);
+        new_file_map.emplace(it->first, file);
 
         // next file map may can not open
         gpid pid = get_gpid();

--- a/src/replica/mutation_log.cpp
+++ b/src/replica/mutation_log.cpp
@@ -361,6 +361,7 @@ void mutation_log::init_states()
     _private_log_info = {0, 0};
     _plog_max_decree_on_disk = 0;
     _plog_max_commit_on_disk = 0;
+    _cleanable_decree = 0;
 }
 
 error_code mutation_log::open(replay_callback read_callback,
@@ -896,6 +897,18 @@ void mutation_log::update_max_commit_on_disk_no_lock(decree d)
     if (d > _plog_max_commit_on_disk) {
         _plog_max_commit_on_disk = d;
     }
+}
+
+decree mutation_log::get_cleanable_decree() const
+{
+    zauto_lock l(_lock);
+    return _cleanable_decree;
+}
+
+void mutation_log::set_cleanable_decree(decree d)
+{
+    zauto_lock l(_lock);
+    _cleanable_decree = d;
 }
 
 bool mutation_log::get_learn_state(gpid gpid, decree start, /*out*/ learn_state &state) const

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -404,7 +404,7 @@ private:
     // be less than _plog_max_decree_on_disk.
     decree _plog_max_commit_on_disk;
 
-    decree _cleanable_decree;  // for deal with gc conflict
+    decree _cleanable_decree; // for deal with gc conflict
 };
 
 typedef dsn::ref_ptr<mutation_log> mutation_log_ptr;

--- a/src/replica/mutation_log.h
+++ b/src/replica/mutation_log.h
@@ -301,6 +301,9 @@ public:
 
     task_tracker *tracker() { return &_tracker; }
 
+    decree get_cleanable_decree() const;
+    void set_cleanable_decree(decree target);
+
 protected:
     // 'size' is data size to write; the '_global_end_offset' will be updated by 'size'.
     // can switch file only when create_new_log_if_needed = true;
@@ -400,6 +403,8 @@ private:
     // for plog. Since it is set with mutation.data.header.last_committed_decree, it must
     // be less than _plog_max_decree_on_disk.
     decree _plog_max_commit_on_disk;
+
+    decree _cleanable_decree;  // for deal with gc conflict
 };
 
 typedef dsn::ref_ptr<mutation_log> mutation_log_ptr;

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -163,6 +163,7 @@ void replica::on_checkpoint_timer()
         }
     }
 
+    _private_log->set_cleanable_decree(cleanable_decree);
     tasking::enqueue(LPC_GARBAGE_COLLECT_LOGS_AND_REPLICAS,
                      &_tracker,
                      [this, plog, cleanable_decree, valid_start_offset] {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#2014

### What is changed and how does it work?
Old logic: If some file open with err  `ERR_FILE_OPERATION_FAILED`,  the others file could as a paramater to build a log_file object. However, plog GC thread can remove the file between those two actiion.(Just as the condition following...)
![image](https://github.com/apache/incubator-pegasus/assets/110282526/bfd3e86e-40a9-4622-a573-d7e8978ab3a9)


New logic: Add some judgement logic in `find_log_file_to_start` to prevent those plog (which has possible already be removed) from `open_read`.


##### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

