### PR TITLE
fix(github): add write permission to module labeler

### DIFF
--- a/.github/workflows/module_labeler_conf.yml
+++ b/.github/workflows/module_labeler_conf.yml
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+permissions:
+  contents: write
+
 github:
   - .github/**/*
 admin-cli:


### PR DESCRIPTION
Fix https://github.com/apache/incubator-pegasus/issues/2105.