### PR TITLE
feat(duplication): add a new option to configure the duration of the delay until the next execution if there is no mutation to be loaded

### DIFF
--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -74,7 +74,7 @@ void load_mutation::run()
         std::min(_replica->private_log()->max_decree_on_disk(), _replica->last_applied_decree());
     if (_start_decree > max_plog_committed_decree) {
         // Wait for a while if no mutation was added.
-        repeat(FLAGS_dup_no_mutation_load_delay_ms * 1_ms);
+        repeat(std::chrono::milliseconds(FLAGS_dup_no_mutation_load_delay_ms));
         return;
     }
 

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -50,8 +50,6 @@ namespace dsn {
 
 namespace replication {
 
-using namespace literals::chrono_literals;
-
 //                     //
 // mutation_duplicator //
 //                     //
@@ -73,6 +71,7 @@ void load_mutation::run()
     const auto max_plog_committed_decree =
         std::min(_replica->private_log()->max_decree_on_disk(), _replica->last_applied_decree());
     if (_start_decree > max_plog_committed_decree) {
+        using namespace literals::chrono_literals;
         // Wait for a while if no mutation was added.
         repeat(FLAGS_dup_no_mutation_load_delay_ms * 1_ms);
         return;

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -50,6 +50,8 @@ namespace dsn {
 
 namespace replication {
 
+using namespace literals::chrono_literals; // NOLINT(google-build-using-namespace)
+
 //                     //
 // mutation_duplicator //
 //                     //
@@ -71,7 +73,6 @@ void load_mutation::run()
     const auto max_plog_committed_decree =
         std::min(_replica->private_log()->max_decree_on_disk(), _replica->last_applied_decree());
     if (_start_decree > max_plog_committed_decree) {
-        using namespace literals::chrono_literals;
         // Wait for a while if no mutation was added.
         repeat(FLAGS_dup_no_mutation_load_delay_ms * 1_ms);
         return;

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -17,11 +17,14 @@
 
 #include "duplication_pipeline.h"
 
-#include <string_view>
 #include <stddef.h>
 #include <algorithm>
+#include <chrono>
+#include <cstdint>
 #include <functional>
+#include <ratio>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "load_from_private_log.h"

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -39,6 +39,7 @@ DSN_DEFINE_uint64(
     dup_no_mutation_load_delay_ms,
     100,
     "The duration of the delay until the next execution if there is no mutation to be loaded.");
+DSN_TAG_VARIABLE(dup_no_mutation_load_delay_ms, FT_MUTABLE);
 
 METRIC_DEFINE_counter(replica,
                       dup_shipped_bytes,

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -17,9 +17,9 @@
 
 #include "duplication_pipeline.h"
 
-#include <stddef.h>
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <ratio>
@@ -53,7 +53,7 @@ namespace dsn {
 
 namespace replication {
 
-using namespace literals::chrono_literals; // NOLINT(google-build-using-namespace)
+using literals::chrono_literals::operator"" _ms;
 
 //                     //
 // mutation_duplicator //

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -33,7 +33,6 @@
 #include "replica/replica.h"
 #include "runtime/rpc/rpc_holder.h"
 #include "utils/autoref_ptr.h"
-#include "utils/chrono_literals.h"
 #include "utils/errors.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
@@ -52,8 +51,6 @@ METRIC_DEFINE_counter(replica,
 namespace dsn {
 
 namespace replication {
-
-using literals::chrono_literals::operator"" _ms;
 
 //                     //
 // mutation_duplicator //

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -20,9 +20,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
-#include <cstdint>
 #include <functional>
-#include <ratio>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -31,7 +29,6 @@
 #include "replica/duplication/replica_duplicator.h"
 #include "replica/mutation_log.h"
 #include "replica/replica.h"
-#include "runtime/rpc/rpc_holder.h"
 #include "utils/autoref_ptr.h"
 #include "utils/errors.h"
 #include "utils/flags.h"


### PR DESCRIPTION
A new option is added for duplication to configure the duration of the delay
until the next execution if there is no mutation to be loaded:

```diff
[replication]
+ dup_no_mutation_load_delay_ms = 100
```