### PR TITLE
build: restrict the `CMake` version installed on Ubuntu 20.04 and 22.04 to 3.x.x

### DIFF
--- a/docker/pegasus-build-env/ubuntu2004/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2004/Dockerfile
@@ -58,7 +58,7 @@ RUN add-apt-repository ppa:git-core/ppa -y; \
     apt-get install pkg-config -y --no-install-recommends; \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir cmake
+RUN pip3 install --no-cache-dir cmake==3.31.6
 
 RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz -P /opt/thrift && \
     cd /opt/thrift && tar xzf thrift-0.11.0.tar.gz && cd thrift-0.11.0 && ./bootstrap.sh && \

--- a/docker/pegasus-build-env/ubuntu2204/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2204/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update -y; \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir --upgrade pip
-RUN pip3 install --no-cache-dir cmake
+RUN pip3 install --no-cache-dir cmake==3.31.6
 
 ARG THRIFT_VERSION=0.11.0
 RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz -P /opt/thrift && \


### PR DESCRIPTION
Resolve https://github.com/apache/incubator-pegasus/issues/2244.

The reason for failing to build `thirdparties-src-*` images is that the `CMake` version
is too new (currently 4.0.0) in the build environment  for both Ubuntu 20.04 and 22.04,
while some third-party dependencies still rely on older `CMake syntax`, e.g. `thrift-0.9.3`
declares `cmake_minimum_required(VERSION 2.8.12)` in its `CMakeLists.txt`. Such legacy
syntax is not fully compatible with the newest versions of `CMake`.

To solve this problem, we restrict the `CMake` version installed in the Ubuntu 20.04 and
22.04 environments to a newer 3.x.x version that also maintains compatibility with legacy
`CMakeLists.txt` files.