### PR TITLE
fix(rockylinux): add the missing ccache package

### DIFF
--- a/docker/pegasus-build-env/rockylinux9/Dockerfile
+++ b/docker/pegasus-build-env/rockylinux9/Dockerfile
@@ -17,9 +17,11 @@
 
 FROM rockylinux/rockylinux:9.5.20241118
 
-RUN dnf -y install autoconf \
+RUN dnf -y install epel-release && \
+    dnf -y install autoconf \
                    automake \
                    bison \
+                   ccache \
                    cmake \
                    cyrus-sasl-devel \
                    file \


### PR DESCRIPTION
`ccache` is not distributed by the Rockylinux official repository, instead, we
can install it though `EPEL`.