### PR TITLE
fix(build): Fix a linkage error of thrift

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -73,7 +73,7 @@ header:
     - 'thirdparty/fix_rocksdb-cmake-PORTABLE-option.patch'
     - 'thirdparty/fix_snappy-Wsign-compare-warning.patch'
     - 'thirdparty/fix_s2_build_with_absl_and_gtest.patch'
-    - 'thirdparty/fix_thrift_for_cpp11.patch'
+    - 'thirdparty/fix_thrift_build_and_link_errors.patch'
     # TODO(yingchun): shell/* files are import from thirdparties, we can move them to thirdparty later.
     # Copyright (c) 2016, Adi Shavit
     - 'src/shell/argh.h'

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -152,7 +152,7 @@ ExternalProject_Add(thrift
         URL ${OSS_URL_PREFIX}/thrift-0.9.3.tar.gz
         http://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
         URL_MD5 88d667a8ae870d5adeca8cb7d6795442
-        PATCH_COMMAND patch -p1 < ${TP_DIR}/fix_thrift_for_cpp11.patch
+        PATCH_COMMAND patch -p1 < ${TP_DIR}/fix_thrift_build_and_link_errors.patch
         CMAKE_ARGS -DCMAKE_BUILD_TYPE=release
         -DWITH_JAVA=OFF
         -DWITH_PYTHON=OFF

--- a/thirdparty/fix_thrift_build_and_link_errors.patch
+++ b/thirdparty/fix_thrift_build_and_link_errors.patch
@@ -51,3 +51,16 @@ index dadaac3..ef32fe1 100644
      } // apache::thrift::stdcxx::placeholders
    }}} // apache::thrift::stdcxx
  #endif
+diff --git a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+index e4077bc10..00512990a 100644
+--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
++++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+@@ -528,7 +528,7 @@ uint32_t TJSONProtocol::writeJSONDouble(double num) {
+   bool special = false;
+   switch (boost::math::fpclassify(num)) {
+   case FP_INFINITE:
+-    if (boost::math::signbit(num)) {
++    if (std::signbit(num)) {
+       val = kThriftNegativeInfinity;
+     } else {
+       val = kThriftInfinity;


### PR DESCRIPTION
Fix a linkage error on MacOS, the error looks like:
```
Undefined symbols for architecture x86_64:
  "int boost::math::signbit<double>(double)", referenced from:
      apache::thrift::protocol::TJSONProtocol::writeJSONDouble(double) in libthrift.a(TJSONProtocol.cpp.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[ 31%] Building CXX object src/block_service/test/CMakeFiles/dsn_block_service_test.dir/hdfs_service_test.cpp.o
make[2]: *** [src/base/test/base_test] Error 1
make[1]: *** [src/base/test/CMakeFiles/base_test.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

This error also appears on Linux when I tried to bump boost to 1.86.0. We
use a very old version of thrift (0.9.3), it uses `boost::math::signbit()`
which can use replaced by `std::signbit()`. This patch makes this change.