### PR TITLE
feat(duplication): support resumable download for checkpoint files during full duplication on the server side

### DIFF
--- a/idl/utils.thrift
+++ b/idl/utils.thrift
@@ -43,13 +43,15 @@ enum pattern_match_type
     PMT_MATCH_REGEX,
 }
 
+// Specify which algorithm is used to calculate the checksum of a file.
 enum checksum_type
 {
     CST_INVALID = 0,
 
-    // 
+    // Do NOT calculate by any algorithm, which means no content will be
+    // generated.
     CST_NONE,
 
-    // 
+    // Use md5sum to calculate.
     CST_MD5,
 }

--- a/src/common/consensus.thrift
+++ b/src/common/consensus.thrift
@@ -27,6 +27,7 @@
 include "../../idl/dsn.thrift"
 include "../../idl/dsn.layer2.thrift"
 include "../../idl/metadata.thrift"
+include "../../idl/utils.thrift"
 
 namespace cpp dsn.replication
 
@@ -131,6 +132,12 @@ struct learn_state
 
     // Used by duplication. Holds the start_decree of this round of learn.
     5:optional i64   learn_start_decree;
+
+    // 
+    6:optional list<i64>        file_sizes;
+
+    //
+    7:optional list<string>     file_checksums;
 }
 
 enum learner_status
@@ -157,6 +164,8 @@ struct learn_request
     // learnee will copy the missing logs.
     7:optional i64               max_gced_decree;
     8:optional dsn.host_port     hp_learner;
+
+    9:optional utils.checksum_type      checksum = utils.checksum_type.CST_NONE;
 }
 
 struct learn_response

--- a/src/common/consensus.thrift
+++ b/src/common/consensus.thrift
@@ -165,7 +165,7 @@ struct learn_request
     7:optional i64               max_gced_decree;
     8:optional dsn.host_port     hp_learner;
 
-    9:optional utils.checksum_type      checksum = utils.checksum_type.CST_NONE;
+    9:optional utils.checksum_type      checksum_type = utils.checksum_type.CST_NONE;
 }
 
 struct learn_response

--- a/src/common/consensus.thrift
+++ b/src/common/consensus.thrift
@@ -167,10 +167,10 @@ struct learn_request
     8:optional dsn.host_port     hp_learner;
 
     // checksum_type is only used to implement resumable checkpoint download for duplication.
-    // It decide which algorithm the dup master will use to calculate the checksum for each
-    // file (learn_request will be sent from the dup follower to dup master). Since it is only
-    // used for duplication, by default it is CST_NONE which means do not calculate checksum
-    // and file size.
+    // It decides which algorithm the dup master will use to calculate the checksum for each
+    // file (learn_request will be sent from the dup follower to the dup master). Since it is
+    // only used for duplication, by default it is CST_NONE which means do not calculate file
+    // size and checksum.
     9:optional utils.checksum_type      checksum_type = utils.checksum_type.CST_NONE;
 }
 

--- a/src/common/consensus.thrift
+++ b/src/common/consensus.thrift
@@ -133,10 +133,11 @@ struct learn_state
     // Used by duplication. Holds the start_decree of this round of learn.
     5:optional i64   learn_start_decree;
 
-    // 
+    // file_sizes and file_checksums are only used to implement resumable checkpoint download
+    // for duplication. While the dup follower receives file_sizes and file_checksums, it will
+    // decide which files it already has and which files it should fetch from the dup master
+    // (the dup master will reply to the dup follower with learn_response).
     6:optional list<i64>        file_sizes;
-
-    //
     7:optional list<string>     file_checksums;
 }
 
@@ -165,6 +166,11 @@ struct learn_request
     7:optional i64               max_gced_decree;
     8:optional dsn.host_port     hp_learner;
 
+    // checksum_type is only used to implement resumable checkpoint download for duplication.
+    // It decide which algorithm the dup master will use to calculate the checksum for each
+    // file (learn_request will be sent from the dup follower to dup master). Since it is only
+    // used for duplication, by default it is CST_NONE which means do not calculate checksum
+    // and file size.
     9:optional utils.checksum_type      checksum_type = utils.checksum_type.CST_NONE;
 }
 

--- a/src/replica/mutation.h
+++ b/src/replica/mutation.h
@@ -81,9 +81,6 @@ public:
     mutation();
     ~mutation() override;
 
-    DISALLOW_COPY_AND_ASSIGN(mutation);
-    DISALLOW_MOVE_AND_ASSIGN(mutation);
-
     // copy mutation from an existing mutation, typically used in partition split
     // mutation should not reply to client, because parent has already replied
     static mutation_ptr copy_no_reply(const mutation_ptr &old_mu);
@@ -238,6 +235,9 @@ private:
     uint64_t _tid;          // trace id, unique in process
     static std::atomic<uint64_t> s_tid;
     bool _is_sync_to_child; // for partition split
+
+    DISALLOW_COPY_AND_ASSIGN(mutation);
+    DISALLOW_MOVE_AND_ASSIGN(mutation);
 };
 
 class replica;

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -64,12 +64,10 @@
 #include "utils/uniq_timestamp_us.h"
 #include "utils_types.h"
 
-namespace pegasus {
-namespace server {
+namespace pegasus::server {
 class pegasus_server_test_base;
 class rocksdb_wrapper_test;
-} // namespace server
-} // namespace pegasus
+} // namespace pegasus::server
 
 namespace dsn {
 class gpid;

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -708,7 +708,16 @@ private:
     // Currently only used for unit test to get the count of backup requests.
     int64_t get_backup_request_count() const;
 
-private:
+    template <typename TApp,
+              typename... Args,
+              typename = typename std::enable_if<
+                  std::is_base_of<replication_app_base,
+                                  typename std::remove_pointer<TApp>::type>::value>::type>
+    void create_app_for_test(Args &&...args)
+    {
+        _app = std::make_unique<TApp>(std::forward<Args>(args)...);
+    }
+
     friend class ::dsn::replication::test::test_checker;
     friend class ::dsn::replication::mutation_log_tool;
     friend class ::dsn::replication::mutation_queue;

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -34,6 +34,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "common/json_helper.h"
@@ -54,7 +55,6 @@
 #include "runtime/serverlet.h"
 #include "task/task.h"
 #include "task/task_tracker.h"
-#include "utils_types.h"
 #include "utils/autoref_ptr.h"
 #include "utils/error_code.h"
 #include "utils/metrics.h"
@@ -62,6 +62,7 @@
 #include "utils/thread_access_checker.h"
 #include "utils/throttling_controller.h"
 #include "utils/uniq_timestamp_us.h"
+#include "utils_types.h"
 
 namespace pegasus {
 namespace server {

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -291,8 +291,18 @@ public:
                                                    uint32_t delay_ms,
                                                    trigger_checkpoint_callback callback);
 
+    // The same as the above except that `callback` is empty.
     void async_trigger_manual_emergency_checkpoint(decree min_checkpoint_decree, uint32_t delay_ms);
 
+    // Get the last checkpoint info and put it into the response to reply to the dup follower.
+    //
+    // Parameters:
+    // - `checksum_type`: specify which algorithm the server (namely dup master) will use to
+    // calculate the checksum for each file. This parameter is used to implement resumable
+    // checkpoint download for duplication: the client (namely dup follower) receives the file
+    // sizes and checksums, then decides which files it should fetch from the server accordingly.
+    // CST_NONE means do not calculate checksum and file size.
+    // - `response`: the output parameter, used to respond to the dup follower.
     void on_query_last_checkpoint(utils::checksum_type::type checksum_type,
                                   learn_response &response);
 
@@ -707,6 +717,7 @@ private:
     // Currently only used for unit test to get the count of backup requests.
     int64_t get_backup_request_count() const;
 
+    // Support self-defined `replication_app_base` at runtime which is only used for test.
     template <typename TApp,
               typename... Args,
               typename = typename std::enable_if<

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -301,7 +301,7 @@ public:
     // calculate the checksum for each file. This parameter is used to implement resumable
     // checkpoint download for duplication: the client (namely dup follower) receives the file
     // sizes and checksums, then decides which files it should fetch from the server accordingly.
-    // CST_NONE means do not calculate checksum and file size.
+    // CST_NONE means do not calculate file size and checksum.
     // - `response`: the output parameter, used to respond to the dup follower.
     void on_query_last_checkpoint(utils::checksum_type::type checksum_type,
                                   learn_response &response);

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -292,7 +292,8 @@ public:
                                                    uint32_t delay_ms,
                                                    trigger_checkpoint_callback callback = {});
 
-    void on_query_last_checkpoint(utils::checksum_type::type checksum_type, utils::learn_response &response);
+    void on_query_last_checkpoint(utils::checksum_type::type checksum_type,
+                                  learn_response &response);
 
     std::shared_ptr<replica_duplicator_manager> get_duplication_manager() const
     {

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -54,6 +54,7 @@
 #include "runtime/serverlet.h"
 #include "task/task.h"
 #include "task/task_tracker.h"
+#include "utils_types.h"
 #include "utils/autoref_ptr.h"
 #include "utils/error_code.h"
 #include "utils/metrics.h"
@@ -291,7 +292,8 @@ public:
                                                    uint32_t delay_ms,
                                                    trigger_checkpoint_callback callback = {});
 
-    void on_query_last_checkpoint(learn_response &response);
+    void on_query_last_checkpoint(utils::checksum_type::type checksum_type, utils::learn_response &response);
+
     std::shared_ptr<replica_duplicator_manager> get_duplication_manager() const
     {
         return _duplication_mgr;

--- a/src/replica/replica.h
+++ b/src/replica/replica.h
@@ -290,7 +290,9 @@ public:
     // - `callback`: the callback processor handling the error code of triggering checkpoint.
     void async_trigger_manual_emergency_checkpoint(decree min_checkpoint_decree,
                                                    uint32_t delay_ms,
-                                                   trigger_checkpoint_callback callback = {});
+                                                   trigger_checkpoint_callback callback);
+
+    void async_trigger_manual_emergency_checkpoint(decree min_checkpoint_decree, uint32_t delay_ms);
 
     void on_query_last_checkpoint(utils::checksum_type::type checksum_type,
                                   learn_response &response);

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -359,6 +359,8 @@ void replica::on_query_last_checkpoint(utils::checksum_type::type checksum_type,
 
     std::vector<int64_t> file_sizes;
     std::vector<std::string> file_checksums;
+    file_sizes.reserve(response.state.files.size());
+    file_checksums.reserve(response.state.files.size());
     for (auto &file : response.state.files) {
         int64_t size = 0;
         if (dsn_unlikely(

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -25,12 +25,13 @@
  */
 
 #include <fmt/core.h>
-#include <stdint.h>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "common/gpid.h"
@@ -60,11 +61,14 @@
 #include "utils/chrono_literals.h"
 #include "utils/env.h"
 #include "utils/error_code.h"
+#include "utils/errors.h"
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/metrics.h"
+#include "utils/ports.h"
 #include "utils/thread_access_checker.h"
+#include "utils_types.h"
 
 /// The checkpoint of the replicated app part of replica.
 
@@ -245,6 +249,12 @@ void replica::async_trigger_manual_emergency_checkpoint(decree min_checkpoint_de
         },
         get_gpid().thread_hash(),
         std::chrono::milliseconds(delay_ms));
+}
+
+void replica::async_trigger_manual_emergency_checkpoint(decree min_checkpoint_decree,
+                                                        uint32_t delay_ms)
+{
+    async_trigger_manual_emergency_checkpoint(min_checkpoint_decree, delay_ms, {});
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -56,6 +56,7 @@
 #include "task/task.h"
 #include "utils/autoref_ptr.h"
 #include "utils/blob.h"
+#include "utils/checksum.h"
 #include "utils/chrono_literals.h"
 #include "utils/env.h"
 #include "utils/error_code.h"
@@ -314,7 +315,8 @@ void replica::init_checkpoint(bool is_emergency)
 }
 
 // ThreadPool: THREAD_POOL_REPLICATION
-void replica::on_query_last_checkpoint(utils::checksum_type::type checksum_type, learn_response &response)
+void replica::on_query_last_checkpoint(utils::checksum_type::type checksum_type,
+                                       learn_response &response)
 {
     _checker.only_one_thread_access();
 
@@ -326,59 +328,57 @@ void replica::on_query_last_checkpoint(utils::checksum_type::type checksum_type,
     if (dsn_unlikely(_app->get_checkpoint(0, blob(), response.state) != ERR_OK)) {
         response.err = ERR_GET_LEARN_STATE_FAILED;
         return;
-    } 
+    }
 
-        response.err = ERR_OK;
-        response.last_committed_decree = last_committed_decree();
-        // for example: base_local_dir = "./data" + "checkpoint.1024" = "./data/checkpoint.1024"
-        response.base_local_dir = utils::filesystem::path_combine(
-            _app->data_dir(), checkpoint_folder(response.state.to_decree_included));
-        SET_IP_AND_HOST_PORT(
-            response, learnee, _stub->primary_address(), _stub->primary_host_port());
+    response.err = ERR_OK;
+    response.last_committed_decree = last_committed_decree();
+    // for example: base_local_dir = "./data" + "checkpoint.1024" = "./data/checkpoint.1024"
+    response.base_local_dir = utils::filesystem::path_combine(
+        _app->data_dir(), checkpoint_folder(response.state.to_decree_included));
+    SET_IP_AND_HOST_PORT(response, learnee, _stub->primary_address(), _stub->primary_host_port());
 
-        if (checksum_type <= utils::checksum_type::CST_NONE) {
+    if (checksum_type <= utils::checksum_type::CST_NONE) {
         for (auto &file : response.state.files) {
             // response.state.files contain file absolute path， for example:
             // "./data/checkpoint.1024/1.sst" use `substr` to get the file name: 1.sst
             file = file.substr(response.base_local_dir.length() + 1);
         }
+    }
+
+    std::vector<int64_t> file_sizes;
+    std::vector<std::string> file_checksums;
+    for (auto &file : response.state.files) {
+        int64_t size = 0;
+        if (!utils::filesystem::file_size(file, utils::FileDataType::kSensitive, size)) {
+            LOG_ERROR_PREFIX("get size of file failed: file = {}", file);
+            response.err = ERR_GET_LEARN_STATE_FAILED;
+            break;
         }
 
-        std::vector<int64_t> file_sizes;
-        std::vector<std::string> file_checksums;
-        for (auto &file : response.state.files) {
-            int64_t size = 0;
-            if (!utils::filesystem::file_size(
-                    file_path, utils::FileDataType::kSensitive, size)) {
-                LOG_ERROR_PREFIX("get size of file failed: file = {}", file);
-                response.err = ERR_GET_LEARN_STATE_FAILED;
-                break;
-            }
-
-            std::string checksum;
-            const auto err = calc_checksum(file, checksum_type, checksum);
-            if (dsn_unlikely(err != ERR_OK)) {
-                LOG_ERROR_PREFIX("calculate checksum failed: file = {}, err = {}", file, err);
-                response.err = ERR_GET_LEARN_STATE_FAILED;
-                return;
-            }
-
-            file_sizes.push_back(size);
-            file_checksums.push_back(std::move(checksum));
-
-            // response.state.files contain file absolute path， for example:
-            // "./data/checkpoint.1024/1.sst" use `substr` to get the file name: 1.sst
-            file = file.substr(response.base_local_dir.length() + 1);
-        }
-
-        if (file_sizes.empty()) {
+        std::string checksum;
+        const auto result = calc_checksum(file, checksum_type, checksum);
+        if (dsn_unlikely(!result)) {
+            LOG_ERROR_PREFIX("calculate checksum failed: file = {}, err = {}", file, result);
+            response.err = ERR_GET_LEARN_STATE_FAILED;
             return;
         }
 
-        response.__isset.file_sizes = true;
-        response.__isset.file_checksums = true;
-        response.file_sizes = std::move(file_sizes);
-        response.file_checksums = std::move(file_checksums);
+        file_sizes.push_back(size);
+        file_checksums.push_back(std::move(checksum));
+
+        // response.state.files contain file absolute path， for example:
+        // "./data/checkpoint.1024/1.sst" use `substr` to get the file name: 1.sst
+        file = file.substr(response.base_local_dir.length() + 1);
+    }
+
+    if (file_sizes.empty()) {
+        return;
+    }
+
+    response.state.__isset.file_sizes = true;
+    response.state.__isset.file_checksums = true;
+    response.state.file_sizes = std::move(file_sizes);
+    response.state.file_checksums = std::move(file_checksums);
 }
 
 // run in background thread

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -353,16 +353,19 @@ void replica::on_query_last_checkpoint(utils::checksum_type::type checksum_type,
             // "./data/checkpoint.1024/1.sst" use `substr` to get the file name: 1.sst
             file = file.substr(response.base_local_dir.length() + 1);
         }
+
+        return;
     }
 
     std::vector<int64_t> file_sizes;
     std::vector<std::string> file_checksums;
     for (auto &file : response.state.files) {
         int64_t size = 0;
-        if (!utils::filesystem::file_size(file, utils::FileDataType::kSensitive, size)) {
+        if (dsn_unlikely(
+                !utils::filesystem::file_size(file, utils::FileDataType::kSensitive, size))) {
             LOG_ERROR_PREFIX("get size of file failed: file = {}", file);
             response.err = ERR_GET_LEARN_STATE_FAILED;
-            break;
+            return;
         }
 
         std::string checksum;

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1213,9 +1213,10 @@ void replica_stub::on_query_last_checkpoint(query_last_checkpoint_info_rpc rpc)
     replica_ptr rep = get_replica(request.pid);
     if (dsn_unlikely(rep == nullptr)) {
         response.err = ERR_OBJECT_NOT_FOUND;
+        return;
     }
 
-    rep->on_query_last_checkpoint(request.checksum, response);
+    rep->on_query_last_checkpoint(request.checksum_type, response);
 }
 
 // ThreadPool: THREAD_POOL_DEFAULT

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1213,9 +1213,9 @@ void replica_stub::on_query_last_checkpoint(query_last_checkpoint_info_rpc rpc)
     replica_ptr rep = get_replica(request.pid);
     if (dsn_unlikely(rep == nullptr)) {
         response.err = ERR_OBJECT_NOT_FOUND;
-    } 
+    }
 
-        rep->on_query_last_checkpoint(request.checksum, response);
+    rep->on_query_last_checkpoint(request.checksum, response);
 }
 
 // ThreadPool: THREAD_POOL_DEFAULT

--- a/src/replica/replica_stub.cpp
+++ b/src/replica/replica_stub.cpp
@@ -1211,11 +1211,11 @@ void replica_stub::on_query_last_checkpoint(query_last_checkpoint_info_rpc rpc)
     learn_response &response = rpc.response();
 
     replica_ptr rep = get_replica(request.pid);
-    if (rep != nullptr) {
-        rep->on_query_last_checkpoint(response);
-    } else {
+    if (dsn_unlikely(rep == nullptr)) {
         response.err = ERR_OBJECT_NOT_FOUND;
-    }
+    } 
+
+        rep->on_query_last_checkpoint(request.checksum, response);
 }
 
 // ThreadPool: THREAD_POOL_DEFAULT

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -494,6 +494,7 @@ private:
     friend class replica_disk_test_base;
     friend class replica_disk_migrate_test;
     friend class replica_stub_test_base;
+    friend class pegasus::server::pegasus_server_test_base;
     friend class open_replica_test;
     friend class replica_follower;
     friend class replica_follower_test;

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -71,6 +71,12 @@
 #include "utils/metrics.h"
 #include "utils/zlocks.h"
 
+namespace pegasus::server {
+
+class pegasus_server_test_base;
+
+} // namespace pegasus::server
+
 namespace dsn::utils {
 
 class ex_lock;

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <fmt/core.h>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -38,9 +37,7 @@
 #include "common/replication_common.h"
 #include "common/replication_enums.h"
 #include "common/replication_other_types.h"
-#include "consensus_types.h"
 #include "dsn.layer2_types.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "http/http_server.h"
 #include "http/http_status_code.h"
@@ -69,7 +66,6 @@
 #include "utils/string_conv.h"
 #include "utils/synchronize.h"
 #include "utils/test_macros.h"
-#include "utils_types.h"
 
 DSN_DECLARE_bool(fd_disabled);
 DSN_DECLARE_string(cold_backup_root);

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -527,13 +527,13 @@ TEST_P(replica_test, test_query_last_checkpoint_info)
 
     learn_response resp;
     // last_checkpoint hasn't exist
-    _mock_replica->on_query_last_checkpoint(resp);
+    _mock_replica->on_query_last_checkpoint(utils::checksum_type::CST_NONE,resp);
     ASSERT_EQ(resp.err, ERR_PATH_NOT_FOUND);
 
     // query ok
     _mock_replica->update_last_durable_decree(100);
     _mock_replica->set_last_committed_decree(200);
-    _mock_replica->on_query_last_checkpoint(resp);
+    _mock_replica->on_query_last_checkpoint(utils::checksum_type::CST_NONE,resp);
     ASSERT_EQ(resp.last_committed_decree, 200);
     ASSERT_STR_CONTAINS(resp.base_local_dir, "/data/checkpoint.100");
 }

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -527,13 +527,13 @@ TEST_P(replica_test, test_query_last_checkpoint_info)
 
     learn_response resp;
     // last_checkpoint hasn't exist
-    _mock_replica->on_query_last_checkpoint(utils::checksum_type::CST_NONE,resp);
+    _mock_replica->on_query_last_checkpoint(utils::checksum_type::CST_NONE, resp);
     ASSERT_EQ(resp.err, ERR_PATH_NOT_FOUND);
 
     // query ok
     _mock_replica->update_last_durable_decree(100);
     _mock_replica->set_last_committed_decree(200);
-    _mock_replica->on_query_last_checkpoint(utils::checksum_type::CST_NONE,resp);
+    _mock_replica->on_query_last_checkpoint(utils::checksum_type::CST_NONE, resp);
     ASSERT_EQ(resp.last_committed_decree, 200);
     ASSERT_STR_CONTAINS(resp.base_local_dir, "/data/checkpoint.100");
 }

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -15,9 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <stddef.h>
-#include <stdint.h>
+#include <fmt/core.h>
 #include <atomic>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -514,29 +515,6 @@ TEST_P(replica_test, test_trigger_manual_emergency_checkpoint)
     test_trigger_manual_emergency_checkpoint(
         101, ERR_TRY_AGAIN, [this]() { ASSERT_FALSE(is_checkpointing()); });
     _mock_replica->tracker()->wait_outstanding_tasks();
-}
-
-TEST_P(replica_test, test_query_last_checkpoint_info)
-{
-    // test no exist gpid
-    auto req = std::make_unique<learn_request>();
-    req->pid = gpid(100, 100);
-    query_last_checkpoint_info_rpc rpc =
-        query_last_checkpoint_info_rpc(std::move(req), RPC_QUERY_LAST_CHECKPOINT_INFO);
-    stub->on_query_last_checkpoint(rpc);
-    ASSERT_EQ(rpc.response().err, ERR_OBJECT_NOT_FOUND);
-
-    learn_response resp;
-    // last_checkpoint hasn't exist
-    _mock_replica->on_query_last_checkpoint(utils::checksum_type::CST_NONE, resp);
-    ASSERT_EQ(resp.err, ERR_PATH_NOT_FOUND);
-
-    // query ok
-    _mock_replica->update_last_durable_decree(100);
-    _mock_replica->set_last_committed_decree(200);
-    _mock_replica->on_query_last_checkpoint(utils::checksum_type::CST_NONE, resp);
-    ASSERT_EQ(resp.last_committed_decree, 200);
-    ASSERT_STR_CONTAINS(resp.base_local_dir, "/data/checkpoint.100");
 }
 
 TEST_P(replica_test, test_clear_on_failure)

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -68,6 +68,7 @@
 #include "utils/string_conv.h"
 #include "utils/synchronize.h"
 #include "utils/test_macros.h"
+#include "utils_types.h"
 
 DSN_DECLARE_bool(fd_disabled);
 DSN_DECLARE_string(cold_backup_root);

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2232,13 +2232,14 @@ private:
 {
     CHECK(_is_open, "");
 
-    int64_t ci = last_durable_decree();
+    const int64_t ci = last_durable_decree();
     if (ci == 0) {
         LOG_ERROR_PREFIX("no checkpoint found");
         return ::dsn::ERR_OBJECT_NOT_FOUND;
     }
 
-    auto chkpt_dir = ::dsn::utils::filesystem::path_combine(data_dir(), chkpt_get_dir_name(ci));
+    const auto chkpt_dir =
+        ::dsn::utils::filesystem::path_combine(data_dir(), chkpt_get_dir_name(ci));
     state.files.clear();
     if (!::dsn::utils::filesystem::get_subfiles(chkpt_dir, state.files, true)) {
         LOG_ERROR_PREFIX("list files in checkpoint dir {} failed", chkpt_dir);

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -479,7 +479,6 @@ private:
     void
     log_expired_data(const char *op, const dsn::rpc_address &addr, const rocksdb::Slice &key) const;
 
-private:
     static const std::chrono::seconds kServerStatUpdateTimeSec;
     static const std::string COMPRESSION_HEADER;
 

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -249,6 +249,7 @@ public:
 private:
     friend class manual_compact_service_test;
     friend class pegasus_compression_options_test;
+    friend class pegasus_server_test_base;
     friend class pegasus_server_impl_test;
     friend class hotkey_collector_test;
     FRIEND_TEST(pegasus_server_impl_test, default_data_version);

--- a/src/server/test/CMakeLists.txt
+++ b/src/server/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(MY_PROJ_LIBS
         dsn.failure_detector
         dsn.replication.zookeeper_provider
         dsn_utils
+        test_utils
         rocksdb
         lz4
         zstd

--- a/src/server/test/capacity_unit_calculator_test.cpp
+++ b/src/server/test/capacity_unit_calculator_test.cpp
@@ -104,7 +104,7 @@ protected:
 public:
     dsn::blob key, hash_key;
 
-    capacity_unit_calculator_test() : pegasus_server_test_base()
+    capacity_unit_calculator_test()
     {
         _cal = std::make_unique<mock_capacity_unit_calculator>(_server);
         pegasus_generate_key(key, dsn::blob::create_from_bytes("h"), dsn::blob());

--- a/src/server/test/capacity_unit_calculator_test.cpp
+++ b/src/server/test/capacity_unit_calculator_test.cpp
@@ -106,7 +106,7 @@ public:
 
     capacity_unit_calculator_test() : pegasus_server_test_base()
     {
-        _cal = std::make_unique<mock_capacity_unit_calculator>(_server.get());
+        _cal = std::make_unique<mock_capacity_unit_calculator>(_server);
         pegasus_generate_key(key, dsn::blob::create_from_bytes("h"), dsn::blob());
         hash_key = dsn::blob::create_from_bytes("key");
     }

--- a/src/server/test/hotkey_collector_test.cpp
+++ b/src/server/test/hotkey_collector_test.cpp
@@ -107,7 +107,7 @@ TEST(hotkey_collector_public_func_test, find_outlier_index_test)
 class coarse_collector_test : public pegasus_server_test_base
 {
 public:
-    coarse_collector_test() : coarse_collector(_server.get(), FLAGS_hotkey_buckets_num){};
+    coarse_collector_test() : coarse_collector(_server, FLAGS_hotkey_buckets_num){};
 
     hotkey_coarse_data_collector coarse_collector;
 
@@ -164,7 +164,7 @@ public:
     int max_queue_size = 1000;
     int target_bucket_index = 0;
     hotkey_fine_data_collector fine_collector;
-    fine_collector_test() : fine_collector(_server.get(), 1, max_queue_size)
+    fine_collector_test() : fine_collector(_server, 1, max_queue_size)
     {
         fine_collector.change_target_bucket(0);
     };

--- a/src/server/test/manual_compact_service_test.cpp
+++ b/src/server/test/manual_compact_service_test.cpp
@@ -48,7 +48,7 @@ public:
     manual_compact_service_test()
     {
         start();
-        manual_compact_svc = std::make_unique<pegasus_manual_compact_service>(_server.get());
+        manual_compact_svc = std::make_unique<pegasus_manual_compact_service>(_server);
     }
 
     void set_compact_time(int64_t ts)

--- a/src/server/test/manual_compact_service_test.cpp
+++ b/src/server/test/manual_compact_service_test.cpp
@@ -51,13 +51,13 @@ public:
         manual_compact_svc = std::make_unique<pegasus_manual_compact_service>(_server);
     }
 
-    void set_compact_time(int64_t ts)
+    void set_compact_time(int64_t ts) const
     {
         manual_compact_svc->_manual_compact_last_finish_time_ms.store(
             static_cast<uint64_t>(ts * 1000));
     }
 
-    void set_mock_now(uint64_t mock_now_sec)
+    void set_mock_now(uint64_t mock_now_sec) const
     {
         manual_compact_svc->_mock_now_timestamp = mock_now_sec * 1000;
     }

--- a/src/server/test/pegasus_compression_options_test.cpp
+++ b/src/server/test/pegasus_compression_options_test.cpp
@@ -21,7 +21,6 @@
 #include <rocksdb/db.h>
 #include <rocksdb/options.h>
 #include <map>
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -193,8 +193,7 @@ protected:
                 std::shared_ptr<local_test_file> local_file;
                 NO_FATALS(local_test_file::create(
                     file_path, std::string(expected_file_sizes[i], 'a'), local_file));
-                ASSERT_TRUE(
-                    local_files.emplace(std::move(file_path), std::move(local_file)).second);
+                ASSERT_TRUE(local_files.emplace(file_path, local_file).second);
             }
         }
 

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include <map>
 #include <memory>
 #include <set>
@@ -244,12 +245,7 @@ protected:
             resp.state.file_checksums, resp.state.files, expected_file_checksums);
     }
 
-    void test_query_last_checkpoint(const dsn::gpid &pid, const dsn::error_code &expected_err)
-    {
-        test_query_last_checkpoint(
-            true, pid, dsn::utils::checksum_type::CST_INVALID, expected_err, 0, 0, {}, {}, {});
-    }
-
+    // Only test for failed cases.
     void test_query_last_checkpoint(bool create_checkpoint_dir,
                                     const dsn::gpid &pid,
                                     const dsn::error_code &expected_err)
@@ -265,6 +261,14 @@ protected:
                                    {});
     }
 
+    // Only test for failed cases.
+    void test_query_last_checkpoint(const dsn::gpid &pid, const dsn::error_code &expected_err)
+    {
+        test_query_last_checkpoint(
+            true, pid, expected_err);
+    }
+
+    // Test for each checksum type.
     void test_query_last_checkpoint_for_all_checksum_types(
         dsn::replication::decree expected_last_committed_decree,
         dsn::replication::decree expected_last_durable_decree,
@@ -296,6 +300,7 @@ private:
         ASSERT_EQ(expected_file_names, ordered_file_names);
     }
 
+    // Sort `file_properties` so that its order is consistent with that of `file_names`.
     template <typename TFileProperty>
     static std::vector<TFileProperty>
     sort_checkpoint_file_properties(const std::vector<TFileProperty> &file_properties,
@@ -451,14 +456,14 @@ TEST_P(pegasus_server_impl_test, test_load_from_duplication_data)
     dsn::utils::filesystem::remove_file_name(new_file);
 }
 
-// Failed to get last checkpoint since the replica does not exist.
+// Fail to get last checkpoint since the replica does not exist.
 TEST_P(pegasus_server_impl_test, test_query_last_checkpoint_with_replica_not_found)
 {
     // To make sure the replica does not exist, give a gpid that does not exist.
     test_query_last_checkpoint(dsn::gpid(101, 101), dsn::ERR_OBJECT_NOT_FOUND);
 }
 
-// Failed to get last checkpoint since it does not exist.
+// Fail to get last checkpoint since it does not exist.
 TEST_P(pegasus_server_impl_test, test_query_last_checkpoint_with_last_checkpoint_not_exist)
 {
     // To make sure the last checkpoint does not exist, set last_durable_decree zero.
@@ -468,7 +473,7 @@ TEST_P(pegasus_server_impl_test, test_query_last_checkpoint_with_last_checkpoint
     test_query_last_checkpoint(_gpid, dsn::ERR_PATH_NOT_FOUND);
 }
 
-// Failed to get last checkpoint since its dir does not exist.
+// Fail to get last checkpoint since its dir does not exist.
 TEST_P(pegasus_server_impl_test, test_query_last_checkpoint_with_last_checkpoint_dir_not_exist)
 {
     ASSERT_EQ(dsn::ERR_OK, start());

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -264,8 +264,7 @@ protected:
     // Only test for failed cases.
     void test_query_last_checkpoint(const dsn::gpid &pid, const dsn::error_code &expected_err)
     {
-        test_query_last_checkpoint(
-            true, pid, expected_err);
+        test_query_last_checkpoint(true, pid, expected_err);
     }
 
     // Test for each checksum type.

--- a/src/server/test/pegasus_server_test_base.h
+++ b/src/server/test/pegasus_server_test_base.h
@@ -24,10 +24,11 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include "common/fs_manager.h"
-#include "utils/flags.h"
 #include "replica/replica_stub.h"
 #include "test_util/test_util.h"
+#include "utils/casts.h"
 #include "utils/filesystem.h"
+#include "utils/flags.h"
 
 DSN_DECLARE_bool(encrypt_data_at_rest);
 
@@ -50,7 +51,7 @@ public:
     {
         // Remove rdb to prevent rocksdb recovery from last test.
         dsn::utils::filesystem::remove_path("./test_dir");
-        _replica_stub = new dsn::replication::replica_stub();
+        _replica_stub = std::make_unique<dsn::replication::replica_stub>();
         _replica_stub->get_fs_manager()->initialize({"test_dir"}, {"test_tag"});
 
         // Use different gpid for encryption and non-encryption test to avoid reopening a rocksdb
@@ -64,16 +65,26 @@ public:
         dsn::app_info app_info;
         app_info.app_type = "pegasus";
 
+        initialize_replica(app_info);
+
+        CHECK(dsn::utils::filesystem::create_directory(_server->data_dir()),
+              "create data dir {} failed",
+              _server->data_dir());
+    }
+
+    void initialize_replica(const dsn::app_info &app_info)
+    {
+        _replica.reset();
+
         auto *dn = _replica_stub->get_fs_manager()->find_best_dir_for_new_replica(_gpid);
         CHECK_NOTNULL(dn, "");
-        _replica = new dsn::replication::replica(_replica_stub, _gpid, app_info, dn, false, false);
-        const auto dir_data = dsn::utils::filesystem::path_combine(
-            _replica->dir(), dsn::replication::replication_app_base::kDataDir);
-        CHECK(dsn::utils::filesystem::create_directory(dir_data),
-              "create data dir {} failed",
-              dir_data);
 
-        _server = std::make_unique<mock_pegasus_server_impl>(_replica);
+        _replica =
+            new dsn::replication::replica(_replica_stub.get(), _gpid, app_info, dn, false, false);
+        _replica_stub->_replicas[_gpid] = _replica;
+
+        _replica->create_app_for_test<mock_pegasus_server_impl>(_replica.get());
+        _server = dsn::down_cast<mock_pegasus_server_impl *>(_replica->_app.get());
     }
 
     dsn::error_code start(const std::map<std::string, std::string> &envs = {})
@@ -91,20 +102,27 @@ public:
         return _server->start(idx, argv);
     }
 
+    void set_last_committed_decree(dsn::replication::decree d)
+    {
+        _replica->_prepare_list->reset(d);
+    }
+
+    void set_last_durable_decree(dsn::replication::decree d)
+    {
+        _server->set_last_durable_decree(d);
+    }
+
     ~pegasus_server_test_base() override
     {
         // do not clear state
         _server->stop(false);
-
-        delete _replica_stub;
-        delete _replica;
     }
 
 protected:
-    std::unique_ptr<mock_pegasus_server_impl> _server;
-    dsn::replication::replica *_replica = nullptr;
-    dsn::replication::replica_stub *_replica_stub = nullptr;
+    std::unique_ptr<dsn::replication::replica_stub> _replica_stub;
     dsn::gpid _gpid;
+    dsn::replication::replica_ptr _replica;
+    mock_pegasus_server_impl *_server;
 };
 
 } // namespace server

--- a/src/server/test/pegasus_server_test_base.h
+++ b/src/server/test/pegasus_server_test_base.h
@@ -87,7 +87,7 @@ public:
         _server = dsn::down_cast<mock_pegasus_server_impl *>(_replica->_app.get());
     }
 
-    dsn::error_code start(const std::map<std::string, std::string> &envs = {})
+    dsn::error_code start(const std::map<std::string, std::string> &envs)
     {
         std::unique_ptr<char *[]> argvs = std::make_unique<char *[]>(1 + envs.size() * 2);
         char **argv = argvs.get();
@@ -101,6 +101,8 @@ public:
         }
         return _server->start(idx, argv);
     }
+
+    dsn::error_code start() { return start({}); }
 
     void set_last_committed_decree(dsn::replication::decree d)
     {

--- a/src/server/test/pegasus_server_write_test.cpp
+++ b/src/server/test/pegasus_server_write_test.cpp
@@ -55,7 +55,7 @@ public:
     pegasus_server_write_test() : pegasus_server_test_base()
     {
         start();
-        _server_write = std::make_unique<pegasus_server_write>(_server.get());
+        _server_write = std::make_unique<pegasus_server_write>(_server);
     }
 
     void test_batch_writes()

--- a/src/server/test/pegasus_server_write_test.cpp
+++ b/src/server/test/pegasus_server_write_test.cpp
@@ -52,7 +52,7 @@ class pegasus_server_write_test : public pegasus_server_test_base
     std::unique_ptr<pegasus_server_write> _server_write;
 
 public:
-    pegasus_server_write_test() : pegasus_server_test_base()
+    pegasus_server_write_test()
     {
         start();
         _server_write = std::make_unique<pegasus_server_write>(_server);

--- a/src/server/test/pegasus_write_service_impl_test.cpp
+++ b/src/server/test/pegasus_write_service_impl_test.cpp
@@ -62,7 +62,7 @@ protected:
     void SetUp() override
     {
         ASSERT_EQ(dsn::ERR_OK, start());
-        _server_write = std::make_unique<pegasus_server_write>(_server.get());
+        _server_write = std::make_unique<pegasus_server_write>(_server);
         _write_impl = _server_write->_write_svc->_impl.get();
         _rocksdb_wrapper = _write_impl->_rocksdb_wrapper.get();
     }

--- a/src/server/test/pegasus_write_service_test.cpp
+++ b/src/server/test/pegasus_write_service_test.cpp
@@ -59,7 +59,7 @@ public:
     void SetUp() override
     {
         start();
-        _server_write = std::make_unique<pegasus_server_write>(_server.get());
+        _server_write = std::make_unique<pegasus_server_write>(_server);
         _write_svc = _server_write->_write_svc.get();
     }
 

--- a/src/server/test/rocksdb_wrapper_test.cpp
+++ b/src/server/test/rocksdb_wrapper_test.cpp
@@ -18,7 +18,8 @@
  */
 
 #include <fmt/core.h>
-#include <stdint.h>
+#include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -37,8 +38,8 @@
 #include "utils/blob.h"
 #include "utils/error_code.h"
 
-namespace pegasus {
-namespace server {
+namespace pegasus::server {
+
 class rocksdb_wrapper_test : public pegasus_server_test_base
 {
 protected:
@@ -224,5 +225,5 @@ TEST_P(rocksdb_wrapper_test, verify_timetag_compatible_with_version_0)
         _rocksdb_wrapper->_pegasus_data_version, std::move(get_ctx.raw_value), user_value);
     ASSERT_EQ(user_value.to_string(), value);
 }
-} // namespace server
-} // namespace pegasus
+
+} // namespace pegasus::server

--- a/src/server/test/rocksdb_wrapper_test.cpp
+++ b/src/server/test/rocksdb_wrapper_test.cpp
@@ -56,7 +56,7 @@ public:
     void SetUp() override
     {
         ASSERT_EQ(::dsn::ERR_OK, start());
-        _server_write = std::make_unique<pegasus_server_write>(_server.get());
+        _server_write = std::make_unique<pegasus_server_write>(_server);
         _rocksdb_wrapper = _server_write->_write_svc->_impl->_rocksdb_wrapper.get();
 
         pegasus::pegasus_generate_key(
@@ -79,16 +79,12 @@ public:
     void set_app_duplicating()
     {
         _server->stop(false);
-        delete _replica;
 
         dsn::app_info app_info;
         app_info.app_type = "pegasus";
         app_info.duplicating = true;
 
-        auto *dn = _replica_stub->get_fs_manager()->find_best_dir_for_new_replica(_gpid);
-        CHECK_NOTNULL(dn, "");
-        _replica = new dsn::replication::replica(_replica_stub, _gpid, app_info, dn, false, false);
-        _server = std::make_unique<mock_pegasus_server_impl>(_replica);
+        initialize_replica(app_info);
 
         SetUp();
     }

--- a/src/server/test/rocksdb_wrapper_test.cpp
+++ b/src/server/test/rocksdb_wrapper_test.cpp
@@ -21,25 +21,21 @@
 #include <stdint.h>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
-#include "common/fs_manager.h"
 #include "dsn.layer2_types.h"
 #include "gtest/gtest.h"
 #include "pegasus_key_schema.h"
 #include "pegasus_server_test_base.h"
 #include "pegasus_utils.h"
 #include "pegasus_value_schema.h"
-#include "replica/replica.h"
-#include "replica/replica_stub.h"
 #include "server/pegasus_server_write.h"
 #include "server/pegasus_write_service.h"
 #include "server/pegasus_write_service_impl.h"
 #include "server/rocksdb_wrapper.h"
 #include "utils/blob.h"
 #include "utils/error_code.h"
-#include "utils/fmt_logging.h"
-#include <string_view>
 
 namespace pegasus {
 namespace server {

--- a/src/test_util/test_util.cpp
+++ b/src/test_util/test_util.cpp
@@ -20,7 +20,6 @@
 #include <gtest/gtest-spi.h>
 #include <chrono>
 #include <thread>
-#include <utility>
 
 #include "gtest/gtest.h"
 #include "rocksdb/env.h"
@@ -52,7 +51,7 @@ void local_test_file::create(const std::string &path,
         dsn::utils::filesystem::file_size(path, dsn::utils::FileDataType::kSensitive, meta.size));
     ASSERT_EQ(dsn::ERR_OK, dsn::utils::filesystem::md5sum(path, meta.md5));
 
-    file = std::shared_ptr<local_test_file>(new local_test_file(std::move(meta)), deleter);
+    file = std::shared_ptr<local_test_file>(new local_test_file(meta), deleter);
 }
 
 void local_test_file::create(const std::string &path, std::shared_ptr<local_test_file> &file)
@@ -60,9 +59,7 @@ void local_test_file::create(const std::string &path, std::shared_ptr<local_test
     return create(path, "write some data.", file);
 }
 
-local_test_file::local_test_file(dsn::replication::file_meta &&meta) : _file_meta(std::move(meta))
-{
-}
+local_test_file::local_test_file(const dsn::replication::file_meta &meta) : _file_meta(meta) {}
 
 local_test_file::~local_test_file()
 {

--- a/src/test_util/test_util.cpp
+++ b/src/test_util/test_util.cpp
@@ -50,6 +50,16 @@ void create_local_test_file(const std::string &full_name, dsn::replication::file
         full_name, dsn::utils::FileDataType::kSensitive, fm->size));
 }
 
+void generate_test_file(const std::string &file_path, int64_t file_size)
+{
+    const auto status =
+        rocksdb::WriteStringToFile(dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive),
+                                   rocksdb::Slice(std::string(file_size, 'a')),
+                                   file_path,
+                                   /* should_sync */ true);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+}
+
 void AssertEventually(const std::function<void(void)> &f, int timeout_sec, WaitBackoff backoff)
 {
     // TODO(yingchun): should use mono time

--- a/src/test_util/test_util.h
+++ b/src/test_util/test_util.h
@@ -93,6 +93,8 @@ private:
 
 void create_local_test_file(const std::string &full_name, dsn::replication::file_meta *fm);
 
+// Generate a file under `file_path` with size `file_size`. The file is filled with
+// `file_size` 'a's.
 void generate_test_file(const std::string &file_path, int64_t file_size);
 
 #define ASSERT_EVENTUALLY(expr)                                                                    \

--- a/src/test_util/test_util.h
+++ b/src/test_util/test_util.h
@@ -30,12 +30,13 @@
 
 #include "metadata_types.h"
 #include "runtime/api_layer1.h"
-#include "utils/env.h"
 // IWYU refused to include "utils/defer.h" everywhere, both in .h and .cpp files.
 // However, once "utils/defer.h" is not included, it is inevitable that compilation
 // will fail since dsn::defer is referenced. Thus force IWYU to keep it.
 #include "utils/defer.h" // IWYU pragma: keep
+#include "utils/env.h"
 #include "utils/flags.h"
+#include "utils/ports.h"
 #include "utils/test_macros.h"
 
 DSN_DECLARE_bool(encrypt_data_at_rest);
@@ -100,10 +101,10 @@ public:
     // Generate a file whose content is arbitrary.
     static void create(const std::string &path, std::shared_ptr<local_test_file> &file);
 
-    const dsn::replication::file_meta &get_file_meta() const { return _file_meta; }
+    [[nodiscard]] const dsn::replication::file_meta &get_file_meta() const { return _file_meta; }
 
 private:
-    local_test_file(dsn::replication::file_meta &&meta);
+    explicit local_test_file(const dsn::replication::file_meta &meta);
     ~local_test_file();
 
     static void deleter(local_test_file *ptr) { delete ptr; }

--- a/src/test_util/test_util.h
+++ b/src/test_util/test_util.h
@@ -46,7 +46,8 @@ class file_meta;
 
 #define PRESERVE_VAR(name, expr)                                                                   \
     const auto PRESERVED_##name = expr;                                                            \
-    auto PRESERVED_##name##_cleanup = dsn::defer([PRESERVED_##name]() { expr = PRESERVED_##name; })
+    const auto PRESERVED_##name##_cleanup =                                                        \
+        dsn::defer([PRESERVED_##name]() { expr = PRESERVED_##name; })
 
 // Save the current value of a flag and restore it at the end of the function.
 #define PRESERVE_FLAG(name) PRESERVE_VAR(FLAGS_##name, FLAGS_##name)

--- a/src/test_util/test_util.h
+++ b/src/test_util/test_util.h
@@ -93,6 +93,8 @@ private:
 
 void create_local_test_file(const std::string &full_name, dsn::replication::file_meta *fm);
 
+void generate_test_file(const std::string &file_path, int64_t file_size);
+
 #define ASSERT_EVENTUALLY(expr)                                                                    \
     do {                                                                                           \
         AssertEventually(expr);                                                                    \

--- a/src/utils/checksum.cpp
+++ b/src/utils/checksum.cpp
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "utils/checksum.h"
+
+#include "utils/error_code.h"
+#include "utils/filesystem.h"
+#include "utils/ports.h"
+
+namespace dsn {
+
+error_s calc_checksum(const std::string &file_path, utils::checksum_type::type type, std::string &result)
+{
+    switch (type) {
+        case utils::checksum_type::CST_MD5:
+        const auto err = utils::filesystem::md5sum(file_path, result);
+        if (dsn_unlikely(err != ERR_OK)) {
+            return FMT_ERR(err, "md5sum failed: err={}", err);
+        }
+
+        break;
+
+        case utils::checksum_type::CST_NONE:
+        break;
+
+    default:
+        return FMT_ERR(ERR_NOT_IMPLEMENTED,
+                       "checksum_type is not supported: val={}, str={}",
+                       static_cast<int>(type),
+                       enum_to_string(type));
+    }
+
+    return error_s::ok();
+}
+
+} // namespace dsn
+

--- a/src/utils/checksum.cpp
+++ b/src/utils/checksum.cpp
@@ -30,7 +30,7 @@ calc_checksum(const std::string &file_path, utils::checksum_type::type type, std
     case utils::checksum_type::CST_MD5: {
         const auto err = utils::filesystem::md5sum(file_path, result);
         if (dsn_unlikely(err != ERR_OK)) {
-            return FMT_ERR(err, "md5sum failed: err={}", err);
+            return FMT_ERR(err, "md5sum failed: err = {}", err);
         }
 
     } break;
@@ -40,7 +40,7 @@ calc_checksum(const std::string &file_path, utils::checksum_type::type type, std
 
     default:
         return FMT_ERR(ERR_NOT_IMPLEMENTED,
-                       "checksum_type is not supported: val={}, str={}",
+                       "checksum_type is not supported: val = {}, str = {}",
                        static_cast<int>(type),
                        enum_to_string(type));
     }

--- a/src/utils/checksum.cpp
+++ b/src/utils/checksum.cpp
@@ -23,18 +23,19 @@
 
 namespace dsn {
 
-error_s calc_checksum(const std::string &file_path, utils::checksum_type::type type, std::string &result)
+error_s
+calc_checksum(const std::string &file_path, utils::checksum_type::type type, std::string &result)
 {
     switch (type) {
-        case utils::checksum_type::CST_MD5:
+    case utils::checksum_type::CST_MD5: {
         const auto err = utils::filesystem::md5sum(file_path, result);
         if (dsn_unlikely(err != ERR_OK)) {
             return FMT_ERR(err, "md5sum failed: err={}", err);
         }
 
-        break;
+    } break;
 
-        case utils::checksum_type::CST_NONE:
+    case utils::checksum_type::CST_NONE:
         break;
 
     default:
@@ -48,4 +49,3 @@ error_s calc_checksum(const std::string &file_path, utils::checksum_type::type t
 }
 
 } // namespace dsn
-

--- a/src/utils/checksum.h
+++ b/src/utils/checksum.h
@@ -31,6 +31,15 @@ ENUM_REG_WITH_CUSTOM_NAME(utils::checksum_type::CST_NONE, none)
 ENUM_REG_WITH_CUSTOM_NAME(utils::checksum_type::CST_MD5, md5)
 ENUM_END2(utils::checksum_type::type, checksum_type)
 
+// Calculate the checksum for a file.
+//
+// Parameters:
+// - `file_path`: the path of the file.
+// - `type`: decides which algorithm is used to calculate the checksum for the file.
+// CST_NONE means do not calculate the checksum.
+// - `result`: the output parameter that holds the resulting checksum.
+//
+// Return ok if succeed in calculating, otherwise return corresponding error.
 error_s
 calc_checksum(const std::string &file_path, utils::checksum_type::type type, std::string &result);
 

--- a/src/utils/checksum.h
+++ b/src/utils/checksum.h
@@ -25,13 +25,13 @@
 
 namespace dsn {
 
-ENUM_BEGIN2(checksum_type::type, checksum_type, checksum_type::CST_INVALID)
-ENUM_REG_WITH_CUSTOM_NAME(checksum_type::CST_INVALID, invalid)
-ENUM_REG_WITH_CUSTOM_NAME(checksum_type::CST_NONE, all)
-ENUM_REG_WITH_CUSTOM_NAME(checksum_type::CST_MD5, exact)
-ENUM_END2(checksum_type::type, checksum_type)
+ENUM_BEGIN2(utils::checksum_type::type, checksum_type, utils::checksum_type::CST_INVALID)
+ENUM_REG_WITH_CUSTOM_NAME(utils::checksum_type::CST_INVALID, invalid)
+ENUM_REG_WITH_CUSTOM_NAME(utils::checksum_type::CST_NONE, none)
+ENUM_REG_WITH_CUSTOM_NAME(utils::checksum_type::CST_MD5, md5)
+ENUM_END2(utils::checksum_type::type, checksum_type)
 
-error_s calc_checksum(const std::string &file_path, utils::checksum_type::type type, std::string &result);
+error_s
+calc_checksum(const std::string &file_path, utils::checksum_type::type type, std::string &result);
 
 } // namespace dsn
-

--- a/src/utils/checksum.h
+++ b/src/utils/checksum.h
@@ -15,41 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-namespace cpp dsn.utils
-namespace go utils
-namespace java org.apache.pegasus.utils
+#pragma once
 
-// How a string matches to a given pattern.
-enum pattern_match_type
-{
-    PMT_INVALID = 0,
+#include <string>
 
-    // The string always matches no matter what the given pattern is.
-    PMT_MATCH_ALL,
+#include "utils_types.h"
+#include "utils/enum_helper.h"
+#include "utils/errors.h"
 
-    // The string must exactly equal to the given pattern.
-    PMT_MATCH_EXACT,
+namespace dsn {
 
-    // The string must appear anywhere in the given pattern.
-    PMT_MATCH_ANYWHERE,
+ENUM_BEGIN2(checksum_type::type, checksum_type, checksum_type::CST_INVALID)
+ENUM_REG_WITH_CUSTOM_NAME(checksum_type::CST_INVALID, invalid)
+ENUM_REG_WITH_CUSTOM_NAME(checksum_type::CST_NONE, all)
+ENUM_REG_WITH_CUSTOM_NAME(checksum_type::CST_MD5, exact)
+ENUM_END2(checksum_type::type, checksum_type)
 
-    // The string must start with the given pattern.
-    PMT_MATCH_PREFIX,
+error_s calc_checksum(const std::string &file_path, utils::checksum_type::type type, std::string &result);
 
-    // The string must end with the given pattern.
-    PMT_MATCH_POSTFIX,
+} // namespace dsn
 
-    // The string must match the given pattern as a regular expression.
-    PMT_MATCH_REGEX,
-}
-
-enum checksum_type
-{
-    CST_INVALID = 0,
-
-    // 
-    CST_NONE,
-
-    // 
-    CST_MD5,
-}

--- a/src/utils/test/CMakeLists.txt
+++ b/src/utils/test/CMakeLists.txt
@@ -30,11 +30,12 @@ set(MY_PROJ_NAME dsn_utils_tests)
 set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS
+        test_utils
+        dsn_replication_common
         dsn_http
         dsn_runtime
         dsn_utils
         gtest
-        test_utils
         rocksdb
         lz4
         zstd

--- a/src/utils/test/checksum_test.cpp
+++ b/src/utils/test/checksum_test.cpp
@@ -18,17 +18,19 @@
 #include "utils/checksum.h"
 
 #include <cstdint>
+#include <memory>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 #include "gtest/gtest.h"
 #include "test_util/test_util.h"
-#include "utils/defer.h"
 #include "utils/env.h"
 #include "utils/error_code.h"
 #include "utils/errors.h"
 #include "utils/filesystem.h"
 #include "utils/flags.h"
+#include "utils/test_macros.h"
 #include "utils_types.h"
 
 DSN_DECLARE_bool(encrypt_data_at_rest);

--- a/src/utils/test/checksum_test.cpp
+++ b/src/utils/test/checksum_test.cpp
@@ -23,6 +23,7 @@
 #include "gtest/gtest.h"
 #include "test_util/test_util.h"
 #include "utils/defer.h"
+#include "utils/env.h"
 #include "utils/error_code.h"
 #include "utils/errors.h"
 #include "utils/filesystem.h"

--- a/src/utils/test/checksum_test.cpp
+++ b/src/utils/test/checksum_test.cpp
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "utils/checksum.h"
+
+#include <rocksdb/env.h>
+#include <rocksdb/slice.h>
+#include <rocksdb/status.h>
+
+#include "gtest/gtest.h"
+#include "test_util/test_util.h"
+#include "utils_types.h"
+#include "utils/env.h"
+#include "utils/errors.h"
+#include "utils/defer.h"
+#include "utils/filesystem.h"
+
+DSN_DECLARE_bool(encrypt_data_at_rest);
+
+namespace dsn {
+
+namespace {
+
+void generate_test_file(const std::string &file_path, int64_t file_size)
+{
+    const auto status =
+        rocksdb::WriteStringToFile(utils::PegasusEnv(dsn::utils::FileDataType::kSensitive),
+                                   rocksdb::Slice(std::string(file_size, 'a')),
+                                   file_path,
+                                   /* should_sync */ true);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+}
+
+} // anonymous namespace
+
+struct calc_checksum_case
+{
+    int64_t file_size;
+    utils::checksum_type::type type;
+    error_code expected_err;
+    std::string expected_checksum;
+};
+
+class CalcChecksumTest : public testing::TestWithParam<calc_checksum_case>
+{
+public:
+    void test_calc_md5(bool encrypted) const
+    {
+        static const std::string kFilePath("test_file_for_calc_checksum");
+
+        PRESERVE_FLAG(encrypt_data_at_rest);
+        FLAGS_encrypt_data_at_rest = encrypted;
+
+        const auto &test_case = GetParam();
+
+        generate_test_file(kFilePath, test_case.file_size);
+        const auto cleanup = defer([]() { utils::filesystem::remove_path(kFilePath); });
+
+        int64_t file_size = 0;
+        ASSERT_TRUE(
+            utils::filesystem::file_size(kFilePath, utils::FileDataType::kSensitive, file_size));
+        ASSERT_EQ(test_case.file_size, file_size);
+
+        std::string actual_checksum;
+        const auto actual_status = calc_checksum(kFilePath, test_case.type, actual_checksum);
+        ASSERT_EQ(test_case.expected_err, actual_status.code());
+        if (!actual_status) {
+            return;
+        }
+
+        ASSERT_EQ(test_case.expected_checksum, actual_checksum);
+    }
+};
+
+const std::vector<calc_checksum_case> calc_checksum_tests = {
+    {0, utils::checksum_type::CST_MD5, ERR_OK, "d41d8cd98f00b204e9800998ecf8427e"},
+    {1, utils::checksum_type::CST_MD5, ERR_OK, "0cc175b9c0f1b6a831c399e269772661"},
+    {2, utils::checksum_type::CST_MD5, ERR_OK, "4124bc0a9335c27f086f24ba207a4912"},
+    {4095, utils::checksum_type::CST_MD5, ERR_OK, "559110baa849c7608ee70abe1d76273e"},
+    {4096, utils::checksum_type::CST_MD5, ERR_OK, "21a199c53f422a380e20b162fb6ebe9c"},
+    {4097, utils::checksum_type::CST_MD5, ERR_OK, "8cfc1a0bd8cd76599e76e5e721c6e62e"},
+    {4095, utils::checksum_type::CST_NONE, ERR_OK, ""},
+    {4096, utils::checksum_type::CST_NONE, ERR_OK, ""},
+    {4097, utils::checksum_type::CST_NONE, ERR_OK, ""},
+    {4095, utils::checksum_type::CST_INVALID, ERR_NOT_IMPLEMENTED, ""},
+    {4096, utils::checksum_type::CST_INVALID, ERR_NOT_IMPLEMENTED, ""},
+    {4097, utils::checksum_type::CST_INVALID, ERR_NOT_IMPLEMENTED, ""},
+};
+
+TEST_P(CalcChecksumTest, CalcEncryptedMD5) { test_calc_md5(true); }
+
+TEST_P(CalcChecksumTest, CalcUnencryptedMD5) { test_calc_md5(false); }
+
+INSTANTIATE_TEST_SUITE_P(ChecksumTest, CalcChecksumTest, testing::ValuesIn(calc_checksum_tests));
+
+} // namespace dsn

--- a/src/utils/test/checksum_test.cpp
+++ b/src/utils/test/checksum_test.cpp
@@ -44,7 +44,7 @@ struct calc_checksum_case
 
 class CalcChecksumTest : public testing::TestWithParam<calc_checksum_case>
 {
-public:
+protected:
     static void test_calc_checksum(bool encrypted)
     {
         static const std::string kFilePath("test_file_for_calc_checksum");

--- a/src/utils/test_macros.h
+++ b/src/utils/test_macros.h
@@ -39,3 +39,13 @@
 
 #define ASSERT_STR_NOT_CONTAINS(str, substr)                                                       \
     ASSERT_THAT(str, testing::Not(testing::HasSubstr(substr)))
+
+#define ASSERT_STR_STARTSWITH(str, substr) ASSERT_THAT(str, testing::StartsWith(substr))
+
+#define ASSERT_STR_NOT_STARTSWITH(str, substr)                                                     \
+    ASSERT_THAT(str, testing::Not(testing::StartsWith(substr)))
+
+#define ASSERT_STR_ENDSWITH(str, substr) ASSERT_THAT(str, testing::EndsWith(substr))
+
+#define ASSERT_STR_NOT_ENDSWITH(str, substr)                                                       \
+    ASSERT_THAT(str, testing::Not(testing::EndsWith(substr)))

--- a/src/utils/test_macros.h
+++ b/src/utils/test_macros.h
@@ -34,18 +34,23 @@
         }                                                                                          \
     } while (0)
 
-// Substring matches.
+// Assert that `str` should contain the given `substr`.
 #define ASSERT_STR_CONTAINS(str, substr) ASSERT_THAT(str, testing::HasSubstr(substr))
 
+// Assert that `str` should not contain the given `substr`.
 #define ASSERT_STR_NOT_CONTAINS(str, substr)                                                       \
     ASSERT_THAT(str, testing::Not(testing::HasSubstr(substr)))
 
-#define ASSERT_STR_STARTSWITH(str, substr) ASSERT_THAT(str, testing::StartsWith(substr))
+// Assert that `str` should begin with the given `prefix`.
+#define ASSERT_STR_STARTSWITH(str, prefix) ASSERT_THAT(str, testing::StartsWith(prefix))
 
-#define ASSERT_STR_NOT_STARTSWITH(str, substr)                                                     \
-    ASSERT_THAT(str, testing::Not(testing::StartsWith(substr)))
+// Assert that `str` should not begin with the given `prefix`.
+#define ASSERT_STR_NOT_STARTSWITH(str, prefix)                                                     \
+    ASSERT_THAT(str, testing::Not(testing::StartsWith(prefix)))
 
-#define ASSERT_STR_ENDSWITH(str, substr) ASSERT_THAT(str, testing::EndsWith(substr))
+// Assert that `str` should end with the given `suffix`.
+#define ASSERT_STR_ENDSWITH(str, suffix) ASSERT_THAT(str, testing::EndsWith(suffix))
 
-#define ASSERT_STR_NOT_ENDSWITH(str, substr)                                                       \
-    ASSERT_THAT(str, testing::Not(testing::EndsWith(substr)))
+// Assert that `str` should not end with the given `suffix`.
+#define ASSERT_STR_NOT_ENDSWITH(str, suffix)                                                       \
+    ASSERT_THAT(str, testing::Not(testing::EndsWith(suffix)))


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2242

When a dup follower requests the latest checkpoint information from the dup
master, the server supports returning the size and checksum of each file under
the checkpoint directory. This allows the client to decide which files to fetch:
- if it is the first time downloading the checkpoint, all files need to be downloaded;
- if it is the second time or later, only files that are missing or partially downloaded
locally need to be fetched.

Additionally, the client is allowed to specify the checksum algorithm to use —
currently, only MD5 is supported.
