### PR TITLE
feat(make_idempotent): support `atomic_idempotent` for `create` and `ls` commands on shell

### DIFF
--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -351,6 +351,7 @@ error_s replication_ddl_client::list_apps(bool detailed,
     tp_general.add_column("drop_time");
     tp_general.add_column("drop_expire");
     tp_general.add_column("envs_count");
+    tp_general.add_column("atomic_idempotent");
 
     int available_app_count = 0;
     for (const auto &info : apps) {
@@ -392,6 +393,7 @@ error_s replication_ddl_client::list_apps(bool detailed,
         tp_general.append_data(drop_time);
         tp_general.append_data(drop_expire_time);
         tp_general.append_data(info.envs.size());
+        tp_general.append_data(info.atomic_idempotent);
     }
     multi_printer.add(std::move(tp_general));
 

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -186,11 +186,12 @@ dsn::error_code replication_ddl_client::wait_app_ready(const std::string &app_na
 
 dsn::error_code replication_ddl_client::create_app(const std::string &app_name,
                                                    const std::string &app_type,
-                                                   int partition_count,
-                                                   int replica_count,
+                                                   int32_t partition_count,
+                                                   int32_t replica_count,
                                                    const std::map<std::string, std::string> &envs,
                                                    bool is_stateless,
-                                                   bool success_if_exist)
+                                                   bool success_if_exist,
+                                                   bool atomic_idempotent)
 {
     if (partition_count < 1) {
         fmt::println(stderr, "create app {} failed: partition_count should >= 1", app_name);
@@ -213,6 +214,7 @@ dsn::error_code replication_ddl_client::create_app(const std::string &app_name,
     req->options.app_type = app_type;
     req->options.envs = envs;
     req->options.is_stateful = !is_stateless;
+    req->options.__set_atomic_idempotent(atomic_idempotent);
 
     dsn::replication::configuration_create_app_response resp;
     RETURN_EC_NOT_OK_MSG(request_meta_and_wait_response(RPC_CM_CREATE_APP, req, resp),
@@ -233,6 +235,17 @@ dsn::error_code replication_ddl_client::create_app(const std::string &app_name,
     }
 
     return error;
+}
+
+dsn::error_code replication_ddl_client::create_app(const std::string &app_name,
+                                                   const std::string &app_type,
+                                                   int32_t partition_count,
+                                                   int32_t replica_count,
+                                                   const std::map<std::string, std::string> &envs
+                                                   )
+{
+    return create_app(app_name, app_type, partition_count, replica_count, envs, false,
+            true, false);
 }
 
 dsn::error_code replication_ddl_client::drop_app(const std::string &app_name, int reserve_seconds)

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -241,11 +241,9 @@ dsn::error_code replication_ddl_client::create_app(const std::string &app_name,
                                                    const std::string &app_type,
                                                    int32_t partition_count,
                                                    int32_t replica_count,
-                                                   const std::map<std::string, std::string> &envs
-                                                   )
+                                                   const std::map<std::string, std::string> &envs)
 {
-    return create_app(app_name, app_type, partition_count, replica_count, envs, false,
-            true, false);
+    return create_app(app_name, app_type, partition_count, replica_count, envs, false, true, false);
 }
 
 dsn::error_code replication_ddl_client::drop_app(const std::string &app_name, int reserve_seconds)

--- a/src/client/replication_ddl_client.h
+++ b/src/client/replication_ddl_client.h
@@ -80,11 +80,19 @@ public:
 
     dsn::error_code create_app(const std::string &app_name,
                                const std::string &app_type,
-                               int partition_count,
-                               int replica_count,
+                               int32_t partition_count,
+                               int32_t replica_count,
                                const std::map<std::string, std::string> &envs,
                                bool is_stateless,
-                               bool success_if_exist = true);
+                               bool success_if_exist ,
+                                                   bool atomic_idempotent);
+
+    dsn::error_code create_app(const std::string &app_name,
+                               const std::string &app_type,
+                               int32_t partition_count,
+                               int32_t replica_count,
+                               const std::map<std::string, std::string> &envs
+                               );
 
     // 'reserve_seconds' == 0 means use default value in configuration
     // FLAGS_hold_seconds_for_dropped_app.

--- a/src/client/replication_ddl_client.h
+++ b/src/client/replication_ddl_client.h
@@ -87,6 +87,8 @@ public:
                                bool success_if_exist,
                                bool atomic_idempotent);
 
+    // The same as the above while both `is_stateless` and `atomic_idempotent` are set false
+    // and `success_if_exist` is set true.
     dsn::error_code create_app(const std::string &app_name,
                                const std::string &app_type,
                                int32_t partition_count,

--- a/src/client/replication_ddl_client.h
+++ b/src/client/replication_ddl_client.h
@@ -84,15 +84,14 @@ public:
                                int32_t replica_count,
                                const std::map<std::string, std::string> &envs,
                                bool is_stateless,
-                               bool success_if_exist ,
-                                                   bool atomic_idempotent);
+                               bool success_if_exist,
+                               bool atomic_idempotent);
 
     dsn::error_code create_app(const std::string &app_name,
                                const std::string &app_type,
                                int32_t partition_count,
                                int32_t replica_count,
-                               const std::map<std::string, std::string> &envs
-                               );
+                               const std::map<std::string, std::string> &envs);
 
     // 'reserve_seconds' == 0 means use default value in configuration
     // FLAGS_hold_seconds_for_dropped_app.

--- a/src/geo/test/geo_test.cpp
+++ b/src/geo/test/geo_test.cpp
@@ -66,7 +66,7 @@ public:
                   dsn::PEGASUS_CLUSTER_SECTION_NAME, "onebox", meta_list),
               "load_servers_from_config failed");
         auto ddl_client = new dsn::replication::replication_ddl_client(meta_list);
-        dsn::error_code error = ddl_client->create_app("temp_geo", "pegasus", 4, 3, {}, false);
+        dsn::error_code error = ddl_client->create_app("temp_geo", "pegasus", 4, 3, {});
         CHECK_EQ(dsn::ERR_OK, error);
         _geo_client.reset(new pegasus::geo::geo_client("config.ini", "onebox", "temp", "temp_geo"));
     }

--- a/src/geo/test/geo_test.cpp
+++ b/src/geo/test/geo_test.cpp
@@ -65,9 +65,8 @@ public:
         CHECK(dsn::replication::replica_helper::load_servers_from_config(
                   dsn::PEGASUS_CLUSTER_SECTION_NAME, "onebox", meta_list),
               "load_servers_from_config failed");
-        auto ddl_client = new dsn::replication::replication_ddl_client(meta_list);
-        dsn::error_code error = ddl_client->create_app("temp_geo", "pegasus", 4, 3, {});
-        CHECK_EQ(dsn::ERR_OK, error);
+        dsn::replication::replication_ddl_client ddl_client(meta_list);
+        CHECK_EQ(dsn::ERR_OK, ddl_client.create_app("temp_geo", "pegasus", 4, 3, {}));
         _geo_client.reset(new pegasus::geo::geo_client("config.ini", "onebox", "temp", "temp_geo"));
     }
 

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -1081,7 +1081,7 @@ private:
     do {                                                                                           \
         const std::string __str(cmd(__VA_ARGS__, "").str());                                       \
         if (!::dsn::utils::parse_kv_map(__str.c_str(), map, item_splitter, kv_splitter)) {         \
-            SHELL_PRINTLN_ERROR("invalid envs: '{}'", __str);                                      \
+            SHELL_PRINTLN_ERROR("invalid kvs: '{}'", __str);                                       \
             return false;                                                                          \
         }                                                                                          \
     } while (false)

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -1048,6 +1048,20 @@ private:
         }                                                                                          \
     } while (false)
 
+// A helper macro to parse an optional command argument, the result is filled in an int32_t
+// variable 'value'.
+//
+// Variable arguments are `name` or `init_list` of argh::parser::operator(). See argh::parser
+// for details.
+#define PARSE_OPT_INT(value, def_val, ...)                                                        \
+    do {                                                                                           \
+        const auto param = cmd(__VA_ARGS__, (def_val)).str();                                      \
+        if (!::dsn::buf2int32(param, value)) {                                                    \
+            SHELL_PRINTLN_ERROR("invalid command, '{}' should be a signed integer", param);     \
+            return false;                                                                          \
+        }                                                                                          \
+    } while (false)
+
 // Parse enum value from the parameters of command line.
 #define PARSE_OPT_ENUM(enum_val, invalid_val, ...)                                                 \
     do {                                                                                           \
@@ -1060,6 +1074,16 @@ private:
             }                                                                                      \
             enum_val = __val;                                                                      \
         }                                                                                          \
+    } while (false)
+
+// Parse the provided parameter into the map by the specified delimiters.
+#define PARSE_OPT_KV_MAP(map, item_splitter, kv_splitter, ...)                                                    \
+    do {                                                                                           \
+        const std::string __str(cmd(__VA_ARGS__, "").str());                                      \
+        if (!::dsn::utils::parse_kv_map(__str.c_str(), map, item_splitter, kv_splitter)                                   {\
+            SHELL_PRINTLN_ERROR("invalid envs: '{}'", __str);     \
+            return false;  \
+            }            \
     } while (false)
 
 #define RETURN_FALSE_IF_NOT(expr, ...)                                                             \

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -1053,11 +1053,11 @@ private:
 //
 // Variable arguments are `name` or `init_list` of argh::parser::operator(). See argh::parser
 // for details.
-#define PARSE_OPT_INT(value, def_val, ...)                                                        \
+#define PARSE_OPT_INT(value, def_val, ...)                                                         \
     do {                                                                                           \
         const auto param = cmd(__VA_ARGS__, (def_val)).str();                                      \
-        if (!::dsn::buf2int32(param, value)) {                                                    \
-            SHELL_PRINTLN_ERROR("invalid command, '{}' should be a signed integer", param);     \
+        if (!::dsn::buf2int32(param, value)) {                                                     \
+            SHELL_PRINTLN_ERROR("invalid command, '{}' should be a signed integer", param);        \
             return false;                                                                          \
         }                                                                                          \
     } while (false)
@@ -1077,13 +1077,13 @@ private:
     } while (false)
 
 // Parse the provided parameter into the map by the specified delimiters.
-#define PARSE_OPT_KV_MAP(map, item_splitter, kv_splitter, ...)                                                    \
+#define PARSE_OPT_KV_MAP(map, item_splitter, kv_splitter, ...)                                     \
     do {                                                                                           \
-        const std::string __str(cmd(__VA_ARGS__, "").str());                                      \
-        if (!::dsn::utils::parse_kv_map(__str.c_str(), map, item_splitter, kv_splitter)                                   {\
-            SHELL_PRINTLN_ERROR("invalid envs: '{}'", __str);     \
-            return false;  \
-            }            \
+        const std::string __str(cmd(__VA_ARGS__, "").str());                                       \
+        if (!::dsn::utils::parse_kv_map(__str.c_str(), map, item_splitter, kv_splitter)) {         \
+            SHELL_PRINTLN_ERROR("invalid envs: '{}'", __str);                                      \
+            return false;                                                                          \
+        }                                                                                          \
     } while (false)
 
 #define RETURN_FALSE_IF_NOT(expr, ...)                                                             \

--- a/src/shell/command_utils.h
+++ b/src/shell/command_utils.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <set>

--- a/src/shell/command_utils.h
+++ b/src/shell/command_utils.h
@@ -41,7 +41,9 @@ inline dsn::error_s exact_n_pos_arg(const argh::parser &cmd, size_t n)
 {
     // n + 1 means the exact n positional arguments plus the command.
     if (cmd.size() != n + 1) {
-        return FMT_ERR(dsn::ERR_INVALID_PARAMETERS, "except the command, there should be exact {} positional argument", n);
+        return FMT_ERR(dsn::ERR_INVALID_PARAMETERS,
+                       "except the command, there should be exact {} positional argument",
+                       n);
     }
 
     return dsn::error_s::ok();
@@ -86,7 +88,9 @@ inline dsn::error_s validate_cmd(const argh::parser &cmd,
                                  const std::set<std::string> &flags,
                                  size_t num_pos_args)
 {
-    return validate_cmd(cmd, params, flags, [num_pos_args](const argh::parser &cmd) { return exact_n_pos_arg(cmd, num_pos_args);});
+    return validate_cmd(cmd, params, flags, [num_pos_args](const argh::parser &cmd) {
+        return exact_n_pos_arg(cmd, num_pos_args);
+    });
 }
 
 bool validate_ip(shell_context *sc,

--- a/src/shell/command_utils.h
+++ b/src/shell/command_utils.h
@@ -37,7 +37,7 @@ class host_port;
 
 struct shell_context;
 
-// Check if there is exact n positional arguments except the command, where n >= 0.
+// Check if there are exact n positional arguments except the command, where n >= 0.
 inline dsn::error_s exact_n_pos_arg(const argh::parser &cmd, size_t n)
 {
     // n + 1 means the exact n positional arguments plus the command.

--- a/src/shell/command_utils.h
+++ b/src/shell/command_utils.h
@@ -36,13 +36,12 @@ class host_port;
 
 struct shell_context;
 
-// Check if there is not any other positional argument except the command, which means only
-// parameters and flags are needed.
-inline dsn::error_s no_pos_arg(const argh::parser &cmd)
+// Check if there is exact n positional arguments except the command, where n >= 0.
+inline dsn::error_s exact_n_pos_arg(const argh::parser &cmd, size_t n)
 {
-    // 1 means there is not any other positional argument except the command.
-    if (cmd.size() > 1) {
-        return FMT_ERR(dsn::ERR_INVALID_PARAMETERS, "there shouldn't be any positional argument");
+    // n + 1 means the exact n positional arguments plus the command.
+    if (cmd.size() != n + 1) {
+        return FMT_ERR(dsn::ERR_INVALID_PARAMETERS, "except the command, there should be exact {} positional argument", n);
     }
 
     return dsn::error_s::ok();
@@ -80,13 +79,14 @@ validate_cmd(const argh::parser &cmd,
     return dsn::error_s::ok();
 }
 
-// Check if the parameters and flags are in the given set while there is not any positional
-// argument.
+// Check if the parameters and flags are in the given set while there are exact `num_pos_args`
+// positional argument.
 inline dsn::error_s validate_cmd(const argh::parser &cmd,
                                  const std::set<std::string> &params,
-                                 const std::set<std::string> &flags)
+                                 const std::set<std::string> &flags,
+                                 size_t num_pos_args)
 {
-    return validate_cmd(cmd, params, flags, no_pos_arg);
+    return validate_cmd(cmd, params, flags, [num_pos_args](const argh::parser &cmd) { return exact_n_pos_arg(cmd, num_pos_args);});
 }
 
 bool validate_ip(shell_context *sc,

--- a/src/shell/command_utils.h
+++ b/src/shell/command_utils.h
@@ -81,8 +81,8 @@ validate_cmd(const argh::parser &cmd,
     return dsn::error_s::ok();
 }
 
-// Check if the parameters and flags are in the given set while there are exact `num_pos_args`
-// positional argument.
+// Check if the parameters and flags are in the given set, and there are exact `num_pos_args`
+// positional arguments.
 inline dsn::error_s validate_cmd(const argh::parser &cmd,
                                  const std::set<std::string> &params,
                                  const std::set<std::string> &flags,

--- a/src/shell/commands/detect_hotkey.cpp
+++ b/src/shell/commands/detect_hotkey.cpp
@@ -87,7 +87,7 @@ bool detect_hotkey(command_executor *e, shell_context *sc, arguments args)
 
     argh::parser cmd(args.argc, args.argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
 
-    const auto &check = validate_cmd(cmd, params, flags);
+    const auto &check = validate_cmd(cmd, params, flags, 0);
     if (!check) {
         // TODO(wangdan): use SHELL_PRINT* macros instead.
         fmt::print(stderr, "{}\n", check.description());

--- a/src/shell/commands/duplication.cpp
+++ b/src/shell/commands/duplication.cpp
@@ -645,7 +645,7 @@ bool ls_dups(command_executor *e, shell_context *sc, arguments args)
     argh::parser cmd(args.argc, args.argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
 
     // Check if input parameters and flags are valid.
-    const auto &check = validate_cmd(cmd, params, flags);
+    const auto &check = validate_cmd(cmd, params, flags, 0);
     if (!check) {
         SHELL_PRINTLN_ERROR("{}", check.description());
         return false;

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -699,15 +699,20 @@ bool create_app(command_executor *e, shell_context *sc, arguments args)
     const bool atomic_idempotent = cmd[{"-i", "--atomic_idempotent"}];
 
     std::map<std::string, std::string> envs;
-    PARSE_OPT_KV_MAP(envs, 4, ',', '=', {"-e", "--envs"});
+    PARSE_OPT_KV_MAP(envs, ',', '=', {"-e", "--envs"});
 
-    dsn::error_code err =
-        sc->ddl_client->create_app(app_name, "pegasus", partition_count, replica_count, envs, false, success_if_exist, atomic_idempotent);
+    dsn::error_code err = sc->ddl_client->create_app(app_name,
+                                                     "pegasus",
+                                                     partition_count,
+                                                     replica_count,
+                                                     envs,
+                                                     false,
+                                                     success_if_exist,
+                                                     atomic_idempotent);
     if (err == ::dsn::ERR_OK) {
         std::cout << "create app \"" << pegasus::utils::c_escape_string(app_name) << "\" succeed"
                   << std::endl;
-    }
-    else {
+    } else {
         std::cout << "create app \"" << pegasus::utils::c_escape_string(app_name)
                   << "\" failed, error = " << err << std::endl;
     }

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -54,7 +54,6 @@
 #include "utils/output_utils.h"
 #include "utils/ports.h"
 #include "utils/string_conv.h"
-#include "utils/strings.h"
 #include "utils_types.h"
 
 DSN_DEFINE_uint32(shell, tables_sample_interval_ms, 1000, "The interval between sampling metrics.");

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -68,8 +68,8 @@ double convert_to_ratio(double hit, double total)
 bool ls_apps(command_executor *e, shell_context *sc, arguments args)
 {
     // ls [-a|--all] [-d|--detailed] [-j|--json] [-o|--output file_name]
-    // [-s|--status all|available|creating|dropping|dropped] "
-    // [-p|--app_name_pattern str] [-m|--match_type all|exact|anywhere|prefix|postfix]"
+    // [-s|--status all|available|creating|dropping|dropped]
+    // [-p|--app_name_pattern str] [-m|--match_type all|exact|anywhere|prefix|postfix]
 
     // All valid parameters and flags are given as follows.
     static const std::set<std::string> params = {
@@ -79,7 +79,7 @@ bool ls_apps(command_executor *e, shell_context *sc, arguments args)
     argh::parser cmd(args.argc, args.argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
 
     // Check if input parameters and flags are valid.
-    const auto &check = validate_cmd(cmd, params, flags);
+    const auto &check = validate_cmd(cmd, params, flags, 0);
     if (!check) {
         SHELL_PRINTLN_ERROR("{}", check.description());
         return false;
@@ -668,62 +668,50 @@ bool app_stat(command_executor *, shell_context *sc, arguments args)
 
 bool create_app(command_executor *e, shell_context *sc, arguments args)
 {
-    static struct option long_options[] = {{"partition_count", required_argument, 0, 'p'},
-                                           {"replica_count", required_argument, 0, 'r'},
-                                           {"fail_if_exist", no_argument, 0, 'f'},
-                                           {"envs", required_argument, 0, 'e'},
-                                           {0, 0, 0, 0}};
+    // create <app_name> [-p|--partition_count num] [-r|--replica_count num] [-f|--fail_if_exist]
+    // [-i|--atomic_idempotent] [-e|--envs k1=v1,k2=v2...]
 
-    if (args.argc < 2)
+    // All valid parameters and flags are given as follows.
+    static const std::set<std::string> params = {
+        "p", "partition_count", "r", "replica_count", "e", "envs"};
+    static const std::set<std::string> flags = {"f", "fail_if_exist", "i", "atomic_idempotent"};
+
+    argh::parser cmd(args.argc, args.argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
+
+    // Check if input parameters, flags and positional arguments are valid.
+    const auto &check = validate_cmd(cmd, params, flags, 1);
+    if (!check) {
+        SHELL_PRINTLN_ERROR("{}", check.description());
         return false;
-
-    std::string app_name = args.argv[1];
-    bool success_if_exist = true;
-
-    int pc = 4, rc = 3;
-    std::map<std::string, std::string> envs;
-    optind = 0;
-    while (true) {
-        int option_index = 0;
-        int c;
-        c = getopt_long(args.argc, args.argv, "p:r:fe:", long_options, &option_index);
-        if (c == -1)
-            break;
-        switch (c) {
-        case 'p':
-            if (!dsn::buf2int32(optarg, pc)) {
-                fprintf(stderr, "parse %s as partition_count failed\n", optarg);
-                return false;
-            }
-            break;
-        case 'r':
-            if (!dsn::buf2int32(optarg, rc)) {
-                fprintf(stderr, "parse %s as replica_count failed\n", optarg);
-                return false;
-            }
-            break;
-        case 'f':
-            success_if_exist = false;
-            break;
-        case 'e':
-            if (!::dsn::utils::parse_kv_map(optarg, envs, ',', '=')) {
-                fprintf(stderr, "invalid envs: %s\n", optarg);
-                return false;
-            }
-            break;
-        default:
-            return false;
-        }
     }
 
-    ::dsn::error_code err =
-        sc->ddl_client->create_app(app_name, "pegasus", pc, rc, envs, false, success_if_exist);
-    if (err == ::dsn::ERR_OK)
+    std::string app_name = cmd(1).str();
+
+    int32_t partition_count = 0;
+    PARSE_OPT_INT(partition_count, 4, {"-p", "--partition_count"});
+
+    int32_t replica_count = 0;
+    PARSE_OPT_INT(replica_count, 3, {"-r", "--replica_count"});
+
+    // To get `success_if_exist`, just apply logical NOT to `fail_if_exist`.
+    const bool success_if_exist = !cmd[{"-f", "--fail_if_exist"}];
+
+    const bool atomic_idempotent = cmd[{"-i", "--atomic_idempotent"}];
+
+    std::map<std::string, std::string> envs;
+    PARSE_OPT_KV_MAP(envs, 4, ',', '=', {"-e", "--envs"});
+
+    dsn::error_code err =
+        sc->ddl_client->create_app(app_name, "pegasus", partition_count, replica_count, envs, false, success_if_exist, atomic_idempotent);
+    if (err == ::dsn::ERR_OK) {
         std::cout << "create app \"" << pegasus::utils::c_escape_string(app_name) << "\" succeed"
                   << std::endl;
-    else
+    }
+    else {
         std::cout << "create app \"" << pegasus::utils::c_escape_string(app_name)
                   << "\" failed, error = " << err << std::endl;
+    }
+
     return true;
 }
 

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -678,13 +678,15 @@ bool create_app(command_executor *e, shell_context *sc, arguments args)
 
     argh::parser cmd(args.argc, args.argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
 
-    // Check if input parameters, flags and positional arguments are valid.
+    // Check if the input parameters and flags are valid, and there are exact one positional
+    // argument (i.e. app_name).
     const auto &check = validate_cmd(cmd, params, flags, 1);
     if (!check) {
         SHELL_PRINTLN_ERROR("{}", check.description());
         return false;
     }
 
+    // Get the only positional argument as app_name.
     std::string app_name = cmd(1).str();
 
     int32_t partition_count = 0;
@@ -693,11 +695,12 @@ bool create_app(command_executor *e, shell_context *sc, arguments args)
     int32_t replica_count = 0;
     PARSE_OPT_INT(replica_count, 3, {"-r", "--replica_count"});
 
-    // To get `success_if_exist`, just apply logical NOT to `fail_if_exist`.
+    // To get `success_if_exist`, just apply logical NOT to the flag `fail_if_exist`.
     const bool success_if_exist = !cmd[{"-f", "--fail_if_exist"}];
 
     const bool atomic_idempotent = cmd[{"-i", "--atomic_idempotent"}];
 
+    // Parse each env name/value pair with specified delimiters.
     std::map<std::string, std::string> envs;
     PARSE_OPT_KV_MAP(envs, ',', '=', {"-e", "--envs"});
 

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -109,7 +109,7 @@ static command_executor commands[] = {
         "create",
         "create an app",
         "<app_name> [-p|--partition_count num] [-r|--replica_count num] [-f|--fail_if_exist] "
-        "[-e|--envs k1=v1,k2=v2...]",
+        "[-i|--atomic_idempotent] [-e|--envs k1=v1,k2=v2...]",
         create_app,
     },
     {

--- a/src/test/function_test/base_api/test_copy.cpp
+++ b/src/test/function_test/base_api/test_copy.cpp
@@ -17,11 +17,12 @@
  * under the License.
  */
 
-#include <limits.h>
-#include <string.h>
-#include <time.h>
 #include <atomic>
+#include <climits>
+#include <cstdint>
 #include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <functional>
 #include <map>
 #include <memory>
@@ -32,8 +33,8 @@
 #include "gtest/gtest.h"
 #include "include/pegasus/client.h"
 #include "pegasus/error.h"
-#include "task/async_calls.h"
 #include "shell/command_helper.h"
+#include "task/async_calls.h"
 #include "test/function_test/utils/test_util.h"
 #include "test/function_test/utils/utils.h"
 #include "test_util/test_util.h"

--- a/src/test/function_test/base_api/test_copy.cpp
+++ b/src/test/function_test/base_api/test_copy.cpp
@@ -92,7 +92,7 @@ public:
                   ddl_client_->create_app(source_app_name, "pegasus", default_partitions, 3, {}));
         ASSERT_EQ(
             dsn::ERR_OK,
-            ddl_client_->create_app(destination_app_name, "pegasus", default_partitions, 2, {}));
+            ddl_client_->create_app(destination_app_name, "pegasus", default_partitions, 3, {}));
         source_client_ =
             pegasus_client_factory::get_client(kClusterName.c_str(), source_app_name.c_str());
         ASSERT_NE(nullptr, source_client_);

--- a/src/test/function_test/base_api/test_copy.cpp
+++ b/src/test/function_test/base_api/test_copy.cpp
@@ -89,10 +89,10 @@ public:
     {
         ASSERT_EQ(
             dsn::ERR_OK,
-            ddl_client_->create_app(source_app_name, "pegasus", default_partitions, 3, {}, false));
+            ddl_client_->create_app(source_app_name, "pegasus", default_partitions, 3, {}));
         ASSERT_EQ(dsn::ERR_OK,
                   ddl_client_->create_app(
-                      destination_app_name, "pegasus", default_partitions, 3, {}, false));
+                      destination_app_name, "pegasus", default_partitions, 2, {}));
         source_client_ =
             pegasus_client_factory::get_client(kClusterName.c_str(), source_app_name.c_str());
         ASSERT_NE(nullptr, source_client_);
@@ -153,7 +153,7 @@ protected:
     const int max_batch_count = 500;
     const int timeout_ms = 5000;
     const int max_multi_set_concurrency = 20;
-    const int default_partitions = 4;
+    const int32_t default_partitions = 4;
 
     char buffer_[256];
     map<string, map<string, string>> expect_data_;

--- a/src/test/function_test/base_api/test_copy.cpp
+++ b/src/test/function_test/base_api/test_copy.cpp
@@ -87,12 +87,11 @@ public:
 
     void create_table_and_get_client()
     {
+        ASSERT_EQ(dsn::ERR_OK,
+                  ddl_client_->create_app(source_app_name, "pegasus", default_partitions, 3, {}));
         ASSERT_EQ(
             dsn::ERR_OK,
-            ddl_client_->create_app(source_app_name, "pegasus", default_partitions, 3, {}));
-        ASSERT_EQ(dsn::ERR_OK,
-                  ddl_client_->create_app(
-                      destination_app_name, "pegasus", default_partitions, 2, {}));
+            ddl_client_->create_app(destination_app_name, "pegasus", default_partitions, 2, {}));
         source_client_ =
             pegasus_client_factory::get_client(kClusterName.c_str(), source_app_name.c_str());
         ASSERT_NE(nullptr, source_client_);

--- a/src/test/function_test/base_api/test_scan.cpp
+++ b/src/test/function_test/base_api/test_scan.cpp
@@ -51,7 +51,7 @@ public:
     {
         test_util::SetUp();
         ASSERT_EQ(dsn::ERR_OK, ddl_client_->drop_app(table_name_, 0));
-        ASSERT_EQ(dsn::ERR_OK, ddl_client_->create_app(table_name_, "pegasus", 8, 3, {}, false));
+        ASSERT_EQ(dsn::ERR_OK, ddl_client_->create_app(table_name_, "pegasus", 8, 3, {}));
         client_ = pegasus_client_factory::get_client(kClusterName.c_str(), table_name_.c_str());
         ASSERT_TRUE(client_ != nullptr);
         ASSERT_NO_FATAL_FAILURE(fill_database());

--- a/src/test/function_test/recovery/test_recovery.cpp
+++ b/src/test/function_test/recovery/test_recovery.cpp
@@ -198,7 +198,7 @@ TEST_F(recovery_test, recovery)
 
         // then wait the apps to ready
         ASSERT_EQ(dsn::ERR_OK,
-                  ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, {}, false));
+                  ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, {}));
 
         ASSERT_NO_FATAL_FAILURE(verify_data(dataset_count));
     }
@@ -223,7 +223,7 @@ TEST_F(recovery_test, recovery)
 
         // then wait the app to ready
         ASSERT_EQ(dsn::ERR_OK,
-                  ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, {}, false));
+                  ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, {}));
 
         ASSERT_NO_FATAL_FAILURE(verify_data(dataset_count));
     }
@@ -256,7 +256,7 @@ TEST_F(recovery_test, recovery)
 
         // then wait the apps to ready
         ASSERT_EQ(dsn::ERR_OK,
-                  ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, {}, false));
+                  ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, {}));
 
         ASSERT_NO_FATAL_FAILURE(verify_data(dataset_count));
     }
@@ -286,7 +286,7 @@ TEST_F(recovery_test, recovery)
 
         // then wait the apps to ready
         ASSERT_EQ(dsn::ERR_OK,
-                  ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, {}, false));
+                  ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, {}));
 
         ASSERT_NO_FATAL_FAILURE(verify_data(dataset_count));
     }

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -98,9 +98,9 @@ void test_util::SetUp()
         ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, kCreateEnvs);
     if (ret == dsn::ERR_INVALID_PARAMETERS) {
         ASSERT_EQ(dsn::ERR_OK, ddl_client_->drop_app(table_name_, 0));
-        ASSERT_EQ(dsn::ERR_OK,
-                  ddl_client_->create_app(
-                      table_name_, "pegasus", partition_count_, 3, kCreateEnvs));
+        ASSERT_EQ(
+            dsn::ERR_OK,
+            ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, kCreateEnvs));
     } else {
         ASSERT_EQ(dsn::ERR_OK, ret);
     }

--- a/src/test/function_test/utils/test_util.cpp
+++ b/src/test/function_test/utils/test_util.cpp
@@ -95,12 +95,12 @@ void test_util::SetUp()
     ddl_client_->set_meta_servers_leader();
 
     dsn::error_code ret =
-        ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, kCreateEnvs, false);
+        ddl_client_->create_app(table_name_, "pegasus", partition_count_, 3, kCreateEnvs);
     if (ret == dsn::ERR_INVALID_PARAMETERS) {
         ASSERT_EQ(dsn::ERR_OK, ddl_client_->drop_app(table_name_, 0));
         ASSERT_EQ(dsn::ERR_OK,
                   ddl_client_->create_app(
-                      table_name_, "pegasus", partition_count_, 3, kCreateEnvs, false));
+                      table_name_, "pegasus", partition_count_, 3, kCreateEnvs));
     } else {
         ASSERT_EQ(dsn::ERR_OK, ret);
     }

--- a/src/test/function_test/utils/test_util.h
+++ b/src/test/function_test/utils/test_util.h
@@ -33,7 +33,7 @@
 // TODO(yingchun): it's too tricky, but I don't know how does it happen, we can fix it later.
 #define TRICKY_CODE_TO_AVOID_LINK_ERROR                                                            \
     do {                                                                                           \
-        ddl_client_->create_app("", "pegasus", 0, 0, {});                                   \
+        ddl_client_->create_app("", "pegasus", 0, 0, {});                                          \
         pegasus_client_factory::get_client("", "");                                                \
     } while (false)
 

--- a/src/test/function_test/utils/test_util.h
+++ b/src/test/function_test/utils/test_util.h
@@ -33,7 +33,7 @@
 // TODO(yingchun): it's too tricky, but I don't know how does it happen, we can fix it later.
 #define TRICKY_CODE_TO_AVOID_LINK_ERROR                                                            \
     do {                                                                                           \
-        ddl_client_->create_app("", "pegasus", 0, 0, {}, false);                                   \
+        ddl_client_->create_app("", "pegasus", 0, 0, {});                                   \
         pegasus_client_factory::get_client("", "");                                                \
     } while (false)
 


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2197

Support `atomic_idempotent` for `create` and `ls` by:
- Add a flag to the `create` command to decide whether the created table is
`atomic_idempotent` (false by default).
- Add a column `atomic_idempotent` to the result shown by `ls` command.