### PR TITLE
fix(github): fix redundant `hadoop-bin` while uploading artifact and build `thirdparties-src` image on each OS version

### DIFF
--- a/.github/actions/rebuild_thirdparty_if_needed/action.yaml
+++ b/.github/actions/rebuild_thirdparty_if_needed/action.yaml
@@ -46,4 +46,6 @@ runs:
         ../admin_tools/download_zk.sh zookeeper-bin
         rm -rf hadoop-bin/share/doc
         rm -rf zookeeper-bin/docs
+        mv hadoop-bin ..
+        mv zookeeper-bin ..
       shell: bash

--- a/.github/actions/unpack_prebuilt_thirdparties/action.yaml
+++ b/.github/actions/unpack_prebuilt_thirdparties/action.yaml
@@ -27,4 +27,6 @@ runs:
         find ./thirdparty -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
         rm -rf ./thirdparty/hadoop-bin/share/doc
         rm -rf ./thirdparty/zookeeper-bin/docs
+        mv hadoop-bin ..
+        mv zookeeper-bin ..
       shell: bash

--- a/.github/actions/unpack_prebuilt_thirdparties/action.yaml
+++ b/.github/actions/unpack_prebuilt_thirdparties/action.yaml
@@ -27,6 +27,6 @@ runs:
         find ./thirdparty -name '*CMakeFiles*' -type d -exec rm -rf "{}" +
         rm -rf ./thirdparty/hadoop-bin/share/doc
         rm -rf ./thirdparty/zookeeper-bin/docs
-        mv hadoop-bin ..
-        mv zookeeper-bin ..
+        mv thirdparty/hadoop-bin ./
+        mv thirdparty/zookeeper-bin ./
       shell: bash

--- a/.github/actions/upload_artifact/action.yaml
+++ b/.github/actions/upload_artifact/action.yaml
@@ -21,8 +21,6 @@ runs:
   steps:
     - name: Tar files
       run: |
-        mv thirdparty/hadoop-bin ./
-        mv thirdparty/zookeeper-bin ./
         rm -rf thirdparty
         # The following operations are tricky, these directories and files don't exist if not build with '--test'.
         # When build binaries for client tests, it's not needed to add '--test'.

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -27,7 +27,7 @@ on:
       - ci-test # testing branch for github action
       - '*dev'
     paths:
-      - .github/actions
+      - .github/actions/**
       - .github/workflows/lint_and_test_cpp.yaml
       - .github/workflows/thirdparty-regular-push.yml
       - build_tools/pack_server.sh

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -93,7 +93,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - centos7
-    if: ${{ needs.build_push_src_docker_images.outputs.os_version == matrix.osversion }}
+    if: needs.build_push_src_docker_images.outputs.os_version == matrix.osversion
     steps:
       # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
@@ -136,7 +136,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - centos7
-    if: ${{ needs.build_push_src_docker_images.outputs.os_version == matrix.osversion }}
+    if: needs.build_push_src_docker_images.outputs.os_version == matrix.osversion
     steps:
       # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
@@ -171,7 +171,7 @@ jobs:
       matrix:
         osversion:
           - ubuntu2204
-    if: ${{ needs.build_push_src_docker_images.outputs.os_version == matrix.osversion }}
+    if: needs.build_push_src_docker_images.outputs.os_version == matrix.osversion
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -206,7 +206,7 @@ jobs:
       matrix:
         osversion:
           - ubuntu2204
-    if: ${{ needs.build_push_src_docker_images.outputs.os_version == matrix.osversion }}
+    if: needs.build_push_src_docker_images.outputs.os_version == matrix.osversion
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -73,6 +73,8 @@ jobs:
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
+            HADOOP_BIN_PATH=hadoop-bin
+            ZOOKEEPER_BIN_PATH=zookeeper-bin
 
   build_push_bin_docker_images:
     runs-on: ubuntu-latest
@@ -116,6 +118,8 @@ jobs:
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
+            HADOOP_BIN_PATH=hadoop-bin
+            ZOOKEEPER_BIN_PATH=zookeeper-bin
 
   build_push_bin_jemalloc_docker_images:
     runs-on: ubuntu-latest
@@ -160,6 +164,8 @@ jobs:
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
             USE_JEMALLOC=ON
+            HADOOP_BIN_PATH=hadoop-bin
+            ZOOKEEPER_BIN_PATH=zookeeper-bin
 
   build_push_bin_test_docker_images:
     runs-on: ubuntu-latest

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -42,6 +42,14 @@ on:
 jobs:
   build_push_src_docker_images:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        osversion:
+          - ubuntu1804
+          - ubuntu2004
+          - ubuntu2204
+          - centos7
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -60,9 +68,10 @@ jobs:
           file: ./docker/thirdparties-src/Dockerfile
           push: true
           tags: |
-            apache/pegasus:thirdparties-src-${{ github.ref_name }}
+            apache/pegasus:thirdparties-src-${{ matrix.osversion }}-${{ github.ref_name }}
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
+            OS_VERSION=${{ matrix.osversion }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -93,7 +93,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - centos7
-    if: ${{ needs.build_push_src_docker_images.outputs.os_version == strategy.matrix.osversion }}
+    if: success()
     steps:
       # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
@@ -136,7 +136,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - centos7
-    if: needs.build_push_src_docker_images.outputs.os_version == matrix.osversion
+    if: success()
     steps:
       # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
@@ -171,7 +171,7 @@ jobs:
       matrix:
         osversion:
           - ubuntu2204
-    if: needs.build_push_src_docker_images.outputs.os_version == matrix.osversion
+    if: success()
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -206,7 +206,7 @@ jobs:
       matrix:
         osversion:
           - ubuntu2204
-    if: needs.build_push_src_docker_images.outputs.os_version == matrix.osversion
+    if: success()
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -49,7 +49,8 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - centos7
+          # TODO(wangdan): disable centos7 temporarily before image build-env-centos7-* is fixed.
+          # - centos7
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -72,9 +73,6 @@ jobs:
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
-      - name: Generate output
-        id: gen_output
-        run: echo "os_version=${{ matrix.osversion }}" >> "$GITHUB_OUTPUT"
 
   build_push_bin_docker_images:
     runs-on: ubuntu-latest
@@ -92,8 +90,8 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - centos7
-    if: success()
+          # TODO(wangdan): disable centos7 temporarily before image build-env-centos7-* is fixed.
+          # - centos7
     steps:
       # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
@@ -135,8 +133,8 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - centos7
-    if: success()
+          # TODO(wangdan): disable centos7 temporarily before image build-env-centos7-* is fixed.
+          # - centos7
     steps:
       # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
@@ -171,7 +169,6 @@ jobs:
       matrix:
         osversion:
           - ubuntu2204
-    if: success()
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -206,7 +203,6 @@ jobs:
       matrix:
         osversion:
           - ubuntu2204
-    if: success()
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -93,7 +93,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - centos7
-    if: needs.build_push_src_docker_images.outputs.os_version == matrix.osversion
+    if: ${{ needs.build_push_src_docker_images.outputs.os_version == matrix.osversion }}
     steps:
       # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -93,7 +93,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - centos7
-    if: ${{ needs.build_push_src_docker_images.outputs.os_version == matrix.osversion }}
+    if: ${{ needs.build_push_src_docker_images.outputs.os_version == strategy.matrix.osversion }}
     steps:
       # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -72,8 +72,9 @@ jobs:
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Generate output
+        id: gen_output
+        run: echo "os_version=${{ matrix.osversion }}" >> "$GITHUB_OUTPUT"
 
   build_push_bin_docker_images:
     runs-on: ubuntu-latest
@@ -92,6 +93,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - centos7
+    if: ${{ needs.build_push_src_docker_images.outputs.os_version == matrix.osversion }}
     steps:
       # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
@@ -116,8 +118,6 @@ jobs:
           build-args: |
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
 
   build_push_bin_jemalloc_docker_images:
     runs-on: ubuntu-latest
@@ -136,6 +136,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - centos7
+    if: ${{ needs.build_push_src_docker_images.outputs.os_version == matrix.osversion }}
     steps:
       # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
@@ -161,8 +162,6 @@ jobs:
             GITHUB_BRANCH=${{ github.ref_name }}
             OS_VERSION=${{ matrix.osversion }}
             USE_JEMALLOC=ON
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
 
   build_push_bin_test_docker_images:
     runs-on: ubuntu-latest
@@ -172,6 +171,7 @@ jobs:
       matrix:
         osversion:
           - ubuntu2204
+    if: ${{ needs.build_push_src_docker_images.outputs.os_version == matrix.osversion }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -197,8 +197,6 @@ jobs:
             ROCKSDB_PORTABLE=1
             HADOOP_BIN_PATH=hadoop-bin
             ZOOKEEPER_BIN_PATH=zookeeper-bin
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
 
   build_push_bin_test_jemalloc_docker_images:
     runs-on: ubuntu-latest
@@ -208,6 +206,7 @@ jobs:
       matrix:
         osversion:
           - ubuntu2204
+    if: ${{ needs.build_push_src_docker_images.outputs.os_version == matrix.osversion }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -234,5 +233,3 @@ jobs:
             USE_JEMALLOC=ON
             HADOOP_BIN_PATH=hadoop-bin
             ZOOKEEPER_BIN_PATH=zookeeper-bin
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/admin_tools/download_hadoop.sh
+++ b/admin_tools/download_hadoop.sh
@@ -21,15 +21,18 @@ set -e
 
 CWD=$(cd "$(dirname "$0")" && pwd)
 
-if [ $# -ge 1 ]; then
-    HADOOP_BIN_PATH=$1
+if [ $# -lt 1 ]; then
+    echo "Invalid arguments !"
+    echo "USAGE: $0 <HADOOP_BIN_PATH>"
 fi
+
+HADOOP_BIN_PATH=$1
 
 HADOOP_VERSION="hadoop-3.3.6"
 arch_output=$(arch)
 if [ "$arch_output"x == "aarch64"x ]; then
-  HADOOP_PACKAGE_MD5="369f899194a920e0d1c3c3bc1718b3b5"
-  HADOOP_BASE_NAME=${HADOOP_VERSION}-"$(arch)"
+    HADOOP_PACKAGE_MD5="369f899194a920e0d1c3c3bc1718b3b5"
+    HADOOP_BASE_NAME=${HADOOP_VERSION}-"$(arch)"
 else
     if [ "$arch_output"x != "x86_64"x ]; then
         echo "WARNING: unrecognized CPU architecture '$arch_output', use 'x86_64' as default"

--- a/admin_tools/download_hadoop.sh
+++ b/admin_tools/download_hadoop.sh
@@ -24,6 +24,7 @@ CWD=$(cd "$(dirname "$0")" && pwd)
 if [ $# -lt 1 ]; then
     echo "Invalid arguments !"
     echo "USAGE: $0 <HADOOP_BIN_PATH>"
+    exit 1
 fi
 
 HADOOP_BIN_PATH=$1

--- a/admin_tools/download_package.sh
+++ b/admin_tools/download_package.sh
@@ -68,7 +68,7 @@ fi
 rm -rf "${DIR_NAME}"
 
 echo "Decompressing ${PACKAGE_NAME} ..."
-if ! tar xf "${PACKAGE_NAME}"; then
+if ! tar zxf "${PACKAGE_NAME}"; then
     echo "ERROR: decompress ${PACKAGE_NAME} failed"
     rm -f "${PACKAGE_NAME}"
     exit 1

--- a/admin_tools/download_package.sh
+++ b/admin_tools/download_package.sh
@@ -68,7 +68,7 @@ fi
 rm -rf "${DIR_NAME}"
 
 echo "Decompressing ${PACKAGE_NAME} ..."
-if ! tar zxf "${PACKAGE_NAME}"; then
+if ! tar xf "${PACKAGE_NAME}"; then
     echo "ERROR: decompress ${PACKAGE_NAME} failed"
     rm -f "${PACKAGE_NAME}"
     exit 1

--- a/admin_tools/download_package.sh
+++ b/admin_tools/download_package.sh
@@ -19,19 +19,14 @@
 
 set -e
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 3 ]; then
     echo "Invalid arguments !"
-    echo "USAGE: $0 <PACKAGE_BASE_NAME> <PACKAGE_MD5> [TARGET_PATH]"
+    echo "USAGE: $0 <PACKAGE_BASE_NAME> <PACKAGE_MD5> <TARGET_PATH>"
     exit 1
 fi
 
 PACKAGE_BASE_NAME=$1
 PACKAGE_MD5=$2
-
-if [ $# -lt 3 ]; then
-    echo "TARGET_PATH is not provided, thus do not try to download ${PACKAGE_BASE_NAME}"
-    exit 0
-fi
 
 TARGET_PATH=$3
 if [ -d "${TARGET_PATH}" ]; then

--- a/admin_tools/download_zk.sh
+++ b/admin_tools/download_zk.sh
@@ -24,6 +24,7 @@ CWD=$(cd $(dirname $0) && pwd)
 if [ $# -lt 1 ]; then
     echo "Invalid arguments !"
     echo "USAGE: $0 <ZOOKEEPER_BIN_PATH>"
+    exit 1
 fi
 
 ZOOKEEPER_BIN_PATH=$1

--- a/admin_tools/download_zk.sh
+++ b/admin_tools/download_zk.sh
@@ -21,9 +21,12 @@ set -e
 
 CWD=$(cd $(dirname $0) && pwd)
 
-if [ $# -ge 1 ]; then
-    ZOOKEEPER_BIN_PATH=$1
+if [ $# -lt 1 ]; then
+    echo "Invalid arguments !"
+    echo "USAGE: $0 <ZOOKEEPER_BIN_PATH>"
 fi
+
+ZOOKEEPER_BIN_PATH=$1
 
 ZOOKEEPER_VERSION=3.7.0
 ZOOKEEPER_DIR_NAME=apache-zookeeper-${ZOOKEEPER_VERSION}-bin

--- a/docker/README.md
+++ b/docker/README.md
@@ -51,7 +51,10 @@ It packages the downloaded sources into a zip in the container, so that
 other repos can easily extract third-parties from the container (via `docker cp`),
 without downloading from the cloud object storage.
 
-- `apache/pegasus:thirdparties-src-<branch>`
+- `apache/pegasus:thirdparties-src-centos7-<branch>`
+- `apache/pegasus:thirdparties-src-ubuntu1804-<branch>`
+- `apache/pegasus:thirdparties-src-ubuntu2004-<branch>`
+- `apache/pegasus:thirdparties-src-ubuntu2204-<branch>`
 
 ## thirdparties-bin
 

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -24,11 +24,11 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
     yum -y install centos-release-scl \
                    scl-utils \
-                   epel-release --exclude=aarch64 && \
+                   epel-release && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    yum -y install devtoolset-7-gcc \
+    yum --disablerepo=centos-sclo-rh -y install devtoolset-7-gcc \
                    devtoolset-7-gcc-c++ \
                    java-1.8.0-openjdk-devel.x86_64 \
                    python3 \
@@ -54,7 +54,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
                    flex \
                    krb5-devel \
                    cyrus-sasl-devel \
-                   patch --exclude=aarch64 && \
+                   patch && \
     yum -y install ca-certificates && \
     yum clean all && \
     rm -rf /var/cache/yum;

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -28,7 +28,8 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    yum --disablerepo=centos-sclo-rh --enablerepo=centos-sclo-rh-x86_64 --disablerepo=centos-sclo-sclo --enablerepo=centos-sclo-sclo-x86_64 -y install \
+    #yum --disablerepo=centos-sclo-rh --enablerepo=centos-sclo-rh-x86_64 --disablerepo=centos-sclo-sclo --enablerepo=centos-sclo-sclo-x86_64 -y install \
+    yum --skip-broken -y install \
                    devtoolset-7-gcc.x86_64 \
                    devtoolset-7-gcc-c++.x86_64 \
                    java-1.8.0-openjdk-devel.x86_64 \

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -22,13 +22,14 @@ LABEL maintainer=wutao
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    yum --disablerepo=centos-sclo-rh -y install centos-release-scl \
+    yum -y install centos-release-scl \
                    scl-utils \
                    epel-release --exclude=aarch64 && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    yum --disablerepo=centos-sclo-rh -y install devtoolset-7-gcc \
+    yum --disablerepo=centos-sclo-rh --disablerepo=centos-sclo-sclo -y install \
+                   devtoolset-7-gcc \
                    devtoolset-7-gcc-c++ \
                    java-1.8.0-openjdk-devel.x86_64 \
                    python3 \

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -56,7 +56,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
                    krb5-devel \
                    cyrus-sasl-devel \
                    patch --exclude=aarch64 && \
-    yum -y install ca-certificates && \
+    yum --disablerepo=centos-sclo-rh --disablerepo=centos-sclo-sclo -y install ca-certificates && \
     yum clean all && \
     rm -rf /var/cache/yum;
 

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer=wutao
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    yum -y install centos-release-scl \
+    yum --disablerepo=centos-sclo-rh -y install centos-release-scl \
                    scl-utils \
                    epel-release --exclude=aarch64 && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -24,7 +24,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
     yum -y install centos-release-scl \
                    scl-utils \
-                   epel-release --setopt=basearch=x86_64 --disablerepo=*aarch64* && \
+                   epel-release --exclude=aarch64 && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
@@ -54,7 +54,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
                    flex \
                    krb5-devel \
                    cyrus-sasl-devel \
-                   patch --setopt=basearch=x86_64 --disablerepo=*aarch64* && \
+                   patch --exclude=aarch64 && \
     yum -y install ca-certificates && \
     yum clean all && \
     rm -rf /var/cache/yum;

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -54,7 +54,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
                    flex \
                    krb5-devel \
                    cyrus-sasl-devel \
-                   patch && \
+                   patch --setopt=basearch=x86_64 --disablerepo=*aarch64* && \
     yum -y install ca-certificates && \
     yum clean all && \
     rm -rf /var/cache/yum;

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM centos:7.6.1810
+FROM centos7.9.2009
 
 LABEL maintainer=wutao
 

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -22,15 +22,15 @@ LABEL maintainer=wutao
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    yum --setopt=basearch=x86_64 -y install centos-release-scl \
+    yum -y install centos-release-scl \
                    scl-utils \
-                   epel-release && \
+                   epel-release --exclude=aarch64 && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    yum --setopt=basearch=x86_64 -y install \
-                   devtoolset-7-gcc \
-                   devtoolset-7-gcc-c++ \
+    yum -y install \
+                   devtoolset-7-gcc.x86_64 \
+                   devtoolset-7-gcc-c++.x86_64 \
                    java-1.8.0-openjdk-devel.x86_64 \
                    python3 \
                    automake \
@@ -55,8 +55,8 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
                    flex \
                    krb5-devel \
                    cyrus-sasl-devel \
-                   patch && \
-    yum --setopt=basearch=x86_64 -y install ca-certificates && \
+                   patch --exclude=aarch64 && \
+    yum --disablerepo=centos-sclo-rh --disablerepo=centos-sclo-sclo -y install ca-certificates && \
     yum clean all && \
     rm -rf /var/cache/yum;
 

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM centos:7.9.2009
+FROM centos:7.5.1804
 
 LABEL maintainer=wutao
 
@@ -24,14 +24,12 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
     yum -y install centos-release-scl \
                    scl-utils \
-                   epel-release --exclude=aarch64 && \
+                   epel-release && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    #yum --disablerepo=centos-sclo-rh --enablerepo=centos-sclo-rh-x86_64 --disablerepo=centos-sclo-sclo --enablerepo=centos-sclo-sclo-x86_64 -y install \
-    yum --skip-broken -y install \
-                   devtoolset-7-gcc.x86_64 \
-                   devtoolset-7-gcc-c++.x86_64 \
+    yum -y install devtoolset-7-gcc \
+                   devtoolset-7-gcc-c++ \
                    java-1.8.0-openjdk-devel.x86_64 \
                    python3 \
                    automake \
@@ -56,8 +54,8 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
                    flex \
                    krb5-devel \
                    cyrus-sasl-devel \
-                   patch --exclude=aarch64 && \
-    yum --disablerepo=centos-sclo-rh --disablerepo=centos-sclo-sclo -y install ca-certificates && \
+                   patch && \
+    yum -y install ca-certificates && \
     yum clean all && \
     rm -rf /var/cache/yum;
 

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -24,7 +24,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
     yum -y install centos-release-scl \
                    scl-utils \
-                   epel-release --setopt=basearch=x86_64 && \
+                   epel-release --setopt=basearch=x86_64 --disablerepo=*aarch64* && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -23,7 +23,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
     yum -y install centos-release-scl \
-                   scl-utils \
+                   scl-utils --setopt=basearch=x86_64 \
                    epel-release && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -28,7 +28,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    yum -y install \
+    yum --disablerepo=centos-sclo-rh --enablerepo=centos-sclo-rh-x86_64 --disablerepo=centos-sclo-sclo --enablerepo=centos-sclo-sclo-x86_64 -y install \
                    devtoolset-7-gcc.x86_64 \
                    devtoolset-7-gcc-c++.x86_64 \
                    java-1.8.0-openjdk-devel.x86_64 \

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -24,7 +24,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
     yum -y install centos-release-scl \
                    scl-utils \
-                   epel-release && \
+                   epel-release --exclude=aarch64 && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
@@ -54,7 +54,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
                    flex \
                    krb5-devel \
                    cyrus-sasl-devel \
-                   patch && \
+                   patch --exclude=aarch64 && \
     yum -y install ca-certificates && \
     yum clean all && \
     rm -rf /var/cache/yum;

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -22,13 +22,13 @@ LABEL maintainer=wutao
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    yum -y install centos-release-scl \
+    yum --setopt=basearch=x86_64 -y install centos-release-scl \
                    scl-utils \
-                   epel-release --exclude=aarch64 && \
+                   epel-release && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
-    yum --disablerepo=centos-sclo-rh --disablerepo=centos-sclo-sclo -y install \
+    yum --setopt=basearch=x86_64 -y install \
                    devtoolset-7-gcc \
                    devtoolset-7-gcc-c++ \
                    java-1.8.0-openjdk-devel.x86_64 \
@@ -55,8 +55,8 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
                    flex \
                    krb5-devel \
                    cyrus-sasl-devel \
-                   patch --exclude=aarch64 && \
-    yum --disablerepo=centos-sclo-rh --disablerepo=centos-sclo-sclo -y install ca-certificates && \
+                   patch && \
+    yum --setopt=basearch=x86_64 -y install ca-certificates && \
     yum clean all && \
     rm -rf /var/cache/yum;
 

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -23,8 +23,8 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
     yum -y install centos-release-scl \
-                   scl-utils --setopt=basearch=x86_64 \
-                   epel-release && \
+                   scl-utils \
+                   epel-release --setopt=basearch=x86_64 && \
     sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM centos7.9.2009
+FROM centos:7.9.2009
 
 LABEL maintainer=wutao
 

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM centos:7.9.2009
+FROM centos:7.6.1810
 
 LABEL maintainer=wutao
 

--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM centos:7.5.1804
+FROM centos:7.9.2009
 
 LABEL maintainer=wutao
 

--- a/docker/thirdparties-bin/Dockerfile
+++ b/docker/thirdparties-bin/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG GITHUB_BRANCH=master
 ARG OS_VERSION=centos7
-FROM apache/pegasus:thirdparties-src-${GITHUB_BRANCH} as builder
+FROM apache/pegasus:thirdparties-src-${OS_VERSION}-${GITHUB_BRANCH} as builder
 FROM apache/pegasus:build-env-${OS_VERSION}-${GITHUB_BRANCH}
 
 WORKDIR /root

--- a/docker/thirdparties-bin/Dockerfile
+++ b/docker/thirdparties-bin/Dockerfile
@@ -28,8 +28,8 @@ ARG GITHUB_BRANCH
 ARG GITHUB_REPOSITORY_URL=https://github.com/apache/incubator-pegasus.git
 ARG ROCKSDB_PORTABLE=native
 ARG USE_JEMALLOC=OFF
-ARG HADOOP_BIN_PATH
-ARG ZOOKEEPER_BIN_PATH
+ARG HADOOP_BIN_PATH=hadoop-bin
+ARG ZOOKEEPER_BIN_PATH=zookeeper-bin
 RUN git clone --depth=1 --branch=${GITHUB_BRANCH} ${GITHUB_REPOSITORY_URL} \
     && cd incubator-pegasus/thirdparty \
     && unzip /root/thirdparties-src.zip -d . \

--- a/docker/thirdparties-src/Dockerfile
+++ b/docker/thirdparties-src/Dockerfile
@@ -16,7 +16,8 @@
 # under the License.
 
 ARG GITHUB_BRANCH=master
-FROM apache/pegasus:build-env-centos7-${GITHUB_BRANCH} as builder
+ARG OS_VERSION=centos7
+FROM apache/pegasus:build-env-${OS_VERSION}-${GITHUB_BRANCH} as builder
 
 WORKDIR /root
 


### PR DESCRIPTION
Resolve https://github.com/apache/incubator-pegasus/issues/2136:

- move `hadoop-bin` dir into the specified position at the stage of rebuilding/unpacking
`thirdparty` instead of uploading artifact;  
- build `thirdparties-src` image on Ubuntu instead of EOL CentOS 7 to make downstream
workflows work.