### PR TITLE
feat(bulk_load): reduce partition ingest time

### DIFF
--- a/src/common/bulk_load_common.cpp
+++ b/src/common/bulk_load_common.cpp
@@ -17,13 +17,11 @@
 
 #include "bulk_load_common.h"
 
-namespace dsn {
-namespace replication {
+namespace dsn::replication {
 const std::string bulk_load_constant::BULK_LOAD_INFO("bulk_load_info");
 const int32_t bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL = 10000;
 const int32_t bulk_load_constant::BULK_LOAD_INGEST_REQUEST_INTERVAL = 150;
 const std::string bulk_load_constant::BULK_LOAD_METADATA("bulk_load_metadata");
 const std::string bulk_load_constant::BULK_LOAD_LOCAL_ROOT_DIR("bulk_load");
 const int32_t bulk_load_constant::PROGRESS_FINISHED = 100;
-} // namespace replication
-} // namespace dsn
+} // namespace dsn::replication

--- a/src/common/bulk_load_common.cpp
+++ b/src/common/bulk_load_common.cpp
@@ -20,7 +20,8 @@
 namespace dsn {
 namespace replication {
 const std::string bulk_load_constant::BULK_LOAD_INFO("bulk_load_info");
-const int32_t bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL = 10;
+const int32_t bulk_load_constant::BULK_LOAD_REQUEST_INTERVAL = 10000;
+const int32_t bulk_load_constant::BULK_LOAD_INGEST_REQUEST_INTERVAL = 150;
 const std::string bulk_load_constant::BULK_LOAD_METADATA("bulk_load_metadata");
 const std::string bulk_load_constant::BULK_LOAD_LOCAL_ROOT_DIR("bulk_load");
 const int32_t bulk_load_constant::PROGRESS_FINISHED = 100;

--- a/src/common/bulk_load_common.h
+++ b/src/common/bulk_load_common.h
@@ -47,6 +47,7 @@ class bulk_load_constant
 public:
     static const std::string BULK_LOAD_INFO;
     static const int32_t BULK_LOAD_REQUEST_INTERVAL;
+    static const int32_t BULK_LOAD_INGEST_REQUEST_INTERVAL;
     static const std::string BULK_LOAD_METADATA;
     static const std::string BULK_LOAD_LOCAL_ROOT_DIR;
     static const int32_t PROGRESS_FINISHED;

--- a/src/meta/meta_bulk_load_service.cpp
+++ b/src/meta/meta_bulk_load_service.cpp
@@ -1266,11 +1266,12 @@ void bulk_load_service::partition_ingestion(const std::string &app_name, const g
     if (!try_partition_ingestion(pc, app->helpers->contexts[pid.get_partition_index()])) {
         LOG_WARNING(
             "app({}) partition({}) couldn't execute ingestion, wait and try later", app_name, pid);
-        tasking::enqueue(LPC_META_STATE_NORMAL,
-                         _meta_svc->tracker(),
-                         std::bind(&bulk_load_service::partition_ingestion, this, app_name, pid),
-                         pid.thread_hash(),
-                         std::chrono::milliseconds(bulk_load_constant::BULK_LOAD_INGEST_REQUEST_INTERVAL));
+        tasking::enqueue(
+            LPC_META_STATE_NORMAL,
+            _meta_svc->tracker(),
+            std::bind(&bulk_load_service::partition_ingestion, this, app_name, pid),
+            pid.thread_hash(),
+            std::chrono::milliseconds(bulk_load_constant::BULK_LOAD_INGEST_REQUEST_INTERVAL));
         return;
     }
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2194

The main reason is that during the ingest phase, the time between meta's RPC_BULK_LOAD transmissions is too long (once every 10 seconds). Shortening this time interval can cut down the partition write-blocking time.

##### Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
Before：partition ingest time 30s.
After refactor: partition ingest time 300~900ms.
