### PR TITLE
fix(duplication): fix unexpected ERR_NOT_ENOUGH_MEMBER while checking if the remote table with only one replica is ready for duplication

### DIFF
--- a/src/meta/duplication/duplication_info.cpp
+++ b/src/meta/duplication/duplication_info.cpp
@@ -173,6 +173,7 @@ void duplication_info::persist_status()
 
     _is_altering = false;
     _status = _next_status;
+    // Now we don't know what exactly is the next status, thus set DS_INIT temporarily.
     _next_status = duplication_status::DS_INIT;
     _fail_mode = _next_fail_mode;
 }

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -545,19 +545,19 @@ void meta_duplication_service::check_follower_app_if_create_completed(
         _meta_svc->tracker(),
         [dup, this](error_code err, query_cfg_response &&resp) mutable {
             FAIL_POINT_INJECT_NOT_RETURN_F(
-                "create_app_ok", [dup, &err, &resp](std::string_view num_secondaries_str) -> void {
+                "create_app_ok",
+                [dup, &err, &resp](std::string_view remote_replica_count_str) -> void {
                     const host_port primary("localhost", 34801);
 
-                    int32_t num_secondaries = 0;
-                    CHECK_TRUE(buf2int32(num_secondaries_str, num_secondaries));
+                    int32_t remote_replica_count = 0;
+                    CHECK_TRUE(buf2int32(remote_replica_count_str, remote_replica_count));
+                    CHECK_GT(remote_replica_count, 0);
+                    CHECK_EQ(dup->remote_replica_count, remote_replica_count);
 
                     std::vector<host_port> secondaries;
-                    for (int32_t i = 0; i < num_secondaries; ++i) {
+                    for (int32_t i = 0; i < remote_replica_count - 1; ++i) {
                         secondaries.emplace_back("localhost", static_cast<uint16_t>(34802 + i));
                     }
-
-                    const int32_t remote_replica_count = 1 + secondaries.size();
-                    CHECK_EQ(dup->remote_replica_count, remote_replica_count);
 
                     for (int32_t i = 0; i < dup->partition_count; ++i) {
                         partition_configuration pc;

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -336,10 +336,12 @@ void meta_duplication_service::do_add_duplication(std::shared_ptr<app_state> &ap
     std::queue<std::string> nodes({get_duplication_path(*app), std::to_string(dup->id)});
     _meta_svc->get_meta_storage()->create_node_recursively(
         std::move(nodes), std::move(value), [app, this, dup, rpc, resp_err]() mutable {
-            LOG_INFO("[{}] add duplication successfully [app_name: {}, remote_cluster_name: {}]",
+            LOG_INFO("[{}] add duplication successfully [app_name: {}, remote_cluster_name: {}, "
+                     "remote_app_name: {}]",
                      dup->log_prefix(),
                      app->app_name,
-                     dup->remote_cluster_name);
+                     dup->remote_cluster_name,
+                     dup->remote_app_name);
 
             // The duplication starts only after it's been persisted.
             dup->persist_status();
@@ -484,43 +486,45 @@ void meta_duplication_service::create_follower_app_for_duplication(
 
     dsn::message_ex *msg = dsn::message_ex::create_request(RPC_CM_CREATE_APP);
     dsn::marshall(msg, request);
-    rpc::call(dsn::dns_resolver::instance().resolve_address(meta_servers),
-              msg,
-              _meta_svc->tracker(),
-              [=](error_code err, configuration_create_app_response &&resp) mutable {
-                  FAIL_POINT_INJECT_NOT_RETURN_F("update_app_request_ok",
-                                                 [&](std::string_view s) -> void { err = ERR_OK; });
-                  error_code create_err = err == ERR_OK ? resp.err : err;
-                  error_code update_err = ERR_NO_NEED_OPERATE;
+    rpc::call(
+        dsn::dns_resolver::instance().resolve_address(meta_servers),
+        msg,
+        _meta_svc->tracker(),
+        [dup, this](error_code err, configuration_create_app_response &&resp) mutable {
+            FAIL_POINT_INJECT_NOT_RETURN_F("update_app_request_ok",
+                                           [&err](std::string_view) -> void { err = ERR_OK; });
 
-                  FAIL_POINT_INJECT_NOT_RETURN_F(
-                      "persist_dup_status_failed",
-                      [&](std::string_view s) -> void { create_err = ERR_OK; });
-                  if (create_err == ERR_OK) {
-                      update_err = dup->alter_status(duplication_status::DS_APP);
-                  }
+            error_code create_err = err == ERR_OK ? resp.err : err;
+            FAIL_POINT_INJECT_NOT_RETURN_F(
+                "persist_dup_status_failed",
+                [&create_err](std::string_view) -> void { create_err = ERR_OK; });
 
-                  FAIL_POINT_INJECT_F("persist_dup_status_failed",
-                                      [&](std::string_view s) -> void { return; });
-                  if (update_err == ERR_OK) {
-                      blob value = dup->to_json_blob();
-                      // Note: this function is `async`, it may not be persisted completed
-                      // after executing, now using `_is_altering` to judge whether `updating` or
-                      // `completed`, if `_is_altering`, dup->alter_status() will return `ERR_BUSY`
-                      _meta_svc->get_meta_storage()->set_data(std::string(dup->store_path),
-                                                              std::move(value),
-                                                              [=]() { dup->persist_status(); });
-                  } else {
-                      LOG_ERROR(
-                          "created follower app[{}.{}] to trigger duplicate checkpoint failed: "
+            error_code update_err = ERR_NO_NEED_OPERATE;
+            if (create_err == ERR_OK) {
+                update_err = dup->alter_status(duplication_status::DS_APP);
+            }
+
+            FAIL_POINT_INJECT_F("persist_dup_status_failed",
+                                [](std::string_view) -> void { return; });
+
+            if (update_err == ERR_OK) {
+                blob value = dup->to_json_blob();
+                // Note: this function is `async`, it may not be persisted completed
+                // after executing, now using `_is_altering` to judge whether `updating` or
+                // `completed`, if `_is_altering`, dup->alter_status() will return `ERR_BUSY`
+                _meta_svc->get_meta_storage()->set_data(std::string(dup->store_path),
+                                                        std::move(value),
+                                                        [dup]() { dup->persist_status(); });
+            } else {
+                LOG_ERROR("create follower app[{}.{}] to trigger duplicate checkpoint failed: "
                           "duplication_status = {}, create_err = {}, update_err = {}",
                           dup->remote_cluster_name,
-                          dup->app_name,
+                          dup->remote_app_name,
                           duplication_status_to_string(dup->status()),
                           create_err,
                           update_err);
-                  }
-              });
+            }
+        });
 }
 
 void meta_duplication_service::check_follower_app_if_create_completed(
@@ -535,79 +539,81 @@ void meta_duplication_service::check_follower_app_if_create_completed(
 
     dsn::message_ex *msg = dsn::message_ex::create_request(RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX);
     dsn::marshall(msg, meta_config_request);
-    rpc::call(dsn::dns_resolver::instance().resolve_address(meta_servers),
-              msg,
-              _meta_svc->tracker(),
-              [=](error_code err, query_cfg_response &&resp) mutable {
-                  FAIL_POINT_INJECT_NOT_RETURN_F("create_app_ok", [&](std::string_view s) -> void {
-                      err = ERR_OK;
-                      int count = dup->partition_count;
-                      while (count-- > 0) {
-                          const host_port primary("localhost", 34801);
-                          const host_port secondary1("localhost", 34802);
-                          const host_port secondary2("localhost", 34803);
+    rpc::call(
+        dsn::dns_resolver::instance().resolve_address(meta_servers),
+        msg,
+        _meta_svc->tracker(),
+        [dup, this](error_code err, query_cfg_response &&resp) mutable {
+            FAIL_POINT_INJECT_NOT_RETURN_F(
+                "create_app_ok", [dup, &err, &resp](std::string_view) -> void {
+                    err = ERR_OK;
+                    int count = dup->partition_count;
+                    while (count-- > 0) {
+                        const host_port primary("localhost", 34801);
+                        const host_port secondary1("localhost", 34802);
+                        const host_port secondary2("localhost", 34803);
 
-                          partition_configuration pc;
-                          SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, primary);
-                          SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, secondary1, secondary2);
-                          resp.partitions.emplace_back(pc);
-                      }
-                  });
+                        partition_configuration pc;
+                        SET_IP_AND_HOST_PORT_BY_DNS(pc, primary, primary);
+                        SET_IPS_AND_HOST_PORTS_BY_DNS(pc, secondaries, secondary1, secondary2);
+                        resp.partitions.emplace_back(pc);
+                    }
+                });
 
-                  // - ERR_INCONSISTENT_STATE: partition count of response isn't equal with local
-                  // - ERR_INACTIVE_STATE: the follower table hasn't been healthy
-                  error_code query_err = err == ERR_OK ? resp.err : err;
-                  if (query_err == ERR_OK) {
-                      if (resp.partitions.size() != dup->partition_count) {
-                          query_err = ERR_INCONSISTENT_STATE;
-                      } else {
-                          for (const auto &pc : resp.partitions) {
-                              if (!pc.hp_primary) {
-                                  query_err = ERR_INACTIVE_STATE;
-                                  break;
-                              }
+            // - ERR_INCONSISTENT_STATE: partition count of response isn't equal with local
+            // - ERR_INACTIVE_STATE: the follower table hasn't been healthy
+            error_code query_err = err == ERR_OK ? resp.err : err;
+            if (query_err == ERR_OK) {
+                if (resp.partitions.size() != dup->partition_count) {
+                    query_err = ERR_INCONSISTENT_STATE;
+                } else {
+                    for (const auto &pc : resp.partitions) {
+                        if (!pc.hp_primary) {
+                            query_err = ERR_INACTIVE_STATE;
+                            break;
+                        }
 
-                              if (pc.hp_secondaries.empty()) {
-                                  query_err = ERR_NOT_ENOUGH_MEMBER;
-                                  break;
-                              }
+                        if (1 + pc.hp_secondaries.size() < dup->remote_replica_count &&
+                            pc.hp_secondaries.empty()) {
+                            query_err = ERR_NOT_ENOUGH_MEMBER;
+                            break;
+                        }
 
-                              for (const auto &secondary : pc.hp_secondaries) {
-                                  if (!secondary) {
-                                      query_err = ERR_INACTIVE_STATE;
-                                      break;
-                                  }
-                              }
-                          }
-                      }
-                  }
+                        for (const auto &secondary : pc.hp_secondaries) {
+                            if (!secondary) {
+                                query_err = ERR_INACTIVE_STATE;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
 
-                  error_code update_err = ERR_NO_NEED_OPERATE;
-                  if (query_err == ERR_OK) {
-                      update_err = dup->alter_status(duplication_status::DS_LOG);
-                  }
+            error_code update_err = ERR_NO_NEED_OPERATE;
+            if (query_err == ERR_OK) {
+                update_err = dup->alter_status(duplication_status::DS_LOG);
+            }
 
-                  FAIL_POINT_INJECT_F("persist_dup_status_failed",
-                                      [&](std::string_view s) -> void { return; });
-                  if (update_err == ERR_OK) {
-                      blob value = dup->to_json_blob();
-                      // Note: this function is `async`, it may not be persisted completed
-                      // after executing, now using `_is_altering` to judge whether `updating` or
-                      // `completed`, if `_is_altering`, dup->alter_status() will return `ERR_BUSY`
-                      _meta_svc->get_meta_storage()->set_data(std::string(dup->store_path),
-                                                              std::move(value),
-                                                              [dup]() { dup->persist_status(); });
-                  } else {
-                      LOG_ERROR(
-                          "query follower app[{}.{}] replica configuration completed, result: "
+            FAIL_POINT_INJECT_F("persist_dup_status_failed",
+                                [](std::string_view) -> void { return; });
+            if (update_err == ERR_OK) {
+                blob value = dup->to_json_blob();
+                // Note: this function is `async`, it may not be persisted completed
+                // after executing, now using `_is_altering` to judge whether `updating` or
+                // `completed`, if `_is_altering`, dup->alter_status() will return `ERR_BUSY`
+                _meta_svc->get_meta_storage()->set_data(std::string(dup->store_path),
+                                                        std::move(value),
+                                                        [dup]() { dup->persist_status(); });
+            } else {
+                LOG_ERROR("query follower app[{}.{}] replica configuration completed, result: "
                           "duplication_status = {}, query_err = {}, update_err = {}",
                           dup->remote_cluster_name,
                           dup->remote_app_name,
                           duplication_status_to_string(dup->status()),
                           query_err,
                           update_err);
-                  }
-              });
+            }
+        });
 }
 
 void meta_duplication_service::do_update_partition_confirmed(

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -573,8 +573,9 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                             break;
                         }
 
-                        if (1 + pc.hp_secondaries.size() < dup->remote_replica_count &&
-                            pc.hp_secondaries.empty()) {
+                        // if (1 + pc.hp_secondaries.size() < pc.max_replica_count &&
+                        //    pc.hp_secondaries.empty()) {
+                        if (pc.hp_secondaries.empty()) {
                             query_err = ERR_NOT_ENOUGH_MEMBER;
                             break;
                         }
@@ -596,6 +597,7 @@ void meta_duplication_service::check_follower_app_if_create_completed(
 
             FAIL_POINT_INJECT_F("persist_dup_status_failed",
                                 [](std::string_view) -> void { return; });
+
             if (update_err == ERR_OK) {
                 blob value = dup->to_json_blob();
                 // Note: this function is `async`, it may not be persisted completed

--- a/src/meta/duplication/meta_duplication_service.cpp
+++ b/src/meta/duplication/meta_duplication_service.cpp
@@ -612,9 +612,8 @@ void meta_duplication_service::check_follower_app_if_create_completed(
                             break;
                         }
 
-                        // if (1 + pc.hp_secondaries.size() < pc.max_replica_count &&
-                        //    pc.hp_secondaries.empty()) {
-                        if (pc.hp_secondaries.empty()) {
+                        if (1 + pc.hp_secondaries.size() < pc.max_replica_count &&
+                            pc.hp_secondaries.empty()) {
                             query_err = ERR_NOT_ENOUGH_MEMBER;
                             break;
                         }

--- a/src/meta/test/meta_duplication_service_test.cpp
+++ b/src/meta/test/meta_duplication_service_test.cpp
@@ -975,20 +975,67 @@ TEST_F(meta_duplication_service_test, check_follower_app_if_create_completed)
         bool is_altering;
         duplication_status::type cur_status;
         duplication_status::type next_status;
-    } test_cases[] = {{3,
+    } test_cases[] = {// 3 remote replicas with both primary and secondaries valid.
+                      {3,
                        {"create_app_ok"},
-                       {"void(3)"},
+                       {"void(true,2,0)"},
                        false,
                        duplication_status::DS_LOG,
                        duplication_status::DS_INIT},
+                      // 3 remote replicas with primary invalid and all secondaries valid.
+                      {3,
+                       {"create_app_ok"},
+                       {"void(false,2,0)"},
+                       false,
+                       duplication_status::DS_APP,
+                       duplication_status::DS_INIT},
+                      // 3 remote replicas with primary valid and only one secondary present
+                      // and valid.
+                      {3,
+                       {"create_app_ok"},
+                       {"void(true,1,0)"},
+                       false,
+                       duplication_status::DS_LOG,
+                       duplication_status::DS_INIT},
+                      // 3 remote replicas with primary valid and one secondary invalid.
+                      {3,
+                       {"create_app_ok"},
+                       {"void(true,1,1)"},
+                       false,
+                       duplication_status::DS_APP,
+                       duplication_status::DS_INIT},
+                      // 3 remote replicas with primary valid and only one secondary present
+                      // and invalid.
+                      {3,
+                       {"create_app_ok"},
+                       {"void(true,0,1)"},
+                       false,
+                       duplication_status::DS_APP,
+                       duplication_status::DS_INIT},
+                      // 3 remote replicas with primary valid and both secondaries absent.
+                      {3,
+                       {"create_app_ok"},
+                       {"void(true,0,0)"},
+                       false,
+                       duplication_status::DS_APP,
+                       duplication_status::DS_INIT},
+                      // 1 remote replicas with primary valid.
                       {1,
                        {"create_app_ok"},
-                       {"void(1)"},
+                       {"void(true,0,0)"},
                        false,
                        duplication_status::DS_LOG,
                        duplication_status::DS_INIT},
-                      // the case just `palace holder`, actually
-                      // `check_follower_app_if_create_completed` is failed by default in unit test
+                      // 1 remote replicas with primary invalid.
+                      {1,
+                       {"create_app_ok"},
+                       {"void(false,0,0)"},
+                       false,
+                       duplication_status::DS_APP,
+                       duplication_status::DS_INIT},
+                      // The case is just a "palace holder", actually
+                      // `check_follower_app_if_create_completed` would fail by default
+                      // in unit test.
                       {3,
                        {"create_app_failed"},
                        {"off()"},
@@ -997,7 +1044,7 @@ TEST_F(meta_duplication_service_test, check_follower_app_if_create_completed)
                        duplication_status::DS_INIT},
                       {3,
                        {"create_app_ok", "persist_dup_status_failed"},
-                       {"void(3)", "return()"},
+                       {"void(true,2,0)", "return()"},
                        true,
                        duplication_status::DS_APP,
                        duplication_status::DS_LOG}};
@@ -1006,13 +1053,15 @@ TEST_F(meta_duplication_service_test, check_follower_app_if_create_completed)
     for (const auto &test : test_cases) {
         const auto &app_name = fmt::format("check_follower_app_if_create_completed_test_{}", i++);
         create_app(app_name);
-        auto app = find_app(app_name);
 
+        auto app = find_app(app_name);
         auto dup_add_resp = create_dup(app_name, test.remote_replica_count);
         auto dup = app->duplications[dup_add_resp.dupid];
+
         // 'check_follower_app_if_create_completed' must execute under duplication_status::DS_APP,
-        // so force update it
+        // so force update it.
         force_update_dup_status(dup, duplication_status::DS_APP);
+
         fail::setup();
         for (int i = 0; i < test.fail_cfg_name.size(); i++) {
             fail::cfg(test.fail_cfg_name[i], test.fail_cfg_action[i]);
@@ -1020,6 +1069,7 @@ TEST_F(meta_duplication_service_test, check_follower_app_if_create_completed)
         check_follower_app_if_create_completed(dup);
         wait_all();
         fail::teardown();
+
         ASSERT_EQ(dup->is_altering(), test.is_altering);
         ASSERT_EQ(next_status(dup), test.next_status);
         ASSERT_EQ(dup->status(), test.cur_status);

--- a/src/meta/test/meta_duplication_service_test.cpp
+++ b/src/meta/test/meta_duplication_service_test.cpp
@@ -963,24 +963,34 @@ TEST_F(meta_duplication_service_test, check_follower_app_if_create_completed)
 {
     struct test_case
     {
+        int32_t replica_count;
         std::vector<std::string> fail_cfg_name;
         std::vector<std::string> fail_cfg_action;
         bool is_altering;
         duplication_status::type cur_status;
         duplication_status::type next_status;
-    } test_cases[] = {{{"create_app_ok"},
+    } test_cases[] = {{3,
+                       {"create_app_ok"},
+                       {"void()"},
+                       false,
+                       duplication_status::DS_LOG,
+                       duplication_status::DS_INIT},
+                      {1,
+                       {"create_app_ok"},
                        {"void()"},
                        false,
                        duplication_status::DS_LOG,
                        duplication_status::DS_INIT},
                       // the case just `palace holder`, actually
                       // `check_follower_app_if_create_completed` is failed by default in unit test
-                      {{"create_app_failed"},
+                      {3,
+                       {"create_app_failed"},
                        {"off()"},
                        false,
                        duplication_status::DS_APP,
                        duplication_status::DS_INIT},
-                      {{"create_app_ok", "persist_dup_status_failed"},
+                      {3,
+                       {"create_app_ok", "persist_dup_status_failed"},
                        {"void()", "return()"},
                        true,
                        duplication_status::DS_APP,
@@ -988,7 +998,7 @@ TEST_F(meta_duplication_service_test, check_follower_app_if_create_completed)
 
     for (const auto &test : test_cases) {
         const auto test_app = fmt::format("{}{}", test.fail_cfg_name[0], test.fail_cfg_name.size());
-        create_app(test_app);
+        create_app(test_app, 8, test.replica_count);
         auto app = find_app(test_app);
 
         auto dup_add_resp = create_dup(test_app);

--- a/src/meta/test/meta_test_base.cpp
+++ b/src/meta/test/meta_test_base.cpp
@@ -182,14 +182,16 @@ std::vector<host_port> meta_test_base::ensure_enough_alive_nodes(int min_node_co
     return nodes;
 }
 
-void meta_test_base::create_app(const std::string &name, uint32_t partition_count)
+void meta_test_base::create_app(const std::string &name,
+                                int32_t partition_count,
+                                int32_t replica_count)
 {
     configuration_create_app_request req;
     configuration_create_app_response resp;
     req.app_name = name;
     req.options.app_type = "simple_kv";
     req.options.partition_count = partition_count;
-    req.options.replica_count = 3;
+    req.options.replica_count = replica_count;
     req.options.success_if_exist = false;
     req.options.is_stateful = true;
     req.options.envs["value_version"] = "1";

--- a/src/meta/test/meta_test_base.h
+++ b/src/meta/test/meta_test_base.h
@@ -57,8 +57,13 @@ public:
 
     std::vector<host_port> ensure_enough_alive_nodes(int min_node_count);
 
-    // create an app for test with specified name and specified partition count
-    void create_app(const std::string &name, uint32_t partition_count);
+    // Create an app for test with specified name, partition count and replica count.
+    void create_app(const std::string &name, int32_t partition_count, int32_t replica_count);
+
+    void create_app(const std::string &name, int32_t partition_count)
+    {
+        create_app(name, partition_count, 3);
+    }
 
     void create_app(const std::string &name) { create_app(name, 8); }
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2092

While the remote table created with only one replica for the full duplication
(copying checkpoints), the duplication would get stuck in `DS_APP` status
forever due to `ERR_NOT_ENOUGH_MEMBER`. The reason is that the check
would fail once there is no secondary replica. However, for single-replica tables,
there is certainly not any secondary replica.