### PR TITLE
fix(go-client): fix the data race issue caused by concurrent read/write access to the session list of `metaCall`

### DIFF
--- a/go-client/session/meta_call.go
+++ b/go-client/session/meta_call.go
@@ -172,11 +172,11 @@ func (c *metaCall) issueBackupMetas(ctx context.Context) {
 
 	var wg sync.WaitGroup
 	for i := range metas {
-		wg.Add(1)
-
 		if i == lead {
 			continue
 		}
+
+		wg.Add(1)
 
 		// concurrently issue RPC to the rest of meta servers.
 		go func(idx int) {

--- a/go-client/session/meta_session.go
+++ b/go-client/session/meta_session.go
@@ -97,9 +97,11 @@ func (m *MetaManager) call(ctx context.Context, callFunc metaCallFunc) (metaResp
 	call := newMetaCall(lead, m.metas, callFunc, m.metaIPAddrs)
 	resp, err := call.Run(ctx)
 	if err == nil {
+		call.lock.Lock()
 		m.setCurrentLeader(int(call.newLead))
 		m.setNewMetas(call.metas)
 		m.setMetaIPAddrs(call.metaIPAddrs)
+		call.lock.Unlock()
 	}
 	return resp, err
 }

--- a/go-client/session/meta_session.go
+++ b/go-client/session/meta_session.go
@@ -97,11 +97,11 @@ func (m *MetaManager) call(ctx context.Context, callFunc metaCallFunc) (metaResp
 	call := newMetaCall(lead, m.metas, callFunc, m.metaIPAddrs)
 	resp, err := call.Run(ctx)
 	if err == nil {
-		call.lock.Lock()
+		call.lock.RLock()
 		m.setCurrentLeader(int(call.newLead))
 		m.setNewMetas(call.metas)
 		m.setMetaIPAddrs(call.metaIPAddrs)
-		call.lock.Unlock()
+		call.lock.RUnlock()
 	}
 	return resp, err
 }

--- a/go-client/session/meta_session.go
+++ b/go-client/session/meta_session.go
@@ -93,8 +93,7 @@ func NewMetaManager(addrs []string, creator NodeSessionCreator) *MetaManager {
 }
 
 func (m *MetaManager) call(ctx context.Context, callFunc metaCallFunc) (metaResponse, error) {
-	lead := m.getCurrentLeader()
-	call := newMetaCall(lead, m.metas, callFunc, m.metaIPAddrs)
+	call := newMetaCall(m.getCurrentLeader(), m.metas, callFunc, m.metaIPAddrs)
 	resp, err := call.Run(ctx)
 	if err == nil {
 		call.lock.RLock()


### PR DESCRIPTION
Fix https://github.com/apache/incubator-pegasus/issues/2256.

The data race was caused by:
1. The `issueBackupMetas()` function returns without waiting for all subroutines
to complete;
2. Concurrent access (read/write) to the `metas` member (the session list) of the
`metaCall` struct was not properly synchronized with mutual exclusion.