### PR TITLE
chore: update actions download-artifact and up-artifact to v4

### DIFF
--- a/.github/actions/download_artifact/action.yaml
+++ b/.github/actions/download_artifact/action.yaml
@@ -22,7 +22,7 @@ runs:
     - name: Unpack prebuilt third-parties
       uses: "./.github/actions/unpack_prebuilt_thirdparties"
     - name: Download tarball
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}_artifact_${{ github.sha }}
         path: .

--- a/.github/actions/upload_artifact/action.yaml
+++ b/.github/actions/upload_artifact/action.yaml
@@ -30,7 +30,7 @@ runs:
         tar -zcvhf ${ARTIFACT_NAME}_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       shell: bash
     - name: Upload tarball
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}_artifact_${{ github.sha }}
         path: ${{ env.ARTIFACT_NAME }}_builder.tar


### PR DESCRIPTION
As the actions/download-artifact@v3 and actions/upload-artifact@v3 are scheduled for deprecation on November 30, 2024, this patch updates them to v4.

https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact
https://github.com/actions/download-artifact?tab=readme-ov-file#actionsdownload-artifact