### PR TITLE
fix: deal with duplication and balance race

### DIFF
--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -67,6 +67,7 @@ void load_mutation::run()
     decree last_decree = _duplicator->progress().last_decree;
     _start_decree = last_decree + 1;
 
+    _duplicator->get_loading_private_log_state(true);
     // Load the mutations from plog that have been committed recently, if any.
     const auto max_plog_committed_decree =
         std::min(_replica->private_log()->max_decree_on_disk(), _replica->last_applied_decree());

--- a/src/replica/duplication/duplication_pipeline.cpp
+++ b/src/replica/duplication/duplication_pipeline.cpp
@@ -67,7 +67,7 @@ void load_mutation::run()
     decree last_decree = _duplicator->progress().last_decree;
     _start_decree = last_decree + 1;
 
-    _duplicator->get_loading_private_log_state(true);
+    _duplicator->set_loading_private_log_state(true);
     // Load the mutations from plog that have been committed recently, if any.
     const auto max_plog_committed_decree =
         std::min(_replica->private_log()->max_decree_on_disk(), _replica->last_applied_decree());

--- a/src/replica/duplication/load_from_private_log.cpp
+++ b/src/replica/duplication/load_from_private_log.cpp
@@ -274,6 +274,7 @@ void load_from_private_log::replay_log_block()
     // case2: !err.is_ok(err.code() == ERR_HANDLE_EOF) and no next file, need commit the last
     // mutations()
     step_down_next_stage(_mutation_batch.last_decree(), _mutation_batch.move_all_mutations());
+    _duplicator->set_loading_private_log_state(false);
 }
 
 load_from_private_log::load_from_private_log(replica *r, replica_duplicator *dup)

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -93,6 +93,8 @@ replica_duplicator::replica_duplicator(const duplication_entry &ent, replica *r)
                     _replica->private_log()->max_commit_on_disk());
 
     _status = ent.status;
+    _is_loading_private_log.store(false);
+
 
     const auto it = ent.progress.find(get_gpid().get_partition_index());
     CHECK_PREFIX_MSG(it != ent.progress.end(),

--- a/src/replica/duplication/replica_duplicator.cpp
+++ b/src/replica/duplication/replica_duplicator.cpp
@@ -95,7 +95,6 @@ replica_duplicator::replica_duplicator(const duplication_entry &ent, replica *r)
     _status = ent.status;
     _is_loading_private_log.store(false);
 
-
     const auto it = ent.progress.find(get_gpid().get_partition_index());
     CHECK_PREFIX_MSG(it != ent.progress.end(),
                      "partition({}) not found in duplication progress: "

--- a/src/replica/duplication/replica_duplicator.h
+++ b/src/replica/duplication/replica_duplicator.h
@@ -163,8 +163,14 @@ public:
 
         writer.EndObject();
     }
-    void set_loading_private_log_state(bool is_loading) { _is_loading_private_log.store(is_loading,std::memory_order_release); }
-    bool get_loading_private_log_state() { return _is_loading_private_log.load(std::memory_order_acquire); }
+    void set_loading_private_log_state(bool is_loading)
+    {
+        _is_loading_private_log.store(is_loading, std::memory_order_release);
+    }
+    bool get_loading_private_log_state()
+    {
+        return _is_loading_private_log.load(std::memory_order_acquire);
+    }
 
 private:
     friend class duplication_test_base;

--- a/src/replica/duplication/replica_duplicator.h
+++ b/src/replica/duplication/replica_duplicator.h
@@ -163,6 +163,8 @@ public:
 
         writer.EndObject();
     }
+    void set_loading_private_log_state(bool is_loading) { _is_loading_private_log.store(is_loading,std::memory_order_release); }
+    bool get_loading_private_log_state() { return _is_loading_private_log.load(std::memory_order_acquire); }
 
 private:
     friend class duplication_test_base;
@@ -205,6 +207,8 @@ private:
     // TODO(wutao1): calculate the counters independently for each remote cluster
     //               if we need to duplicate to multiple clusters someday.
     METRIC_VAR_DECLARE_counter(dup_confirmed_mutations);
+
+    std::atomic_bool _is_loading_private_log;
 };
 
 typedef std::unique_ptr<replica_duplicator> replica_duplicator_u_ptr;

--- a/src/replica/duplication/replica_duplicator_manager.h
+++ b/src/replica/duplication/replica_duplicator_manager.h
@@ -104,13 +104,13 @@ public:
         }
         return false;
     }
+    // called by close replica also
+    void remove_all_duplications();
 
 private:
     void sync_duplication(const duplication_entry &ent);
 
     void remove_non_existed_duplications(const std::map<dupid_t, duplication_entry> &);
-
-    void remove_all_duplications();
 
 private:
     friend class duplication_sync_timer_test;

--- a/src/replica/duplication/replica_duplicator_manager.h
+++ b/src/replica/duplication/replica_duplicator_manager.h
@@ -95,6 +95,15 @@ public:
         }
         writer.EndArray();
     }
+    bool check_still_have_dup_pipeline_loading()
+    {
+        for (auto &kv : _duplications) {
+            if (kv.second->get_loading_private_log_state()) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 private:
     void sync_duplication(const duplication_entry &ent);

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -740,6 +740,5 @@ bool replica::having_dup_loading()
     return _duplication_mgr->check_still_have_dup_pipeline_loading();
 }
 
-
 } // namespace replication
 } // namespace dsn

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -732,5 +732,14 @@ void replica::METRIC_FUNC_NAME_SET(dup_pending_mutations)()
     METRIC_SET(*_duplication_mgr, dup_pending_mutations);
 }
 
+bool replica::having_dup_loading()
+{
+    if (_duplication_mgr == nullptr) {
+        return false;
+    }
+    return _duplication_mgr->check_still_have_dup_pipeline_loading();
+}
+
+
 } // namespace replication
 } // namespace dsn

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -306,6 +306,8 @@ public:
 
     void update_app_duplication_status(bool duplicating);
 
+    bool having_dup_loading();
+
     //
     // Backup
     //

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1723,8 +1723,9 @@ void replica_stub::on_node_query_reply_scatter2(replica_stub_ptr this_, gpid id)
 
         // deal with unexpected close when duplication and balance function running at the same time
         if (replica->status() == partition_status::PS_INACTIVE && replica->having_dup_loading()) {
-            LOG_DEBUG("%s: replica not exists on meta server,and still have dup on it. wait to close",
-                   replica->name());
+            LOG_DEBUG(
+                "%s: replica not exists on meta server,and still have dup on it. wait to close",
+                replica->name());
             return;
         }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#1589 

### What is changed and how does it work?
I used to use #1590 fix this bug.  This method mainly achieves the purpose through delay close replica when duplication doing.
However, I later thought that this method was not smart enough, and it would cause the problem of double close replica in some cases.Although I have limited the occurrence of bugs through some logic, this logic is still fragile.
So I changed my mindset and proactively stopped dup when closing the replica. 


### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

##### Code changes
**What happen in Pegasus**:
![image](https://github.com/user-attachments/assets/00550e2e-21ce-4f93-a1a6-2e3c992f6e84)


**After this changer**:
![image](https://github.com/user-attachments/assets/111aa650-f5a3-43a5-947d-1dce71da7271)


