### PR TITLE
fix(java-client): package `org.apache.pegasus.utils` does not exist while building java client

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -427,6 +427,7 @@
             <excludes>
               <exclude>src/main/java/org/apache/pegasus/apps/*</exclude>
               <exclude>src/main/java/org/apache/pegasus/replication/*</exclude>
+              <exclude>src/main/java/org/apache/pegasus/utils/*</exclude>
             </excludes>
             <googleJavaFormat>
               <version>1.7</version>

--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -487,6 +487,7 @@
             <include>partition_split.thrift</include>
             <include>rrdb.thrift</include>
             <include>security.thrift</include>
+            <include>utils.thrift</include>
           </includes>
           <thriftExecutable>thrift</thriftExecutable>
           <outputDirectory>${project.basedir}/src/main/java</outputDirectory>


### PR DESCRIPTION
Fix https://github.com/apache/incubator-pegasus/issues/2188.

`idl/utils.thrift` was introduced before and has not been added into java client
to generate necessary source files which make workflow for building failed. It
should also be excluded from spotless check just like what have been done for
other thrift files.