### PR TITLE
fix: fix build failure on Apple M chips

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -123,6 +123,7 @@ ExternalProject_Add(abseil
         URL ${OSS_URL_PREFIX}/abseil-20230802.1.zip
         https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip
         URL_MD5 5c6193dbc82834f8e762c6a28c9cc615
+        PATCH_COMMAND patch -p1 < ${TP_DIR}/fix_absl_build_on_macos_arm64.patch
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         -DABSL_FIND_GOOGLETEST=OFF

--- a/thirdparty/fix_absl_build_on_macos_arm64.patch
+++ b/thirdparty/fix_absl_build_on_macos_arm64.patch
@@ -1,0 +1,13 @@
+diff --git a/absl/copts/AbseilConfigureCopts.cmake b/absl/copts/AbseilConfigureCopts.cmake
+index 3f737c81..8b0c3240 100644
+--- a/absl/copts/AbseilConfigureCopts.cmake
++++ b/absl/copts/AbseilConfigureCopts.cmake
+@@ -42,7 +42,7 @@ if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES [[Clang]])
+     string(TOUPPER "${_arch}" _arch_uppercase)
+     string(REPLACE "X86_64" "X64" _arch_uppercase ${_arch_uppercase})
+     foreach(_flag IN LISTS ABSL_RANDOM_HWAES_${_arch_uppercase}_FLAGS)
+-      list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Xarch_${_arch}" "${_flag}")
++      list(APPEND ABSL_RANDOM_RANDEN_COPTS "SHELL:-Xarch_${_arch} ${_flag}")
+     endforeach()
+   endforeach()
+   # If a compiler happens to deal with an argument for a currently unused


### PR DESCRIPTION
Fix the build failure on MacOS with M chips, the error is:
```
c++: error: unsupported option '-msse4.1' for target 'arm64-apple-darwin24.4.0'
```

Add the patch from https://github.com/abseil/abseil-cpp/commit/26ee072e14dea17fa8870d47cd7e8b4cc1c95e93