### PR TITLE
ci: fix the workflow building images of compilation environment for centos7 on Github

### DIFF
--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           context: .
           file: ./docker/pegasus-build-env/${{ matrix.dockertag }}/Dockerfile
           push: true


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/apache/incubator-pegasus/issues/2135.

CentOS 7.5.1804 does not support `aarch64` in [sclo](https://vault.centos.org/7.5.1804/sclo/).
Thus just remove `linux/arm64` from Github workflow.

### What is changed and how does it work?


### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

##### Code changes

- Has exported function/method change
- Has exported variable/fields change
- Has interface methods change
- Has persistent data change

##### Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

##### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
