### PR TITLE
fix(java-client): fix client query meta server failed when authentication is enabled

### DIFF
--- a/java-client/src/main/java/org/apache/pegasus/rpc/async/MetaSession.java
+++ b/java-client/src/main/java/org/apache/pegasus/rpc/async/MetaSession.java
@@ -249,6 +249,7 @@ public class MetaSession extends HostNameResolver {
       return;
     }
 
+    round.lastSession.getInterceptorManager().onConnected(round.lastSession);
     retryQueryMeta(round, needDelay);
   }
 

--- a/java-client/src/main/java/org/apache/pegasus/rpc/async/ReplicaSession.java
+++ b/java-client/src/main/java/org/apache/pegasus/rpc/async/ReplicaSession.java
@@ -427,6 +427,10 @@ public class ReplicaSession {
     return false;
   }
 
+  public ReplicaSessionInterceptorManager getInterceptorManager() {
+    return interceptorManager;
+  }
+
   final class DefaultHandler extends SimpleChannelInboundHandler<RequestEntry> {
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Issue #2112

### What is changed and how does it work?
Exposing the interceptorManager. 
Let java client retry accesses meta server with authentication information.
