### PR TITLE
fix(scripts): Fix the way the wait_manual_compact function parses the shell output

### DIFF
--- a/admin_tools/pegasus_manual_compact.sh
+++ b/admin_tools/pegasus_manual_compact.sh
@@ -122,7 +122,7 @@ function wait_manual_compact()
         queue_count=$(awk 'BEGIN {count=0} {match($0, /"recent_enqueue_at":"([^"]+)"/, enqueue); match($0, /"recent_start_at":"([^"]+)"/, start); if (1 in enqueue && enqueue[1] != "-" && start[1] == "-") {count++}} END {print count}' "$query_log_file")
         running_count=$(awk 'BEGIN {count=0} {match($0, /"recent_start_at":"([^"]+)"/, start); if (1 in start && start[1] != "-") {count++}} END {print count}' "$query_log_file")
         processing_count=$((queue_count+running_count))
-        finish_count=$(awk 'BEGIN {count=0} {match($0, /"recent_enqueue_at":"([^"]+)"/, enqueue); match($0, /"recent_start_at":"([^"]+)"/, start); match($0, /"last_finish":"([^"]+)"/, finish); if (enqueue[1] == "-" && start[1] == "-" && 1 in finish && finish[1] != "-") {count++}} END {print count}' "$query_log_file")
+        finish_count=$(awk -v date="$earliest_finish_time_ms" 'BEGIN {count=0} {match($0, /"recent_enqueue_at":"([^"]+)"/, enqueue); match($0, /"recent_start_at":"([^"]+)"/, start); match($0, /"last_finish":"([^"]+)"/, finish); if (enqueue[1] == "-" && start[1] == "-" && 1 in finish && finish[1] >= date) {count++}} END {print count}' "$query_log_file")
         not_finish_count=$((total_replica_count-finish_count))
 
         if [ ${processing_count} -eq 0 -a ${finish_count} -eq ${total_replica_count} ]; then


### PR DESCRIPTION
… remote_command -t replica-server replica.query-compact  shell command.

### What problem does this PR solve? 
[#2190](https://github.com/apache/incubator-pegasus/issues/2190)


### What is changed and how does it work?

The [commit 2d68748](https://github.com/apache/incubator-pegasus/commit/2d68748264500a3fb3850a0dcfc8af8e8595a19a#:~:text=info%5B%22recent_enqueue_at%22%5D) changed the output format of the shell command remote_command -t replica-server replica.query-compact ${app_id}, which caused the wait_manual_compact function to still parse the output based on the original format, leading to incorrect behavior. It has now been fixed by modifying the parsing method.


