### PR TITLE
feat(logging): Make it possible to print logs to stderr when using screen_logger

### DIFF
--- a/src/utils/logging_provider.h
+++ b/src/utils/logging_provider.h
@@ -71,7 +71,10 @@ protected:
 
     static logging_provider *create_default_instance();
 
+    logging_provider(log_level_t stderr_start_level) : _stderr_start_level(stderr_start_level) {}
+
     std::vector<std::unique_ptr<command_deregister>> _cmds;
+    const log_level_t _stderr_start_level;
 };
 
 void set_log_prefixed_message_func(std::function<std::string()> func);

--- a/src/utils/simple_logger.h
+++ b/src/utils/simple_logger.h
@@ -44,7 +44,7 @@ namespace tools {
 class screen_logger : public logging_provider
 {
 public:
-    explicit screen_logger(const char *, const char *) : _short_header(true) {}
+    explicit screen_logger(const char *, const char *);
     ~screen_logger() override = default;
 
     void log(const char *file,
@@ -56,12 +56,12 @@ public:
     virtual void flush();
 
 private:
-    static void print_header(log_level_t log_level);
+    void print_header(log_level_t log_level);
     void print_long_header(const char *file,
                            const char *function,
                            const int line,
                            log_level_t log_level);
-    static void print_body(const char *body, log_level_t log_level);
+    void print_body(const char *body, log_level_t log_level);
 
     ::dsn::utils::ex_lock_nr _lock;
     const bool _short_header;
@@ -119,7 +119,6 @@ private:
     FILE *_log;
     // The byte size of the current log file.
     uint64_t _file_bytes;
-    const log_level_t _stderr_start_level;
 };
 } // namespace tools
 } // namespace dsn

--- a/src/utils/test/fmt_logging_test.cpp
+++ b/src/utils/test/fmt_logging_test.cpp
@@ -27,13 +27,14 @@
 #include <fmt/core.h>
 #include <memory>
 
+#include "absl/strings/string_view.h"
 #include "common/gpid.h"
 #include "common/replication.codes.h"
 #include "gtest/gtest.h"
 #include "runtime/task/task_code.h"
 #include "utils/error_code.h"
 #include "utils/errors.h"
-#include "absl/strings/string_view.h"
+#include "utils/fmt_logging.h"
 
 namespace dsn {
 namespace replication {

--- a/src/utils/test/fmt_logging_test.cpp
+++ b/src/utils/test/fmt_logging_test.cpp
@@ -47,6 +47,7 @@ TEST(fmt_logging, basic)
     ASSERT_EQ(fmt::format("{}", LPC_REPLICATION_LOW), "LPC_REPLICATION_LOW");
     ASSERT_EQ(absl::string_view("yes"), "yes");
     ASSERT_EQ(fmt::format("{}", absl::string_view("yes\0yes")), "yes\0yes");
+    ASSERT_DEATH(CHECK(false, "CHECK false in test"), "CHECK false in test");
 }
 
 } // namespace replication


### PR DESCRIPTION
If using `screen_logger`, the logs are only printed to stdout.

This patch introduces a new config
`[tools.screen_logger]stderr_start_level_on_stdout`
to define the lowest level of log messages to be copied to
stderr in addition to stdout. This is useful for testing.

A test using `ASSERT_DEATH` is added to check the logs are printed
to stderr indeed.