### PR TITLE
fix(github): zookeeper-bin cannot be found while uploading artifact

### DIFF
--- a/.github/actions/rebuild_thirdparty_if_needed/action.yaml
+++ b/.github/actions/rebuild_thirdparty_if_needed/action.yaml
@@ -46,6 +46,4 @@ runs:
         ../admin_tools/download_zk.sh zookeeper-bin
         rm -rf hadoop-bin/share/doc
         rm -rf zookeeper-bin/docs
-        mv hadoop-bin ..
-        mv zookeeper-bin ..
       shell: bash

--- a/.github/actions/upload_artifact/action.yaml
+++ b/.github/actions/upload_artifact/action.yaml
@@ -21,6 +21,8 @@ runs:
   steps:
     - name: Tar files
       run: |
+        mv thirdparty/hadoop-bin ./
+        mv thirdparty/zookeeper-bin ./
         rm -rf thirdparty
         # The following operations are tricky, these directories and files don't exist if not build with '--test'.
         # When build binaries for client tests, it's not needed to add '--test'.


### PR DESCRIPTION
Fix https://github.com/apache/incubator-pegasus/issues/2128.

Only move `hadoop-bin` and `zookeeper-bin` out of third-party
directory immediately before uploading artifact.