### PR TITLE
ci(github): fix that sbt could not be found while checking format for Scala

### DIFF
--- a/.github/workflows/lint_and_test_scala-client.yml
+++ b/.github/workflows/lint_and_test_scala-client.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install sbt
         run: |
           curl -s "https://get.sdkman.io" | bash
-          source /github/home/.sdkman/bin/sdkman-init.sh
+          source ${HOME}/.sdkman/bin/sdkman-init.sh
           sdk install sbt
           sbt -V
       - name: Check format with sbt
@@ -92,7 +92,7 @@ jobs:
       - name: Install sbt
         run: |
           curl -s "https://get.sdkman.io" | bash
-          source /github/home/.sdkman/bin/sdkman-init.sh
+          source ${HOME}/.sdkman/bin/sdkman-init.sh
           sdk install sbt
           sbt -V
       - name: Download thrift

--- a/.github/workflows/lint_and_test_scala-client.yml
+++ b/.github/workflows/lint_and_test_scala-client.yml
@@ -35,7 +35,7 @@ env:
   ARTIFACT_NAME: release_for_scala_client
 
 jobs:
-  format:
+  check_format:
     name: Format
     runs-on: ubuntu-latest
     steps:
@@ -43,13 +43,19 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
-      - name: format
+      - name: Install sbt
+        run: |
+          curl -s "https://get.sdkman.io" | bash
+          source /github/home/.sdkman/bin/sdkman-init.sh
+          sdk install sbt
+          sbt -V
+      - name: Check format with sbt
         working-directory: ./scala-client
         run: sbt scalafmtSbtCheck scalafmtCheck test:scalafmtCheck
 
   build_server:
     name: Build server
-    needs: format
+    needs: check_format
     runs-on: ubuntu-latest
     env:
       USE_JEMALLOC: OFF
@@ -74,7 +80,7 @@ jobs:
         java: [ '8', '11']
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -83,7 +89,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - name: Setup sbt
+      - name: Install sbt
         run: |
           curl -s "https://get.sdkman.io" | bash
           source /github/home/.sdkman/bin/sdkman-init.sh

--- a/.github/workflows/lint_and_test_scala-client.yml
+++ b/.github/workflows/lint_and_test_scala-client.yml
@@ -49,9 +49,12 @@ jobs:
           source ${HOME}/.sdkman/bin/sdkman-init.sh
           sdk install sbt
           sbt -V
+          which sbt
       - name: Check format with sbt
         working-directory: ./scala-client
-        run: sbt scalafmtSbtCheck scalafmtCheck test:scalafmtCheck
+        run: |
+          which sbt
+          sbt scalafmtSbtCheck scalafmtCheck test:scalafmtCheck
 
   build_server:
     name: Build server

--- a/.github/workflows/lint_and_test_scala-client.yml
+++ b/.github/workflows/lint_and_test_scala-client.yml
@@ -46,14 +46,13 @@ jobs:
       - name: Install sbt
         run: |
           curl -s "https://get.sdkman.io" | bash
-          source ${HOME}/.sdkman/bin/sdkman-init.sh
+          source "${HOME}/.sdkman/bin/sdkman-init.sh"
           sdk install sbt
           sbt -V
-          which sbt
       - name: Check format with sbt
         working-directory: ./scala-client
         run: |
-          which sbt
+          source "${HOME}/.sdkman/bin/sdkman-init.sh"
           sbt scalafmtSbtCheck scalafmtCheck test:scalafmtCheck
 
   build_server:
@@ -95,7 +94,7 @@ jobs:
       - name: Install sbt
         run: |
           curl -s "https://get.sdkman.io" | bash
-          source ${HOME}/.sdkman/bin/sdkman-init.sh
+          source "${HOME}/.sdkman/bin/sdkman-init.sh"
           sdk install sbt
           sbt -V
       - name: Download thrift
@@ -116,5 +115,5 @@ jobs:
       - name: Run Scala client tests
         working-directory: ./scala-client
         run: |
-          source /github/home/.sdkman/bin/sdkman-init.sh
+          source "${HOME}/.sdkman/bin/sdkman-init.sh"
           sbt test


### PR DESCRIPTION
Resolve https://github.com/apache/incubator-pegasus/issues/2237.

Install `sbt` with [sdkman](https://get.sdkman.io) before checking format. Also
bump actions/cache from v2 to v3 for Scala workflows.