### PR TITLE
ci(github): fix Go workflows which failed due to Ubuntu 20.04 retirement

### DIFF
--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -71,5 +71,16 @@ jobs:
           push: true
           tags: |
             apache/pegasus:build-env-${{ matrix.dockertag }}-${{ github.ref_name }}
+      - name: Build and push for Go
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          context: .
+          file: ./docker/pegasus-build-env/ubuntu2204/Dockerfile
+          push: true
+          tags: |
+            apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
+          build-args: |
+            THRIFT_VERSION=0.13.0
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -77,17 +77,12 @@ jobs:
   build_go_compilation_env_docker_images:
     runs-on: ubuntu-latest
     env:
-      # The glibc version on ubuntu1804 is lower than the node20 required, so
-      # we need to force the node version to 16.
-      # See more details: https://github.com/actions/checkout/issues/1809
       ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
       fail-fast: false
     steps:
       - name: Checkout
-        # The glibc version on ubuntu1804 is lower than the actions/checkout@v4 required, so
-        # we need to force to use actions/checkout@v3.
         uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -103,7 +98,7 @@ jobs:
         with:
           platforms: linux/amd64
           context: .
-          file: ./docker/pegasus-build-env/ubuntu2204/Dockerfile
+          file: ./docker/pegasus-build-env/go/Dockerfile
           push: true
           tags: |
             apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go

--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -84,3 +84,41 @@ jobs:
             THRIFT_VERSION=0.13.0
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+
+  build_go_compilation_env_docker_images:
+    runs-on: ubuntu-latest
+    env:
+      # The glibc version on ubuntu1804 is lower than the node20 required, so
+      # we need to force the node version to 16.
+      # See more details: https://github.com/actions/checkout/issues/1809
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        # The glibc version on ubuntu1804 is lower than the actions/checkout@v4 required, so
+        # we need to force to use actions/checkout@v3.
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          context: .
+          file: ./docker/pegasus-build-env/ubuntu2204/Dockerfile
+          push: true
+          tags: |
+            apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
+          build-args: |
+            THRIFT_VERSION=0.13.0
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -102,6 +102,11 @@ jobs:
           push: true
           tags: |
             apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
+          # go-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0
+          # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0,
+          # however ubuntu-20.04 LTS runner has been retired on 2025-04-15. Thus we choose to
+          # build thrift 0.13.0 in a image based on ubuntu-22.04 whose thrift version is 0.16.0
+          # by default.
           build-args: |
             THRIFT_VERSION=0.13.0
       - name: Image digest

--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -71,17 +71,6 @@ jobs:
           push: true
           tags: |
             apache/pegasus:build-env-${{ matrix.dockertag }}-${{ github.ref_name }}
-      - name: Build and push for Go
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64
-          context: .
-          file: ./docker/pegasus-build-env/ubuntu2204/Dockerfile
-          push: true
-          tags: |
-            apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
-          build-args: |
-            THRIFT_VERSION=0.13.0
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 

--- a/.github/workflows/lint_and_test_admin-cli.yml
+++ b/.github/workflows/lint_and_test_admin-cli.yml
@@ -43,11 +43,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
-      - name: golangci-lint
+      - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.56.2
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.18

--- a/.github/workflows/lint_and_test_admin-cli.yml
+++ b/.github/workflows/lint_and_test_admin-cli.yml
@@ -49,7 +49,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.64.8
+          version: v1.56.2
           working-directory: ./admin-cli
 
   build:

--- a/.github/workflows/lint_and_test_admin-cli.yml
+++ b/.github/workflows/lint_and_test_admin-cli.yml
@@ -43,13 +43,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.64.8
           working-directory: ./admin-cli
 
   build:
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - name: Compile

--- a/.github/workflows/lint_and_test_admin-cli.yml
+++ b/.github/workflows/lint_and_test_admin-cli.yml
@@ -41,7 +41,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/lint_and_test_collector.yml
+++ b/.github/workflows/lint_and_test_collector.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - name: Format
@@ -57,7 +57,9 @@ jobs:
   lint:
     name: Lint
     needs: format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,20 +73,22 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.64.8
           working-directory: ./collector
 
   build:
     name: Build
     needs: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - name: Build

--- a/.github/workflows/lint_and_test_collector.yml
+++ b/.github/workflows/lint_and_test_collector.yml
@@ -59,7 +59,7 @@ jobs:
     needs: format
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
+      image: apache/pegasus:build-env-ubuntu2204-${{ github.base_ref }}-go
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
+      image: apache/pegasus:build-env-ubuntu2204-${{ github.base_ref }}-go
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint_and_test_collector.yml
+++ b/.github/workflows/lint_and_test_collector.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.64.8
+          version: v1.56.2
           working-directory: ./collector
 
   build:

--- a/.github/workflows/lint_and_test_collector.yml
+++ b/.github/workflows/lint_and_test_collector.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.18

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Lint Go
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.56.2
+          version: v1.57.0
           working-directory: ./go-client
 
   build_server:

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -76,7 +76,7 @@ jobs:
         run: make build
       # because some files are generated after building, so lint after the build step
       - name: Lint Go
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.5
           working-directory: ./go-client

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Lint Go Client
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.64.8
+          version: v1.56.2
           working-directory: ./go-client
 
   build_server:

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - name: Format
@@ -59,8 +59,6 @@ jobs:
   lint:
     name: Lint
     needs: format
-    # go-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0
-    # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
     runs-on: ubuntu-latest
     container:
       image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
@@ -71,11 +69,11 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
-      - name: Build
+      - name: Build Go Client
         working-directory: ./go-client
         run: make build
       # because some files are generated after building, so lint after the build step
-      - name: Lint Go
+      - name: Lint Go Client
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.64.8
@@ -120,7 +118,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - uses: "./.github/actions/download_artifact"

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           version: v1.56.2
           working-directory: ./go-client
+          args: --build-tags="" --build-flags="-buildvcs=false"
         env:
           GOVCS: '*:off'
 

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -62,9 +62,20 @@ jobs:
     # go-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0
     # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
     runs-on: ubuntu-latest
-    container:
-      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
+    #container:
+    #  image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
     steps:
+      - name: Install thrift
+        run: |
+          export THRIFT_VERSION=0.13.0
+          wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/v${THRIFT_VERSION}.tar.gz
+          tar -xzf v${THRIFT_VERSION}.tar.gz
+          cd thrift-${THRIFT_VERSION}
+          ./bootstrap.sh
+          ./configure --enable-libs=no
+          make -j $(nproc)
+          make install
+          cd - && rm -rf thrift-${THRIFT_VERSION} v${THRIFT_VERSION}.tar.gz
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Go

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -67,6 +67,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -75,14 +77,13 @@ jobs:
         working-directory: ./go-client
         run: make build
       # because some files are generated after building, so lint after the build step
-      - name: Lint
+      - name: Lint Go
         uses: golangci/golangci-lint-action@v3
-        run: golangci-lint run --out-format=github-actions --path-prefix=./go-client
-        env:
-          GOVCS: '*:off'
         with:
           version: v1.56.2
           working-directory: ./go-client
+        env:
+          GOVCS: '*:off'
 
   build_server:
     name: Build server

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -62,20 +62,9 @@ jobs:
     # go-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0
     # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
     runs-on: ubuntu-latest
-    #container:
-    #  image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
+    container:
+      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
     steps:
-      - name: Install thrift
-        run: |
-          export THRIFT_VERSION=0.13.0
-          wget --progress=dot:giga https://github.com/apache/thrift/archive/refs/tags/v${THRIFT_VERSION}.tar.gz
-          tar -xzf v${THRIFT_VERSION}.tar.gz
-          cd thrift-${THRIFT_VERSION}
-          ./bootstrap.sh
-          ./configure --enable-libs=no
-          make -j $(nproc)
-          make install
-          cd - && rm -rf thrift-${THRIFT_VERSION} v${THRIFT_VERSION}.tar.gz
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Go

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -69,11 +69,11 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
-      - name: Build Go Client
+      - name: Build
         working-directory: ./go-client
         run: make build
       # because some files are generated after building, so lint after the build step
-      - name: Lint Go Client
+      - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.56.2
@@ -117,7 +117,7 @@ jobs:
           cd - && rm -rf thrift-${THRIFT_VERSION} v${THRIFT_VERSION}.tar.gz
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.18

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Lint Go
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.57.0
+          version: v2.1.5
           working-directory: ./go-client
 
   build_server:

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -67,6 +67,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -61,7 +61,7 @@ jobs:
     needs: format
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
+      image: apache/pegasus:build-env-ubuntu2204-${{ github.base_ref }}-go
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -67,8 +67,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -79,6 +77,9 @@ jobs:
       # because some files are generated after building, so lint after the build step
       - name: Lint
         uses: golangci/golangci-lint-action@v3
+        run: golangci-lint run --out-format=github-actions --path-prefix=./go-client
+        env:
+          GOVCS: '*:off'
         with:
           version: v1.56.2
           working-directory: ./go-client

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -76,9 +76,9 @@ jobs:
         run: make build
       # because some files are generated after building, so lint after the build step
       - name: Lint Go
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v2.1.5
+          version: v1.64.8
           working-directory: ./go-client
 
   build_server:

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -61,10 +61,10 @@ jobs:
     needs: format
     # go-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0
     # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: apache/pegasus:build-env-ubuntu2204-${{ github.base_ref }}-go
     steps:
-      - name: Install thrift
-        run: sudo apt-get install -y thrift-compiler
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Go

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -63,7 +63,7 @@ jobs:
     # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
     runs-on: ubuntu-latest
     container:
-      image: apache/pegasus:build-env-ubuntu2204-${{ github.base_ref }}-go
+      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -62,13 +62,13 @@ jobs:
     # go-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0
     # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
     runs-on: ubuntu-latest
-    #container:
-    #  image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
+    container:
+      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - name: Build

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -62,13 +62,11 @@ jobs:
     # go-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0
     # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
     runs-on: ubuntu-latest
-    container:
-      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
+    #container:
+    #  image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -82,9 +80,6 @@ jobs:
         with:
           version: v1.56.2
           working-directory: ./go-client
-          args: --build-tags="" --build-flags="-buildvcs=false"
-        env:
-          GOVCS: '*:off'
 
   build_server:
     name: Build server

--- a/.github/workflows/lint_and_test_pegic.yml
+++ b/.github/workflows/lint_and_test_pegic.yml
@@ -43,11 +43,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
-      - name: golangci-lint
+      - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.56.2
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.18

--- a/.github/workflows/lint_and_test_pegic.yml
+++ b/.github/workflows/lint_and_test_pegic.yml
@@ -41,7 +41,12 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.18
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/lint_and_test_pegic.yml
+++ b/.github/workflows/lint_and_test_pegic.yml
@@ -45,7 +45,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.64.8
+          version: v1.56.2
           working-directory: ./pegic
 
   build:

--- a/.github/workflows/lint_and_test_pegic.yml
+++ b/.github/workflows/lint_and_test_pegic.yml
@@ -45,7 +45,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.64.8
           working-directory: ./pegic
 
   build:
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - name: Compile 

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Lint go-client
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.64.8
+          version: v1.56.2
           working-directory: ./go-client
       - name: Build admin-cli
         run: make
@@ -110,7 +110,7 @@ jobs:
       - name: Lint admin-cli
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.64.8
+          version: v1.56.2
           working-directory: ./admin-cli
       - name: Build pegic
         run: make
@@ -118,7 +118,7 @@ jobs:
       - name: Lint pegic
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.64.8
+          version: v1.56.2
           working-directory: ./pegic
 
   build_java:

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -86,16 +86,14 @@ jobs:
 
   build_and_lint_go:
     name: Build and Lint Golang
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
     steps:
-      - name: Install thrift
-        # go-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0
-        # to generate code as well. The thrift-compiler version on ubuntu-20.04 is 0.13.0
-        run: sudo apt-get install -y thrift-compiler
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - name: Build go-client
@@ -104,7 +102,7 @@ jobs:
       - name: Lint go-client
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.64.8
           working-directory: ./go-client
       - name: Build admin-cli
         run: make
@@ -112,7 +110,7 @@ jobs:
       - name: Lint admin-cli
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.64.8
           working-directory: ./admin-cli
       - name: Build pegic
         run: make
@@ -120,7 +118,7 @@ jobs:
       - name: Lint pegic
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.64.8
           working-directory: ./pegic
 
   build_java:

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
@@ -104,6 +104,14 @@ jobs:
         with:
           version: v1.56.2
           working-directory: ./go-client
+      - name: Build collector
+        run: make
+        working-directory: ./collector
+      - name: Lint collector
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.56.2
+          working-directory: ./collector
       - name: Build admin-cli
         run: make
         working-directory: ./admin-cli

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,10 +19,10 @@ linters:
   enable:
     - gofmt
     - goimports
-    - golint
+    - revive
     - bodyclose
     - exhaustive
-    - exportloopref
+    - copyloopvar
 
 linters-settings:
   exhaustive:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,13 +16,21 @@
 # under the License.
 ---
 linters:
+  # TODO(wangdan): consider replacing 'golint' with 'revive' because 'golint' is
+  # deprecated (since v1.41.0, its repository has been archived by the owner).
+  #
+  # After Go is upgraded to v1.22, consider replacing 'exportloopref' with 'copyloopvar'
+  # because as of Go 1.22, the problem resolved by 'exportloopref' no longer occurs and
+  # fixed by Go team (https://go.dev/blog/loopvar-preview).
+  #
+  # After all of above are bumped, consider upgrading golangci-lint (e.g. to v1.64.8).
   enable:
     - gofmt
     - goimports
-    - revive
+    - golint
     - bodyclose
     - exhaustive
-    - copyloopvar
+    - exportloopref
 
 linters-settings:
   exhaustive:

--- a/docker/pegasus-build-env/go/Dockerfile
+++ b/docker/pegasus-build-env/go/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update -y; \
                        unzip; \
     rm -rf /var/lib/apt/lists/*
 
-ARG THRIFT_VERSION=0.11.0
+ARG THRIFT_VERSION=0.13.0
 RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz -P /opt/thrift && \
     cd /opt/thrift && tar xzf thrift-${THRIFT_VERSION}.tar.gz && cd thrift-${THRIFT_VERSION} && ./bootstrap.sh && \
     ./configure --enable-libs=no && \

--- a/docker/pegasus-build-env/go/Dockerfile
+++ b/docker/pegasus-build-env/go/Dockerfile
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM ubuntu:22.04
+
+ENV TZ=Asia/Shanghai
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update -y; \
+    apt-get install -y --no-install-recommends \
+                       automake \
+                       build-essential \
+                       bison \
+                       flex \
+		       g++ \
+                       libboost-dev \
+                       libevent-dev \
+                       libssl-dev \
+                       libtool \
+		       make \
+                       pkg-config \
+		       ca-certificates \
+                       wget \
+                       unzip; \
+    rm -rf /var/lib/apt/lists/*
+
+ARG THRIFT_VERSION=0.11.0
+RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz -P /opt/thrift && \
+    cd /opt/thrift && tar xzf thrift-${THRIFT_VERSION}.tar.gz && cd thrift-${THRIFT_VERSION} && ./bootstrap.sh && \
+    ./configure --enable-libs=no && \
+    make -j$(($(nproc)/2+1)) && make install && cd - && \
+    rm -rf thrift-${THRIFT_VERSION} thrift-${THRIFT_VERSION}.tar.gz

--- a/docker/pegasus-build-env/ubuntu2204/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2204/Dockerfile
@@ -56,11 +56,12 @@ RUN apt-get update -y; \
 RUN pip3 install --no-cache-dir --upgrade pip
 RUN pip3 install --no-cache-dir cmake
 
-RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz -P /opt/thrift && \
-    cd /opt/thrift && tar xzf thrift-0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \
+ARG THRIFT_VERSION=0.11.0
+RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz -P /opt/thrift && \
+    cd /opt/thrift && tar xzf thrift-${THRIFT_VERSION}.tar.gz && cd thrift-${THRIFT_VERSION} && ./bootstrap.sh && \
     ./configure --enable-libs=no && \
     make -j$(($(nproc)/2+1)) && make install && cd - && \
-    rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz
+    rm -rf thrift-${THRIFT_VERSION} thrift-${THRIFT_VERSION}.tar.gz
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV CLASSPATH=$JAVA_HOME/lib/


### PR DESCRIPTION
Resolve https://github.com/apache/incubator-pegasus/issues/2241.

Go workflows run on Ubuntu 20.04 because Go client uses thrift-compiler 0.13.0
to generate code and the thrift-compiler version on Ubuntu 20.04 is 0.13.0. However
Ubuntu 20.04 runner has been retired and removed on 2025-04-15. To solve this
problem, we choose to build thrift 0.13.0 in a image based on Ubuntu 22.04.

Also add Collector to the workflow for regular building.