### PR TITLE
chore(gha): introduce RockyLinux as an action runner

### DIFF
--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -35,7 +35,7 @@ jobs:
   build_compilation_env_docker_images:
     runs-on: ubuntu-latest
     env:
-      # The glibc version on ubuntu1804 and centos7 is lower than the node20 required, so
+      # The glibc version on ubuntu1804 is lower than the node20 required, so
       # we need to force the node version to 16.
       # See more details: https://github.com/actions/checkout/issues/1809
       ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
@@ -47,10 +47,10 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - centos7
+          - rockylinux9
     steps:
       - name: Checkout
-        # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
+        # The glibc version on ubuntu1804 is lower than the actions/checkout@v4 required, so
         # we need to force to use actions/checkout@v3.
         uses: actions/checkout@v4
       - name: Set up QEMU

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -444,8 +444,8 @@ jobs:
           ./run.sh build --test --skip_thirdparty -j $(sysctl -n hw.physicalcpu)
           ccache -s
 
-  build_debug_on_centos7:
-    name: Build Debug on CentOS 7
+  build_debug_on_rockylinux9:
+    name: Build Debug on Rockylinux 9
     needs:
       - cpp_clang_format_linter
     runs-on: ubuntu-latest
@@ -453,10 +453,8 @@ jobs:
       USE_JEMALLOC: OFF
       BUILD_OPTIONS: -t debug --test --separate_servers
       PACK_OPTIONS: --separate_servers
-      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container:
-      image: apache/pegasus:thirdparties-bin-centos7-${{ github.base_ref }}
+      image: apache/pegasus:thirdparties-bin-rockylinux9-${{ github.base_ref }}
     steps:
       - name: Clone code
         uses: actions/checkout@v3

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -47,7 +47,7 @@ jobs:
     name: Build Cpp
     runs-on: ubuntu-latest
     env:
-      # The glibc version on ubuntu1804 and centos7 is lower than the node20 required, so
+      # The glibc version on ubuntu1804 is lower than the node20 required, so
       # we need to force the node version to 16.
       # See more details: https://github.com/actions/checkout/issues/1809
       ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
@@ -59,7 +59,7 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - centos7
+          - rockylinux9
         compiler:
           - "gcc,g++"
         include:
@@ -76,7 +76,7 @@ jobs:
         working-directory: /root/incubator-pegasus
     steps:
       - name: Clone Apache Pegasus Source
-        # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
+        # The glibc version on ubuntu1804 is lower than the actions/checkout@v4 required, so
         # we need to force to use actions/checkout@v3.
         uses: actions/checkout@v3
       - name: Unpack prebuilt third-parties

--- a/.github/workflows/standardization_lint.yaml
+++ b/.github/workflows/standardization_lint.yaml
@@ -58,7 +58,7 @@ jobs:
       - uses: hadolint/hadolint-action@v3.1.0
         with:
           recursive: true
-          ignore: 'DL3033,DL3013,DL3059,SC2086,DL3003,SC2164,DL3008,DL3007,DL3006,DL4001'
+          ignore: 'DL3033,DL3013,DL3059,SC2086,DL3003,SC2164,DL3008,DL3007,DL3006,DL4001,DL3041'
 
   license_check:
     name: Check License

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -49,7 +49,7 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - centos7
+          - rockylinux9
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -78,7 +78,7 @@ jobs:
   build_push_bin_docker_images:
     runs-on: ubuntu-latest
     env:
-      # The glibc version on ubuntu1804 and centos7 is lower than the node20 required, so
+      # The glibc version on ubuntu1804 is lower than the node20 required, so
       # we need to force the node version to 16.
       # See more details: https://github.com/actions/checkout/issues/1809
       ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
@@ -91,9 +91,9 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - centos7
+          - rockylinux9
     steps:
-      # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
+      # The glibc version on ubuntu1804 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
       - uses: actions/checkout@v3
       - name: Set up QEMU
@@ -122,7 +122,7 @@ jobs:
   build_push_bin_jemalloc_docker_images:
     runs-on: ubuntu-latest
     env:
-      # The glibc version on ubuntu1804 and centos7 is lower than the node20 required, so
+      # The glibc version on ubuntu1804 is lower than the node20 required, so
       # we need to force the node version to 16.
       # See more details: https://github.com/actions/checkout/issues/1809
       ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
@@ -135,9 +135,9 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - centos7
+          - rockylinux9
     steps:
-      # The glibc version on ubuntu1804 and centos7 is lower than the actions/checkout@v4 required, so
+      # The glibc version on ubuntu1804 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
       - uses: actions/checkout@v3
       - name: Set up QEMU

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,7 +35,7 @@ Building environment for Pegasus compilation.
 
 Github Actions automatically rebuilds and publishes build-env for every commit.
 
-- `apache/pegasus:build-env-centos7-<branch>`
+- `apache/pegasus:build-env-rockylinux9-<branch>`
 - `apache/pegasus:build-env-ubuntu1804-<branch>`
 - `apache/pegasus:build-env-ubuntu2004-<branch>`
 - `apache/pegasus:build-env-ubuntu2204-<branch>`
@@ -51,7 +51,7 @@ It packages the downloaded sources into a zip in the container, so that
 other repos can easily extract third-parties from the container (via `docker cp`),
 without downloading from the cloud object storage.
 
-- `apache/pegasus:thirdparties-src-centos7-<branch>`
+- `apache/pegasus:thirdparties-src-rockylinux9-<branch>`
 - `apache/pegasus:thirdparties-src-ubuntu1804-<branch>`
 - `apache/pegasus:thirdparties-src-ubuntu2004-<branch>`
 - `apache/pegasus:thirdparties-src-ubuntu2204-<branch>`
@@ -61,7 +61,7 @@ without downloading from the cloud object storage.
 This is a Docker image for Pegasus unit-testing. It prebuilts the thirdparty libraries,
 so jobs based on this image can skip building third-parties.
 
-- `apache/pegasus:thirdparties-bin-centos7-<branch>`
+- `apache/pegasus:thirdparties-bin-rockylinux9-<branch>`
 - `apache/pegasus:thirdparties-bin-ubuntu1804-<branch>`
 - `apache/pegasus:thirdparties-bin-ubuntu2004-<branch>`
 - `apache/pegasus:thirdparties-bin-ubuntu2204-<branch>`

--- a/docker/pegasus-build-env/rocky9/Dockerfile
+++ b/docker/pegasus-build-env/rocky9/Dockerfile
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM rockylinux/rockylinux:9.5-minimal
+
+RUN dnf upgrade --refresh \
+    dnf -y install autoconf \
+                   automake \
+                   bison \
+                   cmake \
+                   cyrus-sasl-devel \
+                   file \
+                   flex \
+                   gdb \
+                   git \
+                   java-1.8.0-openjdk-devel \
+                   krb5-devel \
+                   libaio-devel \
+                   libtool \
+                   make \
+                   maven \
+                   nmap-ncat \
+                   openssl-devel \
+                   patch \
+                   python3 \
+                   unzip \
+                   vim \
+                   wget \
+                   which \
+                   zip \
+                   zlib \
+                   zlib-devel && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf;
+
+RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz -P /opt/thrift && \
+    cd /opt/thrift && tar xzf thrift-0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
+    ./configure --enable-libs=no && \
+    make -j$(($(nproc)/2+1)) && make install && cd - && \
+    rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz
+
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+
+WORKDIR /root/apache

--- a/docker/pegasus-build-env/rockylinux9/Dockerfile
+++ b/docker/pegasus-build-env/rockylinux9/Dockerfile
@@ -15,16 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rockylinux/rockylinux:9.5-minimal
+FROM rockylinux/rockylinux:9.5.20241118
 
-RUN dnf upgrade --refresh \
-    dnf -y install autoconf \
+RUN dnf -y install autoconf \
                    automake \
                    bison \
                    cmake \
                    cyrus-sasl-devel \
                    file \
                    flex \
+                   gcc-c++ \
                    gdb \
                    git \
                    java-1.8.0-openjdk-devel \
@@ -45,7 +45,7 @@ RUN dnf upgrade --refresh \
                    zlib \
                    zlib-devel && \
     dnf clean all && \
-    rm -rf /var/cache/dnf;
+    rm -rf /var/cache/dnf
 
 RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz -P /opt/thrift && \
     cd /opt/thrift && tar xzf thrift-0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \

--- a/docker/thirdparties-bin/Dockerfile
+++ b/docker/thirdparties-bin/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG GITHUB_BRANCH=master
-ARG OS_VERSION=centos7
+ARG OS_VERSION=rockylinux9
 FROM apache/pegasus:thirdparties-src-${OS_VERSION}-${GITHUB_BRANCH} as builder
 FROM apache/pegasus:build-env-${OS_VERSION}-${GITHUB_BRANCH}
 

--- a/docker/thirdparties-src/Dockerfile
+++ b/docker/thirdparties-src/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG GITHUB_BRANCH=master
-ARG OS_VERSION=centos7
+ARG OS_VERSION=rockylinux9
 FROM apache/pegasus:build-env-${OS_VERSION}-${GITHUB_BRANCH} as builder
 
 WORKDIR /root


### PR DESCRIPTION
Since the node16 has been removed in Github actions, the CentOS 7 is hard to run as
a runner, we have to make many tricky works if we want to do that.

As an alternative, this patch introduces RockyLinux 9 as a new github runner.

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/