### PR TITLE
fix(duplication): deal with bulkload dup crash

### DIFF
--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -239,6 +239,10 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
     auto batch_request = std::make_unique<dsn::apps::duplicate_request>();
     uint batch_count = 0;
     uint batch_bytes = 0;
+    // The rpc codes should be ignored:
+    // - RPC_RRDB_RRDB_DUPLICATE: Now not supports duplicating the deuplicate mutations to the
+    // remote cluster.
+    // - RPC_RRDB_RRDB_BULK_LOAD: Now not supports the control flow RPC.
     const static std::set<int> ingnored_rpc_code = {dsn::apps::RPC_RRDB_RRDB_DUPLICATE,
                                                     dsn::apps::RPC_RRDB_RRDB_BULK_LOAD};
 
@@ -249,9 +253,6 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
         dsn::blob raw_message = std::get<2>(mut);
         auto dreq = std::make_unique<dsn::apps::duplicate_request>();
 
-        // ignore if it is a DUPLICATE or BULKLOAD
-        // Because DUPLICATE comes from other clusters should not be forwarded to any other
-        // destinations. A DUPLICATE is meant to be targeting only one cluster.
         if (gutil::ContainsKey(ingnored_rpc_code, rpc_code)) {
             // It it do not recommend to use bulkload and normal writing in the same app,
             // it may also cause inconsistency between actual data and expected data

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -264,15 +264,15 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
                 LOG_DEBUG_PREFIX("Ignore sending bulkload rpc when doing duplication");
             }
             continue;
-        } else {
-            dsn::apps::duplicate_entry entry;
-            entry.__set_raw_message(raw_message);
-            entry.__set_task_code(rpc_code);
-            entry.__set_timestamp(std::get<0>(mut));
-            entry.__set_cluster_id(dsn::replication::get_current_dup_cluster_id());
-            batch_request->entries.emplace_back(std::move(entry));
-            batch_bytes += raw_message.length();
         }
+
+        dsn::apps::duplicate_entry entry;
+        entry.__set_raw_message(raw_message);
+        entry.__set_task_code(rpc_code);
+        entry.__set_timestamp(std::get<0>(mut));
+        entry.__set_cluster_id(dsn::replication::get_current_dup_cluster_id());
+        batch_request->entries.emplace_back(std::move(entry));
+        batch_bytes += raw_message.length();
 
         if (batch_count == muts.size() || batch_bytes >= FLAGS_duplicate_log_batch_bytes ||
             batch_bytes >= dsn::replication::FLAGS_dup_max_allowed_write_size) {

--- a/src/server/pegasus_mutation_duplicator.cpp
+++ b/src/server/pegasus_mutation_duplicator.cpp
@@ -250,6 +250,9 @@ void pegasus_mutation_duplicator::duplicate(mutation_tuple_set muts, callback cb
             // Because DUPLICATE comes from other clusters should not be forwarded to any other
             // destinations. A DUPLICATE is meant to be targeting only one cluster.
             continue;
+        } else if (rpc_code == dsn::apps::RPC_RRDB_RRDB_BULK_LOAD) {
+            LOG_DEBUG_PREFIX("Ignore sending bulkload rpc when doing duplication");
+            continue;
         } else {
             dsn::apps::duplicate_entry entry;
             entry.__set_raw_message(raw_message);

--- a/src/server/pegasus_mutation_duplicator.h
+++ b/src/server/pegasus_mutation_duplicator.h
@@ -24,6 +24,7 @@
 #include <deque>
 #include <map>
 #include <string>
+#include <set>
 
 #include "replica/duplication/mutation_duplicator.h"
 #include "rrdb/rrdb.client.h"
@@ -96,6 +97,9 @@ private:
 // Decodes the binary `request_data` into write request in thrift struct, and
 // calculates the hash value from the write's hash key.
 extern uint64_t get_hash_from_request(dsn::task_code rpc_code, const dsn::blob &request_data);
+
+const std::set<int> ingnored_rpc_code = {dsn::apps::RPC_RRDB_RRDB_DUPLICATE,
+                                         dsn::apps::RPC_RRDB_RRDB_BULK_LOAD};
 
 } // namespace server
 } // namespace pegasus

--- a/src/server/pegasus_mutation_duplicator.h
+++ b/src/server/pegasus_mutation_duplicator.h
@@ -97,9 +97,5 @@ private:
 // Decodes the binary `request_data` into write request in thrift struct, and
 // calculates the hash value from the write's hash key.
 extern uint64_t get_hash_from_request(dsn::task_code rpc_code, const dsn::blob &request_data);
-
-const std::set<int> ingnored_rpc_code = {dsn::apps::RPC_RRDB_RRDB_DUPLICATE,
-                                         dsn::apps::RPC_RRDB_RRDB_BULK_LOAD};
-
 } // namespace server
 } // namespace pegasus

--- a/src/server/pegasus_mutation_duplicator.h
+++ b/src/server/pegasus_mutation_duplicator.h
@@ -24,7 +24,6 @@
 #include <deque>
 #include <map>
 #include <string>
-#include <set>
 
 #include "replica/duplication/mutation_duplicator.h"
 #include "rrdb/rrdb.client.h"
@@ -97,5 +96,6 @@ private:
 // Decodes the binary `request_data` into write request in thrift struct, and
 // calculates the hash value from the write's hash key.
 extern uint64_t get_hash_from_request(dsn::task_code rpc_code, const dsn::blob &request_data);
+
 } // namespace server
 } // namespace pegasus


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#2100 

### What is changed and how does it work?
Make replica server skip `RPC_RRDB_RRDB_BULK_LOAD` code when reply the plog.

##### Tests <!-- At least one of them must be included. -->
- Unit test
- Manual test
