### PR TITLE
feat(make_idempotent): support making `check_and_mutate` request idempotent in `pegasus_write_service::impl`

### DIFF
--- a/idl/rrdb.thrift
+++ b/idl/rrdb.thrift
@@ -72,13 +72,18 @@ enum update_type
 {
     UT_PUT,
     UT_INCR,
-    UT_CHECK_AND_SET
+    UT_CHECK_AND_SET,
+    UT_CHECK_AND_MUTATE_PUT,
+    UT_CHECK_AND_MUTATE_REMOVE
 }
 
 // The single-put request, just writes a key/value pair into storage, which is certainly
 // idempotent.
 struct update_request
 {
+    // Once `type` is UT_CHECK_AND_MUTATE_REMOVE, only `key` would be used (as one of 
+    // the keys in the check_and_mutate_request that should be deleted), while `value`
+    // and `expire_ts_seconds` would be ignored.
     1:dsn.blob      key;
     2:dsn.blob      value;
     3:i32           expire_ts_seconds;
@@ -89,11 +94,16 @@ struct update_request
     // optional, or
     // - a put request translated from an incr request, if `type` is UT_INCR, or
     // - a put request translated from a check_and_set request, if `type` is UT_CHECK_AND_SET.
+    // - a put request translated from a mutate of MO_PUT in a check_and_mutate request, if
+    // `type` is UT_CHECK_AND_MUTATE_PUT.
+    // - a remove request translated from a mutate of MO_DELETE in a check_and_mutate request,
+    // if `type` is UT_CHECK_AND_MUTATE_REMOVE.
     4:optional update_type type;
 
-    // Following 3 fields are only available while type = UT_CHECK_AND_SET, used to build
-    // check_and_set_response to reply to the client, once this put request is translated
-    // from the non-idempotent check_and_set_request.
+    // Following 3 fields are only available while `type` is UT_CHECK_AND_SET, UT_CHECK_AND_MUTATE_PUT
+    // or UT_CHECK_AND_MUTATE_REMOVE, used to build check_and_set_response or check_and_mutate_response
+    // to reply to the client, once this put request is translated from check_and_set_request or
+    // check_and_mutate_request.
     5:optional bool     check_value_returned;
     6:optional bool     check_value_exist; // Used only if check_value_returned is true.
     7:optional dsn.blob check_value; // Used only if both check_value_returned and
@@ -285,12 +295,13 @@ struct check_and_mutate_request
 
 struct check_and_mutate_response
 {
-    1:i32            error; // return kTryAgain if check not passed.
-                            // return kInvalidArgument if check type is int compare and
-                            // check_operand/check_value is not integer or out of range.
+    1:i32            error; // Return kTryAgain if check not passed.
+                            // Return kInvalidArgument if check_type is comparing integers and
+                            // check_value/check_operand is not a valid integer or out of range.
     2:bool           check_value_returned;
-    3:bool           check_value_exist; // used only if check_value_returned is true
-    4:dsn.blob       check_value; // used only if check_value_returned and check_value_exist is true
+    3:bool           check_value_exist; // Used only if check_value_returned is true.
+    4:dsn.blob       check_value; // Used only if both check_value_returned and
+                                  // check_value_exist are true.
     5:i32            app_id;
     6:i32            partition_index;
     7:i64            decree;

--- a/idl/rrdb.thrift
+++ b/idl/rrdb.thrift
@@ -77,7 +77,7 @@ enum update_type
     UT_CHECK_AND_MUTATE_REMOVE
 }
 
-// The single-put request, just apply a key/value pair into storage, which is certainly
+// The single-update request, just applies a key/value pair into storage, which is certainly
 // idempotent.
 struct update_request
 {
@@ -88,14 +88,16 @@ struct update_request
     2:dsn.blob      value;
     3:i32           expire_ts_seconds;
 
-    // This field marks the type of a single-put request, mainly used to differentiate a general
-    // single-put request from the one translated from a non-idempotent atomic write request:
+    // This field marks the type of a single-update request, mainly used to differentiate a
+    // general single-put request from the one translated from an atomic write request which
+    // may be:
     // - a general single-put request, if `type` is UT_PUT or not set by default as it's
     // optional, or
     // - a put request translated from an incr request, if `type` is UT_INCR, or
-    // - a put request translated from a check_and_set request, if `type` is UT_CHECK_AND_SET.
+    // - a put request translated from a check_and_set request, if `type` is UT_CHECK_AND_SET,
+    // or
     // - a put request translated from a mutate of MO_PUT in a check_and_mutate request, if
-    // `type` is UT_CHECK_AND_MUTATE_PUT.
+    // `type` is UT_CHECK_AND_MUTATE_PUT, or
     // - a remove request translated from a mutate of MO_DELETE in a check_and_mutate request,
     // if `type` is UT_CHECK_AND_MUTATE_REMOVE.
     4:optional update_type type;

--- a/idl/rrdb.thrift
+++ b/idl/rrdb.thrift
@@ -77,12 +77,12 @@ enum update_type
     UT_CHECK_AND_MUTATE_REMOVE
 }
 
-// The single-put request, just writes a key/value pair into storage, which is certainly
+// The single-put request, just apply a key/value pair into storage, which is certainly
 // idempotent.
 struct update_request
 {
-    // Once `type` is UT_CHECK_AND_MUTATE_REMOVE, only `key` would be used (as one of 
-    // the keys in the check_and_mutate_request that should be deleted), while `value`
+    // Once `type` is UT_CHECK_AND_MUTATE_REMOVE, only `key` would be used (as one of the
+    // composite keys from check_and_mutate_request that should be deleted), while `value`
     // and `expire_ts_seconds` would be ignored.
     1:dsn.blob      key;
     2:dsn.blob      value;

--- a/src/base/idl_utils.h
+++ b/src/base/idl_utils.h
@@ -48,5 +48,6 @@ namespace apps {
 USER_DEFINED_ENUM_FORMATTER(cas_check_type::type)
 USER_DEFINED_ENUM_FORMATTER(filter_type::type)
 USER_DEFINED_ENUM_FORMATTER(mutate_operation::type)
+USER_DEFINED_ENUM_FORMATTER(update_type::type)
 } // namespace apps
 } // namespace dsn

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -532,8 +532,8 @@ public:
         return rocksdb::Status::kOk;
     }
 
-    // Used to call make_idempotent for incr and check_and_set to get the idempotent single
-    // put request which is stored as the only element of `updates`.
+    // Used to call make_idempotent() for incr and check_and_set to get the idempotent single-put
+    // request which is stored as the unique element of `updates`.
     //
     // This interface is provided to ensure consistency between the make_idempotent() interfaces
     // of incr/check_and_set operations and that of check_and_mutate (both using std::vector for
@@ -564,8 +564,8 @@ public:
         // Verify operation type for each mutate.
         for (size_t i = 0; i < req.mutate_list.size(); ++i) {
             const auto &mu = req.mutate_list[i];
-            if (dsn_likely(mu.operation == ::dsn::apps::mutate_operation::MO_PUT ||
-                           mu.operation == ::dsn::apps::mutate_operation::MO_DELETE)) {
+            if (dsn_likely(mu.operation == dsn::apps::mutate_operation::MO_PUT ||
+                           mu.operation == dsn::apps::mutate_operation::MO_DELETE)) {
                 continue;
             }
 

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -604,7 +604,7 @@ public:
         }
 
         dsn::blob check_value;
-        bool value_exist = !get_ctx.expired && get_ctx.found;
+        const bool value_exist = !get_ctx.expired && get_ctx.found;
         if (value_exist) {
             pegasus_extract_user_data(
                 _pegasus_data_version, std::move(get_ctx.raw_value), check_value);

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -232,6 +232,11 @@ int rocksdb_wrapper::write_batch_delete(int64_t decree, std::string_view raw_key
     return s.code();
 }
 
+int rocksdb_wrapper::write_batch_delete(int64_t decree, const dsn::blob &raw_key)
+{
+    return write_batch_delete(decree, raw_key.to_string_view());
+}
+
 void rocksdb_wrapper::clear_up_write_batch() { _write_batch->Clear(); }
 
 int rocksdb_wrapper::ingest_files(int64_t decree,

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -112,6 +112,12 @@ int rocksdb_wrapper::get(std::string_view raw_key, /*out*/ db_get_context *ctx)
     return s.code();
 }
 
+int rocksdb_wrapper::get(const dsn::blob &raw_key,
+                         /*out*/ db_get_context *ctx)
+{
+    return get(raw_key.to_string_view(), ctx);
+}
+
 int rocksdb_wrapper::write_batch_put(int64_t decree,
                                      std::string_view raw_key,
                                      std::string_view value,

--- a/src/server/rocksdb_wrapper.h
+++ b/src/server/rocksdb_wrapper.h
@@ -74,6 +74,7 @@ public:
                             int32_t expire_sec);
     int write(int64_t decree);
     int write_batch_delete(int64_t decree, std::string_view raw_key);
+    int write_batch_delete(int64_t decree, const dsn::blob &raw_key);
     void clear_up_write_batch();
     int ingest_files(int64_t decree,
                      const std::vector<std::string> &sst_file_list,

--- a/src/server/rocksdb_wrapper.h
+++ b/src/server/rocksdb_wrapper.h
@@ -59,6 +59,8 @@ public:
     /// \result ctx.expired=true if record expired. Still rocksdb::Status::kOk is returned.
     /// \result ctx.found=false if record is not found. Still rocksdb::Status::kOk is returned.
     int get(std::string_view raw_key, /*out*/ db_get_context *ctx);
+    int get(const dsn::blob &raw_key,
+            /*out*/ db_get_context *ctx);
 
     int write_batch_put(int64_t decree,
                         std::string_view raw_key,


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2197

Implement two APIs in `pegasus_write_service::impl` to make `check_and_mutate`
requests idempotent.

Unlike `incr` and `check_and_set`, a `check_and_mutate` request may be translated
into multiple `put` and `remove` requests. To conveniently store both in the same
`std::vector`, they are all converted into `update_request` objects, with the `type`
field used to distinguish between them:

- implement `make_idempotent()` function to translate a `check_and_mutate` request
into multiple single-put and single-remove requests which are naturally idempotent,
and process the possible errors during the translation, e.g. failed to read the check
value or did not pass the check;
- implement `put()` function to apply multiple single-put and single-remove requests
into the RocksDB instance (certainly the atomicity of the batch operations must be
guaranteed) and make response for `check_and_mutate`.
