### PR TITLE
fix(java-client): fix `Negotiation failed` after a session with authentication enabled is closed

### DIFF
--- a/java-client/src/main/java/org/apache/pegasus/rpc/async/ReplicaSession.java
+++ b/java-client/src/main/java/org/apache/pegasus/rpc/async/ReplicaSession.java
@@ -477,9 +477,19 @@ public class ReplicaSession {
     }
   }
 
-  // For test.
+  // Only for test.
   ConnState getState() {
     return fields.state;
+  }
+
+  interface AuthPendingChecker {
+    void onCheck(Queue<RequestEntry> realAuthPendingSend);
+  }
+
+  void checkAuthPending(AuthPendingChecker checker) {
+    synchronized (authPendingSend) {
+      checker.onCheck(authPendingSend);
+    }
   }
 
   interface MessageResponseFilter {

--- a/java-client/src/main/java/org/apache/pegasus/rpc/async/ReplicaSession.java
+++ b/java-client/src/main/java/org/apache/pegasus/rpc/async/ReplicaSession.java
@@ -299,10 +299,16 @@ public class ReplicaSession {
 
   // After the authentication is reset, a new Negotiation would be launched.
   private void resetAuth() {
+    int pendingSize;
     synchronized (authPendingSend) {
       authSucceed = false;
-      authPendingSend.clear();
+      pendingSize = authPendingSend.size();
     }
+
+    logger.info(
+        "authentication is reset for session {}, with still {} request entries pending",
+        name(),
+        pendingSize);
   }
 
   // Notify the RPC sender if failure occurred.
@@ -405,6 +411,10 @@ public class ReplicaSession {
       authPendingSend.clear();
     }
 
+    logger.info(
+        "authentication is successful for session {}, then {} pending request entries would be sent",
+        name(),
+        authPendingSend.size());
     sendPendingRequests(swappedPendingSend, fields);
   }
 

--- a/java-client/src/main/java/org/apache/pegasus/security/AuthReplicaSessionInterceptor.java
+++ b/java-client/src/main/java/org/apache/pegasus/security/AuthReplicaSessionInterceptor.java
@@ -24,7 +24,7 @@ import org.apache.pegasus.rpc.async.ReplicaSession;
 import org.apache.pegasus.rpc.interceptor.ReplicaSessionInterceptor;
 
 public class AuthReplicaSessionInterceptor implements ReplicaSessionInterceptor, Closeable {
-  private AuthProtocol protocol;
+  private final AuthProtocol protocol;
 
   public AuthReplicaSessionInterceptor(ClientOptions options) throws IllegalArgumentException {
     this.protocol = options.getCredential().getProtocol();
@@ -37,7 +37,7 @@ public class AuthReplicaSessionInterceptor implements ReplicaSessionInterceptor,
 
   @Override
   public boolean onSendMessage(ReplicaSession session, final ReplicaSession.RequestEntry entry) {
-    // tryPendRequest returns false means that the negotiation is succeed now
+    // tryPendRequest returns false means that the negotiation is successful now.
     return protocol.isAuthRequest(entry) || !session.tryPendRequest(entry);
   }
 

--- a/java-client/src/test/java/org/apache/pegasus/rpc/async/ReplicaSessionTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/rpc/async/ReplicaSessionTest.java
@@ -60,9 +60,12 @@ public class ReplicaSessionTest {
 
   @BeforeEach
   public void before(TestInfo testInfo) throws Exception {
-    final String metaList = "127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603";
-    manager = new ClusterManager(ClientOptions.builder().metaServers(metaList).build());
-    System.out.println("test started: " + testInfo.getDisplayName());
+    manager =
+        new ClusterManager(
+            ClientOptions.builder()
+                .metaServers("127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603")
+                .build());
+    logger.info("test started: {}", testInfo.getDisplayName());
   }
 
   @AfterEach
@@ -322,6 +325,11 @@ public class ReplicaSessionTest {
             });
     queryCfgEntry.callback = cb;
     queryCfgEntry.timeoutTask = null;
+
+    // Also insert into pendingResponse since ReplicaSession#sendPendingRequests() would check
+    // sequenceId in it.
+    assertTrue(rs.pendingResponse.isEmpty());
+    rs.pendingResponse.put(queryCfgEntry.sequenceId, queryCfgEntry);
 
     // Initially session has not been authenticated.
     assertTrue(rs.tryPendRequest(queryCfgEntry));

--- a/java-client/src/test/java/org/apache/pegasus/rpc/async/ReplicaSessionTest.java
+++ b/java-client/src/test/java/org/apache/pegasus/rpc/async/ReplicaSessionTest.java
@@ -50,6 +50,7 @@ import org.apache.thrift.protocol.TProtocol;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 
@@ -58,9 +59,10 @@ public class ReplicaSessionTest {
   private ClusterManager manager;
 
   @BeforeEach
-  public void before() throws Exception {
+  public void before(TestInfo testInfo) throws Exception {
     final String metaList = "127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603";
     manager = new ClusterManager(ClientOptions.builder().metaServers(metaList).build());
+    System.out.println("test started: " + testInfo.getDisplayName());
   }
 
   @AfterEach


### PR DESCRIPTION
Resolve https://github.com/apache/incubator-pegasus/issues/2133.

After the session with authentication enabled to remote server is closed(e.g.
the server is killed), the flag(i.e. `authSucceed`) marking whether the session
has been authenticated is still kept `true`. Afterwards, while trying to creating
another new connection to the same remote server for this session, some requests
would be pending before it is connected successfully. Once the session is connected,
the pending requests would be sent to the remote server. Typically, the first element
of the pending queue would be a non-negotiation request(`query_cfg_request` to
the meta server for example), and the second one would be a negotiation request.
Normally, the non-negotiation request would be moved to another pending queue
for authentication; however, since the flag still marks that the session has been
authenticated successfully, the non-negotiation request would be directed to the
remote server which would never reply to the client since the server think that the
negotiation has not been launched. However, since the client has actually launched
the negotiation, it would close the session due to timeout or having not receiving
response from the server for long time. Therefore, the above process would repeat
again.

To fix this problem, the flag should be reset after the session is closed. Then, the
client would never send non-negotiation requests before the negotiation with the
server becomes successful.