### PR TITLE
feat(duplication): make the task code for incremental loading from private logs configurable

### DIFF
--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -161,7 +161,7 @@ void replica_duplicator::start_dup_log()
     _load = std::make_unique<load_mutation>(this, _replica, _load_private.get());
 
     from(*_load).link(*_ship).link(*_load);
-    fork(*_load_private, LPC_REPLICATION_LONG_LOW, 0).link(*_ship);
+    fork(*_load_private, LPC_REPLICATION_LONG_COMMON, 0).link(*_ship);
 
     run_pipeline();
 }

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -46,15 +46,14 @@ METRIC_DEFINE_counter(replica,
                       dsn::metric_unit::kMutations,
                       "The number of confirmed mutations for dup");
 
-DSN_DEFINE_bool("replication",
+DSN_DEFINE_bool(replication,
                 load_from_private_log_level_common,
                 false,
                 "The level of load_from_private_log when doing a duplication.Be false means the "
                 "task level of replaing plog is low, otherwise the task level is common");
 DSN_TAG_VARIABLE(load_from_private_log_level_common, FT_MUTABLE);
 
-namespace dsn {
-namespace replication {
+namespace dsn::replication {
 
 replica_duplicator::replica_duplicator(const duplication_entry &ent, replica *r)
     : replica_base(r),
@@ -329,5 +328,5 @@ void replica_duplicator::set_duplication_plog_checking(bool checking)
     _replica->set_duplication_plog_checking(checking);
 }
 
-} // namespace replication
-} // namespace dsn
+} // namespace dsn::replication
+

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -46,11 +46,12 @@ METRIC_DEFINE_counter(replica,
                       dsn::metric_unit::kMutations,
                       "The number of confirmed mutations for dup");
 
-DSN_DEFINE_string(replication,
-                  dup_load_plog_task,
-                  "LPC_REPLICATION_LONG_LOW",
-                  "The task code for incremental loading from private logs while duplicating. Tasks with "
-                  "TASK_PRIORITY_HIGH are not recommended.");
+DSN_DEFINE_string(
+    replication,
+    dup_load_plog_task,
+    "LPC_REPLICATION_LONG_LOW",
+    "The task code for incremental loading from private logs while duplicating. Tasks with "
+    "TASK_PRIORITY_HIGH are not recommended.");
 DSN_TAG_VARIABLE(dup_load_plog_task, FT_MUTABLE);
 
 namespace dsn::replication {
@@ -169,12 +170,11 @@ void replica_duplicator::start_dup_log()
     _load = std::make_unique<load_mutation>(this, _replica, _load_private.get());
 
     from(*_load).link(*_ship).link(*_load);
-    auto dup_load_plog_task =
-        dsn::task_code::try_get(FLAGS_dup_load_plog_task, TASK_CODE_INVALID);
+    auto dup_load_plog_task = dsn::task_code::try_get(FLAGS_dup_load_plog_task, TASK_CODE_INVALID);
     if (dup_load_plog_task == TASK_CODE_INVALID) {
         dup_load_plog_task = LPC_REPLICATION_LONG_LOW;
         LOG_ERROR_PREFIX("invalid dup_load_plog_task ({}), set it to LPC_REPLICATION_LONG_LOW",
-                                              FLAGS_dup_load_plog_task);
+                         FLAGS_dup_load_plog_task);
     }
     fork(*_load_private, dup_load_plog_task, 0).link(*_ship);
 

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -329,4 +329,3 @@ void replica_duplicator::set_duplication_plog_checking(bool checking)
 }
 
 } // namespace dsn::replication
-

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -35,8 +35,10 @@
 #include "load_from_private_log.h"
 #include "replica/mutation_log.h"
 #include "replica/replica.h"
+#include "task/task_code.h"
 #include "utils/autoref_ptr.h"
 #include "utils/error_code.h"
+#include "utils/flags.h"
 #include "utils/fmt_logging.h"
 
 METRIC_DEFINE_counter(replica,

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -47,7 +47,7 @@ METRIC_DEFINE_counter(replica,
                       "The number of confirmed mutations for dup");
 
 DSN_DEFINE_string(replication,
-                  load_from_private_log_level,
+                  dup_load_plog_task,
                   "LPC_REPLICATION_LONG_LOW",
                   "The level of load_from_private_log when doing a duplication.Be false means the "
                   "task level of replaing plog is low, otherwise the task level is common (We do "

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -49,9 +49,8 @@ METRIC_DEFINE_counter(replica,
 DSN_DEFINE_string(replication,
                   dup_load_plog_task,
                   "LPC_REPLICATION_LONG_LOW",
-                  "The level of load_from_private_log when doing a duplication.Be false means the "
-                  "task level of replaing plog is low, otherwise the task level is common (We do "
-                  "not recommend high level)");
+                  "The task code for incremental loading from private logs while duplicating. Tasks with "
+                  "TASK_PRIORITY_HIGH are not recommended.");
 DSN_TAG_VARIABLE(dup_load_plog_task, FT_MUTABLE);
 
 namespace dsn::replication {

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -52,7 +52,7 @@ DSN_DEFINE_string(replication,
                   "The level of load_from_private_log when doing a duplication.Be false means the "
                   "task level of replaing plog is low, otherwise the task level is common (We do "
                   "not recommend high level)");
-DSN_TAG_VARIABLE(load_from_private_log_level, FT_MUTABLE);
+DSN_TAG_VARIABLE(dup_load_plog_task, FT_MUTABLE);
 
 namespace dsn::replication {
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/apache/incubator-pegasus/issues/2183

### What is changed and how does it work?

We can make the task code configurable, allowing the thread priority incremental
loading from private logs of to be adjusted from **LOW** to **COMMON**, thereby
enabling support for low-latency real-time synchronization.


##### Performance Testing <!-- At least one of them must be included. -->
I do some test cases as following:
In these test cases, I first wrote 8k QPS of write traffic to the master cluster (this is the traffic that my test cluster will not generate dup log backlogs) to verify the effect of the priority modification. Then I wrote 20k QPS of write traffic to the master cluster (this is the traffic that my test cluster will generate a certain degree of dup log backlogs) to verify the effect of the priority modification.

| load/ship task priority | load_from_private_log task priority | qps  | duplicate_log_batch_bytes | plog Maximum backlog | Master cluster write delay p99 | master/slave dup delay     |
| -------------------- | -------------------------------- | ---- | ------------------------- | ----------- | ---------------- | ------------------------ |
| LOW                  | LOW                              | 8K   | 4096                      | 9k          | 1ms              | p95 127ms、p99 27473ms   |
| LOW                  | COMMON                           | 8K   | 4096                      | 200         | 1ms              | p95 101ms、p99 109ms     |
| HIGH                 | HIGH                             | 8K   | 4096                      | 150         | 1ms              | p95 107ms、p99 115ms     |
| LOW                  | LOW                              | 20K  | 4096                      | 61K         | 1.5ms            | p95 139ms、p99 20506ms   |
| LOW                  | COMMON                           | 20K  | 4096                      | 42K         | 1.5ms            | p95 126ms、p99 18127ms   |
| LOW                  | COMMON                           | 20K  | 0                         | Continue to increase over time    | 1.5ms            | 95 10618ms、p99 303519ms |


As you see , change the priority from LOW to COMMON of `load_from_private_log` will not t increase the online delay. And priority from LOW to HIGH is no benefit for further speeding up duplication.

So based on the above experimental conclusions, I think this issues' argument is valid.

