### PR TITLE
refactor: support close admin-cli client

### DIFF
--- a/admin-cli/cmd/init.go
+++ b/admin-cli/cmd/init.go
@@ -34,5 +34,5 @@ var pegasusClient *executor.Client
 func Init(metaList []string) {
 	globalMetaList = metaList
 
-	pegasusClient = executor.NewClient(os.Stdout, globalMetaList)
+	pegasusClient, _ = executor.NewClient(os.Stdout, globalMetaList, true)
 }

--- a/admin-cli/executor/client.go
+++ b/admin-cli/executor/client.go
@@ -73,11 +73,11 @@ func NewClient(writer io.Writer, metaAddrs []string, willExit bool) (*Client, er
 	}, nil
 }
 
-func CloseClient(writer io.Writer, client *Client) error {
+func CloseClient(client *Client) error {
 	var errorStrings []string
 	err := client.Meta.Close()
 	if err != nil {
-		fmt.Fprintf(writer, "fatal: failed to close meta session [%s]\n", err)
+		fmt.Printf("Error: failed to close meta session [%s]\n", err)
 		errorStrings = append(errorStrings, err.Error())
 	}
 
@@ -85,7 +85,7 @@ func CloseClient(writer io.Writer, client *Client) error {
 
 	err = client.Nodes.CloseAllNodes()
 	if err != nil {
-		fmt.Fprintf(writer, "fatal: failed to close nodes session [%s]\n", err)
+		fmt.Printf("Error: failed to close nodes session [%s]\n", err)
 		errorStrings = append(errorStrings, err.Error())
 	}
 

--- a/admin-cli/executor/client.go
+++ b/admin-cli/executor/client.go
@@ -88,6 +88,8 @@ func CloseClient(client *Client) error {
 		fmt.Printf("Error: failed to close nodes session [%s]\n", err)
 		errorStrings = append(errorStrings, err.Error())
 	}
-
-	return fmt.Errorf("%s", strings.Join(errorStrings, "\n"))
+	if len(errorStrings) != 0 {
+		return fmt.Errorf("%s", strings.Join(errorStrings, "\n"))
+	}
+	return nil
 }

--- a/admin-cli/executor/client.go
+++ b/admin-cli/executor/client.go
@@ -77,7 +77,7 @@ func CloseClient(client *Client) error {
 	var errorStrings []string
 	err := client.Meta.Close()
 	if err != nil {
-		fmt.Printf("Error: failed to close meta session [%s]\n", err)
+		fmt.Printf("Error: failed to close meta session [%s].\n", err)
 		errorStrings = append(errorStrings, err.Error())
 	}
 
@@ -85,7 +85,7 @@ func CloseClient(client *Client) error {
 
 	err = client.Nodes.CloseAllNodes()
 	if err != nil {
-		fmt.Printf("Error: failed to close nodes session [%s]\n", err)
+		fmt.Printf("Error: failed to close nodes session [%s].\n", err)
 		errorStrings = append(errorStrings, err.Error())
 	}
 	if len(errorStrings) != 0 {

--- a/admin-cli/executor/disk_info.go
+++ b/admin-cli/executor/disk_info.go
@@ -22,12 +22,10 @@ package executor
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/apache/incubator-pegasus/admin-cli/tabular"
 	"github.com/apache/incubator-pegasus/admin-cli/util"
-	"github.com/apache/incubator-pegasus/go-client/idl/admin"
 	"github.com/apache/incubator-pegasus/go-client/idl/base"
 	"github.com/apache/incubator-pegasus/go-client/idl/radmin"
 	"github.com/apache/incubator-pegasus/go-client/session"
@@ -93,31 +91,6 @@ func QueryAllNodesDiskInfo(client *Client, tableName string) (map[string]*radmin
 		resp, err := SendQueryDiskInfoRequest(client, address, tableName)
 		if err != nil {
 			return respMap, err
-		}
-		respMap[address] = resp
-	}
-	return respMap, nil
-}
-
-func QueryAliveNodesDiskInfo(client *Client, tableName string) (map[string]*radmin.QueryDiskInfoResponse, error) {
-	respMap := make(map[string]*radmin.QueryDiskInfoResponse)
-	nodeInfos, err := client.Meta.ListNodes()
-	if err != nil {
-		return respMap, err
-	}
-	for _, nodeInfo := range nodeInfos {
-		if nodeInfo.Status != admin.NodeStatus_NS_ALIVE {
-			continue
-		}
-		address := nodeInfo.GetAddress().GetAddress()
-		resp, err := SendQueryDiskInfoRequest(client, address, tableName)
-		if err != nil {
-			// this replica server haven't the table partition.
-			if strings.Contains(err.Error(), "ERR_OBJECT_NOT_FOUND") {
-				continue
-			} else {
-				return respMap, err
-			}
 		}
 		respMap[address] = resp
 	}

--- a/admin-cli/executor/toolkits/tablemigrator/switcher.go
+++ b/admin-cli/executor/toolkits/tablemigrator/switcher.go
@@ -59,7 +59,8 @@ func SwitchMetaAddrs(client *executor.Client, zkAddr string, zkRoot string, tabl
 
 	originMeta := client.Meta
 	targetAddrList := strings.Split(targetAddrs, ",")
-	targetMeta := executor.NewClient(os.Stdout, targetAddrList).Meta
+	pegasusClient, _ := executor.NewClient(os.Stdout, targetAddrList, true)
+	targetMeta := pegasusClient.Meta
 	env := map[string]string{
 		"replica.deny_client_request": "reconfig*all",
 	}

--- a/admin-cli/util/pegasus_node.go
+++ b/admin-cli/util/pegasus_node.go
@@ -84,6 +84,14 @@ func (n *PegasusNode) RPCAddress() *base.RPCAddress {
 	return base.NewRPCAddress(n.IP, n.Port)
 }
 
+func (n *PegasusNode) Close() error {
+	if n.session != nil {
+		return n.session.Close()
+	} else {
+		return nil
+	}
+}
+
 // NewNodeFromTCPAddr creates a node from tcp address.
 // NOTE:
 //   - Will not initialize TCP connection unless needed.
@@ -210,4 +218,18 @@ func (m *PegasusNodeManager) GetPerfSession(addr string, ntype session.NodeType)
 	}
 
 	return aggregate.WrapPerf(addr, node.session)
+}
+
+func (m *PegasusNodeManager) CloseAllNodes() error {
+	var errorStrings []string
+	for _, n := range m.nodes {
+		err := n.Close()
+		if err != nil {
+			errorStrings = append(errorStrings, err.Error())
+		}
+	}
+	if len(errorStrings) != 0 {
+		return fmt.Errorf("%s", strings.Join(errorStrings, "\n"))
+	}
+	return nil
 }

--- a/admin-cli/util/pegasus_node.go
+++ b/admin-cli/util/pegasus_node.go
@@ -87,9 +87,8 @@ func (n *PegasusNode) RPCAddress() *base.RPCAddress {
 func (n *PegasusNode) Close() error {
 	if n.session != nil {
 		return n.session.Close()
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // NewNodeFromTCPAddr creates a node from tcp address.


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2160

Current admin-cli client does not provide an interface to close replica server TCP connections.
And `QueryAllNodesDiskInfo` function is difficult to use. `SendQueryDiskInfoRequest` function is private.

### What problem does this PR solve? <!--add issue link with summary if exists-->
support close client, disconnect tcp link with replica server.

##### Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
The TCP connection to the replica server cannot be closed.
![image](https://github.com/user-attachments/assets/138c34af-66d7-4cd2-9362-084e2adc2471)

After support close client，the persistent TCP connection between admincli and the replica server can be disconnected.
![image](https://github.com/user-attachments/assets/de495f7e-8eaf-4f96-9917-e143f55fa1b0)



