### PR TITLE
fix(blob): allow `blob` object to be initialized with null-pointer char array whose length must be zero

### DIFF
--- a/src/utils/blob.h
+++ b/src/utils/blob.h
@@ -109,7 +109,13 @@ public:
     /// NOTE: this operation is not efficient since it involves a memory copy.
     [[nodiscard]] static blob create_from_bytes(const char *s, size_t len)
     {
-        CHECK_NOTNULL(s, "null source pointer would lead to undefined behaviour");
+        if (s == nullptr) {
+            // TODO(wangdan): decide if an empty blob could be returned, which is initialized
+            // by default constructor blob() whose length is zero and all pointers(_holder,
+            // _buffer and _data) are null.
+            CHECK_EQ_MSG(len, 0, "null source pointer with non-zero length would lead to "
+                    "undefined behaviour");
+        }
 
         std::shared_ptr<char> s_arr(new char[len], std::default_delete<char[]>());
         memcpy(s_arr.get(), s, len);

--- a/src/utils/blob.h
+++ b/src/utils/blob.h
@@ -113,8 +113,10 @@ public:
             // TODO(wangdan): decide if an empty blob could be returned, which is initialized
             // by default constructor blob() whose length is zero and all pointers(_holder,
             // _buffer and _data) are null.
-            CHECK_EQ_MSG(len, 0, "null source pointer with non-zero length would lead to "
-                    "undefined behaviour");
+            CHECK_EQ_MSG(len,
+                         0,
+                         "null source pointer with non-zero length would lead to "
+                         "undefined behaviour");
         }
 
         std::shared_ptr<char> s_arr(new char[len], std::default_delete<char[]>());

--- a/src/utils/blob.h
+++ b/src/utils/blob.h
@@ -109,15 +109,9 @@ public:
     /// NOTE: this operation is not efficient since it involves a memory copy.
     [[nodiscard]] static blob create_from_bytes(const char *s, size_t len)
     {
-        if (s == nullptr) {
-            // TODO(wangdan): decide if an empty blob could be returned, which is initialized
-            // by default constructor blob() whose length is zero and all pointers(_holder,
-            // _buffer and _data) are null.
-            CHECK_EQ_MSG(len,
-                         0,
-                         "null source pointer with non-zero length would lead to "
-                         "undefined behaviour");
-        }
+        DCHECK(s != nullptr || len == 0,
+               "null source pointer with non-zero length would lead to "
+               "undefined behaviour");
 
         std::shared_ptr<char> s_arr(new char[len], std::default_delete<char[]>());
         memcpy(s_arr.get(), s, len);

--- a/src/utils/test/blob_test.cpp
+++ b/src/utils/test/blob_test.cpp
@@ -24,15 +24,24 @@
 
 namespace dsn {
 
-TEST(BlobTest, CreateFromNullptr)
+TEST(BlobTest, CreateFromZeroLengthNullptr)
 {
     const auto &obj = blob::create_from_bytes(nullptr, 0);
 
-    // TODO(wangdan): once create_from_bytes() could return an empty blob, add case
-    // to test if all pointers are null.
     EXPECT_EQ(0, obj.length());
     EXPECT_EQ(0, obj.size());
 }
+
+#ifndef NDEBUG
+
+TEST(BlobTest, CreateFromNonZeroLengthNullptr)
+{
+    ASSERT_DEATH({ const auto &obj = blob::create_from_bytes(nullptr, 1); },
+                 "null source pointer with non-zero length would lead to "
+                 "undefined behaviour");
+}
+
+#endif
 
 struct blob_base_case
 {

--- a/src/utils/test/blob_test.cpp
+++ b/src/utils/test/blob_test.cpp
@@ -24,6 +24,16 @@
 
 namespace dsn {
 
+TEST(BlobTest, CreateFromNullptr)
+{
+    const auto &obj = blob::create_from_bytes(nullptr, 0);
+
+    // TODO(wangdan): once create_from_bytes() could return an empty blob, add case
+    // to test if all pointers are null.
+        EXPECT_EQ(0, obj.length());
+        EXPECT_EQ(0, obj.size());
+}
+
 struct blob_base_case
 {
     std::string expected_str;
@@ -32,7 +42,7 @@ struct blob_base_case
 class BlobBaseTest : public testing::TestWithParam<blob_base_case>
 {
 public:
-    void SetUp() override
+    void BlobBaseTest()
     {
         const auto &test_case = GetParam();
         _expected_str = test_case.expected_str;

--- a/src/utils/test/blob_test.cpp
+++ b/src/utils/test/blob_test.cpp
@@ -30,8 +30,8 @@ TEST(BlobTest, CreateFromNullptr)
 
     // TODO(wangdan): once create_from_bytes() could return an empty blob, add case
     // to test if all pointers are null.
-        EXPECT_EQ(0, obj.length());
-        EXPECT_EQ(0, obj.size());
+    EXPECT_EQ(0, obj.length());
+    EXPECT_EQ(0, obj.size());
 }
 
 struct blob_base_case
@@ -42,7 +42,7 @@ struct blob_base_case
 class BlobBaseTest : public testing::TestWithParam<blob_base_case>
 {
 public:
-    void BlobBaseTest()
+    BlobBaseTest()
     {
         const auto &test_case = GetParam();
         _expected_str = test_case.expected_str;


### PR DESCRIPTION
Fix https://github.com/apache/incubator-pegasus/issues/2109.

Null-pointer char array with zero length is allowed to be used to initialize
`blob` object. Use `DCHECK` instead to check if the pointer is valid while
initializing `blob` object.