### PR TITLE
Fix missing dependencies in Dockerfile for Pegasus 2.5.0 build

### DIFF
--- a/docker/pegasus-build-env/ubuntu2004/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2004/Dockerfile
@@ -49,7 +49,10 @@ RUN apt-get update -y; \
                        libkrb5-dev \
                        libsasl2-dev \
                        maven \
-                       flex; \
+                       flex \
+                       libsnappy-dev \
+                       liblz4-dev \
+                       libzstd-dev; \
     rm -rf /var/lib/apt/lists/*
 
 RUN add-apt-repository ppa:git-core/ppa -y; \


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Without these dependencies, the build fails at the CMake stage with errors indicating that snappy, lz4, and zstd could not be found.

```
CMake Error at /usr/local/lib/python3.8/dist-packages/cmake/data/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find snappy (missing: snappy_LIBRARIES snappy_INCLUDE_DIRS)
CMake Error at /usr/local/lib/python3.8/dist-packages/cmake/data/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find lz4 (missing: lz4_LIBRARIES lz4_INCLUDE_DIRS)
CMake Error at /usr/local/lib/python3.8/dist-packages/cmake/data/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find zstd (missing: zstd_LIBRARIES zstd_INCLUDE_DIRS)
```

### What is changed and how does it work?

This commit adds the missing packages `libsnappy-dev`, `liblz4-dev`, and `libzstd-dev` to the official build Dockerfile. These libraries are required for building Pegasus 2.5.0 successfully, especially when compiling RocksDB dependencies.

### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

##### Code changes

- Has exported function/method change
- Has exported variable/fields change
- Has interface methods change
- Has persistent data change

##### Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

##### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
