### PR TITLE
fix(duplication): `min_checkpoint_decree` was reset to the invalid decree after replica server was restarted

### DIFF
--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -260,18 +260,16 @@ error_s replica_duplicator::update_progress(const duplication_progress &p)
 
 void replica_duplicator::verify_start_decree(decree start_decree)
 {
-    decree confirmed_decree = progress().confirmed_decree;
-    decree last_decree = progress().last_decree;
-    decree max_gced_decree = get_max_gced_decree();
+    const auto max_gced_decree = get_max_gced_decree();
     CHECK_LT_PREFIX_MSG(
         max_gced_decree,
         start_decree,
-        "the logs haven't yet duplicated were accidentally truncated "
-        "[max_gced_decree: {}, start_decree: {}, confirmed_decree: {}, last_decree: {}]",
+        "the logs haven't yet duplicated were accidentally truncated [max_gced_decree: {}, "
+        "start_decree: {}, confirmed_decree: {}, last_decree: {}]",
         max_gced_decree,
         start_decree,
-        confirmed_decree,
-        last_decree);
+        progress().confirmed_decree,
+        progress().last_decree);
 }
 
 decree replica_duplicator::get_max_gced_decree() const

--- a/src/replica/duplication/replica_duplicator.h
+++ b/src/replica/duplication/replica_duplicator.h
@@ -157,8 +157,8 @@ public:
 
         {
             zauto_read_lock l(_lock);
-            JSON_ENCODE_OBJ(writer, confirmed_decree, _progress.last_decree);
-            JSON_ENCODE_OBJ(writer, persisted_decree, _progress.confirmed_decree);
+            JSON_ENCODE_OBJ(writer, replica_confirmed_decree, _progress.last_decree);
+            JSON_ENCODE_OBJ(writer, meta_persisted_decree, _progress.confirmed_decree);
         }
 
         writer.EndObject();

--- a/src/replica/duplication/test/dup_replica_http_service_test.cpp
+++ b/src/replica/duplication/test/dup_replica_http_service_test.cpp
@@ -43,6 +43,7 @@ INSTANTIATE_TEST_SUITE_P(, dup_replica_http_service_test, ::testing::Values(fals
 TEST_P(dup_replica_http_service_test, query_duplication_handler)
 {
     auto pri = stub->add_primary_replica(1, 1);
+    pri->init_private_log(pri->dir());
 
     // primary confirmed_decree
     duplication_entry ent;

--- a/src/replica/duplication/test/dup_replica_http_service_test.cpp
+++ b/src/replica/duplication/test/dup_replica_http_service_test.cpp
@@ -42,7 +42,7 @@ INSTANTIATE_TEST_SUITE_P(, dup_replica_http_service_test, ::testing::Values(fals
 
 TEST_P(dup_replica_http_service_test, query_duplication_handler)
 {
-    auto pri = stub->add_primary_replica(1, 1);
+    auto *pri = stub->add_primary_replica(1, 1);
     pri->init_private_log(pri->dir());
 
     // primary confirmed_decree

--- a/src/replica/duplication/test/duplication_sync_timer_test.cpp
+++ b/src/replica/duplication/test/duplication_sync_timer_test.cpp
@@ -285,7 +285,7 @@ public:
 
         for (int appid = 1; appid <= 3; appid++) {
             auto *rep = stub->find_replica(appid, 1);
-            auto dup = find_dup(rep, 1);
+            auto *dup = find_dup(rep, 1);
 
             ASSERT_EQ(3, dup->progress().confirmed_decree);
         }

--- a/src/replica/duplication/test/mutation_batch_test.cpp
+++ b/src/replica/duplication/test/mutation_batch_test.cpp
@@ -34,6 +34,7 @@
 #include "replica/duplication/replica_duplicator.h"
 #include "replica/mutation.h"
 #include "replica/prepare_list.h"
+#include "replica/test/mock_utils.h"
 #include "runtime/task/task_code.h"
 #include "utils/autoref_ptr.h"
 #include "utils/blob.h"

--- a/src/replica/duplication/test/mutation_batch_test.cpp
+++ b/src/replica/duplication/test/mutation_batch_test.cpp
@@ -42,7 +42,7 @@ namespace dsn::replication {
 
 class mutation_batch_test : public duplication_test_base
 {
-public:
+protected:
     mutation_batch_test()
     {
         _replica->init_private_log(_replica->dir());
@@ -50,19 +50,19 @@ public:
         _batcher = std::make_unique<mutation_batch>(_duplicator.get());
     }
 
-    void reset_buffer(const decree last_commit, const decree start, const decree end)
+    void reset_buffer(const decree last_commit, const decree start, const decree end) const
     {
         _batcher->_mutation_buffer->reset(last_commit);
         _batcher->_mutation_buffer->_start_decree = start;
         _batcher->_mutation_buffer->_end_decree = end;
     }
 
-    void commit_buffer(const decree current_decree)
+    void commit_buffer(const decree current_decree) const
     {
         _batcher->_mutation_buffer->commit(current_decree, COMMIT_TO_DECREE_HARD);
     }
 
-    void check_mutation_contents(const std::vector<std::string> &expected_mutations)
+    void check_mutation_contents(const std::vector<std::string> &expected_mutations) const
     {
         const auto all_mutations = _batcher->move_all_mutations();
 

--- a/src/replica/duplication/test/mutation_batch_test.cpp
+++ b/src/replica/duplication/test/mutation_batch_test.cpp
@@ -43,23 +43,28 @@ namespace dsn::replication {
 class mutation_batch_test : public duplication_test_base
 {
 public:
-    mutation_batch_test() : _duplicator(create_test_duplicator(0)), _batcher(_duplicator.get()) {}
+    mutation_batch_test()
+    {
+        _replica->init_private_log(_replica->dir());
+        _duplicator = create_test_duplicator(0);
+        _batcher = std::make_unique<mutation_batch>(_duplicator.get());
+    }
 
     void reset_buffer(const decree last_commit, const decree start, const decree end)
     {
-        _batcher._mutation_buffer->reset(last_commit);
-        _batcher._mutation_buffer->_start_decree = start;
-        _batcher._mutation_buffer->_end_decree = end;
+        _batcher->_mutation_buffer->reset(last_commit);
+        _batcher->_mutation_buffer->_start_decree = start;
+        _batcher->_mutation_buffer->_end_decree = end;
     }
 
     void commit_buffer(const decree current_decree)
     {
-        _batcher._mutation_buffer->commit(current_decree, COMMIT_TO_DECREE_HARD);
+        _batcher->_mutation_buffer->commit(current_decree, COMMIT_TO_DECREE_HARD);
     }
 
     void check_mutation_contents(const std::vector<std::string> &expected_mutations)
     {
-        const auto all_mutations = _batcher.move_all_mutations();
+        const auto all_mutations = _batcher->move_all_mutations();
 
         std::vector<std::string> actual_mutations;
         std::transform(all_mutations.begin(),
@@ -71,7 +76,7 @@ public:
     }
 
     std::unique_ptr<replica_duplicator> _duplicator;
-    mutation_batch _batcher;
+    std::unique_ptr<mutation_batch> _batcher;
 };
 
 INSTANTIATE_TEST_SUITE_P(, mutation_batch_test, ::testing::Values(false, true));
@@ -80,38 +85,38 @@ TEST_P(mutation_batch_test, prepare_mutation)
 {
     auto mu1 = create_test_mutation(1, 0, "first mutation");
     set_last_applied_decree(1);
-    ASSERT_TRUE(_batcher.add(mu1));
-    ASSERT_EQ(1, _batcher.last_decree());
+    ASSERT_TRUE(_batcher->add(mu1));
+    ASSERT_EQ(1, _batcher->last_decree());
 
     auto mu2 = create_test_mutation(2, 1, "abcde");
     set_last_applied_decree(2);
-    ASSERT_TRUE(_batcher.add(mu2));
-    ASSERT_EQ(2, _batcher.last_decree());
+    ASSERT_TRUE(_batcher->add(mu2));
+    ASSERT_EQ(2, _batcher->last_decree());
 
     auto mu3 = create_test_mutation(3, 2, "hello world");
-    ASSERT_TRUE(_batcher.add(mu3));
+    ASSERT_TRUE(_batcher->add(mu3));
 
     // The last decree has not been updated.
-    ASSERT_EQ(2, _batcher.last_decree());
+    ASSERT_EQ(2, _batcher->last_decree());
 
     auto mu4 = create_test_mutation(4, 2, "foo bar");
-    ASSERT_TRUE(_batcher.add(mu4));
-    ASSERT_EQ(2, _batcher.last_decree());
+    ASSERT_TRUE(_batcher->add(mu4));
+    ASSERT_EQ(2, _batcher->last_decree());
 
     // The committed mutation would be ignored.
     auto mu2_another = create_test_mutation(2, 1, "another second mutation");
-    ASSERT_TRUE(_batcher.add(mu2_another));
-    ASSERT_EQ(2, _batcher.last_decree());
+    ASSERT_TRUE(_batcher->add(mu2_another));
+    ASSERT_EQ(2, _batcher->last_decree());
 
     // The mutation with duplicate decree would be ignored.
     auto mu3_another = create_test_mutation(3, 2, "123 xyz");
-    ASSERT_TRUE(_batcher.add(mu3_another));
-    ASSERT_EQ(2, _batcher.last_decree());
+    ASSERT_TRUE(_batcher->add(mu3_another));
+    ASSERT_EQ(2, _batcher->last_decree());
 
     auto mu5 = create_test_mutation(5, 2, "5th mutation");
     set_last_applied_decree(5);
-    ASSERT_TRUE(_batcher.add(mu5));
-    ASSERT_EQ(5, _batcher.last_decree());
+    ASSERT_TRUE(_batcher->add(mu5));
+    ASSERT_EQ(5, _batcher->last_decree());
 
     check_mutation_contents({"first mutation", "abcde", "hello world", "foo bar", "5th mutation"});
 }
@@ -119,7 +124,7 @@ TEST_P(mutation_batch_test, prepare_mutation)
 TEST_P(mutation_batch_test, add_null_mutation)
 {
     auto mu = create_test_mutation(1, nullptr);
-    _batcher.add_mutation_if_valid(mu, 0);
+    _batcher->add_mutation_if_valid(mu, 0);
 
     check_mutation_contents({""});
 }
@@ -127,7 +132,7 @@ TEST_P(mutation_batch_test, add_null_mutation)
 TEST_P(mutation_batch_test, add_empty_mutation)
 {
     auto mu = create_test_mutation(1, "");
-    _batcher.add_mutation_if_valid(mu, 0);
+    _batcher->add_mutation_if_valid(mu, 0);
 
     check_mutation_contents({""});
 }
@@ -138,7 +143,7 @@ TEST_P(mutation_batch_test, add_string_view_mutation)
     auto mu = create_test_mutation(1, nullptr);
     const std::string data("hello");
     mu->data.updates.back().data = blob(data.data(), 0, data.size());
-    _batcher.add_mutation_if_valid(mu, 0);
+    _batcher->add_mutation_if_valid(mu, 0);
 
     check_mutation_contents({"hello"});
 }
@@ -146,7 +151,7 @@ TEST_P(mutation_batch_test, add_string_view_mutation)
 TEST_P(mutation_batch_test, add_a_valid_mutation)
 {
     auto mu = create_test_mutation(1, "hello");
-    _batcher.add_mutation_if_valid(mu, 0);
+    _batcher->add_mutation_if_valid(mu, 0);
 
     check_mutation_contents({"hello"});
 }
@@ -156,13 +161,13 @@ TEST_P(mutation_batch_test, add_multiple_valid_mutations)
     // The mutation could not be reused, since in mutation_batch::add_mutation_if_valid
     // the elements of mutation::data::updates would be moved and nullified.
     auto mu1 = create_test_mutation(1, "hello");
-    _batcher.add_mutation_if_valid(mu1, 0);
+    _batcher->add_mutation_if_valid(mu1, 0);
 
     auto mu2 = create_test_mutation(2, "world");
-    _batcher.add_mutation_if_valid(mu2, 2);
+    _batcher->add_mutation_if_valid(mu2, 2);
 
     auto mu3 = create_test_mutation(3, "hi");
-    _batcher.add_mutation_if_valid(mu3, 2);
+    _batcher->add_mutation_if_valid(mu3, 2);
 
     check_mutation_contents({"hello", "world", "hi"});
 }
@@ -170,17 +175,17 @@ TEST_P(mutation_batch_test, add_multiple_valid_mutations)
 TEST_P(mutation_batch_test, add_invalid_mutation)
 {
     auto mu2 = create_test_mutation(2, "world");
-    _batcher.add_mutation_if_valid(mu2, 2);
+    _batcher->add_mutation_if_valid(mu2, 2);
 
     // mu1 would be ignored, since its decree is less than the start decree.
     auto mu1 = create_test_mutation(1, "hello");
-    _batcher.add_mutation_if_valid(mu1, 2);
+    _batcher->add_mutation_if_valid(mu1, 2);
 
     auto mu3 = create_test_mutation(3, "hi");
-    _batcher.add_mutation_if_valid(mu3, 2);
+    _batcher->add_mutation_if_valid(mu3, 2);
 
     auto mu4 = create_test_mutation(1, "ok");
-    _batcher.add_mutation_if_valid(mu4, 1);
+    _batcher->add_mutation_if_valid(mu4, 1);
 
     // "ok" would be the first, since its timestamp (i.e. decree in create_test_mutation)
     // is the smallest.
@@ -191,7 +196,7 @@ TEST_P(mutation_batch_test, ignore_non_idempotent_write)
 {
     auto mu = create_test_mutation(1, "hello");
     mu->data.updates[0].code = RPC_DUPLICATION_NON_IDEMPOTENT_WRITE;
-    _batcher.add_mutation_if_valid(mu, 0);
+    _batcher->add_mutation_if_valid(mu, 0);
     check_mutation_contents({});
 }
 
@@ -202,7 +207,7 @@ TEST_P(mutation_batch_test, mutation_buffer_commit)
     // details.
     reset_buffer(10, 15, 20);
     commit_buffer(15);
-    ASSERT_EQ(14, _batcher.last_decree());
+    ASSERT_EQ(14, _batcher->last_decree());
 }
 
 } // namespace dsn::replication

--- a/src/replica/duplication/test/replica_duplicator_test.cpp
+++ b/src/replica/duplication/test/replica_duplicator_test.cpp
@@ -69,12 +69,13 @@ public:
         return dup->_min_checkpoint_decree;
     }
 
-    void test_new_duplicator(const std::string &remote_app_name, bool specify_remote_app_name)
+    void test_new_duplicator(const std::string &remote_app_name,
+                             bool specify_remote_app_name,
+                             int64_t confirmed_decree)
     {
         const dupid_t dupid = 1;
         const std::string remote = "remote_address";
         const duplication_status::type status = duplication_status::DS_PAUSE;
-        const int64_t confirmed_decree = 100;
 
         duplication_entry dup_ent;
         dup_ent.dupid = dupid;
@@ -90,8 +91,13 @@ public:
         ASSERT_EQ(remote, duplicator->remote_cluster_name());
         ASSERT_EQ(remote_app_name, duplicator->remote_app_name());
         ASSERT_EQ(status, duplicator->_status);
+        ASSERT_EQ(1, duplicator->_min_checkpoint_decree);
         ASSERT_EQ(confirmed_decree, duplicator->progress().confirmed_decree);
-        ASSERT_EQ(confirmed_decree, duplicator->progress().last_decree);
+        if (confirmed_decree == invalid_decree) {
+            ASSERT_EQ(1, duplicator->progress().last_decree);
+        } else {
+            ASSERT_EQ(confirmed_decree, duplicator->progress().last_decree);
+        }
 
         auto &expected_env = *duplicator;
         ASSERT_EQ(duplicator->tracker(), expected_env.__conf.tracker);
@@ -144,12 +150,25 @@ INSTANTIATE_TEST_SUITE_P(, replica_duplicator_test, ::testing::Values(false, tru
 
 TEST_P(replica_duplicator_test, new_duplicator_without_remote_app_name)
 {
-    test_new_duplicator("temp", false);
+    test_new_duplicator("temp", false, 100);
 }
 
 TEST_P(replica_duplicator_test, new_duplicator_with_remote_app_name)
 {
-    test_new_duplicator("another_test_app", true);
+    test_new_duplicator("another_test_app", true, 100);
+}
+
+// Initial confirmed decree immediately after the duplication was created is `invalid_decree`
+// which was synced from meta server.
+TEST_P(replica_duplicator_test, new_duplicator_with_initial_confirmed_decree)
+{
+    test_new_duplicator("test_initial_confirmed_decree", true, invalid_decree);
+}
+
+// The duplication progressed and confirmed decree became valid.
+TEST_P(replica_duplicator_test, new_duplicator_with_non_initial_confirmed_decree)
+{
+    test_new_duplicator("test_non_initial_confirmed_decree", true, 1);
 }
 
 TEST_P(replica_duplicator_test, pause_start_duplication) { test_pause_start_duplication(); }
@@ -160,7 +179,7 @@ TEST_P(replica_duplicator_test, duplication_progress)
 
     // Start duplication from empty replica.
     ASSERT_EQ(1, min_checkpoint_decree(duplicator));
-    ASSERT_EQ(0, duplicator->progress().last_decree);
+    ASSERT_EQ(1, duplicator->progress().last_decree);
     ASSERT_EQ(invalid_decree, duplicator->progress().confirmed_decree);
 
     // Update the max decree that has been duplicated to the remote cluster.


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2098

After the replica server was restarted, `min_checkpoint_decree` would be
reset to the invalid decree(-1), which is wrong for an existing duplication that
is still in the status of `DS_PREPARE`, meaning the replica would continue
to generate checkpoints for the full duplication. The duplication in the status
of `DS_PREPARE` would call `replica_duplicator::prepare_dup()` which makes
an assertion that `min_checkpoint_decree` must be greater than 0. Therefore,
the replica server would always exit abnormally due to the failed assertion.