### PR TITLE
ci: bump dorny/paths-filter from v2 to v3.0.2

### DIFF
--- a/.github/actions/rebuild_thirdparty_if_needed/action.yaml
+++ b/.github/actions/rebuild_thirdparty_if_needed/action.yaml
@@ -19,7 +19,7 @@ name: Rebuild thirdparty if needed
 runs:
   using: composite
   steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3.0.2
       id: changes
       with:
         filters: |


### PR DESCRIPTION
Resolve https://github.com/apache/incubator-pegasus/issues/2219.

Fix workflows that failed as dorny/paths-filter@v2 is not allowed to be used.