### PR TITLE
chore: Upgrade to use macOS 15 in action

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -413,11 +413,11 @@ jobs:
     name: Build Release on macOS
     needs:
       - cpp_clang_format_linter
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - name: Install Softwares
         run: |
-          # Preinstalled softwares: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md
+          # Preinstalled softwares: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-15-Readme.md
           brew install ccache
           brew install openssl@1.1
       - uses: actions/checkout@v4
@@ -429,7 +429,7 @@ jobs:
           key: macos_build_ccache
           restore-keys: |
             macos_build_ccache
-            macos-12-thirdparty-bins
+            macos-15-thirdparty-bins
       - name: Build thirdparty
         working-directory: thirdparty
         run: |


### PR DESCRIPTION
Fix the issue:

> The macOS-12 environment is deprecated, consider switching to macOS-13,
> macOS-14 (macos-latest) or macOS-15. For more details, see
> https://github.com/actions/runner-images/issues/10721