### PR TITLE
fix(meta): fix null pointer while clearing environment variables after table was dropped

### DIFF
--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -41,6 +41,7 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <type_traits>
 #include <unordered_map>
 
 #include "common/duplication_common.h"

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -227,17 +227,6 @@ private:
 
 void meta_service_test_app::app_envs_basic_test()
 {
-    static const std::vector<std::string> kValues = {
-        "1712846598",
-        "6",
-        dsn::replica_envs::MANUAL_COMPACT_BOTTOMMOST_LEVEL_COMPACTION_FORCE,
-        "1712846598",
-        "-1",
-        dsn::replica_envs::MANUAL_COMPACT_BOTTOMMOST_LEVEL_COMPACTION_SKIP,
-        dsn::replica_envs::ROCKSDB_ENV_USAGE_SCENARIO_NORMAL,
-        "1",
-        "0"};
-
     static const std::vector<std::string> kKeys = {
         dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
         dsn::replica_envs::MANUAL_COMPACT_ONCE_TARGET_LEVEL,
@@ -248,6 +237,17 @@ void meta_service_test_app::app_envs_basic_test()
         dsn::replica_envs::ROCKSDB_USAGE_SCENARIO,
         dsn::replica_envs::ROCKSDB_CHECKPOINT_RESERVE_MIN_COUNT,
         dsn::replica_envs::ROCKSDB_CHECKPOINT_RESERVE_TIME_SECONDS};
+
+    static const std::vector<std::string> kValues = {
+        "1712846598",
+        "6",
+        dsn::replica_envs::MANUAL_COMPACT_BOTTOMMOST_LEVEL_COMPACTION_FORCE,
+        "1712846598",
+        "-1",
+        dsn::replica_envs::MANUAL_COMPACT_BOTTOMMOST_LEVEL_COMPACTION_SKIP,
+        dsn::replica_envs::ROCKSDB_ENV_USAGE_SCENARIO_NORMAL,
+        "1",
+        "0"};
 
     server_state_test test;
     test.load_apps({"test_app1",

--- a/src/meta/test/server_state_test.cpp
+++ b/src/meta/test/server_state_test.cpp
@@ -59,7 +59,9 @@ DSN_DECLARE_string(meta_state_service_type);
 namespace dsn {
 namespace replication {
 
-static const std::vector<std::string> keys = {
+namespace {
+
+const std::vector<std::string> keys = {
     dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
     dsn::replica_envs::MANUAL_COMPACT_ONCE_TARGET_LEVEL,
     dsn::replica_envs::MANUAL_COMPACT_ONCE_BOTTOMMOST_LEVEL_COMPACTION,
@@ -69,7 +71,7 @@ static const std::vector<std::string> keys = {
     dsn::replica_envs::ROCKSDB_USAGE_SCENARIO,
     dsn::replica_envs::ROCKSDB_CHECKPOINT_RESERVE_MIN_COUNT,
     dsn::replica_envs::ROCKSDB_CHECKPOINT_RESERVE_TIME_SECONDS};
-static const std::vector<std::string> values = {
+const std::vector<std::string> values = {
     "1712846598",
     "6",
     dsn::replica_envs::MANUAL_COMPACT_BOTTOMMOST_LEVEL_COMPACTION_FORCE,
@@ -80,28 +82,27 @@ static const std::vector<std::string> values = {
     "1",
     "0"};
 
-static const std::vector<std::string> del_keys = {
-    dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
-    dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
-    dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
-static const std::set<std::string> del_keys_set = {
-    dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
-    dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
-    dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
+const std::vector<std::string> del_keys = {dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
+                                           dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
+                                           dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
+const std::set<std::string> del_keys_set = {dsn::replica_envs::MANUAL_COMPACT_ONCE_TRIGGER_TIME,
+                                            dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME,
+                                            dsn::replica_envs::ROCKSDB_USAGE_SCENARIO};
 
-static const std::string clear_prefix = "rocksdb";
+const std::string clear_prefix = "rocksdb";
 
-// if str = "prefix.xxx" then return prefix
-// else return ""
-static std::string acquire_prefix(const std::string &str)
+// If `str` is <prefix>.xxx, return <prefix>; otherwise return empty string("").
+std::string acquire_prefix(const std::string &str)
 {
-    auto index = str.find('.');
-    if (index == std::string::npos) {
-        return "";
-    } else {
-        return str.substr(0, index);
+    const auto &dot = str.find('.');
+    if (dot == std::string::npos) {
+        return {};
     }
+
+    return str.substr(0, dot);
 }
+
+} // anonymous namespace
 
 class server_state_test
 {

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -28,7 +28,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2149.

Previously we've fixed the problem that meta server failed due to null pointer while
setting environment variables locally immediately after a table was dropped in
https://github.com/apache/incubator-pegasus/pull/2148. There's the same problem
while clearing environment variables.