### PR TITLE
chore(CI): Force CI to run on node16

### DIFF
--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -34,6 +34,12 @@ on:
 jobs:
   build_compilation_env_docker_images:
     runs-on: ubuntu-latest
+    env:
+      # The glibc version on ubuntu1804 and centos7 is lower than the node20 required, so
+      # we need to force the node version to 16.
+      # See more details: https://github.com/actions/checkout/issues/1809
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -46,6 +46,12 @@ jobs:
   build_cpp:
     name: Build Cpp
     runs-on: ubuntu-latest
+    env:
+      # The glibc version on ubuntu1804 and centos7 is lower than the node20 required, so
+      # we need to force the node version to 16.
+      # See more details: https://github.com/actions/checkout/issues/1809
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -68,6 +68,12 @@ jobs:
 
   build_push_bin_docker_images:
     runs-on: ubuntu-latest
+    env:
+      # The glibc version on ubuntu1804 and centos7 is lower than the node20 required, so
+      # we need to force the node version to 16.
+      # See more details: https://github.com/actions/checkout/issues/1809
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     needs: build_push_src_docker_images
     strategy:
       fail-fast: false
@@ -104,6 +110,12 @@ jobs:
 
   build_push_bin_jemalloc_docker_images:
     runs-on: ubuntu-latest
+    env:
+      # The glibc version on ubuntu1804 and centos7 is lower than the node20 required, so
+      # we need to force the node version to 16.
+      # See more details: https://github.com/actions/checkout/issues/1809
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     needs: build_push_src_docker_images
     strategy:
       fail-fast: false


### PR DESCRIPTION
The glibc version on ubuntu1804 and centos7 is lower than the node20 required, so
we need to force the node version to 16 when running CI.

See more details: https://github.com/actions/checkout/issues/1809