### PR TITLE
feat(make_idempotent): support making `check_and_set` request idempotent in `pegasus_write_service`

### DIFF
--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -86,7 +86,7 @@ METRIC_DEFINE_percentile_int64(replica,
                                dsn::metric_unit::kNanoSeconds,
                                "The duration that an incr request is made idempotent, "
                                "including reading the current value from storage engine, "
-                               "increasing it by a given amount, and translate the incr"
+                               "increasing it by a given amount, and translate the incr "
                                "request into the single-put request. Only used for the "
                                "primary replicas");
 

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -86,17 +86,17 @@ METRIC_DEFINE_percentile_int64(replica,
                                dsn::metric_unit::kNanoSeconds,
                                "The duration that an incr request is made idempotent, "
                                "including reading the current value from storage engine, "
-                               "increasing it by a given amount, and translate the incr "
+                               "increasing it by a given amount and translating the incr "
                                "request into the single-put request. Only used for the "
                                "primary replicas");
 
 METRIC_DEFINE_percentile_int64(replica,
                                make_check_and_set_idempotent_latency_ns,
                                dsn::metric_unit::kNanoSeconds,
-                               "The duration that an check_and_set request is made "
+                               "The duration that a check_and_set request is made "
                                "idempotent, including reading the check value from "
-                               "storage engine, validate the check conditions, and "
-                               "translate the check_and_set request into the single-put "
+                               "storage engine, validating the check conditions and "
+                               "translating the check_and_set request into the single-put "
                                "request. Only used for the primary replicas");
 
 METRIC_DEFINE_percentile_int64(replica,

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -239,7 +239,7 @@ int pegasus_write_service::make_idempotent(const dsn::apps::incr_request &req,
 {
     METRIC_VAR_AUTO_LATENCY(make_incr_idempotent_latency_ns);
 
-    return err = _impl->make_idempotent(req, err_resp, update);
+    return _impl->make_idempotent(req, err_resp, update);
 }
 
 int pegasus_write_service::put(const db_write_context &ctx,
@@ -280,7 +280,7 @@ int pegasus_write_service::make_idempotent(const dsn::apps::check_and_set_reques
 {
     METRIC_VAR_AUTO_LATENCY(make_check_and_set_idempotent_latency_ns);
 
-    return err = _impl->make_idempotent(req, err_resp, update);
+    return _impl->make_idempotent(req, err_resp, update);
 }
 
 int pegasus_write_service::put(const db_write_context &ctx,
@@ -432,9 +432,8 @@ void pegasus_write_service::batch_finish()
     UPDATE_WRITE_BATCH_METRICS(put);
     UPDATE_WRITE_BATCH_METRICS(remove);
 
-    // Since the duration of translation is unknown for both possible situations where these
-    // put requests are actually translated from atomic requests (see comments in batch_put()),
-    // there's no need to add `_make_incr_idempotent_duration_ns` to the total latency.
+    // These put requests are translated from atomic requests. See comments in batch_put()
+    // for the two possible situations where we are now.
     UPDATE_WRITE_BATCH_METRICS(incr);
     UPDATE_WRITE_BATCH_METRICS(check_and_set);
 

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -151,7 +151,7 @@ public:
     // Write a non-idempotent INCR record.
     int incr(int64_t decree, const dsn::apps::incr_request &update, dsn::apps::incr_response &resp);
 
-    // Translate an CHECK_AND_SET request into an idempotent PUT request. Only called by
+    // Translate a CHECK_AND_SET request into an idempotent PUT request. Only called by
     // primary replicas.
     int make_idempotent(const dsn::apps::check_and_set_request &req,
                         dsn::apps::check_and_set_response &err_resp,

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -155,7 +155,7 @@ public:
     // primary replicas.
     int make_idempotent(const dsn::apps::check_and_set_request &req,
                         dsn::apps::check_and_set_response &err_resp,
-                        std::vector<dsn::apps::update_request> &updates);
+                        dsn::apps::update_request &update);
 
     // Write an idempotent CHECK_AND_SET record (i.e. a PUT record) and reply to the client
     // with CHECK_AND_SET response. Only called by primary replicas.


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2197

Implement higher-level APIs `make_idempotent()` and `put()` on
`pegasus_write_service` for `check_and_set` request. Both of them
will Internally call APIs provided by `pegasus_write_service::impl`.
Two metrics are also introduced to measure the duration that make
`incr` and `check_and_set` idempotent.