### PR TITLE
refactor(tests): Use GTEST_SKIP macro to skip useless tests

### DIFF
--- a/src/rpc/test/net_provider_test.cpp
+++ b/src/rpc/test/net_provider_test.cpp
@@ -136,8 +136,10 @@ void rpc_client_session_send(rpc_session_ptr client_session, bool reject = false
 TEST(net_provider_test, asio_net_provider)
 {
     if (dsn::service_engine::instance().spec().semaphore_factory_name ==
-        "dsn::tools::sim_semaphore_provider")
-        return;
+        "dsn::tools::sim_semaphore_provider") {
+        GTEST_SKIP() << "Skip the test in simulator mode, set 'tool = nativerun' in '[core]' "
+                        "section in config file to enable it.";
+    }
 
     ASSERT_TRUE(dsn_rpc_register_handler(
         RPC_TEST_NETPROVIDER, "rpc.test.netprovider", rpc_server_response));
@@ -183,8 +185,10 @@ TEST(net_provider_test, asio_net_provider)
 TEST(net_provider_test, asio_udp_provider)
 {
     if (dsn::service_engine::instance().spec().semaphore_factory_name ==
-        "dsn::tools::sim_semaphore_provider")
-        return;
+        "dsn::tools::sim_semaphore_provider") {
+        GTEST_SKIP() << "Skip the test in simulator mode, set 'tool = nativerun' in '[core]' "
+                        "section in config file to enable it.";
+    }
 
     ASSERT_TRUE(dsn_rpc_register_handler(
         RPC_TEST_NETPROVIDER, "rpc.test.netprovider", rpc_server_response));
@@ -226,8 +230,10 @@ TEST(net_provider_test, asio_udp_provider)
 TEST(net_provider_test, sim_net_provider)
 {
     if (dsn::service_engine::instance().spec().semaphore_factory_name ==
-        "dsn::tools::sim_semaphore_provider")
-        return;
+        "dsn::tools::sim_semaphore_provider") {
+        GTEST_SKIP() << "Skip the test in simulator mode, set 'tool = nativerun' in '[core]' "
+                        "section in config file to enable it.";
+    }
 
     ASSERT_TRUE(dsn_rpc_register_handler(
         RPC_TEST_NETPROVIDER, "rpc.test.netprovider", rpc_server_response));
@@ -256,8 +262,10 @@ TEST(net_provider_test, sim_net_provider)
 TEST(net_provider_test, asio_network_provider_connection_threshold)
 {
     if (dsn::service_engine::instance().spec().semaphore_factory_name ==
-        "dsn::tools::sim_semaphore_provider")
-        return;
+        "dsn::tools::sim_semaphore_provider") {
+        GTEST_SKIP() << "Skip the test in simulator mode, set 'tool = nativerun' in '[core]' "
+                        "section in config file to enable it.";
+    }
 
     ASSERT_TRUE(dsn_rpc_register_handler(
         RPC_TEST_NETPROVIDER, "rpc.test.netprovider", rpc_server_response));

--- a/src/runtime/test/service_api_c.cpp
+++ b/src/runtime/test/service_api_c.cpp
@@ -202,8 +202,11 @@ TEST(core, dsn_semaphore)
 
 TEST(core, dsn_env)
 {
-    if (dsn::service_engine::instance().spec().tool == "simulator")
-        return;
+    if (dsn::service_engine::instance().spec().tool == "simulator") {
+        GTEST_SKIP() << "Skip the test in simulator mode, set 'tool = nativerun' in '[core]' "
+                        "section in config file to enable it.";
+    }
+    ASSERT_EQ("nativerun", dsn::service_engine::instance().spec().tool);
     uint64_t now1 = dsn_now_ns();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     uint64_t now2 = dsn_now_ns();

--- a/src/runtime/test/sim_lock.cpp
+++ b/src/runtime/test/sim_lock.cpp
@@ -89,10 +89,14 @@ typedef std::function<void()> system_callback;
 } // namespace dsn
 TEST(tools_simulator, scheduler)
 {
-    if (dsn::task::get_current_worker() == nullptr)
-        return;
-    if (dsn::service_engine::instance().spec().tool != "simulator")
-        return;
+    if (dsn::task::get_current_worker() == nullptr) {
+        GTEST_SKIP() << "Skip the test in non-worker thread.";
+    }
+    if (dsn::service_engine::instance().spec().tool == "nativerun") {
+        GTEST_SKIP() << "Skip the test in nativerun mode, set 'tool = simulator' in '[core]' "
+                        "section in config file to enable it.";
+    }
+    ASSERT_EQ("simulator", dsn::service_engine::instance().spec().tool);
 
     dsn::tools::sim_worker_state *s =
         dsn::tools::scheduler::task_worker_ext::get(dsn::task::get_current_worker());

--- a/src/runtime/test/task_engine.cpp
+++ b/src/runtime/test/task_engine.cpp
@@ -50,8 +50,11 @@ DEFINE_THREAD_POOL_CODE(THREAD_POOL_FOR_TEST_2)
 
 TEST(core, task_engine)
 {
-    if (dsn::service_engine::instance().spec().tool == "simulator")
-        return;
+    if (dsn::service_engine::instance().spec().tool == "simulator") {
+        GTEST_SKIP() << "Skip the test in simulator mode, set 'tool = nativerun' in '[core]' "
+                        "section in config file to enable it.";
+    }
+    ASSERT_EQ("nativerun", dsn::service_engine::instance().spec().tool);
     service_node *node = task::get_current_node2();
     ASSERT_NE(nullptr, node);
     ASSERT_STREQ("client", node->full_name());


### PR DESCRIPTION
The gtest provided macro `GTEST_SKIP` is better than manual `return`, the
former shows which test cases are skipped explicitly, it's more convenient
for developers to check the result.