### PR TITLE
fix(bulk_load): fix core dump while downloading sst files

### DIFF
--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -530,10 +530,8 @@ void replica_bulk_loader::download_files(const std::string &provider_name,
     }
     if (!download_file_metas.empty()) {
         _download_files_task[download_file_metas.back().name] = tasking::enqueue(
-            LPC_BACKGROUND_BULK_LOAD,
-            tracker(),
-            [this, remote_dir, local_dir, download_file_metas, fs]() mutable {
-                this->download_sst_file(remote_dir, local_dir, download_file_metas, fs);
+            LPC_BACKGROUND_BULK_LOAD, tracker(), [=, file_metas = download_file_metas]() mutable {
+                this->download_sst_file(remote_dir, local_dir, std::move(file_metas), fs);
             });
     }
 }
@@ -542,7 +540,7 @@ void replica_bulk_loader::download_files(const std::string &provider_name,
 void replica_bulk_loader::download_sst_file(
     const std::string &remote_dir,
     const std::string &local_dir,
-    std::vector<::dsn::replication::file_meta> &download_file_metas,
+    std::vector<::dsn::replication::file_meta> &&download_file_metas,
     dist::block_service::block_filesystem *fs)
 {
     if (_status != bulk_load_status::BLS_DOWNLOADING) {
@@ -609,10 +607,8 @@ void replica_bulk_loader::download_sst_file(
     // download next file
     if (!download_file_metas.empty()) {
         _download_files_task[download_file_metas.back().name] = tasking::enqueue(
-            LPC_BACKGROUND_BULK_LOAD,
-            tracker(),
-            [this, remote_dir, local_dir, download_file_metas, fs]() mutable {
-                this->download_sst_file(remote_dir, local_dir, download_file_metas, fs);
+            LPC_BACKGROUND_BULK_LOAD, tracker(), [=, file_metas = download_file_metas]() mutable {
+                this->download_sst_file(remote_dir, local_dir, std::move(file_metas), fs);
             });
     }
 }

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -596,12 +596,12 @@ void replica_bulk_loader::download_sst_file(
         return;
     }
     // download file succeed, update progress
-    download_file_metas.pop_back();
     update_bulk_load_download_progress(f_size, f_meta.name);
     METRIC_VAR_INCREMENT(bulk_load_download_file_successful_count);
     METRIC_VAR_INCREMENT_BY(bulk_load_download_file_bytes, f_size);
 
     // download next file
+    download_file_metas.pop_back();
     if (!download_file_metas.empty()) {
         _download_files_task[download_file_metas.back().name] = tasking::enqueue(
             LPC_BACKGROUND_BULK_LOAD,

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -16,7 +16,9 @@
 // under the License.
 
 #include <fmt/core.h>
+#include <algorithm>
 #include <functional>
+#include <iterator>
 #include <memory>
 #include <string_view>
 #include <unordered_map>
@@ -474,12 +476,11 @@ error_code replica_bulk_loader::start_download(const std::string &remote_dir,
 
     // start download
     _is_downloading.store(true);
-    _download_task =
-        tasking::enqueue(LPC_BACKGROUND_BULK_LOAD,
-                         tracker(),
-                         [this, remote_dir, local_dir, download_file_metas, fs] {
-                             download_sst_file(remote_dir, local_dir, download_file_metas, fs);
-                         });
+    _download_task = tasking::enqueue(
+        LPC_BACKGROUND_BULK_LOAD,
+        tracker(),
+        std::bind(
+            &replica_bulk_loader::download_files, this, provider_name, remote_dir, local_dir));
     return ERR_OK;
 }
 
@@ -528,15 +529,12 @@ void replica_bulk_loader::download_files(const std::string &provider_name,
                   std::back_inserter(download_file_metas));
     }
     if (!download_file_metas.empty()) {
-        _download_files_task[download_file_metas.back().name] =
-            tasking::enqueue(LPC_BACKGROUND_BULK_LOAD,
-                             tracker(),
-                             std::bind(&replica_bulk_loader::download_sst_file,
-                                       this,
-                                       remote_dir,
-                                       local_dir,
-                                       download_file_metas,
-                                       fs));
+        _download_files_task[download_file_metas.back().name] = tasking::enqueue(
+            LPC_BACKGROUND_BULK_LOAD,
+            tracker(),
+            [this, remote_dir, local_dir, download_file_metas, fs]() mutable {
+                this->download_sst_file(remote_dir, local_dir, download_file_metas, fs);
+            });
     }
 }
 
@@ -610,12 +608,12 @@ void replica_bulk_loader::download_sst_file(
 
     // download next file
     if (!download_file_metas.empty()) {
-        _download_files_task[download_file_metas.back().name] =
-            tasking::enqueue(LPC_BACKGROUND_BULK_LOAD,
-                             tracker(),
-                             [this, remote_dir, local_dir, download_file_metas, fs] {
-                                 download_sst_file(remote_dir, local_dir, download_file_metas, fs);
-                             });
+        _download_files_task[download_file_metas.back().name] = tasking::enqueue(
+            LPC_BACKGROUND_BULK_LOAD,
+            tracker(),
+            [this, remote_dir, local_dir, download_file_metas, fs]() mutable {
+                this->download_sst_file(remote_dir, local_dir, download_file_metas, fs);
+            });
     }
 }
 

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -534,7 +534,30 @@ void replica_bulk_loader::download_sst_file(const std::string &remote_dir,
                                             int32_t file_index,
                                             dist::block_service::block_filesystem *fs)
 {
-    const file_meta &f_meta = _metadata.files[file_index];
+    if (_status != bulk_load_status::BLS_DOWNLOADING) {
+        LOG_WARNING_PREFIX("Cancel download_sst_file task, because bulk_load local_status is {}. "
+                           "local_dir: {} , file_index is {}.",
+                           enum_to_string(_status),
+                           local_dir,
+                           file_index);
+        return;
+    }
+    file_meta f_meta;
+    bool get_f_meta = true;
+    {
+        zauto_read_lock l(_lock);
+        if (file_index < _metadata.files.size()) {
+            f_meta = _metadata.files[file_index];
+        } else {
+            get_f_meta = false;
+        }
+    }
+    if (!get_f_meta) {
+        LOG_WARNING_PREFIX("sst file index {} exceeds number of bulkload sst files, Cancel "
+                           "download_sst_file task.",
+                           file_index);
+        return;
+    }
     uint64_t f_size = 0;
     std::string f_md5;
     error_code ec = _stub->_block_service_manager.download_file(
@@ -590,9 +613,17 @@ void replica_bulk_loader::download_sst_file(const std::string &remote_dir,
     METRIC_VAR_INCREMENT_BY(bulk_load_download_file_bytes, f_size);
 
     // download next file
-    if (file_index + 1 < _metadata.files.size()) {
-        const file_meta &next_f_meta = _metadata.files[file_index + 1];
-        _download_files_task[next_f_meta.name] =
+    get_f_meta = true;
+    {
+        zauto_read_lock l(_lock);
+        if (file_index + 1 < _metadata.files.size()) {
+            f_meta = _metadata.files[file_index + 1];
+        } else {
+            get_f_meta = false;
+        }
+    }
+    if (get_f_meta) {
+        _download_files_task[f_meta.name] =
             tasking::enqueue(LPC_BACKGROUND_BULK_LOAD,
                              tracker(),
                              std::bind(&replica_bulk_loader::download_sst_file,

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -474,11 +474,12 @@ error_code replica_bulk_loader::start_download(const std::string &remote_dir,
 
     // start download
     _is_downloading.store(true);
-    _download_task = tasking::enqueue(
-        LPC_BACKGROUND_BULK_LOAD,
-        tracker(),
-        std::bind(
-            &replica_bulk_loader::download_files, this, provider_name, remote_dir, local_dir));
+    _download_task =
+        tasking::enqueue(LPC_BACKGROUND_BULK_LOAD,
+                         tracker(),
+                         [this, remote_dir, local_dir, download_file_metas, fs] {
+                             download_sst_file(remote_dir, local_dir, download_file_metas, fs);
+                         });
     return ERR_OK;
 }
 
@@ -519,41 +520,39 @@ void replica_bulk_loader::download_files(const std::string &provider_name,
     }
 
     // download sst files asynchronously
-    if (!_metadata.files.empty()) {
-        const file_meta &f_meta = _metadata.files[0];
-        _download_files_task[f_meta.name] = tasking::enqueue(
-            LPC_BACKGROUND_BULK_LOAD,
-            tracker(),
-            std::bind(&replica_bulk_loader::download_sst_file, this, remote_dir, local_dir, 0, fs));
+    std::vector<::dsn::replication::file_meta> download_file_metas;
+    {
+        zauto_read_lock l(_lock);
+        std::copy(_metadata.files.begin(),
+                  _metadata.files.end(),
+                  std::back_inserter(download_file_metas));
+    }
+    if (!download_file_metas.empty()) {
+        _download_files_task[download_file_metas.back().name] =
+            tasking::enqueue(LPC_BACKGROUND_BULK_LOAD,
+                             tracker(),
+                             std::bind(&replica_bulk_loader::download_sst_file,
+                                       this,
+                                       remote_dir,
+                                       local_dir,
+                                       download_file_metas,
+                                       fs));
     }
 }
 
 // ThreadPool: THREAD_POOL_DEFAULT
-void replica_bulk_loader::download_sst_file(const std::string &remote_dir,
-                                            const std::string &local_dir,
-                                            int32_t file_index,
-                                            dist::block_service::block_filesystem *fs)
+void replica_bulk_loader::download_sst_file(
+    const std::string &remote_dir,
+    const std::string &local_dir,
+    std::vector<::dsn::replication::file_meta> &download_file_metas,
+    dist::block_service::block_filesystem *fs)
 {
     if (_status != bulk_load_status::BLS_DOWNLOADING) {
-        LOG_WARNING_PREFIX("Cancel download_sst_file task, because bulk_load local_status is {}. "
-                           "local_dir: {} , file_index is {}.",
-                           enum_to_string(_status),
-                           local_dir,
-                           file_index);
+        LOG_WARNING_PREFIX("Cancel download_sst_file task, because bulk_load local_status is {}.",
+                           enum_to_string(_status));
         return;
     }
-    file_meta f_meta;
-    {
-        zauto_read_lock l(_lock);
-        if (file_index < _metadata.files.size()) {
-            f_meta = _metadata.files[file_index];
-        }
-    }
-    if (f_meta.name.empty()) {
-        LOG_WARNING_PREFIX("Cannot get file_meta of {}, cancel download_sst_file task.",
-                           file_index);
-        return;
-    }
+    const file_meta &f_meta = download_file_metas.back();
     uint64_t f_size = 0;
     std::string f_md5;
     error_code ec = _stub->_block_service_manager.download_file(
@@ -604,27 +603,19 @@ void replica_bulk_loader::download_sst_file(const std::string &remote_dir,
         return;
     }
     // download file succeed, update progress
+    download_file_metas.pop_back();
     update_bulk_load_download_progress(f_size, f_meta.name);
     METRIC_VAR_INCREMENT(bulk_load_download_file_successful_count);
     METRIC_VAR_INCREMENT_BY(bulk_load_download_file_bytes, f_size);
 
     // download next file
-    {
-        zauto_read_lock l(_lock);
-        if (file_index + 1 < _metadata.files.size()) {
-            f_meta = _metadata.files[file_index + 1];
-        }
-    }
-    if (!f_meta.name.empty()) {
-        _download_files_task[f_meta.name] =
+    if (!download_file_metas.empty()) {
+        _download_files_task[download_file_metas.back().name] =
             tasking::enqueue(LPC_BACKGROUND_BULK_LOAD,
                              tracker(),
-                             std::bind(&replica_bulk_loader::download_sst_file,
-                                       this,
-                                       remote_dir,
-                                       local_dir,
-                                       file_index + 1,
-                                       fs));
+                             [this, remote_dir, local_dir, download_file_metas, fs] {
+                                 download_sst_file(remote_dir, local_dir, download_file_metas, fs);
+                             });
     }
 }
 

--- a/src/replica/bulk_load/replica_bulk_loader.cpp
+++ b/src/replica/bulk_load/replica_bulk_loader.cpp
@@ -18,7 +18,6 @@
 #include <fmt/core.h>
 #include <algorithm>
 #include <functional>
-#include <iterator>
 #include <memory>
 #include <string_view>
 #include <unordered_map>

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -89,7 +89,7 @@ private:
     // download sst files from remote provider
     void download_sst_file(const std::string &remote_dir,
                            const std::string &local_dir,
-                           int32_t file_index,
+                           std::vector<::dsn::replication::file_meta> &download_file_metas,
                            dist::block_service::block_filesystem *fs);
 
     // \return ERR_PATH_NOT_FOUND: file not exist

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -90,7 +90,7 @@ private:
     // download sst files from remote provider
     void download_sst_file(const std::string &remote_dir,
                            const std::string &local_dir,
-                           std::vector<::dsn::replication::file_meta> &download_file_metas,
+                           std::vector<::dsn::replication::file_meta> &&download_file_metas,
                            dist::block_service::block_filesystem *fs);
 
     // \return ERR_PATH_NOT_FOUND: file not exist

--- a/src/replica/bulk_load/replica_bulk_loader.h
+++ b/src/replica/bulk_load/replica_bulk_loader.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <ostream>
 #include <string>
+#include <vector>
 
 #include "bulk_load_types.h"
 #include "common/replication_other_types.h"

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -27,7 +27,6 @@
 #include <functional>
 #include <memory>
 #include <string_view>
-#include <set>
 #include <tuple>
 #include <utility>
 #include <vector>

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <memory>
 #include <string_view>
+#include <set>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -34,6 +35,7 @@
 #include "client_lib/pegasus_client_impl.h"
 #include "common/common.h"
 #include "common/duplication_common.h"
+#include "common/replication.codes.h"
 #include "duplication_internal_types.h"
 #include "gutil/map_util.h"
 #include "pegasus/client.h"


### PR DESCRIPTION
# What problem does this PR solve? <!--add issue link with summary if exists-->
Related issue:
https://github.com/apache/incubator-pegasus/issues/2006.

### What is changed and how does it work?
Avoid using _metadata.files reference ，and add a  read_lock 

# Tests <!-- At least one of them must be included. -->
Because bulkload imports a large amount of data.
- Manual test
## Test 1: bulkload files miss four sst files.
![image](https://github.com/apache/incubator-pegasus/assets/93246280/71c03c48-7451-4fb6-9029-5ae8808504df)
After fix : Table ingest_p4_10G partition1 is missing files, and the table ballot does not increase after bulkload.
```c++
[2024/5/23 15:11:10] [general]
[2024/5/23 15:11:10] app_name           : ingest_p4_10G
[2024/5/23 15:11:10] app_id             : 100          
[2024/5/23 15:11:10] partition_count    : 4            
[2024/5/23 15:11:10] max_replica_count  : 3            
[2024/5/23 15:11:10] 
[2024/5/23 15:11:10] [replicas]
[2024/5/23 15:11:10] pidx  ballot  replica_count  primary                              secondaries                                                                
[2024/5/23 15:11:10] 0     3       3/3            c3-hadoop-pegasus-tst-st05.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 15:11:10] 1     3       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st05.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 15:11:10] 2     3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 15:11:10] 3     3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 15:11:10] 
[2024/5/23 15:11:10] [nodes]
[2024/5/23 15:11:10] node                                 primary  secondary  total  
[2024/5/23 15:11:10] c3-hadoop-pegasus-tst-st02.bj:31101  1        1          2      
[2024/5/23 15:11:10] c3-hadoop-pegasus-tst-st01.bj:31101  1        1          2      
[2024/5/23 15:11:10] c3-hadoop-pegasus-tst-st05.bj:31101  1        2          3      
[2024/5/23 15:11:10] c3-hadoop-pegasus-tst-st04.bj:31101  0        2          2      
[2024/5/23 15:11:10] c3-hadoop-pegasus-tst-st03.bj:31101  1        2          3      



[2024/5/23 15:13:12] >>> start_bulk_load -a ingest_p4_10G  -c c3tst-performance2 -p hdfs_zjy -r /user/s_pegasus/lpfsplit

[2024/5/23 15:15:58] >>> query_bulk_load_status -a ingest_p4_10G -d
[2024/5/23 15:15:58] [all partitions]
[2024/5/23 15:15:58] partition_index  partition_status  is_cleaned_up  
[2024/5/23 15:15:58] 0                BLS_FAILED        NO             
[2024/5/23 15:15:58] 1                BLS_FAILED        NO             
[2024/5/23 15:15:58] 2                BLS_FAILED        NO             
[2024/5/23 15:15:58] 3                BLS_FAILED        NO    


[2024/5/23 15:16:13] [general]
[2024/5/23 15:16:13] app_name           : ingest_p4_10G
[2024/5/23 15:16:13] app_id             : 100          
[2024/5/23 15:16:13] partition_count    : 4            
[2024/5/23 15:16:13] max_replica_count  : 3            
[2024/5/23 15:16:13] 
[2024/5/23 15:16:13] [replicas]
[2024/5/23 15:16:13] pidx  ballot  replica_count  primary                              secondaries                                                                
[2024/5/23 15:16:13] 0     3       3/3            c3-hadoop-pegasus-tst-st05.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 15:16:13] 1     3       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st05.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 15:16:13] 2     3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 15:16:13] 3     3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 15:16:13] 
[2024/5/23 15:16:13] [nodes]
[2024/5/23 15:16:13] node                                 primary  secondary  total  
[2024/5/23 15:16:13] c3-hadoop-pegasus-tst-st02.bj:31101  1        1          2      
[2024/5/23 15:16:13] c3-hadoop-pegasus-tst-st01.bj:31101  1        1          2      
[2024/5/23 15:16:13] c3-hadoop-pegasus-tst-st05.bj:31101  1        2          3      
[2024/5/23 15:16:13] c3-hadoop-pegasus-tst-st04.bj:31101  0        2          2      
[2024/5/23 15:16:13] c3-hadoop-pegasus-tst-st03.bj:3
``` 
## Test 2: Bulkload Download stage restart a node
After fix ： No continuous core dumps on multiple nodes.
```c++
[2024/5/23 15:59:18] >>> app ingest_p32_10G -dr
[2024/5/23 15:59:18] [parameters]
[2024/5/23 15:59:18] app_name  : ingest_p32_10G
[2024/5/23 15:59:18] detailed  : true          
[2024/5/23 15:59:18] 
[2024/5/23 15:59:18] [general]
[2024/5/23 15:59:18] app_name           : ingest_p32_10G
[2024/5/23 15:59:18] app_id             : 101           
[2024/5/23 15:59:18] partition_count    : 32            
[2024/5/23 15:59:18] max_replica_count  : 3             
[2024/5/23 15:59:18] 
[2024/5/23 15:59:18] [replicas]
[2024/5/23 15:59:18] pidx  ballot  replica_count  primary                              secondaries                                                                
[2024/5/23 15:59:18] 0     3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st05.bj:31101,c3-hadoop-pegasus-tst-st02.bj:31101]  
[2024/5/23 15:59:18] 1     3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 15:59:18] 2     3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 15:59:18] 3     3       3/3            c3-hadoop-pegasus-tst-st05.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st02.bj:31101]  
[2024/5/23 15:59:18] 4     3       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st05.bj:31101,c3-hadoop-pegasus-tst-st02.bj:31101]  
[2024/5/23 15:59:18] 5     3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 15:59:18] 6     3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 15:59:18] 7     3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st05.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 15:59:18] 8     3       3/3            c3-hadoop-pegasus-tst-st05.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st02.bj:31101]  
[2024/5/23 15:59:18] 9     3       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 15:59:18] 10    3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st02.bj:31101]  
[2024/5/23 15:59:18] 11    3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st05.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 15:59:18] 12    3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 15:59:18] 13    3       3/3            c3-hadoop-pegasus-tst-st05.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st02.bj:31101]  
[2024/5/23 15:59:18] 14    3       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 15:59:18] 15    3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st05.bj:31101,c3-hadoop-pegasus-tst-st02.bj:31101]  
[2024/5/23 15:59:18] 16    3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 15:59:18] 17    3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 15:59:18] 18    3       3/3            c3-hadoop-pegasus-tst-st05.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 15:59:18] 19    3       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 15:59:18] 20    3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 15:59:18] 21    3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 15:59:18] 22    3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 15:59:18] 23    3       3/3            c3-hadoop-pegasus-tst-st05.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 15:59:18] 24    3       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 15:59:18] 25    3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 15:59:18] 26    3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 15:59:18] 27    3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st02.bj:31101]  
[2024/5/23 15:59:18] 28    3       3/3            c3-hadoop-pegasus-tst-st05.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 15:59:18] 29    3       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st05.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 15:59:18] 30    3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 15:59:18] 31    3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st05.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  



[2024/5/23 15:59:39] >>> start_bulk_load -a ingest_p32_10G  -c c3tst-performance2 -p hdfs_zjy -r /user/s_pegasus/lpfsplit

[2024/5/23 16:01:18] 2024-05-23 16:01:18 Stop task 4 of replica on 10.142.100.15(0) success
[2024/5/23 16:01:50] 2024-05-23 16:01:50 Start task 4 of replica on 10.142.100.15(0) success

[2024/5/23 16:03:17] [general]
[2024/5/23 16:03:17] app_name           : ingest_p32_10G
[2024/5/23 16:03:17] app_id             : 101           
[2024/5/23 16:03:17] partition_count    : 32            
[2024/5/23 16:03:17] max_replica_count  : 3             
[2024/5/23 16:03:17] 
[2024/5/23 16:03:17] [replicas]
[2024/5/23 16:03:17] pidx  ballot  replica_count  primary                              secondaries                                                                
[2024/5/23 16:03:17] 0     5       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 1     5       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 2     3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 16:03:17] 3     6       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 4     5       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 5     3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 16:03:17] 6     3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 16:03:17] 7     4       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st05.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 16:03:17] 8     6       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 9     5       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 10    3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st02.bj:31101]  
[2024/5/23 16:03:17] 11    5       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 12    4       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 13    6       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 14    5       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 15    5       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 16    3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 16:03:17] 17    4       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 18    6       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 19    3       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 16:03:17] 20    3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st02.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 16:03:17] 21    3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 16:03:17] 22    3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st04.bj:31101]  
[2024/5/23 16:03:17] 23    6       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 24    5       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 25    3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 16:03:17] 26    3       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st01.bj:31101]  
[2024/5/23 16:03:17] 27    3       3/3            c3-hadoop-pegasus-tst-st01.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st02.bj:31101]  
[2024/5/23 16:03:17] 28    6       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st04.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 29    5       3/3            c3-hadoop-pegasus-tst-st03.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
[2024/5/23 16:03:17] 30    3       3/3            c3-hadoop-pegasus-tst-st04.bj:31101  [c3-hadoop-pegasus-tst-st01.bj:31101,c3-hadoop-pegasus-tst-st03.bj:31101]  
[2024/5/23 16:03:17] 31    5       3/3            c3-hadoop-pegasus-tst-st02.bj:31101  [c3-hadoop-pegasus-tst-st03.bj:31101,c3-hadoop-pegasus-tst-st05.bj:31101]  
``` 

# Side effects
Locking `_metadata.files` may incur a performance penalty.