### PR TITLE
fix(download): fix the broken download URL of thrift 0.11.0 tarball

### DIFF
--- a/docker/pegasus-build-env/centos7/Dockerfile
+++ b/docker/pegasus-build-env/centos7/Dockerfile
@@ -68,11 +68,11 @@ RUN wget --progress=dot:giga https://archive.apache.org/dist/maven/maven-3/3.8.3
     && tar -zxf apache-maven-3.8.3-bin.tar.gz \
     && rm apache-maven-3.8.3-bin.tar.gz
 
-RUN wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/0.11.0.tar.gz -P /opt/thrift && \
-    cd /opt/thrift && tar xzf 0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
+RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz -P /opt/thrift && \
+    cd /opt/thrift && tar xzf thrift-0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
     ./configure --enable-libs=no && \
     make -j$(($(nproc)/2+1)) && make install && cd - && \
-    rm -rf thrift-0.11.0 0.11.0.tar.gz
+    rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz
 
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
 ENV PATH="/opt/maven/apache-maven-3.8.3/bin:${PATH}"

--- a/docker/pegasus-build-env/ubuntu1804/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu1804/Dockerfile
@@ -61,11 +61,11 @@ RUN add-apt-repository ppa:git-core/ppa -y; \
 
 RUN pip3 install --no-cache-dir --upgrade pip && pip3 install --no-cache-dir cmake
 
-RUN wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/0.11.0.tar.gz -P /opt/thrift && \
-    cd /opt/thrift && tar xzf 0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
+RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz -P /opt/thrift && \
+    cd /opt/thrift && tar xzf thrift-0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
     ./configure --enable-libs=no && \
     make -j$(($(nproc)/2+1)) && make install && cd - && \
-    rm -rf thrift-0.11.0 0.11.0.tar.gz
+    rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz 
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV CLASSPATH=$JAVA_HOME/lib/

--- a/docker/pegasus-build-env/ubuntu1804/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu1804/Dockerfile
@@ -65,7 +65,7 @@ RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrif
     cd /opt/thrift && tar xzf thrift-0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
     ./configure --enable-libs=no && \
     make -j$(($(nproc)/2+1)) && make install && cd - && \
-    rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz 
+    rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV CLASSPATH=$JAVA_HOME/lib/

--- a/docker/pegasus-build-env/ubuntu2004/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2004/Dockerfile
@@ -60,11 +60,11 @@ RUN add-apt-repository ppa:git-core/ppa -y; \
 
 RUN pip3 install --no-cache-dir cmake
 
-RUN wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/0.11.0.tar.gz -P /opt/thrift && \
-    cd /opt/thrift && tar xzf 0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
+RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz -P /opt/thrift && \
+    cd /opt/thrift && tar xzf thrift-0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
     ./configure --enable-libs=no && \
     make -j$(($(nproc)/2+1)) && make install && cd - && \
-    rm -rf thrift-0.11.0 0.11.0.tar.gz
+    rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV CLASSPATH=$JAVA_HOME/lib/

--- a/docker/pegasus-build-env/ubuntu2204/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2204/Dockerfile
@@ -56,11 +56,11 @@ RUN apt-get update -y; \
 RUN pip3 install --no-cache-dir --upgrade pip
 RUN pip3 install --no-cache-dir cmake
 
-RUN wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/0.11.0.tar.gz -P /opt/thrift && \
-    cd /opt/thrift && tar xzf 0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
+RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz -P /opt/thrift && \
+    cd /opt/thrift && tar xzf thrift-0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
     ./configure --enable-libs=no && \
     make -j$(($(nproc)/2+1)) && make install && cd - && \
-    rm -rf thrift-0.11.0 0.11.0.tar.gz
+    rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV CLASSPATH=$JAVA_HOME/lib/

--- a/java-client/scripts/download_thrift.sh
+++ b/java-client/scripts/download_thrift.sh
@@ -21,7 +21,7 @@
 
 function GenThriftTool() {
     set -e
-    wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/0.11.0.tar.gz -O thrift-0.11.0.tar.gz
+    wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz -O thrift-0.11.0.tar.gz
     tar xzf thrift-0.11.0.tar.gz
     pushd thrift-0.11.0
     ./bootstrap.sh


### PR DESCRIPTION
Resolve https://github.com/apache/incubator-pegasus/issues/2155.

Change the download URL of thrift 0.11.0 tarball to Apache instead of
Github where it was removed recently.