### PR TITLE
chore(CI): Force to use actions/checkout@v3 when OS maybe CentOS 7 or Ubuntu 18.04

### DIFF
--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -50,7 +50,9 @@ jobs:
           - centos7
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
+        # we need to force to use actions/checkout@v3.
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -76,7 +76,9 @@ jobs:
         working-directory: /root/incubator-pegasus
     steps:
       - name: Clone Apache Pegasus Source
-        uses: actions/checkout@v4
+        # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
+        # we need to force to use actions/checkout@v3.
+        uses: actions/checkout@v3
       - name: Unpack prebuilt third-parties
         uses: "./.github/actions/unpack_prebuilt_thirdparties"
       - name: Build Pegasus

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -84,7 +84,9 @@ jobs:
           - ubuntu2204
           - centos7
     steps:
-      - uses: actions/checkout@v4
+      # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
+      # we need to force to use actions/checkout@v3.
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -126,7 +128,9 @@ jobs:
           - ubuntu2204
           - centos7
     steps:
-      - uses: actions/checkout@v4
+      # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
+      # we need to force to use actions/checkout@v3.
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx


### PR DESCRIPTION
To solve problem in GitHub actions:
```
Run actions/checkout@v4
/usr/bin/docker exec  e63787d641b0351b6c65ad895ccd98db84d6796141ad087c4952bc7f68b03753 sh -c "cat /etc/*release | grep ^ID"
/__e/node[20](https://github.com/apache/incubator-pegasus/actions/runs/9908766114/job/27375256228#step:3:21)/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```