### PR TITLE
fix(meta): meta server failed and could not be started normally while setting environment variables after dropping table

### DIFF
--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -332,6 +332,7 @@ private:
     friend class meta_partition_guardian_test;
     friend class meta_service_test;
     friend class meta_service_test_app;
+    friend class server_state_test;
     friend class meta_split_service_test;
     friend class meta_test_base;
     friend class policy_context_test;

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -28,11 +28,11 @@
 #include <boost/lexical_cast.hpp>
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <fmt/core.h>
-#include <string.h>
 #include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <set>
 #include <sstream> // IWYU pragma: keep
 #include <string>

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -3033,10 +3033,7 @@ void server_state::set_app_envs(const app_env_rpc &env_rpc)
             }
 
             if (s == "dropping") {
-                const auto &iter = _exist_apps.find(app_name);
-                CHECK_TRUE(iter != _exist_apps.end());
-
-                iter->second->status = app_status::AS_DROPPING;
+                gutil::FindOrDie(_exist_apps, app_name)->status = app_status::AS_DROPPING;
                 return;
             }
         });

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -3098,6 +3098,8 @@ void server_state::set_app_envs(const app_env_rpc &env_rpc)
         }
 
         const auto &old_envs = dsn::utils::kv_map_to_string(app->envs, ',', '=');
+
+        // Update envs of local memory.
         for (size_t idx = 0; idx < keys.size(); ++idx) {
             app->envs[keys[idx]] = values[idx];
         }

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -36,6 +36,7 @@
 #include <set>
 #include <sstream> // IWYU pragma: keep
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -3032,7 +3032,9 @@ void server_state::set_app_envs(const app_env_rpc &env_rpc)
         }
 
         if (app->status == app_status::AS_DROPPING) {
-            LOG_WARNING("set app envs failed since app(name={}, id={}) is being dropped", app_name, app->app_id);
+            LOG_WARNING("set app envs failed since app(name={}, id={}) is being dropped",
+                        app_name,
+                        app->app_id);
             env_rpc.response().err = ERR_BUSY_DROPPING;
             env_rpc.response().hint_message = "app is being dropped";
             return;
@@ -3059,9 +3061,11 @@ void server_state::set_app_envs(const app_env_rpc &env_rpc)
         // set, otherwise update might be missing. For example, an update is setting the envs
         // while another is dropping a table. The update setting the envs does not contain the
         // dropped state. Once it is applied by remote storage after another update dropping
-        // the table, the state of the table would always be non-dropped on remote storage. 
+        // the table, the state of the table would always be non-dropped on remote storage.
         if (!app) {
-            LOG_ERROR("set app envs failed since app(name={}, id={}) has just been dropped", app_name, app->app_id);
+            LOG_ERROR("set app envs failed since app(name={}, id={}) has just been dropped",
+                      app_name,
+                      app->app_id);
             env_rpc.response().err = ERR_APP_DROPPED;
             env_rpc.response().hint_message = "app has just been dropped";
             return;

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -141,18 +141,24 @@ public:
     void lock_read(zauto_read_lock &other);
     void lock_write(zauto_write_lock &other);
     const meta_view get_meta_view() { return {&_all_apps, &_nodes}; }
+
     std::shared_ptr<app_state> get_app(const std::string &name) const
     {
-        auto iter = _exist_apps.find(name);
-        if (iter == _exist_apps.end())
-            return nullptr;
+        const auto &iter = _exist_apps.find(name);
+        if (iter == _exist_apps.end()) {
+            return std::shared_ptr<app_state>();
+        }
+
         return iter->second;
     }
+
     std::shared_ptr<app_state> get_app(int32_t app_id) const
     {
-        auto iter = _all_apps.find(app_id);
-        if (iter == _all_apps.end())
-            return nullptr;
+        const auto &iter = _all_apps.find(app_id);
+        if (iter == _all_apps.end()) {
+            return std::shared_ptr<app_state>();
+        }
+
         return iter->second;
     }
 

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -42,6 +42,7 @@
 #include "common/gpid.h"
 #include "common/manual_compact.h"
 #include "dsn.layer2_types.h"
+#include "gutil/map_util.h"
 #include "meta/meta_rpc_types.h"
 #include "meta_data.h"
 #include "table_metrics.h"
@@ -143,24 +144,14 @@ public:
 
     meta_view get_meta_view() { return {&_all_apps, &_nodes}; }
 
-    std::shared_ptr<app_state> get_app(const std::string &name) const
+    std::shared_ptr<app_state> get_app(const std::string &app_name) const
     {
-        const auto &iter = _exist_apps.find(name);
-        if (iter == _exist_apps.end()) {
-            return {};
-        }
-
-        return iter->second;
+        return gutil::FindWithDefault(_exist_apps, app_name);
     }
 
     std::shared_ptr<app_state> get_app(int32_t app_id) const
     {
-        const auto &iter = _all_apps.find(app_id);
-        if (iter == _all_apps.end()) {
-            return {};
-        }
-
-        return iter->second;
+        return gutil::FindWithDefault(_all_apps, app_id);
     }
 
     void query_configuration_by_index(const query_cfg_request &request,

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -140,13 +140,14 @@ public:
 
     void lock_read(zauto_read_lock &other);
     void lock_write(zauto_write_lock &other);
-    const meta_view get_meta_view() { return {&_all_apps, &_nodes}; }
+
+    meta_view get_meta_view() { return {&_all_apps, &_nodes}; }
 
     std::shared_ptr<app_state> get_app(const std::string &name) const
     {
         const auto &iter = _exist_apps.find(name);
         if (iter == _exist_apps.end()) {
-            return std::shared_ptr<app_state>();
+            return {};
         }
 
         return iter->second;
@@ -156,7 +157,7 @@ public:
     {
         const auto &iter = _all_apps.find(app_id);
         if (iter == _all_apps.end()) {
-            return std::shared_ptr<app_state>();
+            return {};
         }
 
         return iter->second;

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -416,6 +416,7 @@ private:
     friend class meta_split_service;
     friend class meta_split_service_test;
     friend class meta_service_test_app;
+    friend class server_state_test;
     friend class meta_test_base;
     friend class test::test_checker;
     friend class server_state_restore_test;

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -29,7 +29,7 @@
 // IWYU pragma: no_include <boost/detail/basic_pointerbuf.hpp>
 #include <boost/lexical_cast.hpp>
 #include <gtest/gtest_prod.h>
-#include <stdint.h>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>

--- a/src/meta/test/meta_service_test_app.h
+++ b/src/meta/test/meta_service_test_app.h
@@ -137,7 +137,7 @@ public:
     void json_compacity();
 
     // test server_state set_app_envs/del_app_envs/clear_app_envs
-    void app_envs_basic_test();
+    static void app_envs_basic_test();
 
     // test for bug found
     void adjust_dropped_size();

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -50,7 +50,8 @@
 DSN_DECLARE_string(cluster_root);
 DSN_DECLARE_string(meta_state_service_type);
 
-namespace dsn::replication {
+namespace dsn {
+namespace replication {
 
 static const std::vector<std::string> keys = {
     dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
@@ -62,7 +63,6 @@ static const std::vector<std::string> keys = {
     dsn::replica_envs::ROCKSDB_USAGE_SCENARIO,
     dsn::replica_envs::ROCKSDB_CHECKPOINT_RESERVE_MIN_COUNT,
     dsn::replica_envs::ROCKSDB_CHECKPOINT_RESERVE_TIME_SECONDS};
-
 static const std::vector<std::string> values = {
     "1712846598",
     "6",
@@ -78,7 +78,6 @@ static const std::vector<std::string> del_keys = {
     dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
     dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
     dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
-
 static const std::set<std::string> del_keys_set = {
     dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
     dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
@@ -315,4 +314,5 @@ void meta_service_test_app::app_envs_basic_test()
     }
 }
 
-} // namespace dsn::replication
+} // namespace replication
+} // namespace dsn

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -53,7 +53,9 @@ DSN_DECLARE_string(meta_state_service_type);
 namespace dsn {
 namespace replication {
 
-static const std::vector<std::string> keys = {
+namespace {
+
+const std::vector<std::string> keys = {
     dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
     dsn::replica_envs::MANUAL_COMPACT_ONCE_TARGET_LEVEL,
     dsn::replica_envs::MANUAL_COMPACT_ONCE_BOTTOMMOST_LEVEL_COMPACTION,
@@ -63,7 +65,8 @@ static const std::vector<std::string> keys = {
     dsn::replica_envs::ROCKSDB_USAGE_SCENARIO,
     dsn::replica_envs::ROCKSDB_CHECKPOINT_RESERVE_MIN_COUNT,
     dsn::replica_envs::ROCKSDB_CHECKPOINT_RESERVE_TIME_SECONDS};
-static const std::vector<std::string> values = {
+
+const std::vector<std::string> values = {
     "1712846598",
     "6",
     dsn::replica_envs::MANUAL_COMPACT_BOTTOMMOST_LEVEL_COMPACTION_FORCE,
@@ -74,20 +77,19 @@ static const std::vector<std::string> values = {
     "1",
     "0"};
 
-static const std::vector<std::string> del_keys = {
-    dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
-    dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
-    dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
-static const std::set<std::string> del_keys_set = {
-    dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
-    dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
-    dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
+const std::vector<std::string> del_keys = {dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
+                                           dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
+                                           dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
 
-static const std::string clear_prefix = "rocksdb";
+const std::set<std::string> del_keys_set = {dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
+                                            dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
+                                            dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
+
+const std::string clear_prefix = "rocksdb";
 
 // if str = "prefix.xxx" then return prefix
 // else return ""
-static std::string acquire_prefix(const std::string &str)
+std::string acquire_prefix(const std::string &str)
 {
     auto index = str.find('.');
     if (index == std::string::npos) {
@@ -97,81 +99,154 @@ static std::string acquire_prefix(const std::string &str)
     }
 }
 
+} // anonymous namespace
+
+class server_state_test
+{
+public:
+    server_state_test() : _ms(create_meta_service()), _ss(create_server_state(_ms.get())) {}
+
+    void load_apps(const std::vector<std::string> &app_names)
+    {
+        const auto &apps = fake_apps(app_names);
+        for (const auto &[_, app] : apps) {
+            _ss->_all_apps.emplace(std::make_pair(app->app_id, app));
+        }
+
+        ASSERT_EQ(dsn::ERR_OK, _ss->sync_apps_to_remote_storage());
+    }
+
+    std::shared_ptr<app_state> get_app(const std::string &app_name)
+    {
+        return _ss->get_app(app_name);
+    }
+
+    void set_app_envs(const configuration_update_app_env_request &request)
+    {
+        _ss->set_app_envs(create_app_env_rpc(request));
+        _ss->wait_all_task();
+    }
+
+    void del_app_envs(const configuration_update_app_env_request &request)
+    {
+        _ss->del_app_envs(create_app_env_rpc(request));
+        _ss->wait_all_task();
+    }
+
+    void clear_app_envs(const configuration_update_app_env_request &request)
+    {
+        _ss->clear_app_envs(create_app_env_rpc(request));
+        _ss->wait_all_task();
+    }
+
+private:
+    static std::shared_ptr<app_state> fake_app_state(const std::string &app_name,
+                                                     const int32_t app_id)
+    {
+        dsn::app_info info;
+        info.is_stateful = true;
+        info.app_id = app_id;
+        info.app_type = "simple_kv";
+        info.app_name = app_name;
+        info.max_replica_count = 3;
+        info.partition_count = 32;
+        info.status = dsn::app_status::AS_CREATING;
+        info.envs.clear();
+        return app_state::create(info);
+    }
+
+    static std::map<std::string, std::shared_ptr<app_state>>
+    fake_apps(const std::vector<std::string> &app_names)
+    {
+        std::map<std::string, std::shared_ptr<app_state>> apps;
+
+        int32_t app_id = 1;
+        std::transform(app_names.begin(),
+                       app_names.end(),
+                       std::inserter(apps, apps.end()),
+                       [&app_id](const std::string &app_name) {
+                           return std::make_pair(app_name, fake_app_state(app_name, app_id++));
+                       });
+
+        return apps;
+    }
+
+    static std::unique_ptr<meta_service> create_meta_service()
+    {
+        auto ms = std::make_unique<meta_service>();
+
+        FLAGS_cluster_root = "/meta_test";
+        FLAGS_meta_state_service_type = "meta_state_service_simple";
+        ms->remote_storage_initialize();
+
+        return ms;
+    }
+
+    static std::shared_ptr<server_state> create_server_state(meta_service *ms)
+    {
+        std::string apps_root("/meta_test/apps");
+        const auto &ss = ms->_state;
+        ss->initialize(ms, apps_root);
+
+        return ss;
+    }
+
+    app_env_rpc create_app_env_rpc(const configuration_update_app_env_request &request)
+    {
+        dsn::message_ptr binary_req(dsn::message_ex::create_request(RPC_CM_UPDATE_APP_ENV));
+        dsn::marshall(binary_req, request);
+        dsn::message_ex *recv_msg = create_corresponding_receive(binary_req);
+        return app_env_rpc(recv_msg); // don't need reply
+    }
+
+    std::unique_ptr<meta_service> _ms;
+    std::shared_ptr<server_state> _ss;
+};
+
 void meta_service_test_app::app_envs_basic_test()
 {
-    // create a fake app
-    dsn::app_info info;
-    info.is_stateful = true;
-    info.app_id = 1;
-    info.app_type = "simple_kv";
-    info.app_name = "test_app1";
-    info.max_replica_count = 3;
-    info.partition_count = 32;
-    info.status = dsn::app_status::AS_CREATING;
-    info.envs.clear();
-    std::shared_ptr<app_state> fake_app = app_state::create(info);
-
-    // create meta_service
-    std::shared_ptr<meta_service> meta_svc = std::make_shared<meta_service>();
-    meta_service *svc = meta_svc.get();
-
-    FLAGS_cluster_root = "/meta_test";
-    FLAGS_meta_state_service_type = "meta_state_service_simple";
-    svc->remote_storage_initialize();
-
-    std::string apps_root = "/meta_test/apps";
-    std::shared_ptr<server_state> ss = svc->_state;
-    ss->initialize(svc, apps_root);
-
-    ss->_all_apps.emplace(std::make_pair(fake_app->app_id, fake_app));
-    ASSERT_EQ(dsn::ERR_OK, ss->sync_apps_to_remote_storage());
+    server_state_test test;
+    test.load_apps({"test_app1"});
 
     std::cout << "test server_state::set_app_envs()..." << std::endl;
     {
         configuration_update_app_env_request request;
-        request.__set_app_name(fake_app->app_name);
+        request.__set_app_name("test_app1");
         request.__set_op(app_env_operation::type::APP_ENV_OP_SET);
         request.__set_keys(keys);
         request.__set_values(values);
 
-        dsn::message_ptr binary_req = dsn::message_ex::create_request(RPC_CM_UPDATE_APP_ENV);
-        dsn::marshall(binary_req, request);
-        dsn::message_ex *recv_msg = create_corresponding_receive(binary_req);
-        app_env_rpc rpc(recv_msg); // don't need reply
-        ss->set_app_envs(rpc);
-        ss->wait_all_task();
-        std::shared_ptr<app_state> app = ss->get_app(fake_app->app_name);
-        ASSERT_TRUE(app != nullptr);
-        for (int idx = 0; idx < keys.size(); idx++) {
-            const std::string &key = keys[idx];
-            ASSERT_EQ(app->envs.count(key), 1);
-            ASSERT_EQ(app->envs.at(key), values[idx]);
+        test.set_app_envs(request);
+
+        const auto &app = test.get_app("test_app1");
+        ASSERT_TRUE(app);
+
+        for (size_t idx = 0; idx < keys.size(); ++idx) {
+            const auto &key = keys[idx];
+            ASSERT_EQ(1, app->envs.count(key));
+            ASSERT_EQ(values[idx], app->envs.at(key));
         }
     }
 
     std::cout << "test server_state::del_app_envs()..." << std::endl;
     {
         configuration_update_app_env_request request;
-        request.__set_app_name(fake_app->app_name);
+        request.__set_app_name("test_app1");
         request.__set_op(app_env_operation::type::APP_ENV_OP_DEL);
         request.__set_keys(del_keys);
 
-        dsn::message_ptr binary_req = dsn::message_ex::create_request(RPC_CM_UPDATE_APP_ENV);
-        dsn::marshall(binary_req, request);
-        dsn::message_ex *recv_msg = create_corresponding_receive(binary_req);
-        app_env_rpc rpc(recv_msg); // don't need reply
-        ss->del_app_envs(rpc);
-        ss->wait_all_task();
+        test.del_app_envs(request);
 
-        std::shared_ptr<app_state> app = ss->get_app(fake_app->app_name);
-        ASSERT_TRUE(app != nullptr);
-        for (int idx = 0; idx < keys.size(); idx++) {
+        const auto &app = test.get_app("test_app1");
+        ASSERT_TRUE(app);
+
+        for (size_t idx = 0; idx < keys.size(); ++idx) {
             const std::string &key = keys[idx];
             if (del_keys_set.count(key) >= 1) {
-                ASSERT_EQ(app->envs.count(key), 0);
+                ASSERT_EQ(0, app->envs.count(key));
             } else {
-                ASSERT_EQ(app->envs.count(key), 1);
-                ASSERT_EQ(app->envs.at(key), values[idx]);
+                ASSERT_EQ(1, app->envs.count(key));
+                ASSERT_EQ(values[idx], app->envs.at(key));
             }
         }
     }
@@ -181,31 +256,27 @@ void meta_service_test_app::app_envs_basic_test()
         // test specify prefix
         {
             configuration_update_app_env_request request;
-            request.__set_app_name(fake_app->app_name);
+            request.__set_app_name("test_app1");
             request.__set_op(app_env_operation::type::APP_ENV_OP_CLEAR);
             request.__set_clear_prefix(clear_prefix);
 
-            dsn::message_ptr binary_req = dsn::message_ex::create_request(RPC_CM_UPDATE_APP_ENV);
-            dsn::marshall(binary_req, request);
-            dsn::message_ex *recv_msg = create_corresponding_receive(binary_req);
-            app_env_rpc rpc(recv_msg); // don't need reply
-            ss->clear_app_envs(rpc);
-            ss->wait_all_task();
+            test.clear_app_envs(request);
 
-            std::shared_ptr<app_state> app = ss->get_app(fake_app->app_name);
-            ASSERT_TRUE(app != nullptr);
-            for (int idx = 0; idx < keys.size(); idx++) {
+            const auto &app = test.get_app("test_app1");
+            ASSERT_TRUE(app);
+
+            for (size_t idx = 0; idx < keys.size(); ++idx) {
                 const std::string &key = keys[idx];
                 if (del_keys_set.count(key) <= 0) {
                     if (acquire_prefix(key) == clear_prefix) {
-                        ASSERT_EQ(app->envs.count(key), 0);
+                        ASSERT_EQ(0, app->envs.count(key));
                     } else {
-                        ASSERT_EQ(app->envs.count(key), 1);
-                        ASSERT_EQ(app->envs.at(key), values[idx]);
+                        ASSERT_EQ(1, app->envs.count(key));
+                        ASSERT_EQ(values[idx], app->envs.at(key));
                     }
                 } else {
                     // key already delete
-                    ASSERT_EQ(app->envs.count(key), 0);
+                    ASSERT_EQ(0, app->envs.count(key));
                 }
             }
         }
@@ -213,22 +284,19 @@ void meta_service_test_app::app_envs_basic_test()
         // test clear all
         {
             configuration_update_app_env_request request;
-            request.__set_app_name(fake_app->app_name);
+            request.__set_app_name("test_app1");
             request.__set_op(app_env_operation::type::APP_ENV_OP_CLEAR);
             request.__set_clear_prefix("");
 
-            dsn::message_ptr binary_req = dsn::message_ex::create_request(RPC_CM_UPDATE_APP_ENV);
-            dsn::marshall(binary_req, request);
-            dsn::message_ex *recv_msg = create_corresponding_receive(binary_req);
-            app_env_rpc rpc(recv_msg); // don't need reply
-            ss->clear_app_envs(rpc);
-            ss->wait_all_task();
+            test.clear_app_envs(request);
 
-            std::shared_ptr<app_state> app = ss->get_app(fake_app->app_name);
-            ASSERT_TRUE(app != nullptr);
+            const auto &app = test.get_app("test_app1");
+            ASSERT_TRUE(app);
+
             ASSERT_TRUE(app->envs.empty());
         }
     }
 }
+
 } // namespace replication
 } // namespace dsn

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -246,7 +246,7 @@ void meta_service_test_app::app_envs_basic_test()
     // Failed to setting envs while table was being dropped as the intermediate state.
     TEST_SET_APP_ENVS_FAILED(dropping, ERR_BUSY_DROPPING);
 
-    // The table was found dropped after the new envs have been persistent on the remote
+    // The table was found dropped after the new envs had been persistent on the remote
     // meta storage.
     TEST_SET_APP_ENVS_FAILED(dropped_after, ERR_APP_DROPPED);
 

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -118,7 +118,7 @@ public:
         ASSERT_EQ(dsn::ERR_OK, _ss->sync_apps_to_remote_storage());
     }
 
-    std::shared_ptr<app_state> get_app(const std::string &app_name) const
+    [[nodiscard]] std::shared_ptr<app_state> get_app(const std::string &app_name) const
     {
         return _ss->get_app(app_name);
     }
@@ -253,7 +253,7 @@ void meta_service_test_app::app_envs_basic_test()
 #undef TEST_SET_APP_ENVS_FAILED
 
     // Normal case for setting envs.
-    std::cout << "test server_state::set_app_envs()..." << std::endl;
+    std::cout << "test server_state::set_app_envs(success)..." << std::endl;
     {
         configuration_update_app_env_request request;
         request.__set_app_name("test_app1");

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -24,7 +24,11 @@
  * THE SOFTWARE.
  */
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <set>
@@ -42,6 +46,7 @@
 #include "meta/server_state.h"
 #include "meta_admin_types.h"
 #include "meta_service_test_app.h"
+#include "rpc/rpc_holder.h"
 #include "rpc/rpc_message.h"
 #include "rpc/serialization.h"
 #include "utils/error_code.h"

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -50,12 +50,9 @@
 DSN_DECLARE_string(cluster_root);
 DSN_DECLARE_string(meta_state_service_type);
 
-namespace dsn {
-namespace replication {
+namespace dsn::replication {
 
-namespace {
-
-const std::vector<std::string> keys = {
+static const std::vector<std::string> keys = {
     dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
     dsn::replica_envs::MANUAL_COMPACT_ONCE_TARGET_LEVEL,
     dsn::replica_envs::MANUAL_COMPACT_ONCE_BOTTOMMOST_LEVEL_COMPACTION,
@@ -66,7 +63,7 @@ const std::vector<std::string> keys = {
     dsn::replica_envs::ROCKSDB_CHECKPOINT_RESERVE_MIN_COUNT,
     dsn::replica_envs::ROCKSDB_CHECKPOINT_RESERVE_TIME_SECONDS};
 
-const std::vector<std::string> values = {
+static const std::vector<std::string> values = {
     "1712846598",
     "6",
     dsn::replica_envs::MANUAL_COMPACT_BOTTOMMOST_LEVEL_COMPACTION_FORCE,
@@ -77,19 +74,21 @@ const std::vector<std::string> values = {
     "1",
     "0"};
 
-const std::vector<std::string> del_keys = {dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
-                                           dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
-                                           dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
+static const std::vector<std::string> del_keys = {
+    dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
+    dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
+    dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
 
-const std::set<std::string> del_keys_set = {dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
-                                            dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
-                                            dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
+static const std::set<std::string> del_keys_set = {
+    dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
+    dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
+    dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
 
-const std::string clear_prefix = "rocksdb";
+static const std::string clear_prefix = "rocksdb";
 
 // if str = "prefix.xxx" then return prefix
 // else return ""
-std::string acquire_prefix(const std::string &str)
+static std::string acquire_prefix(const std::string &str)
 {
     auto index = str.find('.');
     if (index == std::string::npos) {
@@ -98,8 +97,6 @@ std::string acquire_prefix(const std::string &str)
         return str.substr(0, index);
     }
 }
-
-} // anonymous namespace
 
 class server_state_test
 {
@@ -191,7 +188,7 @@ private:
         return ss;
     }
 
-    app_env_rpc create_app_env_rpc(const configuration_update_app_env_request &request)
+    static app_env_rpc create_app_env_rpc(const configuration_update_app_env_request &request)
     {
         dsn::message_ptr binary_req(dsn::message_ex::create_request(RPC_CM_UPDATE_APP_ENV));
         dsn::marshall(binary_req, request);
@@ -207,6 +204,26 @@ void meta_service_test_app::app_envs_basic_test()
 {
     server_state_test test;
     test.load_apps({"test_app1"});
+
+    /* std::cout << "test server_state::set_app_envs()..." << std::endl;
+    {
+        configuration_update_app_env_request request;
+        request.__set_app_name(fake_app->app_name);
+        request.__set_op(app_env_operation::type::APP_ENV_OP_SET);
+        request.__set_keys({replica_envs::ROCKSDB_WRITE_BUFFER_SIZE});
+        request.__set_values({"67108864"});
+
+        dsn::message_ptr binary_req = dsn::message_ex::create_request(RPC_CM_UPDATE_APP_ENV);
+        dsn::marshall(binary_req, request);
+        dsn::message_ex *recv_msg = create_corresponding_receive(binary_req);
+        app_env_rpc rpc(recv_msg); // don't need reply
+        ss->set_app_envs(rpc);
+        ss->wait_all_task();
+        std::shared_ptr<app_state> app = ss->get_app(fake_app->app_name);
+        ASSERT_TRUE(app != nullptr);
+        fail::setup();
+        fail::cfg(test.fail_cfg_name, test.fail_cfg_action);
+    } */
 
     std::cout << "test server_state::set_app_envs()..." << std::endl;
     {
@@ -298,5 +315,4 @@ void meta_service_test_app::app_envs_basic_test()
     }
 }
 
-} // namespace replication
-} // namespace dsn
+} // namespace dsn::replication

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -118,7 +118,7 @@ public:
         ASSERT_EQ(dsn::ERR_OK, _ss->sync_apps_to_remote_storage());
     }
 
-    std::shared_ptr<app_state> get_app(const std::string &app_name)
+    std::shared_ptr<app_state> get_app(const std::string &app_name) const
     {
         return _ss->get_app(app_name);
     }
@@ -240,14 +240,19 @@ void meta_service_test_app::app_envs_basic_test()
         fail::teardown();                                                                          \
     } while (0)
 
+    // Failed to setting envs while table was not found.
     TEST_SET_APP_ENVS_FAILED(not_found, ERR_APP_NOT_EXIST);
 
+    // Failed to setting envs while table was being dropped as the intermediate state.
     TEST_SET_APP_ENVS_FAILED(dropping, ERR_BUSY_DROPPING);
 
+    // The table was found dropped after the new envs have been persistent on the remote
+    // meta storage.
     TEST_SET_APP_ENVS_FAILED(dropped_after, ERR_APP_DROPPED);
 
 #undef TEST_SET_APP_ENVS_FAILED
 
+    // Normal case for setting envs.
     std::cout << "test server_state::set_app_envs()..." << std::endl;
     {
         configuration_update_app_env_request request;

--- a/src/meta/test/state_sync_test.cpp
+++ b/src/meta/test/state_sync_test.cpp
@@ -393,7 +393,7 @@ void meta_service_test_app::construct_apps_test()
     generate_node_list(nodes, 1, 1);
     svc->_state->construct_apps({resp}, nodes, hint_message);
 
-    meta_view mv = svc->_state->get_meta_view();
+    const meta_view mv = svc->_state->get_meta_view();
     const app_mapper &mapper = *(mv.apps);
     ASSERT_EQ(6, mv.apps->size());
 

--- a/src/utils/fail_point.h
+++ b/src/utils/fail_point.h
@@ -46,8 +46,9 @@
 // argument, preprocess for this macro would fail for mismatched arguments.
 #define FAIL_POINT_INJECT_F(name, ...)                                                             \
     do {                                                                                           \
-        if (dsn_likely(!::dsn::fail::_S_FAIL_POINT_ENABLED))                                       \
+        if (dsn_likely(!::dsn::fail::_S_FAIL_POINT_ENABLED)) {                                     \
             break;                                                                                 \
+        }                                                                                          \
         auto __Func = __VA_ARGS__;                                                                 \
         auto __Res = ::dsn::fail::eval(name);                                                      \
         if (__Res != nullptr) {                                                                    \
@@ -63,8 +64,9 @@
 // argument, preprocess for this macro would fail for mismatched arguments.
 #define FAIL_POINT_INJECT_NOT_RETURN_F(name, ...)                                                  \
     do {                                                                                           \
-        if (dsn_likely(!::dsn::fail::_S_FAIL_POINT_ENABLED))                                       \
+        if (dsn_likely(!::dsn::fail::_S_FAIL_POINT_ENABLED)) {                                     \
             break;                                                                                 \
+        }                                                                                          \
         auto __Func = __VA_ARGS__;                                                                 \
         auto __Res = ::dsn::fail::eval(name);                                                      \
         if (__Res != nullptr) {                                                                    \


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2149.

There are two problems that should be solved:

1. why the primary meta server failed with `segfault` while dropping tables ?
2. why all meta servers were never be restarted normally after the primary
meta server failed ?

A pegasus cluster would flush security policies to remote meta storage
periodically (by `update_ranger_policy_interval_sec`) in the form of environment
variables. We do this by `server_state::set_app_envs()`. However, after updating
the meta data on the remote storage (namely ZooKeeper), the table is not checked
that if it still exists while updating environment variables of local memory:

```C++
void server_state::set_app_envs(const app_env_rpc &env_rpc)
{

...

    do_update_app_info(app_path, ainfo, [this, app_name, keys, values, env_rpc](error_code ec) {
        CHECK_EQ_MSG(ec, ERR_OK, "update app info to remote storage failed");

        zauto_write_lock l(_lock);
        std::shared_ptr<app_state> app = get_app(app_name);
        std::string old_envs = dsn::utils::kv_map_to_string(app->envs, ',', '=');
        for (int idx = 0; idx < keys.size(); idx++) {
            app->envs[keys[idx]] = values[idx];
        }
        std::string new_envs = dsn::utils::kv_map_to_string(app->envs, ',', '=');
        LOG_INFO("app envs changed: old_envs = {}, new_envs = {}", old_envs, new_envs);
    });
}
```

In `std::string old_envs = dsn::utils::kv_map_to_string(app->envs, ',', '=');`, since
`app` is `nullptr`, `app->envs` would point an invalid address, leading to `segfault`
in `libdsn_utils.so` where `dsn::utils::kv_map_to_string` is.

Therefore, the reason for the 1st problem is very clear: the callback for updating meta
data on remote storage is called immediately after the table is removed, and an invalid
address is accessed due to null pointer.

Then, the meta server would load meta data from remote storage after it is restart.
However, the intermediate status `AS_DROPPING` is also flushed to remote storage
with security policies since all meta data for a table is an unitary `json` object: the whole
`json` would be set to remote storage once any property is updated.

However `AS_DROPPING` is invalid, and cannot pass the assertion which would make
meta server fail again and again, which is the reason of the 2nd problem: 

```C++
server_state::sync_apps_from_remote_storage()
{

...

                    std::shared_ptr<app_state> app = app_state::create(info);
                    {
                        zauto_write_lock l(_lock);
                        _all_apps.emplace(app->app_id, app);
                        if (app->status == app_status::AS_AVAILABLE) {
                            app->status = app_status::AS_CREATING;
                            _exist_apps.emplace(app->app_name, app);
                            _table_metric_entities.create_entity(app->app_id, app->partition_count);
                        } else if (app->status == app_status::AS_DROPPED) {
                            app->status = app_status::AS_DROPPING;
                        } else {
                            CHECK(false,
                                  "invalid status({}) for app({}) in remote storage",
                                  enum_to_string(app->status),
                                  app->get_logname());
                        }
                    }

...

}
```

To fix the 1st problem, we just check if the table still exists after meta data is updated
on the remote storage. To fix the 2nd problem, we prevent meta data with intermediate
status `AS_DROPPING` from being flushed to remote storage.
