### PR TITLE
feat(make_idempotent): support making `incr` request idempotent in `pegasus_write_service::impl`

### DIFF
--- a/idl/rrdb.thrift
+++ b/idl/rrdb.thrift
@@ -68,11 +68,26 @@ enum mutate_operation
     MO_DELETE
 }
 
+enum update_type
+{
+    UT_PUT,
+    UT_INCR
+}
+
+// The single-put request, just writes a key/value pair into storage, which is certainly
+// idempotent.
 struct update_request
 {
     1:dsn.blob      key;
     2:dsn.blob      value;
     3:i32           expire_ts_seconds;
+
+    // This field marks the type of a single-put request, mainly used to differentiate a general
+    // single-put request from the one translated from a non-idempotent atomic write request:
+    // - a general single-put request, if `type` is UT_PUT or not set by default as it's
+    // optional, or
+    // - a put request translated from a non-idempotent incr request, if `type` is UT_INCR.
+    4:optional update_type type;
 }
 
 struct update_response

--- a/src/server/pegasus_server_write.h
+++ b/src/server/pegasus_server_write.h
@@ -89,7 +89,7 @@ private:
 
     friend class pegasus_server_write_test;
     friend class pegasus_write_service_test;
-    friend class pegasus_write_service_impl_test;
+    friend class PegasusWriteServiceImplTest;
     friend class rocksdb_wrapper_test;
 
     std::unique_ptr<pegasus_write_service> _write_svc;

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -191,7 +191,7 @@ private:
 
 private:
     friend class pegasus_write_service_test;
-    friend class pegasus_write_service_impl_test;
+    friend class PegasusWriteServiceImplTest;
     friend class pegasus_server_write_test;
     friend class rocksdb_wrapper_test;
 

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -189,7 +189,6 @@ public:
 private:
     void clear_up_batch_states();
 
-private:
     friend class pegasus_write_service_test;
     friend class PegasusWriteServiceImplTest;
     friend class pegasus_server_write_test;

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -703,7 +703,7 @@ private:
         update.__set_type(type);
     }
 
-    // Build corresponding single-put request for a incr request, and return current status
+    // Build corresponding single-put request for an incr request, and return current status
     // for RocksDB, i.e. kOk.
     static inline int make_idempotent_request_for_incr(const dsn::blob &key,
                                                        int64_t value,

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -847,7 +847,6 @@ private:
         return false;
     }
 
-private:
     friend class pegasus_write_service_test;
     friend class pegasus_server_write_test;
     friend class PegasusWriteServiceImplTest;

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -179,7 +179,7 @@ public:
     {
         // Get old value from the RocksDB instance according to the provided key.
         db_get_context get_ctx;
-        int err = _rocksdb_wrapper->get(req.key.to_string_view(), &get_ctx);
+        const int err = _rocksdb_wrapper->get(req.key.to_string_view(), &get_ctx);
         if (dsn_unlikely(err != rocksdb::Status::kOk)) {
             return make_error_response(err, err_resp);
         }
@@ -254,8 +254,9 @@ public:
             return resp.error;
         }
 
+        // Shouldn't fail to parse since the value must be a valid int64.
         CHECK(dsn::buf2int64(update.value.to_string_view(), resp.new_value),
-              "invalid int64 value for put incr: key={}, value={}",
+              "invalid int64 value for put idempotent incr: key={}, value={}",
               update.key,
               update.value);
 

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -661,21 +661,27 @@ private:
         return raw_key;
     }
 
+    // Calculate expire timestamp in seconds according to `req`, for the keys not present
+    // in the storage.
     template <typename TRequest>
     static inline int32_t calc_expire_on_non_existent(const TRequest &req)
     {
         return req.expire_ts_seconds > 0 ? req.expire_ts_seconds : 0;
     }
 
+    // Calculate expire timestamp in seconds according to `req` and the old value in `get_ctx`,
+    // for the keys existing in the storage.
     template <typename TRequest>
     static inline int32_t calc_expire_on_existing(const TRequest &req,
                                                   const db_get_context &get_ctx)
     {
         if (req.expire_ts_seconds == 0) {
+            // Use the old value for the existing key in `get_ctx` as the expire timestamp.
             return static_cast<int32_t>(get_ctx.expire_ts);
         }
 
         if (req.expire_ts_seconds < 0) {
+            // Reset expire timestamp to 0.
             return 0;
         }
 
@@ -844,10 +850,8 @@ private:
 private:
     friend class pegasus_write_service_test;
     friend class pegasus_server_write_test;
-    friend class pegasus_write_service_impl_test;
+    friend class PegasusWriteServiceImplTest;
     friend class rocksdb_wrapper_test;
-    FRIEND_TEST(pegasus_write_service_impl_test, put_verify_timetag);
-    FRIEND_TEST(pegasus_write_service_impl_test, verify_timetag_compatible_with_version_0);
 
     const std::string _primary_host_port;
     const uint32_t _pegasus_data_version;

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -79,20 +79,25 @@ int rocksdb_wrapper::get(std::string_view raw_key, /*out*/ db_get_context *ctx)
 {
     FAIL_POINT_INJECT_F("db_get", [](std::string_view) -> int { return FAIL_DB_GET; });
 
-    rocksdb::Status s =
+    const rocksdb::Status s =
         _db->Get(_rd_opts, _data_cf, utils::to_rocksdb_slice(raw_key), &ctx->raw_value);
     if (dsn_likely(s.ok())) {
-        // success
+        // The key is found and read successfully.
         ctx->found = true;
         ctx->expire_ts = pegasus_extract_expire_ts(_pegasus_data_version, ctx->raw_value);
         if (check_if_ts_expired(utils::epoch_now(), ctx->expire_ts)) {
             ctx->expired = true;
             METRIC_VAR_INCREMENT(read_expired_values);
+        } else {
+            ctx->expired = false;
         }
         return rocksdb::Status::kOk;
-    } else if (s.IsNotFound()) {
-        // NotFound is an acceptable error
+    }
+
+    if (s.IsNotFound()) {
+        // NotFound is considered normal since the key may not be present in DB now.
         ctx->found = false;
+        ctx->expired = false;
         return rocksdb::Status::kOk;
     }
 

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -82,7 +82,7 @@ int rocksdb_wrapper::get(std::string_view raw_key, /*out*/ db_get_context *ctx)
     const rocksdb::Status s =
         _db->Get(_rd_opts, _data_cf, utils::to_rocksdb_slice(raw_key), &ctx->raw_value);
     if (dsn_likely(s.ok())) {
-        // The key is found and read successfully.
+        // The key is found and its value is read successfully.
         ctx->found = true;
         ctx->expire_ts = pegasus_extract_expire_ts(_pegasus_data_version, ctx->raw_value);
         if (check_if_ts_expired(utils::epoch_now(), ctx->expire_ts)) {

--- a/src/server/test/pegasus_write_service_impl_test.cpp
+++ b/src/server/test/pegasus_write_service_impl_test.cpp
@@ -41,7 +41,14 @@
 #include "utils/fail_point.h"
 #include "utils/string_conv.h"
 
-// IWYU pragma: no_forward_declare <gtest/gtest.h>
+// IWYU pragma: no_forward_declare pegasus::server::IdempotentIncrTest_FailOnGet_Test
+// IWYU pragma: no_forward_declare pegasus::server::IdempotentIncrTest_FailOnPut_Test
+// IWYU pragma: no_forward_declare pegasus::server::IdempotentIncrTest_IncrOnNonNumericRecord_Test
+// IWYU pragma: no_forward_declare pegasus::server::IdempotentIncrTest_IncrOverflowed_Test
+// IWYU pragma: no_forward_declare pegasus::server::NonIdempotentIncrTest_FailOnGet_Test
+// IWYU pragma: no_forward_declare pegasus::server::NonIdempotentIncrTest_FailOnPut_Test
+// IWYU pragma: no_forward_declare pegasus::server::NonIdempotentIncrTest_IncrOnNonNumericRecord_Test
+// IWYU pragma: no_forward_declare pegasus::server::NonIdempotentIncrTest_IncrOverflowed_Test
 
 namespace pegasus::server {
 

--- a/src/utils/blob.h
+++ b/src/utils/blob.h
@@ -26,10 +26,12 @@
 
 #pragma once
 
-#include <memory>
+#include <fmt/core.h>
 #include <cstring>
-
+#include <memory>
 #include <string_view>
+#include <type_traits>
+
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/protocol/TProtocol.h>
 
@@ -124,6 +126,13 @@ public:
         auto *s = new std::string(std::move(bytes));
         std::shared_ptr<char> buf(const_cast<char *>(s->data()), [s](char *) { delete s; });
         return {std::move(buf), static_cast<unsigned int>(s->length())};
+    }
+
+    template <typename TNum,
+              typename = typename std::enable_if<std::is_arithmetic<TNum>::value>::type>
+    [[nodiscard]] static blob create_from_numeric(TNum val)
+    {
+        return create_from_bytes(fmt::format("{}", val));
     }
 
     void assign(const std::shared_ptr<char> &buffer, int offset, unsigned int length)


### PR DESCRIPTION
Implement two APIs making `incr` request idempotent in `pegasus_write_service::impl`:

- translate an `incr` request (non-idempotent) into a single-put request (idempotent),
and process the possible errors during the translation, e.g. failed to read base value for
increment from the RocksDB instance;
- apply the single-put request into the RocksDB instance and make response for `incr`.