### PR TITLE
refactor(tests): Simplify the runtime module unit tests

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -61,7 +61,6 @@ header:
     - 'src/meta/test/suite2'
     - 'src/nfs/test/nfs_test_file1'
     - 'src/nfs/test/nfs_test_file2'
-    - 'src/runtime/test/gtest.filter'
     # Used for tests and should be empty, or ignore all comment lines (otherwise would lead to error).
     - 'src/utils/test/config-empty.ini'
     # Binary files used for tests and could not be added with copyright info (otherwise would lead to error).

--- a/src/runtime/test/CMakeLists.txt
+++ b/src/runtime/test/CMakeLists.txt
@@ -41,6 +41,5 @@ set(MY_BINPLACES
         config-test-sim.ini
         command.txt
         run.sh
-        clear.sh
-        gtest.filter)
+        clear.sh)
 dsn_add_test()

--- a/src/runtime/test/corrupt_message.cpp
+++ b/src/runtime/test/corrupt_message.cpp
@@ -36,7 +36,7 @@
 #include "utils/error_code.h"
 
 // this only works with the fault injector
-TEST(core, corrupt_message)
+TEST(core, DISABLED_corrupt_message)
 {
     int req = 0;
     const auto server = dsn::rpc_address::from_host_port("localhost", 20101);

--- a/src/runtime/test/corrupt_message.cpp
+++ b/src/runtime/test/corrupt_message.cpp
@@ -35,6 +35,8 @@
 #include "runtime/test_utils.h"
 #include "utils/error_code.h"
 
+// TODO(yingchun): the tests are failed because the fault injector is not work well as expected.
+//  Now just disable the tests before we fix it.
 // this only works with the fault injector
 TEST(core, DISABLED_corrupt_message)
 {

--- a/src/runtime/test/gtest.filter
+++ b/src/runtime/test/gtest.filter
@@ -1,3 +1,0 @@
-config-test.ini -core.corrupt_message:core.aio*:core.operation_failed:tools_hpc.*
-config-test-sim.ini -core.corrupt_message:core.aio*:core.operation_failed:tools_hpc.*:tools_simulator.*:task_test.signal_finished_task
-config-test-sim.ini tools_simulator.*

--- a/src/runtime/test/run.sh
+++ b/src/runtime/test/run.sh
@@ -28,13 +28,12 @@ if [ -z "${REPORT_DIR}" ]; then
     REPORT_DIR="."
 fi
 
-while read -r -a line; do
-    test_case=${line[0]}
-    gtest_filter=${line[1]}
+test_cases=(config-test.ini config-test-sim.ini)
+for test_case in ${test_cases[*]}; do
     output_xml="${REPORT_DIR}/dsn_runtime_tests_${test_case/.ini/.xml}"
-    echo "============ run dsn_runtime_tests ${test_case} with gtest_filter ${gtest_filter} ============"
+    echo "============ run dsn_runtime_tests ${test_case} ============"
     ./clear.sh
-    GTEST_OUTPUT="xml:${output_xml}" GTEST_FILTER=${gtest_filter} ./dsn_runtime_tests ${test_case} < command.txt
+    GTEST_OUTPUT="xml:${output_xml}" ./dsn_runtime_tests ${test_case} < command.txt
 
     if [ $? -ne 0 ]; then
         echo "run dsn_runtime_tests $test_case failed"
@@ -50,8 +49,8 @@ while read -r -a line; do
         fi
         exit 1
     fi
-    echo "============ done dsn_runtime_tests ${test_case} with gtest_filter ${gtest_filter} ============"
-done <gtest.filter
+    echo "============ done dsn_runtime_tests ${test_case} ============"
+done
 
 echo "============ done dsn_runtime_tests ============"
 


### PR DESCRIPTION
Now the test `core.corrupt_message` is disabled by `--gtest_filter`, it's a
bit of complex because it uses an external file
(i.e. `src/runtime/test/gtest.filter`), and it just disable
`core.corrupt_message` test case. This can be simplified by adding a
`DISABLED_` prefix, and make sure all other test cases can be ran normally.