### PR TITLE
feat: dynamic reload duplication config

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -30,5 +30,5 @@ set(MY_PROJ_SRC "")
 
 dsn_add_static_library()
 
-target_link_libraries(pegasus_base PUBLIC RocksDB::rocksdb sasl2 gssapi_krb5 krb5 dsn_replication_common)
+target_link_libraries(pegasus_base PUBLIC dsn_replication_common RocksDB::rocksdb sasl2 gssapi_krb5 krb5 dsn_replication_common)
 target_include_directories(pegasus_base PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")

--- a/src/common/duplication_common.cpp
+++ b/src/common/duplication_common.cpp
@@ -18,6 +18,7 @@
 #include "duplication_common.h"
 
 #include <nlohmann/json.hpp>
+#include <cmath>
 #include <cstdint>
 #include <map>
 #include <utility>
@@ -28,6 +29,7 @@
 #include "nlohmann/detail/json_ref.hpp"
 #include "nlohmann/json_fwd.hpp"
 #include "utils/config_api.h"
+#include "utils/configuration.h"
 #include "utils/error_code.h"
 #include "utils/fmt_logging.h"
 #include "utils/singleton.h"

--- a/src/common/duplication_common.h
+++ b/src/common/duplication_common.h
@@ -62,6 +62,8 @@ inline bool is_duplication_status_invalid(duplication_status::type status)
 /// The returned cluster id of get_duplication_cluster_id("wuhan-mi-srv-ad") is 3.
 extern error_with<uint8_t> get_duplication_cluster_id(const std::string &cluster_name);
 
+extern error_with<uint8_t> make_reloading_duplication_config(std::string &config_file);
+
 extern uint8_t get_current_dup_cluster_id_or_default();
 
 extern uint8_t get_current_dup_cluster_id();

--- a/src/common/test/CMakeLists.txt
+++ b/src/common/test/CMakeLists.txt
@@ -40,6 +40,8 @@ set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_BINPLACES
         config-test.ini
+        err-config-test.ini
+        new-config-test.ini
         run.sh
         )
 

--- a/src/common/test/duplication_common_test.cpp
+++ b/src/common/test/duplication_common_test.cpp
@@ -49,7 +49,6 @@ std::string unkown_file = "unknown.ini";
 std::string err_config_file = "err-config-test.ini";
 std::string new_config_file = "new-config-test.ini";
 
-
 TEST(duplication_common, get_duplication_cluster_id)
 {
     ASSERT_EQ(1, get_duplication_cluster_id("master-cluster").get_value());
@@ -93,18 +92,21 @@ TEST(duplication_common, dup_ignore_other_cluster_ids)
     }
 }
 
-TEST(duplication_common, reload_config_file){
-    ASSERT_EQ(make_reloading_duplication_config(unkown_file).get_error().code(), ERR_OBJECT_NOT_FOUND);
-    ASSERT_EQ(make_reloading_duplication_config(err_config_file).get_error().code(), ERR_INVALID_PARAMETERS);
+TEST(duplication_common, reload_config_file)
+{
+    ASSERT_EQ(make_reloading_duplication_config(unkown_file).get_error().code(),
+              ERR_OBJECT_NOT_FOUND);
+    ASSERT_EQ(make_reloading_duplication_config(err_config_file).get_error().code(),
+              ERR_INVALID_PARAMETERS);
 }
-
 
 TEST(duplication_common, reload_get_duplication_cluster_id)
 {
     make_reloading_duplication_config(config_file);
     ASSERT_EQ(get_duplication_cluster_id("master-cluster").get_value(), 1);
     ASSERT_EQ(get_duplication_cluster_id("slave-cluster").get_value(), 2);
-    ASSERT_EQ(get_duplication_cluster_id("strange-cluster").get_error().code(), ERR_OBJECT_NOT_FOUND);
+    ASSERT_EQ(get_duplication_cluster_id("strange-cluster").get_error().code(),
+              ERR_OBJECT_NOT_FOUND);
 
     make_reloading_duplication_config(new_config_file);
     ASSERT_EQ(get_duplication_cluster_id("master-cluster").get_value(), 1);
@@ -117,15 +119,17 @@ TEST(duplication_common, reload_get_meta_list)
     make_reloading_duplication_config(config_file);
     replica_helper replica;
     std::vector<dsn::host_port> addr_vec;
-    //replica.load_meta_servers(addr_vec,"pegasus.clusters","strange-cluster");
-    const char *strange_cluster_server_list = dsn_config_get_value_string("pegasus.clusters","strange-cluster", "", "");
+    // replica.load_meta_servers(addr_vec,"pegasus.clusters","strange-cluster");
+    const char *strange_cluster_server_list =
+        dsn_config_get_value_string("pegasus.clusters", "strange-cluster", "", "");
     dsn::replication::replica_helper::parse_server_list(strange_cluster_server_list, addr_vec);
     ASSERT_EQ(addr_vec.size(), 0);
     addr_vec.clear();
 
     make_reloading_duplication_config(new_config_file);
-    const char *new_strange_cluster_server_list = dsn_config_get_value_string("pegasus.clusters","strange-cluster", "", "");
-    dsn::replication::replica_helper::parse_server_list(new_strange_cluster_server_list,addr_vec);
+    const char *new_strange_cluster_server_list =
+        dsn_config_get_value_string("pegasus.clusters", "strange-cluster", "", "");
+    dsn::replication::replica_helper::parse_server_list(new_strange_cluster_server_list, addr_vec);
     ASSERT_EQ(addr_vec.size(), 2);
 
     std::string addr0 = addr_vec[0].to_string();
@@ -134,8 +138,9 @@ TEST(duplication_common, reload_get_meta_list)
     ASSERT_EQ(addr1, "localhost.test2:37001");
 
     addr_vec.clear();
-    const char *unkonw_cluster_server_list = dsn_config_get_value_string("pegasus.clusters","unknow-cluster", "", "");
-    dsn::replication::replica_helper::parse_server_list(unkonw_cluster_server_list,addr_vec);
+    const char *unkonw_cluster_server_list =
+        dsn_config_get_value_string("pegasus.clusters", "unknow-cluster", "", "");
+    dsn::replication::replica_helper::parse_server_list(unkonw_cluster_server_list, addr_vec);
     ASSERT_EQ(addr_vec.size(), 0);
 }
 

--- a/src/common/test/duplication_common_test.cpp
+++ b/src/common/test/duplication_common_test.cpp
@@ -24,12 +24,17 @@
  * THE SOFTWARE.
  */
 
-#include "common//duplication_common.h"
+#include "common/duplication_common.h"
 
 #include <cstdint>
+#include <memory>
+#include <vector>
 
+#include "common/replication_other_types.h"
 #include "gtest/gtest.h"
+#include "runtime/rpc/rpc_host_port.h"
 #include "test_util/test_util.h"
+#include "utils/config_api.h"
 #include "utils/error_code.h"
 #include "utils/flags.h"
 
@@ -111,22 +116,26 @@ TEST(duplication_common, reload_get_meta_list)
 {
     make_reloading_duplication_config(config_file);
     replica_helper replica;
-    std::vector<dsn::rpc_address> addr_vec;
-    replica.load_meta_servers(addr_vec,"pegasus.clusters","strange-cluster");
+    std::vector<dsn::host_port> addr_vec;
+    //replica.load_meta_servers(addr_vec,"pegasus.clusters","strange-cluster");
+    const char *strange_cluster_server_list = dsn_config_get_value_string("pegasus.clusters","strange-cluster", "", "");
+    dsn::replication::replica_helper::parse_server_list(strange_cluster_server_list, addr_vec);
     ASSERT_EQ(addr_vec.size(), 0);
     addr_vec.clear();
 
     make_reloading_duplication_config(new_config_file);
-    replica.load_meta_servers(addr_vec,"pegasus.clusters","strange-cluster");
+    const char *new_strange_cluster_server_list = dsn_config_get_value_string("pegasus.clusters","strange-cluster", "", "");
+    dsn::replication::replica_helper::parse_server_list(new_strange_cluster_server_list,addr_vec);
     ASSERT_EQ(addr_vec.size(), 2);
 
     std::string addr0 = addr_vec[0].to_string();
     std::string addr1 = addr_vec[1].to_string();
-    ASSERT_EQ(addr0, "127.0.0.1:37001");
-    ASSERT_EQ(addr1, "127.0.0.2:37001");
+    ASSERT_EQ(addr0, "localhost.test1:37001");
+    ASSERT_EQ(addr1, "localhost.test2:37001");
 
     addr_vec.clear();
-    replica.load_meta_servers(addr_vec,"pegasus.clusters","unknow-cluster");
+    const char *unkonw_cluster_server_list = dsn_config_get_value_string("pegasus.clusters","unknow-cluster", "", "");
+    dsn::replication::replica_helper::parse_server_list(unkonw_cluster_server_list,addr_vec);
     ASSERT_EQ(addr_vec.size(), 0);
 }
 

--- a/src/common/test/err-config-test.ini
+++ b/src/common/test/err-config-test.ini
@@ -103,4 +103,4 @@ slave-cluster  = 2
 strange-cluster = 6657
 
 [pegasus.clusters]
-strange-cluster = 127.0.0.1:37001,127.0.0.2:37001
+strange-cluster = localhost.test1:37001,localhost.test2:37001

--- a/src/common/test/err-config-test.ini
+++ b/src/common/test/err-config-test.ini
@@ -1,0 +1,106 @@
+; The MIT License (MIT)
+;
+; Copyright (c) 2015 Microsoft Corporation
+;
+; -=- Robust Distributed System Nucleus (rDSN) -=-
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+
+[apps..default]
+run = true
+count = 1
+;network.client.RPC_CHANNEL_TCP = dsn::tools::sim_network_provider, 65536
+;network.client.RPC_CHANNEL_UDP = dsn::tools::sim_network_provider, 65536
+;network.server.0.RPC_CHANNEL_TCP = dsn::tools::sim_network_provider, 65536
+
+[apps.replica]
+type = replica
+run = true
+count = 1
+ports = 54321
+pools = THREAD_POOL_DEFAULT
+
+[core]
+;tool = simulator
+tool = nativerun
+
+;toollets = tracer, profiler
+;fault_injector
+pause_on_start = false
+cli_local = false
+cli_remote = false
+
+logging_start_level = LOG_LEVEL_DEBUG
+logging_factory_name = dsn::tools::simple_logger
+
+
+[tools.simple_logger]
+fast_flush = true
+short_header = false
+stderr_start_level = LOG_LEVEL_WARNING
+
+[tools.simulator]
+random_seed = 1465902258
+
+[tools.screen_logger]
+short_header = false
+
+[network]
+; how many network threads for network library (used by asio)
+io_service_worker_count = 2
+
+; specification for each thread pool
+[threadpool..default]
+worker_count = 4
+
+[threadpool.THREAD_POOL_DEFAULT]
+name = default
+partitioned = false
+max_input_queue_length = 1024
+worker_priority = THREAD_xPRIORITY_NORMAL
+worker_count = 2
+
+[threadpool.THREAD_POOL_REPLICATION]
+name = replica
+partitioned = true
+max_input_queue_length = 2560
+worker_priority = THREAD_xPRIORITY_NORMAL
+worker_count = 3
+
+[threadpool.THREAD_POOL_REPLICATION_LONG]
+name = replica_long
+
+[task..default]
+is_trace = true
+is_profile = true
+allow_inline = false
+rpc_call_channel = RPC_CHANNEL_TCP
+rpc_message_header_format = dsn
+rpc_timeout_milliseconds = 5000
+
+[replication]
+cluster_name = master-cluster
+
+[duplication-group]
+master-cluster = 1
+slave-cluster  = 2
+strange-cluster = 6657
+
+[pegasus.clusters]
+strange-cluster = 127.0.0.1:37001,127.0.0.2:37001

--- a/src/common/test/new-config-test.ini
+++ b/src/common/test/new-config-test.ini
@@ -103,4 +103,4 @@ slave-cluster  = 2
 strange-cluster = 3
 
 [pegasus.clusters]
-strange-cluster = 127.0.0.1:37001,127.0.0.2:37001
+strange-cluster = localhost.test1:37001,localhost.test2:37001

--- a/src/common/test/new-config-test.ini
+++ b/src/common/test/new-config-test.ini
@@ -1,0 +1,106 @@
+; The MIT License (MIT)
+;
+; Copyright (c) 2015 Microsoft Corporation
+;
+; -=- Robust Distributed System Nucleus (rDSN) -=-
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+
+[apps..default]
+run = true
+count = 1
+;network.client.RPC_CHANNEL_TCP = dsn::tools::sim_network_provider, 65536
+;network.client.RPC_CHANNEL_UDP = dsn::tools::sim_network_provider, 65536
+;network.server.0.RPC_CHANNEL_TCP = dsn::tools::sim_network_provider, 65536
+
+[apps.replica]
+type = replica
+run = true
+count = 1
+ports = 54321
+pools = THREAD_POOL_DEFAULT
+
+[core]
+;tool = simulator
+tool = nativerun
+
+;toollets = tracer, profiler
+;fault_injector
+pause_on_start = false
+cli_local = false
+cli_remote = false
+
+logging_start_level = LOG_LEVEL_DEBUG
+logging_factory_name = dsn::tools::simple_logger
+
+
+[tools.simple_logger]
+fast_flush = true
+short_header = false
+stderr_start_level = LOG_LEVEL_WARNING
+
+[tools.simulator]
+random_seed = 1465902258
+
+[tools.screen_logger]
+short_header = false
+
+[network]
+; how many network threads for network library (used by asio)
+io_service_worker_count = 2
+
+; specification for each thread pool
+[threadpool..default]
+worker_count = 4
+
+[threadpool.THREAD_POOL_DEFAULT]
+name = default
+partitioned = false
+max_input_queue_length = 1024
+worker_priority = THREAD_xPRIORITY_NORMAL
+worker_count = 2
+
+[threadpool.THREAD_POOL_REPLICATION]
+name = replica
+partitioned = true
+max_input_queue_length = 2560
+worker_priority = THREAD_xPRIORITY_NORMAL
+worker_count = 3
+
+[threadpool.THREAD_POOL_REPLICATION_LONG]
+name = replica_long
+
+[task..default]
+is_trace = true
+is_profile = true
+allow_inline = false
+rpc_call_channel = RPC_CHANNEL_TCP
+rpc_message_header_format = dsn
+rpc_timeout_milliseconds = 5000
+
+[replication]
+cluster_name = master-cluster
+
+[duplication-group]
+master-cluster = 1
+slave-cluster  = 2
+strange-cluster = 3
+
+[pegasus.clusters]
+strange-cluster = 127.0.0.1:37001,127.0.0.2:37001

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -48,6 +48,6 @@ add_library(dsn_runtime STATIC
         tool_api.cpp
         tracer.cpp
         zlocks.cpp)
-target_link_libraries(dsn_runtime PRIVATE dsn_security dsn_utils sasl2 gssapi_krb5 krb5)
+target_link_libraries(dsn_runtime PRIVATE dsn_replication_common dsn_security dsn_utils sasl2 gssapi_krb5 krb5)
 define_file_basename_for_sources(dsn_runtime)
 install(TARGETS dsn_runtime DESTINATION "lib")

--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -81,6 +81,7 @@
 #include "utils/strings.h"
 #include "utils/sys_exit_hook.h"
 #include "utils/threadpool_spec.h"
+#include "common/duplication_common.h"
 
 DSN_DEFINE_bool(
     core,
@@ -584,6 +585,35 @@ bool run(const char *config_file,
             dsn_config_dump(*os);
             return oss.str();
         });
+
+    dsn::command_manager::instance().register_command({"dup-config-reload"},
+                                                      "dup-config-reload - reload the new config file on every server",
+                                                      "dup-config-reload  [empty OR reload-this-config-file]. To dynamic update duplication parameter "
+                                                      "1.Put new config on every server.(Include replica server and meta server)"
+                                                      "2.Use this remote command reload config to memory, and get duplication parameter to dup object",
+                                                      [](const std::vector<std::string> &args) {
+                                                          std::ostringstream oss;
+                                                          std::string file_name  = "config.ini";
+                                                          // choose another file to reload
+                                                          if (args.size() > 0) {
+                                                              file_name = args[0];
+                                                          }
+
+                                                          auto reload_influence_lines = dsn::replication::make_reloading_duplication_config(file_name);
+                                                          if (!reload_influence_lines.is_ok()) {
+                                                              oss << "ERR_INVALID_PARAMETERS. Reload duplication config file, error:{"
+                                                                  << reload_influence_lines.get_error() << "}"
+                                                                  << std::endl;
+
+                                                              return oss.str();
+                                                          }
+
+                                                          oss << "ERR_OK. Reload duplication config success, reload_influence_lines:{"
+                                                              << std::to_string(reload_influence_lines.get_value()) << "}"
+                                                              << std::endl;
+                                                          return oss.str();
+                                                      });
+
 
     // invoke customized init after apps are created
     dsn::tools::sys_init_after_app_created.execute();

--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -589,33 +589,35 @@ bool run(const char *config_file,
             return oss.str();
         });
 
-    dump_log_cmd = dsn::command_manager::instance().register_single_command({"dup-config-reload"},
-                                                      "dup-config-reload - reload the new config file on every server",
-                                                      "dup-config-reload  [empty OR reload-this-config-file]. To dynamic update duplication parameter "
-                                                      "1.Put new config on every server.(Include replica server and meta server)"
-                                                      "2.Use this remote command reload config to memory, and get duplication parameter to dup object",
-                                                      [](const std::vector<std::string> &args) {
-                                                          std::ostringstream oss;
-                                                          std::string file_name  = "config.ini";
-                                                          // choose another file to reload
-                                                          if (args.size() > 0) {
-                                                              file_name = args[0];
-                                                          }
+    dump_log_cmd = dsn::command_manager::instance().register_single_command(
+        {"dup-config-reload"},
+        "dup-config-reload - reload the new config file on every server",
+        "dup-config-reload  [empty OR reload-this-config-file]. To dynamic update duplication "
+        "parameter "
+        "1.Put new config on every server.(Include replica server and meta server)"
+        "2.Use this remote command reload config to memory, and get duplication parameter to dup "
+        "object",
+        [](const std::vector<std::string> &args) {
+            std::ostringstream oss;
+            std::string file_name = "config.ini";
+            // choose another file to reload
+            if (args.size() > 0) {
+                file_name = args[0];
+            }
 
-                                                          auto reload_influence_lines = dsn::replication::make_reloading_duplication_config(file_name);
-                                                          if (!reload_influence_lines.is_ok()) {
-                                                              oss << "ERR_INVALID_PARAMETERS. Reload duplication config file, error:{"
-                                                                  << reload_influence_lines.get_error() << "}"
-                                                                  << std::endl;
+            auto reload_influence_lines =
+                dsn::replication::make_reloading_duplication_config(file_name);
+            if (!reload_influence_lines.is_ok()) {
+                oss << "ERR_INVALID_PARAMETERS. Reload duplication config file, error:{"
+                    << reload_influence_lines.get_error() << "}" << std::endl;
 
-                                                              return oss.str();
-                                                          }
+                return oss.str();
+            }
 
-                                                          oss << "ERR_OK. Reload duplication config success, reload_influence_lines:{"
-                                                              << std::to_string(reload_influence_lines.get_value()) << "}"
-                                                              << std::endl;
-                                                          return oss.str();
-                                                      });
+            oss << "ERR_OK. Reload duplication config success, reload_influence_lines:{"
+                << std::to_string(reload_influence_lines.get_value()) << "}" << std::endl;
+            return oss.str();
+        });
 
     // invoke customized init after apps are created
     dsn::tools::sys_init_after_app_created.execute();

--- a/src/utils/config_api.cpp
+++ b/src/utils/config_api.cpp
@@ -39,6 +39,23 @@ bool dsn_config_load(const char *file, const char *arguments)
 
 void dsn_config_dump(std::ostream &os) { g_config.dump(os); }
 
+bool dsn_config_reload(const char *file, const char *arguments, /*out*/dsn::configuration &old_config)
+{
+    old_config = g_config;
+    dsn::configuration temp_config;
+    if(!temp_config.load(file, arguments)){
+        // todo gns: add some error log
+        return false;
+    }
+
+    g_config = std::move(temp_config);
+    return true;
+}
+
+void dsn_config_rollback(dsn::configuration &old_config){
+    g_config = std::move(old_config);
+}
+
 const char *dsn_config_get_value_string(const char *section,
                                         const char *key,
                                         const char *default_value,

--- a/src/utils/config_api.cpp
+++ b/src/utils/config_api.cpp
@@ -27,6 +27,7 @@
 #include "utils/config_api.h"
 
 #include <algorithm>
+#include <utility>
 
 #include "utils/configuration.h"
 

--- a/src/utils/config_api.cpp
+++ b/src/utils/config_api.cpp
@@ -40,11 +40,13 @@ bool dsn_config_load(const char *file, const char *arguments)
 
 void dsn_config_dump(std::ostream &os) { g_config.dump(os); }
 
-bool dsn_config_reload(const char *file, const char *arguments, /*out*/dsn::configuration &old_config)
+bool dsn_config_reload(const char *file,
+                       const char *arguments,
+                       /*out*/ dsn::configuration &old_config)
 {
     old_config = g_config;
     dsn::configuration temp_config;
-    if(!temp_config.load(file, arguments)){
+    if (!temp_config.load(file, arguments)) {
         // todo gns: add some error log
         return false;
     }
@@ -53,9 +55,7 @@ bool dsn_config_reload(const char *file, const char *arguments, /*out*/dsn::conf
     return true;
 }
 
-void dsn_config_rollback(dsn::configuration &old_config){
-    g_config = std::move(old_config);
-}
+void dsn_config_rollback(dsn::configuration &old_config) { g_config = std::move(old_config); }
 
 const char *dsn_config_get_value_string(const char *section,
                                         const char *key,

--- a/src/utils/config_api.h
+++ b/src/utils/config_api.h
@@ -63,6 +63,10 @@
 /// the function is not thread safe.
 bool dsn_config_load(const char *file, const char *arguments);
 
+bool dsn_config_reload(const char *file, const char *arguments, dsn::configuration& old_config);
+
+void dsn_config_rollback(dsn::configuration& old_config);
+
 /// dump the global configuration
 void dsn_config_dump(std::ostream &os);
 

--- a/src/utils/config_api.h
+++ b/src/utils/config_api.h
@@ -31,6 +31,10 @@
 #include <string>
 #include <vector>
 
+namespace dsn {
+    class configuration;
+}  // namespace dsn
+
 /// load a ini configuration file, and replace specific strings in file with arguments.
 ///
 /// the rules of replacement is as follows:

--- a/src/utils/config_api.h
+++ b/src/utils/config_api.h
@@ -32,8 +32,8 @@
 #include <vector>
 
 namespace dsn {
-    class configuration;
-}  // namespace dsn
+class configuration;
+} // namespace dsn
 
 /// load a ini configuration file, and replace specific strings in file with arguments.
 ///
@@ -67,9 +67,9 @@ namespace dsn {
 /// the function is not thread safe.
 bool dsn_config_load(const char *file, const char *arguments);
 
-bool dsn_config_reload(const char *file, const char *arguments, dsn::configuration& old_config);
+bool dsn_config_reload(const char *file, const char *arguments, dsn::configuration &old_config);
 
-void dsn_config_rollback(dsn::configuration& old_config);
+void dsn_config_rollback(dsn::configuration &old_config);
 
 /// dump the global configuration
 void dsn_config_dump(std::ostream &os);

--- a/src/utils/configuration.cpp
+++ b/src/utils/configuration.cpp
@@ -40,8 +40,7 @@ namespace dsn {
 
 configuration::configuration() { _warning = false; }
 
-configuration::~configuration()
-{
+void configuration::clear_configs(){
     for (auto &section_kv : _configs) {
         auto &section = section_kv.second;
         for (auto &kv : section) {
@@ -49,6 +48,20 @@ configuration::~configuration()
         }
     }
     _configs.clear();
+}
+
+void configuration::copy_configs(const config_map& source){
+    for (auto &section_kv : source) {
+        auto &section = section_kv.second;
+        for (auto &kv : section) {
+            _configs[section_kv.first][kv.first] = new conf(*kv.second);
+        }
+    }
+}
+
+configuration::~configuration()
+{
+    clear_configs();
 }
 
 // arguments: k1=v1;k2=v2;k3=v3; ...

--- a/src/utils/configuration.cpp
+++ b/src/utils/configuration.cpp
@@ -40,7 +40,8 @@ namespace dsn {
 
 configuration::configuration() { _warning = false; }
 
-void configuration::clear_configs(){
+void configuration::clear_configs()
+{
     for (auto &section_kv : _configs) {
         auto &section = section_kv.second;
         for (auto &kv : section) {
@@ -50,7 +51,8 @@ void configuration::clear_configs(){
     _configs.clear();
 }
 
-void configuration::copy_configs(const config_map& source){
+void configuration::copy_configs(const config_map &source)
+{
     for (auto &section_kv : source) {
         auto &section = section_kv.second;
         for (auto &kv : section) {
@@ -59,10 +61,7 @@ void configuration::copy_configs(const config_map& source){
     }
 }
 
-configuration::~configuration()
-{
-    clear_configs();
-}
+configuration::~configuration() { clear_configs(); }
 
 // arguments: k1=v1;k2=v2;k3=v3; ...
 // e.g.,

--- a/src/utils/configuration.h
+++ b/src/utils/configuration.h
@@ -71,25 +71,27 @@ public:
 
     void clear_configs();
 
-    void copy_configs(const config_map&);
+    void copy_configs(const config_map &);
 
-    configuration(const configuration& conf)
+    configuration(const configuration &conf)
     {
         _lock.lock();
         copy_configs(conf._configs);
         _lock.unlock();
     }
 
-    configuration(const configuration&& conf)
+    configuration(const configuration &&conf)
     {
         _lock.lock();
         _configs = std::move(conf._configs);
         _lock.unlock();
     }
 
-    configuration& operator=(configuration& conf){
+    configuration &operator=(configuration &conf)
+    {
         // deal with self assignment
-        if(this == &conf) return *this;
+        if (this == &conf)
+            return *this;
         _lock.lock();
         clear_configs();
         copy_configs(conf._configs);
@@ -97,8 +99,10 @@ public:
         return *this;
     }
 
-    configuration& operator=(configuration&& conf){
-        if(this == &conf) return *this;
+    configuration &operator=(configuration &&conf)
+    {
+        if (this == &conf)
+            return *this;
         _lock.lock();
         clear_configs();
         _configs = std::move(conf._configs);

--- a/src/utils/configuration.h
+++ b/src/utils/configuration.h
@@ -35,6 +35,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "string_conv.h"
@@ -43,6 +44,26 @@ namespace dsn {
 
 class configuration
 {
+private:
+    struct conf
+    {
+        std::string section;
+        std::string key;
+        std::string value;
+        int line;
+
+        bool present;
+        std::string dsptr;
+    };
+
+    typedef std::map<std::string, std::map<std::string, conf *>> config_map;
+    std::mutex _lock;
+    config_map _configs;
+
+    std::string _file_name;
+    std::string _file_data;
+    bool _warning;
+
 public:
     configuration();
 
@@ -134,26 +155,6 @@ private:
                                    const char *default_value,
                                    const char **ov,
                                    const char *dsptr);
-
-private:
-    struct conf
-    {
-        std::string section;
-        std::string key;
-        std::string value;
-        int line;
-
-        bool present;
-        std::string dsptr;
-    };
-
-    typedef std::map<std::string, std::map<std::string, conf *>> config_map;
-    std::mutex _lock;
-    config_map _configs;
-
-    std::string _file_name;
-    std::string _file_data;
-    bool _warning;
 };
 
 template <>

--- a/src/utils/configuration.h
+++ b/src/utils/configuration.h
@@ -48,6 +48,43 @@ public:
 
     ~configuration();
 
+    void clear_configs();
+
+    void copy_configs(const config_map&);
+
+    configuration(const configuration& conf)
+    {
+        _lock.lock();
+        copy_configs(conf._configs);
+        _lock.unlock();
+    }
+
+    configuration(const configuration&& conf)
+    {
+        _lock.lock();
+        _configs = std::move(conf._configs);
+        _lock.unlock();
+    }
+
+    configuration& operator=(configuration& conf){
+        // deal with self assignment
+        if(this == &conf) return *this;
+        _lock.lock();
+        clear_configs();
+        copy_configs(conf._configs);
+        _lock.unlock();
+        return *this;
+    }
+
+    configuration& operator=(configuration&& conf){
+        if(this == &conf) return *this;
+        _lock.lock();
+        clear_configs();
+        _configs = std::move(conf._configs);
+        _lock.unlock();
+        return *this;
+    }
+
     // arguments: k1=v1;k2=v2;k3=v3; ...
     // e.g.,
     //    port = %port%


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#2102 

### What is changed and how does it work?
  If the cluster maintainer push new config to target cluster, you can use pegasus-shell to make cluster reload new duplication config without nodes restart.
  I add some function to help servers get their config on time, and we can reload new config ONLY about duplication.


##### Tests <!-- At least one of them must be included. -->
- Unit test
- Manual test (add detailed scripts or steps below)
- Cluster test

##### Code changes

- Has exported function/method change
Move and copy constructors of configuration class.
Some function about reloading dup parameter into memory instance.

##### Related changes
- Need to update the user documentation
- Need to be included in the release note
