### PR TITLE
fix(security): fix DDD diagnose request failure with `app_id = -1` and improve ACL handling

### DIFF
--- a/src/meta/distributed_lock_service_simple.cpp
+++ b/src/meta/distributed_lock_service_simple.cpp
@@ -38,21 +38,29 @@ DEFINE_TASK_CODE(LPC_DIST_LOCK_SVC_RANDOM_EXPIRE, TASK_PRIORITY_COMMON, THREAD_P
 
 namespace {
 
-static void lock_cb_bind_and_enqueue(task_ptr lock_task,
-                                     error_code err,
-                                     const std::string &owner,
-                                     uint64_t version,
-                                     int delay_milliseconds = 0)
+void lock_cb_bind_and_enqueue(task_ptr lock_task,
+                              error_code err,
+                              const std::string &owner,
+                              uint64_t version,
+                              int delay_milliseconds)
 {
-    auto t = dynamic_cast<lock_future *>(lock_task.get());
+    auto *t = dynamic_cast<lock_future *>(lock_task.get());
     t->enqueue_with(err, owner, version, delay_milliseconds);
+}
+
+void lock_cb_bind_and_enqueue(task_ptr lock_task,
+                              error_code err,
+                              const std::string &owner,
+                              uint64_t version)
+{
+    lock_cb_bind_and_enqueue(lock_task, err, owner, version, 0);
 }
 
 } // anonymous namespace
 
 void distributed_lock_service_simple::random_lock_lease_expire(const std::string &lock_id)
 {
-    // TODO: let's test without failure first
+    // TODO(wangdan): let's test without failure first
     return;
 
     std::string owner;
@@ -90,12 +98,12 @@ void distributed_lock_service_simple::random_lock_lease_expire(const std::string
         }
     }
 
-    lock_cb_bind_and_enqueue(lease_callback, ERR_EXPIRED, owner, version, 0);
+    lock_cb_bind_and_enqueue(lease_callback, ERR_EXPIRED, owner, version);
 
     if (!next.owner.empty()) {
         version++;
         error_code err = ERR_OK;
-        lock_cb_bind_and_enqueue(next.grant_callback, err, next.owner, version, 0);
+        lock_cb_bind_and_enqueue(next.grant_callback, err, next.owner, version);
     }
 }
 
@@ -180,7 +188,7 @@ distributed_lock_service_simple::lock(const std::string &lock_id,
         lock_cb_bind_and_enqueue(grant_cb, err, cowner, version);
     }
 
-    return std::pair<task_ptr, task_ptr>(grant_cb, lease_cb);
+    return {grant_cb, lease_cb};
 }
 
 task_ptr distributed_lock_service_simple::cancel_pending_lock(const std::string &lock_id,
@@ -259,7 +267,7 @@ task_ptr distributed_lock_service_simple::unlock(const std::string &lock_id,
 
     if (!next.owner.empty()) {
         error_code err = ERR_OK;
-        lock_cb_bind_and_enqueue(next.grant_callback, err, next.owner, next_version, 0);
+        lock_cb_bind_and_enqueue(next.grant_callback, err, next.owner, next_version);
     }
 
     return t;

--- a/src/meta/distributed_lock_service_simple.cpp
+++ b/src/meta/distributed_lock_service_simple.cpp
@@ -32,8 +32,8 @@
 #include "runtime/api_layer1.h"
 #include "task/async_calls.h"
 
-namespace dsn {
-namespace dist {
+namespace dsn::dist {
+
 DEFINE_TASK_CODE(LPC_DIST_LOCK_SVC_RANDOM_EXPIRE, TASK_PRIORITY_COMMON, THREAD_POOL_META_SERVER)
 
 static void __lock_cb_bind_and_enqueue(task_ptr lock_task,
@@ -299,5 +299,4 @@ error_code distributed_lock_service_simple::query_cache(const std::string &lock_
     return ERR_OK;
 }
 
-} // namespace dist
-} // namespace dsn
+} // namespace dsn::dist

--- a/src/meta/distributed_lock_service_simple.cpp
+++ b/src/meta/distributed_lock_service_simple.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <chrono>
+#include <type_traits>
 
 #include "common/replication.codes.h"
 #include "distributed_lock_service_simple.h"

--- a/src/meta/distributed_lock_service_simple.cpp
+++ b/src/meta/distributed_lock_service_simple.cpp
@@ -285,21 +285,18 @@ task_ptr distributed_lock_service_simple::query_lock(const std::string &lock_id,
 
 error_code distributed_lock_service_simple::query_cache(const std::string &lock_id,
                                                         /*out*/ std::string &owner,
-                                                        /*out*/ uint64_t &version)
+                                                        /*out*/ uint64_t &version) const 
 {
-    error_code err;
-    {
-        zauto_lock l(_lock);
-        auto it = _dlocks.find(lock_id);
-        if (it == _dlocks.end()) {
-            err = ERR_OBJECT_NOT_FOUND;
-        } else {
-            err = ERR_OK;
-            owner = it->second.owner;
-            version = it->second.version;
-        }
+    zauto_lock l(_lock);
+    const auto it = std::as_const(_dlocks).find(lock_id);
+    if (it == _dlocks.end()) {
+        return ERR_OBJECT_NOT_FOUND;
     }
-    return err;
+
+    owner = it->second.owner;
+    version = it->second.version;
+    return ERR_OK;
 }
+
 } // namespace dist
 } // namespace dsn

--- a/src/meta/distributed_lock_service_simple.cpp
+++ b/src/meta/distributed_lock_service_simple.cpp
@@ -285,7 +285,7 @@ task_ptr distributed_lock_service_simple::query_lock(const std::string &lock_id,
 
 error_code distributed_lock_service_simple::query_cache(const std::string &lock_id,
                                                         /*out*/ std::string &owner,
-                                                        /*out*/ uint64_t &version) const 
+                                                        /*out*/ uint64_t &version) const
 {
     zauto_lock l(_lock);
     const auto it = std::as_const(_dlocks).find(lock_id);

--- a/src/meta/distributed_lock_service_simple.h
+++ b/src/meta/distributed_lock_service_simple.h
@@ -56,30 +56,30 @@ public:
     error_code finalize() override { return ERR_OK; }
 
     std::pair<task_ptr, task_ptr> lock(const std::string &lock_id,
-                                               const std::string &myself_id,
-                                               task_code lock_cb_code,
-                                               const lock_callback &lock_cb,
-                                               task_code lease_expire_code,
-                                               const lock_callback &lease_expire_callback,
-                                               const lock_options &opt) override;
+                                       const std::string &myself_id,
+                                       task_code lock_cb_code,
+                                       const lock_callback &lock_cb,
+                                       task_code lease_expire_code,
+                                       const lock_callback &lease_expire_callback,
+                                       const lock_options &opt) override;
 
     task_ptr cancel_pending_lock(const std::string &lock_id,
-                                         const std::string &myself_id,
-                                         task_code cb_code,
-                                         const lock_callback &cb) override;
+                                 const std::string &myself_id,
+                                 task_code cb_code,
+                                 const lock_callback &cb) override;
 
     task_ptr unlock(const std::string &lock_id,
-                            const std::string &myself_id,
-                            bool destroy,
-                            task_code cb_code,
-                            const err_callback &cb) override;
+                    const std::string &myself_id,
+                    bool destroy,
+                    task_code cb_code,
+                    const err_callback &cb) override;
 
     task_ptr
     query_lock(const std::string &lock_id, task_code cb_code, const lock_callback &cb) override;
 
     error_code query_cache(const std::string &lock_id,
-                                   /*out*/ std::string &owner,
-                                   /*out*/ uint64_t &version) const override;
+                           /*out*/ std::string &owner,
+                           /*out*/ uint64_t &version) const override;
 
 private:
     void random_lock_lease_expire(const std::string &lock_id);

--- a/src/meta/distributed_lock_service_simple.h
+++ b/src/meta/distributed_lock_service_simple.h
@@ -40,6 +40,7 @@
 #include "utils/autoref_ptr.h"
 #include "utils/distributed_lock_service.h"
 #include "utils/error_code.h"
+#include "utils/ports.h"
 #include "utils/zlocks.h"
 
 namespace dsn {
@@ -50,7 +51,9 @@ namespace dist {
 class distributed_lock_service_simple : public distributed_lock_service
 {
 public:
-    ~distributed_lock_service_simple() { _tracker.cancel_outstanding_tasks(); }
+    distributed_lock_service_simple() = default;
+    ~distributed_lock_service_simple() override { _tracker.cancel_outstanding_tasks(); }
+
     // no parameter need
     error_code initialize(const std::vector<std::string> &args) override;
     error_code finalize() override { return ERR_OK; }
@@ -84,7 +87,6 @@ public:
 private:
     void random_lock_lease_expire(const std::string &lock_id);
 
-private:
     struct lock_wait_info
     {
         task_ptr grant_callback;
@@ -100,12 +102,16 @@ private:
         std::list<lock_wait_info> pending_list;
     };
 
-    typedef std::unordered_map<std::string, lock_info> locks;
+    using locks = std::unordered_map<std::string, lock_info>;
 
     mutable zlock _lock;
     locks _dlocks; // lock -> owner
 
     dsn::task_tracker _tracker;
+
+    DISALLOW_COPY_AND_ASSIGN(distributed_lock_service_simple);
+    DISALLOW_MOVE_AND_ASSIGN(distributed_lock_service_simple);
 };
+
 } // namespace dist
 } // namespace dsn

--- a/src/meta/distributed_lock_service_simple.h
+++ b/src/meta/distributed_lock_service_simple.h
@@ -43,8 +43,7 @@
 #include "utils/ports.h"
 #include "utils/zlocks.h"
 
-namespace dsn {
-namespace dist {
+namespace dsn::dist {
 
 // A simple version of distributed lock service.
 // NOTE: Only for test purpose.
@@ -113,5 +112,4 @@ private:
     DISALLOW_MOVE_AND_ASSIGN(distributed_lock_service_simple);
 };
 
-} // namespace dist
-} // namespace dsn
+} // namespace dsn::dist

--- a/src/meta/distributed_lock_service_simple.h
+++ b/src/meta/distributed_lock_service_simple.h
@@ -50,12 +50,12 @@ namespace dist {
 class distributed_lock_service_simple : public distributed_lock_service
 {
 public:
-    virtual ~distributed_lock_service_simple() { _tracker.cancel_outstanding_tasks(); }
+    ~distributed_lock_service_simple() { _tracker.cancel_outstanding_tasks(); }
     // no parameter need
-    virtual error_code initialize(const std::vector<std::string> &args) override;
-    virtual error_code finalize() override { return ERR_OK; }
+    error_code initialize(const std::vector<std::string> &args) override;
+    error_code finalize() override { return ERR_OK; }
 
-    virtual std::pair<task_ptr, task_ptr> lock(const std::string &lock_id,
+    std::pair<task_ptr, task_ptr> lock(const std::string &lock_id,
                                                const std::string &myself_id,
                                                task_code lock_cb_code,
                                                const lock_callback &lock_cb,
@@ -63,23 +63,23 @@ public:
                                                const lock_callback &lease_expire_callback,
                                                const lock_options &opt) override;
 
-    virtual task_ptr cancel_pending_lock(const std::string &lock_id,
+    task_ptr cancel_pending_lock(const std::string &lock_id,
                                          const std::string &myself_id,
                                          task_code cb_code,
                                          const lock_callback &cb) override;
 
-    virtual task_ptr unlock(const std::string &lock_id,
+    task_ptr unlock(const std::string &lock_id,
                             const std::string &myself_id,
                             bool destroy,
                             task_code cb_code,
                             const err_callback &cb) override;
 
-    virtual task_ptr
+    task_ptr
     query_lock(const std::string &lock_id, task_code cb_code, const lock_callback &cb) override;
 
-    virtual error_code query_cache(const std::string &lock_id,
+    error_code query_cache(const std::string &lock_id,
                                    /*out*/ std::string &owner,
-                                   /*out*/ uint64_t &version) override;
+                                   /*out*/ uint64_t &version) const override;
 
 private:
     void random_lock_lease_expire(const std::string &lock_id);
@@ -102,7 +102,7 @@ private:
 
     typedef std::unordered_map<std::string, lock_info> locks;
 
-    zlock _lock;
+    mutable zlock _lock;
     locks _dlocks; // lock -> owner
 
     dsn::task_tracker _tracker;

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1624,13 +1624,14 @@ void backup_service::modify_backup_policy(configuration_modify_backup_policy_rpc
 
         for (const auto &appid : request.add_appids) {
             const auto &app = _state->get_app(appid);
-            // TODO: if app is dropped, how to process
+            // TODO(wangdan): if app is dropped, how to process.
             if (app == nullptr) {
                 LOG_WARNING("{}: add app to policy failed, because invalid app({}), ignore it",
                             cur_policy.policy_name,
                             appid);
                 continue;
             }
+
             if (security::access_controller::is_ranger_acl_enabled() &&
                 !_meta_svc->get_access_controller()->allowed(rpc.dsn_request(), app->app_name)) {
                 LOG_WARNING("not authorized to modify backup policy({}) for app id: {}, skip it",

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1342,11 +1342,12 @@ void backup_service::add_backup_policy(dsn::message_ex *msg)
                 msg->release_ref();
                 return;
             }
-            // when the Ranger ACL is enabled, access control will be checked for each table.
-            auto access_controller = _meta_svc->get_access_controller();
-            // adding multiple judgments here is to adapt to the old ACL and avoid checking again.
-            if (access_controller->is_ranger_acl_enabled() &&
-                !access_controller->allowed(copied_msg, app->app_name)) {
+
+            // Once the Ranger ACL is enabled, access control will be checked for each table.
+            // Adding multiple judgments here is to adapt to the old ACL and avoid checking
+            // again.
+            if (security::access_controller::is_ranger_acl_enabled() &&
+                !_meta_svc->get_access_controller()->allowed(copied_msg, app->app_name)) {
                 response.err = ERR_ACL_DENY;
                 response.hint_message =
                     fmt::format("not authorized to add backup policy({}) for app id: {}",
@@ -1623,7 +1624,6 @@ void backup_service::modify_backup_policy(configuration_modify_backup_policy_rpc
 
         for (const auto &appid : request.add_appids) {
             const auto &app = _state->get_app(appid);
-            auto access_controller = _meta_svc->get_access_controller();
             // TODO: if app is dropped, how to process
             if (app == nullptr) {
                 LOG_WARNING("{}: add app to policy failed, because invalid app({}), ignore it",
@@ -1631,8 +1631,8 @@ void backup_service::modify_backup_policy(configuration_modify_backup_policy_rpc
                             appid);
                 continue;
             }
-            if (access_controller->is_ranger_acl_enabled() &&
-                !access_controller->allowed(rpc.dsn_request(), app->app_name)) {
+            if (security::access_controller::is_ranger_acl_enabled() &&
+                !_meta_svc->get_access_controller()->allowed(rpc.dsn_request(), app->app_name)) {
                 LOG_WARNING("not authorized to modify backup policy({}) for app id: {}, skip it",
                             cur_policy.policy_name,
                             appid);

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1345,7 +1345,7 @@ void backup_service::add_backup_policy(dsn::message_ex *msg)
             // when the Ranger ACL is enabled, access control will be checked for each table.
             auto access_controller = _meta_svc->get_access_controller();
             // adding multiple judgments here is to adapt to the old ACL and avoid checking again.
-            if (access_controller->is_enable_ranger_acl() &&
+            if (access_controller->is_ranger_acl_enabled() &&
                 !access_controller->allowed(copied_msg, app->app_name)) {
                 response.err = ERR_ACL_DENY;
                 response.hint_message =
@@ -1631,7 +1631,7 @@ void backup_service::modify_backup_policy(configuration_modify_backup_policy_rpc
                             appid);
                 continue;
             }
-            if (access_controller->is_enable_ranger_acl() &&
+            if (access_controller->is_ranger_acl_enabled() &&
                 !access_controller->allowed(rpc.dsn_request(), app->app_name)) {
                 LOG_WARNING("not authorized to modify backup policy({}) for app id: {}, skip it",
                             cur_policy.policy_name,

--- a/src/meta/meta_backup_service.cpp
+++ b/src/meta/meta_backup_service.cpp
@@ -1344,7 +1344,7 @@ void backup_service::add_backup_policy(dsn::message_ex *msg)
             }
 
             // Once the Ranger ACL is enabled, access control will be checked for each table.
-            // Adding multiple judgments here is to adapt to the old ACL and avoid checking
+            // Adding multiple judgments here is to adapt to the legacy ACL and avoid checking
             // again.
             if (security::access_controller::is_ranger_acl_enabled() &&
                 !_meta_svc->get_access_controller()->allowed(copied_msg, app->app_name)) {

--- a/src/meta/meta_data.h
+++ b/src/meta/meta_data.h
@@ -453,17 +453,21 @@ inline bool is_node_alive(const node_mapper &nodes, const host_port &hp)
 
 inline const partition_configuration *get_config(const app_mapper &apps, const dsn::gpid &gpid)
 {
-    auto iter = apps.find(gpid.get_app_id());
-    if (iter == apps.end() || iter->second->status == app_status::AS_DROPPED)
+    const auto iter = apps.find(gpid.get_app_id());
+    if (iter == apps.end() || iter->second->status == app_status::AS_DROPPED) {
         return nullptr;
+    }
+
     return &(iter->second->pcs[gpid.get_partition_index()]);
 }
 
 inline partition_configuration *get_config(app_mapper &apps, const dsn::gpid &gpid)
 {
-    auto iter = apps.find(gpid.get_app_id());
-    if (iter == apps.end() || iter->second->status == app_status::AS_DROPPED)
+    const auto iter = apps.find(gpid.get_app_id());
+    if (iter == apps.end() || iter->second->status == app_status::AS_DROPPED) {
         return nullptr;
+    }
+
     return &(iter->second->pcs[gpid.get_partition_index()]);
 }
 

--- a/src/meta/meta_server_failure_detector.cpp
+++ b/src/meta/meta_server_failure_detector.cpp
@@ -109,18 +109,16 @@ bool meta_server_failure_detector::get_leader(host_port *leader) const
 {
     FAIL_POINT_INJECT_F("meta_server_failure_detector_get_leader", [leader](std::string_view str) {
         /// the format of str is : true#{ip}:{port} or false#{ip}:{port}
-        auto pos = str.find("#");
+        const auto pos = str.find('#');
         // get leader host_port
-        auto addr_part = str.substr(pos + 1, str.length() - pos - 1);
+        const auto addr_part = str.substr(pos + 1, str.length() - pos - 1);
         *leader = host_port::from_string(addr_part.data());
         CHECK(*leader, "parse {} to rpc_address failed", addr_part);
 
         // get the return value which implies whether the current node is primary or not
         bool is_leader = true;
-        auto is_leader_part = str.substr(0, pos);
-        if (!dsn::buf2bool(is_leader_part, is_leader)) {
-            CHECK(false, "parse {} to bool failed", is_leader_part);
-        }
+        const auto is_leader_part = str.substr(0, pos);
+        CHECK(dsn::buf2bool(is_leader_part, is_leader), "parse {} to bool failed", is_leader_part);
         return is_leader;
     });
 
@@ -140,7 +138,7 @@ bool meta_server_failure_detector::get_leader(host_port *leader) const
     }
 
     std::string lock_owner;
-    uint64_t version;
+    uint64_t version = 0;
     const auto err = _lock_svc->query_cache(_primary_lock_id, lock_owner, version);
     if (err != dsn::ERR_OK) {
         LOG_WARNING("query leader from cache got error({})", err);

--- a/src/meta/meta_server_failure_detector.cpp
+++ b/src/meta/meta_server_failure_detector.cpp
@@ -105,7 +105,7 @@ void meta_server_failure_detector::on_worker_connected(const host_port &node)
     _svc->set_node_state({node}, true);
 }
 
-bool meta_server_failure_detector::get_leader(host_port *leader)
+bool meta_server_failure_detector::get_leader(host_port *leader) const
 {
     FAIL_POINT_INJECT_F("meta_server_failure_detector_get_leader", [leader](std::string_view str) {
         /// the format of str is : true#{ip}:{port} or false#{ip}:{port}
@@ -141,7 +141,7 @@ bool meta_server_failure_detector::get_leader(host_port *leader)
 
     std::string lock_owner;
     uint64_t version;
-    error_code err = _lock_svc->query_cache(_primary_lock_id, lock_owner, version);
+    const auto err = _lock_svc->query_cache(_primary_lock_id, lock_owner, version);
     if (err != dsn::ERR_OK) {
         LOG_WARNING("query leader from cache got error({})", err);
         leader->reset();

--- a/src/meta/meta_server_failure_detector.h
+++ b/src/meta/meta_server_failure_detector.h
@@ -83,7 +83,7 @@ public:
     // leader: the leader's host_port. Invalid if no leader selected
     //         if leader==nullptr, then the new leader won't be returned
     // ret true if i'm the current leader; false if not.
-    bool get_leader(/*output*/ dsn::host_port *leader);
+    bool get_leader(/*output*/ dsn::host_port *leader) const;
 
     // return if acquire the leader lock, or-else blocked forever
     void acquire_leader_lock();

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -69,7 +69,6 @@
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
-#include "utils/ports.h"
 #include "utils/strings.h"
 
 DSN_DECLARE_string(hosts_list);

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -686,8 +686,8 @@ void meta_service::on_list_apps(configuration_list_apps_rpc rpc) const
         return;
     }
 
-    // Short-cut the ACL check: if any ACL (Ranger or old ACL) is disabled, there's no need to
-    // perform ACL verification for each table (by setting the request `msg` to null the ACL
+    // Short-cut the ACL check: if any ACL (Ranger or legacy ACL) is disabled, there's no need
+    // to perform ACL verification for each table (by setting the request `msg` to null the ACL
     // checks can be skipped).
     _state->list_apps(_access_controller->is_acl_enabled() ? rpc.dsn_request() : nullptr,
                       rpc.request(),
@@ -1152,8 +1152,8 @@ void meta_service::on_ddd_diagnose(ddd_diagnose_rpc rpc) const
     auto &response = rpc.response();
 
     // While the client is requesting all DDD partitions (with app_id = -1), we could short-cut
-    // the ACL check: if any ACL (Ranger or old ACL) is disabled, there's no need to perform ACL
-    // verification for each DDD partition (we can just skip the ACL checks).
+    // the ACL check: if any ACL (Ranger or legacy ACL) is disabled, there's no need to perform
+    // ACL verification for each DDD partition (we can just skip the ACL checks).
     if (app_id == -1 && _access_controller->is_acl_enabled()) {
         // Perform ACL checks on all DDD partitions, and only those that pass will be returned
         // to the client.

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -687,8 +687,8 @@ void meta_service::on_list_apps(configuration_list_apps_rpc rpc) const
     }
 
     // Short-cut the ACL check: if any ACL (Ranger or old ACL) is disabled, there's no need to
-    // perform ACL verification for each table (by setting the request `msg` to null, the ACL
-    // check can be skipped).
+    // perform ACL verification for each table (by setting the request `msg` to null the ACL
+    // checks can be skipped).
     _state->list_apps(_access_controller->is_acl_enabled() ? rpc.dsn_request() : nullptr,
                       rpc.request(),
                       rpc.response());
@@ -1152,8 +1152,8 @@ void meta_service::on_ddd_diagnose(ddd_diagnose_rpc rpc) const
     auto &response = rpc.response();
 
     // While the client is requesting all DDD partitions (with app_id = -1), we could short-cut
-    // the ACL check: if any ACL (Ranger or old ACL) is disabled, there's no need to
-    // perform ACL verification for each DDD partition (just skip the ACL check).
+    // the ACL check: if any ACL (Ranger or old ACL) is disabled, there's no need to perform ACL
+    // verification for each DDD partition (we can just skip the ACL checks).
     if (app_id == -1 && _access_controller->is_acl_enabled()) {
         // Perform ACL checks on all DDD partitions, and only those that pass will be returned
         // to the client.

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -69,6 +69,7 @@
 #include "utils/filesystem.h"
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
+#include "utils/ports.h"
 #include "utils/strings.h"
 
 DSN_DECLARE_string(hosts_list);
@@ -153,15 +154,16 @@ namespace replication {
 
 #define CHECK_APP_ID_STATUS_AND_AUTHZ(app_id)                                                      \
     do {                                                                                           \
-        const auto &_app_id = (app_id);                                                            \
-        const auto &_app = _state->get_app(_app_id);                                               \
-        if (!_app) {                                                                               \
-            rpc.response().err = ERR_APP_NOT_EXIST;                                                \
-            LOG_WARNING("reject request on app_id = {}", _app_id);                                 \
+        const auto &__app_id = (app_id);                                                           \
+        std::string __app_name;                                                                    \
+        const auto __err = _state->get_app_name(__app_id, __app_name);                             \
+        if (__err != ERR_OK) {                                                                     \
+            rpc.response().err = __err;                                                            \
+            LOG_WARNING("reject request on app_id = {}, err = {}", __app_id, __err);               \
             return;                                                                                \
         }                                                                                          \
-        const std::string &app_name = _app->app_name;                                              \
-        if (!check_status_and_authz(rpc, nullptr, app_name)) {                                     \
+                                                                                                   \
+        if (!check_status_and_authz(rpc, nullptr, __app_name)) {                                   \
             return;                                                                                \
         }                                                                                          \
     } while (0)

--- a/src/meta/meta_service.cpp
+++ b/src/meta/meta_service.cpp
@@ -156,7 +156,7 @@ namespace replication {
         const auto &_app_id = (app_id);                                                            \
         const auto &_app = _state->get_app(_app_id);                                               \
         if (!_app) {                                                                               \
-            rpc.response().err = ERR_APP_NOT_EXIST;                                           \
+            rpc.response().err = ERR_APP_NOT_EXIST;                                                \
             LOG_WARNING("reject request on app_id = {}", _app_id);                                 \
             return;                                                                                \
         }                                                                                          \
@@ -1129,11 +1129,11 @@ void meta_service::on_ddd_diagnose(ddd_diagnose_rpc rpc) const
     const auto app_id = pid.get_app_id();
 
     if (app_id == -1) {
-    if (!check_leader_status(rpc)) {
-        return;
-    }
+        if (!check_leader_status(rpc)) {
+            return;
+        }
     } else {
-    CHECK_APP_ID_STATUS_AND_AUTHZ(app_id );
+        CHECK_APP_ID_STATUS_AND_AUTHZ(app_id);
     }
 
     std::vector<ddd_partition_info> ddd_partitions;
@@ -1141,9 +1141,9 @@ void meta_service::on_ddd_diagnose(ddd_diagnose_rpc rpc) const
 
     auto &response = rpc.response();
     if (app_id == -1) {
-    _state->get_allowed_partitions(rpc.dsn_request(), ddd_partitions, response.partitions);
+        _state->get_allowed_partitions(rpc.dsn_request(), ddd_partitions, response.partitions);
     } else {
-response.partitions = std::move(ddd_partitions);
+        response.partitions = std::move(ddd_partitions);
     }
 
     response.err = ERR_OK;

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -309,7 +309,7 @@ private:
     // If this meta server is the leader, perform ACL check on `rpc`; also, once the Ranger ACL
     // is enabled, database operations would be required to check the permission on the table
     // whose name is `app_name`. Default databse name (legacy_table_database_mapping_policy_name)
-    // would be used if `aap_name` is empty.
+    // would be used if `app_name` is empty.
     //
     // Reture true if this meta server is not the leader and the ACL checks pass, otherwise
     // false.
@@ -338,17 +338,18 @@ private:
     template <typename TRespType>
     bool check_status_and_authz_with_reply(message_ex *req, TRespType &response_struct) const;
 
-    // The same as the above function, except that `response_struct` is initialized by default
-    // constructor and `app_name` is extracted from `msg`.
+    // The same as the above function, except that `response_struct` is initialized inside the
+    // function by default constructor and `app_name` is extracted from `msg`.
     template <typename TReqType, typename TRespType>
     bool check_status_and_authz_with_reply(message_ex *msg) const;
 
-    // Rteurn true if this meta server is the leader, otherwise false with `forward_address` set
-    // if not null.
+    // Rteurn true if this meta server is the leader, otherwise false with *forward_address
+    // assigned leader (may be empty as HOST_TYPE_INVALID if failed) if `forward_address` is
+    // not null.
     template <typename TRpcHolder>
     bool check_leader_status(TRpcHolder rpc, host_port *forward_address) const;
 
-    // The same as the above function, except that `forward_address` is null.
+    // The same as the above function, except that `forward_address` is set null.
     template <typename TRpcHolder>
     bool check_leader_status(TRpcHolder rpc) const;
 

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -406,27 +406,27 @@ meta_leader_state meta_service::check_leader(TRpcHolder rpc, host_port *forward_
 {
     host_port leader;
     if (_failure_detector->get_leader(&leader)) {
-    return meta_leader_state::kIsLeader;
+        return meta_leader_state::kIsLeader;
     }
 
-        if (!rpc.dsn_request()->header->context.u.is_forward_supported) {
-            if (forward_address != nullptr) {
-                *forward_address = leader;
-            }
-
-            return meta_leader_state::kNotLeaderAndCannotForwardRpc;
+    if (!rpc.dsn_request()->header->context.u.is_forward_supported) {
+        if (forward_address != nullptr) {
+            *forward_address = leader;
         }
 
-        if (leader) {
-            rpc.forward(dsn::dns_resolver::instance().resolve_address(leader));
-            return meta_leader_state::kNotLeaderAndCanForwardRpc;
-        } 
+        return meta_leader_state::kNotLeaderAndCannotForwardRpc;
+    }
 
-            if (forward_address != nullptr) {
-                forward_address->reset();
-            }
+    if (leader) {
+        rpc.forward(dsn::dns_resolver::instance().resolve_address(leader));
+        return meta_leader_state::kNotLeaderAndCanForwardRpc;
+    }
 
-            return meta_leader_state::kNotLeaderAndCannotForwardRpc;
+    if (forward_address != nullptr) {
+        forward_address->reset();
+    }
+
+    return meta_leader_state::kNotLeaderAndCannotForwardRpc;
 }
 
 template <typename TRpcHolder>

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -344,7 +344,7 @@ private:
     bool check_status_and_authz_with_reply(message_ex *msg) const;
 
     // Rteurn true if this meta server is the leader, otherwise false with `forward_address` set
-    // if it is not null.
+    // if not null.
     template <typename TRpcHolder>
     bool check_leader_status(TRpcHolder rpc, host_port *forward_address) const;
 
@@ -493,7 +493,7 @@ bool meta_service::check_status_and_authz(TRpcHolder rpc,
 {
     // Once the Ranger ACL is enabled, only the leader will pull Ranger policies. Therefore,
     // - `_access_controller` will be null if this meta server is not the leader;
-    // - the policies may be outdated if thie meta server was just newly elected as the
+    // - the policies may be outdated if this meta server was just newly elected as the
     // leader.
     if (!check_leader_status(rpc, forward_address)) {
         return false;

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -307,15 +307,13 @@ private:
     //    true:  rpc request check and authentication succeed
     template <typename TRpcHolder>
     bool check_status_and_authz(TRpcHolder rpc,
-                                /*out*/ host_port *forward_address ,
-                                const std::string &app_name ) const;
+                                /*out*/ host_port *forward_address,
+                                const std::string &app_name) const;
     template <typename TRpcHolder>
     bool check_status_and_authz(TRpcHolder rpc,
-                                /*out*/ host_port *forward_address
-                                ) const;
+                                /*out*/ host_port *forward_address) const;
     template <typename TRpcHolder>
-    bool check_status_and_authz(TRpcHolder rpc
-                                ) const;
+    bool check_status_and_authz(TRpcHolder rpc) const;
 
     // app_name: when the Ranger ACL is enabled, some rpc requests need to verify the app_name
     // ret:
@@ -331,8 +329,8 @@ private:
     template <typename TRpcHolder>
     bool check_leader_status(TRpcHolder rpc, host_port *forward_address) const;
 
-template <typename TRpcHolder>
-bool check_leader_status(TRpcHolder rpc) const;
+    template <typename TRpcHolder>
+    bool check_leader_status(TRpcHolder rpc) const;
 
     error_code remote_storage_initialize();
     bool check_freeze() const;
@@ -493,16 +491,13 @@ bool meta_service::check_status_and_authz(TRpcHolder rpc,
 }
 
 template <typename TRpcHolder>
-bool meta_service::check_status_and_authz(TRpcHolder rpc,
-                                          host_port *forward_address
-                                          ) const
+bool meta_service::check_status_and_authz(TRpcHolder rpc, host_port *forward_address) const
 {
     return check_status_and_authz(rpc, forward_address, "");
 }
 
 template <typename TRpcHolder>
-bool meta_service::check_status_and_authz(TRpcHolder rpc
-                                          ) const
+bool meta_service::check_status_and_authz(TRpcHolder rpc) const
 {
     return check_status_and_authz(rpc, nullptr);
 }

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -795,7 +795,7 @@ void partition_guardian::get_ddd_partitions(const gpid &pid,
 
         return;
     }
-    
+
     if (pid.get_partition_index() == -1) {
         for (const auto &ddd_partition : _ddd_partitions) {
             if (ddd_partition.first.get_app_id() == pid.get_app_id()) {
@@ -804,12 +804,12 @@ void partition_guardian::get_ddd_partitions(const gpid &pid,
         }
 
         return;
-    } 
+    }
 
-        const auto ddd_partition = std::as_const(_ddd_partitions).find(pid);
-        if (ddd_partition != _ddd_partitions.end()) {
-            partitions.push_back(ddd_partition->second);
-        }
+    const auto ddd_partition = std::as_const(_ddd_partitions).find(pid);
+    if (ddd_partition != _ddd_partitions.end()) {
+        partitions.push_back(ddd_partition->second);
+    }
 }
 
 } // namespace replication

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -59,8 +59,7 @@ DSN_DEFINE_int64(meta_server,
                  "recovered beyond this time threshold, an attempt will be made to add new "
                  "secondary replicas on other nodes");
 
-namespace dsn {
-namespace replication {
+namespace dsn::replication {
 
 partition_guardian::partition_guardian(meta_service *svc) : _svc(svc)
 {
@@ -813,5 +812,4 @@ void partition_guardian::get_ddd_partitions(const gpid &pid,
     }
 }
 
-} // namespace replication
-} // namespace dsn
+} // namespace dsn::replication

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <ostream>
+#include <type_traits>
 #include <unordered_map>
 
 #include "common/replication_common.h"

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -788,6 +788,7 @@ void partition_guardian::get_ddd_partitions(const gpid &pid,
     zauto_lock l(_ddd_partitions_lock);
 
     if (pid.get_app_id() == -1) {
+        // Choose all ddd partitions.
         partitions.reserve(_ddd_partitions.size());
         for (const auto &[_, ddd_partition] : _ddd_partitions) {
             partitions.push_back(ddd_partition);
@@ -797,6 +798,7 @@ void partition_guardian::get_ddd_partitions(const gpid &pid,
     }
 
     if (pid.get_partition_index() == -1) {
+        // Choose the ddd partitions of the given table.
         for (const auto &[ddd_pid, ddd_partition] : _ddd_partitions) {
             if (ddd_pid.get_app_id() == pid.get_app_id()) {
                 partitions.push_back(ddd_partition);
@@ -806,6 +808,7 @@ void partition_guardian::get_ddd_partitions(const gpid &pid,
         return;
     }
 
+    // If the given partition is ddd, choose it.
     const auto ddd_partition = std::as_const(_ddd_partitions).find(pid);
     if (ddd_partition != _ddd_partitions.end()) {
         partitions.push_back(ddd_partition->second);

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -789,17 +789,17 @@ void partition_guardian::get_ddd_partitions(const gpid &pid,
 
     if (pid.get_app_id() == -1) {
         partitions.reserve(_ddd_partitions.size());
-        for (const auto &ddd_partition : _ddd_partitions) {
-            partitions.push_back(ddd_partition.second);
+        for (const auto &[_, ddd_partition] : _ddd_partitions) {
+            partitions.push_back(ddd_partition);
         }
 
         return;
     }
 
     if (pid.get_partition_index() == -1) {
-        for (const auto &ddd_partition : _ddd_partitions) {
-            if (ddd_partition.first.get_app_id() == pid.get_app_id()) {
-                partitions.push_back(ddd_partition.second);
+        for (const auto &[ddd_pid, ddd_partition] : _ddd_partitions) {
+            if (ddd_pid.get_app_id() == pid.get_app_id()) {
+                partitions.push_back(ddd_partition);
             }
         }
 

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -782,8 +782,10 @@ partition_guardian::ctrl_assign_secondary_black_list(const std::vector<std::stri
     return msg.dump(2);
 }
 
-void partition_guardian::get_ddd_partitions(const gpid &pid,
-                                            std::vector<ddd_partition_info> &partitions) const
+void partition_guardian::get_ddd_partitions(
+        const gpid &pid,
+                                            std::vector<ddd_partition_info> &partitions
+                                            ) const
 {
     zauto_lock l(_ddd_partitions_lock);
 

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -783,26 +783,34 @@ partition_guardian::ctrl_assign_secondary_black_list(const std::vector<std::stri
 }
 
 void partition_guardian::get_ddd_partitions(const gpid &pid,
-                                            std::vector<ddd_partition_info> &partitions)
+                                            std::vector<ddd_partition_info> &partitions) const
 {
     zauto_lock l(_ddd_partitions_lock);
+
     if (pid.get_app_id() == -1) {
         partitions.reserve(_ddd_partitions.size());
-        for (const auto &kv : _ddd_partitions) {
-            partitions.push_back(kv.second);
+        for (const auto &ddd_partition : _ddd_partitions) {
+            partitions.push_back(ddd_partition.second);
         }
-    } else if (pid.get_partition_index() == -1) {
-        for (const auto &kv : _ddd_partitions) {
-            if (kv.first.get_app_id() == pid.get_app_id()) {
-                partitions.push_back(kv.second);
+
+        return;
+    }
+    
+    if (pid.get_partition_index() == -1) {
+        for (const auto &ddd_partition : _ddd_partitions) {
+            if (ddd_partition.first.get_app_id() == pid.get_app_id()) {
+                partitions.push_back(ddd_partition.second);
             }
         }
-    } else {
-        auto find = _ddd_partitions.find(pid);
-        if (find != _ddd_partitions.end()) {
-            partitions.push_back(find->second);
+
+        return;
+    } 
+
+        const auto ddd_partition = std::as_const(_ddd_partitions).find(pid);
+        if (ddd_partition != _ddd_partitions.end()) {
+            partitions.push_back(ddd_partition->second);
         }
-    }
 }
+
 } // namespace replication
 } // namespace dsn

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -782,10 +782,8 @@ partition_guardian::ctrl_assign_secondary_black_list(const std::vector<std::stri
     return msg.dump(2);
 }
 
-void partition_guardian::get_ddd_partitions(
-        const gpid &pid,
-                                            std::vector<ddd_partition_info> &partitions
-                                            ) const
+void partition_guardian::get_ddd_partitions(const gpid &pid,
+                                            std::vector<ddd_partition_info> &partitions) const
 {
     zauto_lock l(_ddd_partitions_lock);
 

--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -31,6 +31,7 @@
 #include "meta_data.h"
 #include "rpc/rpc_host_port.h"
 #include "utils/command_manager.h"
+#include "utils/ports.h"
 #include "utils/zlocks.h"
 
 namespace dsn::replication {

--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -33,8 +33,8 @@
 #include "utils/command_manager.h"
 #include "utils/zlocks.h"
 
-namespace dsn {
-namespace replication {
+namespace dsn::replication {
+
 class meta_service;
 
 class partition_guardian
@@ -107,5 +107,4 @@ private:
     friend class meta_partition_guardian_test;
 };
 
-} // namespace replication
-} // namespace dsn
+} // namespace dsn::replication

--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -105,6 +105,9 @@ private:
     int64_t _replica_assign_delay_ms_for_dropouts;
 
     friend class meta_partition_guardian_test;
+
+    DISALLOW_COPY_AND_ASSIGN(partition_guardian);
+    DISALLOW_MOVE_AND_ASSIGN(partition_guardian);
 };
 
 } // namespace dsn::replication

--- a/src/meta/partition_guardian.h
+++ b/src/meta/partition_guardian.h
@@ -54,7 +54,7 @@ public:
     cure(meta_view view, const dsn::gpid &gpid, configuration_proposal_action &action);
     void reconfig(meta_view view, const configuration_update_request &request);
     void register_ctrl_commands();
-    void get_ddd_partitions(const gpid &pid, std::vector<ddd_partition_info> &partitions);
+    void get_ddd_partitions(const gpid &pid, std::vector<ddd_partition_info> &partitions) const;
     void clear_ddd_partitions()
     {
         zauto_lock l(_ddd_partitions_lock);

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -996,15 +996,17 @@ void server_state::on_config_sync(configuration_query_by_node_rpc rpc)
              response.gc_replicas.size());
 }
 
-bool server_state::query_configuration_by_gpid(dsn::gpid id,
-                                               /*out*/ partition_configuration &pc)
+bool server_state::query_configuration_by_gpid(const dsn::gpid &id,
+                                               /*out*/ partition_configuration &pc) const
 {
     zauto_read_lock l(_lock);
-    const auto *ppc = get_config(_all_apps, id);
+
+    const auto *ppc = get_config(std::as_const(_all_apps), id);
     if (ppc != nullptr) {
         pc = *ppc;
         return true;
     }
+
     return false;
 }
 
@@ -1672,7 +1674,7 @@ void server_state::list_apps(dsn::message_ex *msg,
             continue;
         }
 
-        if (_meta_svc->get_access_controller()->allowed(msg, app->app_name)) {
+        if (msg == nullptr || _meta_svc->get_access_controller()->allowed(msg, app->app_name)) {
             response.infos.push_back(*app);
         }
     }

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -1093,16 +1093,17 @@ void server_state::init_app_partition_node(std::shared_ptr<app_state> &app,
         app_partition_path, LPC_META_STATE_HIGH, on_create_app_partition, value);
 }
 
-void server_state::get_allowed_partitions(dsn::message_ex *msg,std::vector<ddd_partition_info> &&ddd_partitions,
-        std::vector<ddd_partition_info> &allowed_partitions) const
+void server_state::get_allowed_partitions(dsn::message_ex *msg,
+                                          const std::vector<ddd_partition_info> &ddd_partitions,
+                                          std::vector<ddd_partition_info> &allowed_partitions) const
 {
     zauto_read_lock l(_lock);
 
     for (const auto &ddd_partition : ddd_partitions) {
-        const auto &app = get_app(ddd_partition.config.pid);
-    if (_meta_svc->get_access_controller()->allowed(msg, app->app_name)) {
-        allowed_partitions.push_back(ddd_partition);
-    }
+        const auto &app = get_app(ddd_partition.config.pid.get_app_id());
+        if (_meta_svc->get_access_controller()->allowed(msg, app->app_name)) {
+            allowed_partitions.push_back(ddd_partition);
+        }
     }
 }
 
@@ -1630,9 +1631,8 @@ void server_state::recall_app(dsn::message_ex *msg)
 }
 
 void server_state::list_apps(dsn::message_ex *msg,
-        const configuration_list_apps_request &request,
-                             configuration_list_apps_response &response
-                             ) const
+                             const configuration_list_apps_request &request,
+                             configuration_list_apps_response &response) const
 {
     LOG_DEBUG("list app request: {}{}status={}",
               request.__isset.app_name_pattern
@@ -1680,10 +1680,8 @@ void server_state::list_apps(dsn::message_ex *msg,
     response.err = dsn::ERR_OK;
 }
 
-void server_state::list_apps(
-        const configuration_list_apps_request &request,
-                             configuration_list_apps_response &response
-                             ) const
+void server_state::list_apps(const configuration_list_apps_request &request,
+                             configuration_list_apps_response &response) const
 {
     list_apps(nullptr, request, response);
 }

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -996,6 +996,19 @@ void server_state::on_config_sync(configuration_query_by_node_rpc rpc)
              response.gc_replicas.size());
 }
 
+error_code server_state::get_app_name(int32_t app_id, std::string &app_name) const
+{
+    zauto_read_lock l(_lock);
+
+    const auto &app = get_app(app_id);
+    if (!app) {
+        return ERR_APP_NOT_EXIST;
+    }
+
+    app_name = app->app_name;
+    return ERR_OK;
+}
+
 bool server_state::query_configuration_by_gpid(const dsn::gpid &id,
                                                /*out*/ partition_configuration &pc) const
 {

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -1103,6 +1103,11 @@ void server_state::get_allowed_partitions(dsn::message_ex *msg,
 
     for (const auto &ddd_partition : ddd_partitions) {
         const auto &app = get_app(ddd_partition.config.pid.get_app_id());
+        if (!app) {
+            LOG_WARNING("app does not exist: ddd_partition = {}", ddd_partition.config.pid);
+            continue;
+        }
+
         if (_meta_svc->get_access_controller()->allowed(msg, app->app_name)) {
             allowed_partitions.push_back(ddd_partition);
         }

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -180,8 +180,8 @@ public:
     void recall_app(dsn::message_ex *msg);
     void rename_app(configuration_rename_app_rpc rpc);
 
-    // List tables according to `request` into `response`, with non-null `msg` used for ACL
-    // checks.
+    // List tables according to `request` into `response`, with non-null request `msg` from
+    // client used for ACL checks. Null `msg` means disabling ACL checks.
     void list_apps(dsn::message_ex *msg,
                    const configuration_list_apps_request &request,
                    configuration_list_apps_response &response) const;

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -161,14 +161,23 @@ public:
                                       /*out*/ query_cfg_response &response);
     bool query_configuration_by_gpid(const dsn::gpid id, /*out*/ partition_configuration &pc);
 
+    // Foo access control.
+    void get_allowed_partitions(dsn::message_ex *msg,std::vector<ddd_partition_info> &&ddd_partitions,
+            std::vector<ddd_partition_info> &allowed_partitions) const;
+
     // app options
     void create_app(dsn::message_ex *msg);
     void drop_app(dsn::message_ex *msg);
     void recall_app(dsn::message_ex *msg);
     void rename_app(configuration_rename_app_rpc rpc);
-    void list_apps(const configuration_list_apps_request &request,
+    void list_apps(dsn::message_ex *msg,
+            const configuration_list_apps_request &request,
                    configuration_list_apps_response &response,
-                   dsn::message_ex *msg = nullptr) const;
+                   ) const;
+    void list_apps(
+            const configuration_list_apps_request &request,
+                   configuration_list_apps_response &response,
+                   ) const;
     void restore_app(dsn::message_ex *msg);
 
     // app env operations

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -71,6 +71,7 @@ class configuration_recovery_request;
 class configuration_recovery_response;
 class configuration_restore_request;
 class configuration_update_request;
+class ddd_partition_info;
 class query_app_info_response;
 class query_replica_info_response;
 
@@ -159,7 +160,7 @@ public:
 
     void query_configuration_by_index(const query_cfg_request &request,
                                       /*out*/ query_cfg_response &response);
-    bool query_configuration_by_gpid(const dsn::gpid id, /*out*/ partition_configuration &pc);
+    bool query_configuration_by_gpid(dsn::gpid id, /*out*/ partition_configuration &pc);
 
     // Foo access control.
     void get_allowed_partitions(dsn::message_ex *msg,

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -160,7 +160,8 @@ public:
 
     void query_configuration_by_index(const query_cfg_request &request,
                                       /*out*/ query_cfg_response &response);
-    bool query_configuration_by_gpid(dsn::gpid id, /*out*/ partition_configuration &pc);
+    bool query_configuration_by_gpid(const dsn::gpid &id,
+                                     /*out*/ partition_configuration &pc) const;
 
     // Foo access control.
     void get_allowed_partitions(dsn::message_ex *msg,

--- a/src/meta/server_state.h
+++ b/src/meta/server_state.h
@@ -162,8 +162,9 @@ public:
     bool query_configuration_by_gpid(const dsn::gpid id, /*out*/ partition_configuration &pc);
 
     // Foo access control.
-    void get_allowed_partitions(dsn::message_ex *msg,std::vector<ddd_partition_info> &&ddd_partitions,
-            std::vector<ddd_partition_info> &allowed_partitions) const;
+    void get_allowed_partitions(dsn::message_ex *msg,
+                                const std::vector<ddd_partition_info> &ddd_partitions,
+                                std::vector<ddd_partition_info> &allowed_partitions) const;
 
     // app options
     void create_app(dsn::message_ex *msg);
@@ -171,13 +172,10 @@ public:
     void recall_app(dsn::message_ex *msg);
     void rename_app(configuration_rename_app_rpc rpc);
     void list_apps(dsn::message_ex *msg,
-            const configuration_list_apps_request &request,
-                   configuration_list_apps_response &response,
-                   ) const;
-    void list_apps(
-            const configuration_list_apps_request &request,
-                   configuration_list_apps_response &response,
-                   ) const;
+                   const configuration_list_apps_request &request,
+                   configuration_list_apps_response &response) const;
+    void list_apps(const configuration_list_apps_request &request,
+                   configuration_list_apps_response &response) const;
     void restore_app(dsn::message_ex *msg);
 
     // app env operations

--- a/src/ranger/ranger_resource_policy.cpp
+++ b/src/ranger/ranger_resource_policy.cpp
@@ -25,7 +25,7 @@ namespace dsn::ranger {
 
 bool policy_item::match(access_type ac_type, const std::string &user_name) const
 {
-    return static_cast<bool>(access_types & ac_type) && users.count(user_name) != 0;
+    return static_cast<bool>(access_types & ac_type) && gutil::ContainsKey(users, user_name);
 }
 
 template <>

--- a/src/ranger/ranger_resource_policy.cpp
+++ b/src/ranger/ranger_resource_policy.cpp
@@ -21,8 +21,7 @@
 #include "ranger/access_type.h"
 #include "utils/fmt_logging.h"
 
-namespace dsn {
-namespace ranger {
+namespace dsn::ranger {
 
 bool policy_item::match(access_type ac_type, const std::string &user_name) const
 {
@@ -276,5 +275,4 @@ access_control_result do_check_ranger_database_table_policy<policy_check_type::k
     return access_control_result::kPending;
 }
 
-} // namespace ranger
-} // namespace dsn
+} // namespace dsn::ranger

--- a/src/ranger/ranger_resource_policy.h
+++ b/src/ranger/ranger_resource_policy.h
@@ -84,7 +84,7 @@ struct policy_item
     // Check if the 'acl_type' - 'user_name' pair is matched to the policy.
     // Return true if it is matched, otherwise return false.
     // TODO(wanghao): add benchmark test
-    bool match(const access_type &ac_type, const std::string &user_name) const;
+    bool match(access_type ac_type, const std::string &user_name) const;
 };
 
 // Data structure of policies with different priorities
@@ -105,33 +105,31 @@ struct acl_policies
     // Check if 'allow_policies' or 'deny_policies' allow or deny 'user_name' to access the resource
     // by type 'ac_type'.
     template <policy_check_type check_type>
-    policy_check_status policies_check(const access_type &ac_type,
-                                       const std::string &user_name) const;
+    policy_check_status policies_check(access_type ac_type, const std::string &user_name) const;
 
     template <policy_check_type check_type, policy_check_status check_status>
-    policy_check_status do_policies_check(const access_type &ac_type,
-                                          const std::string &user_name) const;
+    policy_check_status do_policies_check(access_type ac_type, const std::string &user_name) const;
 };
 
 template <>
 policy_check_status
-acl_policies::policies_check<policy_check_type::kAllow>(const access_type &ac_type,
+acl_policies::policies_check<policy_check_type::kAllow>(access_type ac_type,
                                                         const std::string &user_name) const;
 
 template <>
 policy_check_status
-acl_policies::policies_check<policy_check_type::kDeny>(const access_type &ac_type,
+acl_policies::policies_check<policy_check_type::kDeny>(access_type ac_type,
                                                        const std::string &user_name) const;
 
 template <>
 policy_check_status
 acl_policies::do_policies_check<policy_check_type::kAllow, policy_check_status::kAllowed>(
-    const access_type &ac_type, const std::string &user_name) const;
+    access_type ac_type, const std::string &user_name) const;
 
 template <>
 policy_check_status
 acl_policies::do_policies_check<policy_check_type::kDeny, policy_check_status::kDenied>(
-    const access_type &ac_type, const std::string &user_name) const;
+    access_type ac_type, const std::string &user_name) const;
 
 // A policy data structure definition of ranger resources
 struct ranger_resource_policy
@@ -215,36 +213,36 @@ struct matched_database_table_policy
 */
 access_control_result
 check_ranger_resource_policy_allowed(const std::vector<ranger_resource_policy> &policies,
-                                     const access_type &ac_type,
+                                     access_type ac_type,
                                      const std::string &user_name,
-                                     const match_database_type &md_type,
+                                     match_database_type md_type,
                                      const std::string &database_name,
                                      const std::string &default_database_name);
 
 template <policy_check_type check_type>
 access_control_result
 do_check_ranger_resource_policy(const std::vector<ranger_resource_policy> &policies,
-                                const access_type &ac_type,
+                                access_type ac_type,
                                 const std::string &user_name,
-                                const match_database_type &md_type,
+                                match_database_type md_type,
                                 const std::string &database_name,
                                 const std::string &default_database_name);
 
 template <>
 access_control_result do_check_ranger_resource_policy<policy_check_type::kAllow>(
     const std::vector<ranger_resource_policy> &policies,
-    const access_type &ac_type,
+    access_type ac_type,
     const std::string &user_name,
-    const match_database_type &md_type,
+    match_database_type md_type,
     const std::string &database_name,
     const std::string &default_database_name);
 
 template <>
 access_control_result do_check_ranger_resource_policy<policy_check_type::kDeny>(
     const std::vector<ranger_resource_policy> &policies,
-    const access_type &ac_type,
+    access_type ac_type,
     const std::string &user_name,
-    const match_database_type &md_type,
+    match_database_type md_type,
     const std::string &database_name,
     const std::string &default_database_name);
 
@@ -252,25 +250,25 @@ access_control_result do_check_ranger_resource_policy<policy_check_type::kDeny>(
 // for DATABASE_TABLE resource, returns 'access_control_result::kDenied' means not.
 access_control_result check_ranger_database_table_policy_allowed(
     const std::vector<matched_database_table_policy> &policies,
-    const access_type &ac_type,
+    access_type ac_type,
     const std::string &user_name);
 
 template <policy_check_type check_type>
 access_control_result
 do_check_ranger_database_table_policy(const std::vector<matched_database_table_policy> &policies,
-                                      const access_type &ac_type,
+                                      access_type ac_type,
                                       const std::string &user_name);
 
 template <>
 access_control_result do_check_ranger_database_table_policy<policy_check_type::kDeny>(
     const std::vector<matched_database_table_policy> &policies,
-    const access_type &ac_type,
+    access_type ac_type,
     const std::string &user_name);
 
 template <>
 access_control_result do_check_ranger_database_table_policy<policy_check_type::kAllow>(
     const std::vector<matched_database_table_policy> &policies,
-    const access_type &ac_type,
+    access_type ac_type,
     const std::string &user_name);
 
 } // namespace ranger

--- a/src/ranger/ranger_resource_policy.h
+++ b/src/ranger/ranger_resource_policy.h
@@ -25,8 +25,7 @@
 #include "common/json_helper.h"
 #include "utils/enum_helper.h"
 
-namespace dsn {
-namespace ranger {
+namespace dsn::ranger {
 
 // Types of policy checks.
 // kAllow means this checks for 'allow_policies' and 'allow_policies_exclude'.
@@ -105,29 +104,31 @@ struct acl_policies
     // Check if 'allow_policies' or 'deny_policies' allow or deny 'user_name' to access the resource
     // by type 'ac_type'.
     template <policy_check_type check_type>
-    policy_check_status policies_check(access_type ac_type, const std::string &user_name) const;
+    [[nodiscard]] policy_check_status policies_check(access_type ac_type,
+                                                     const std::string &user_name) const;
 
     template <policy_check_type check_type, policy_check_status check_status>
-    policy_check_status do_policies_check(access_type ac_type, const std::string &user_name) const;
+    [[nodiscard]] policy_check_status do_policies_check(access_type ac_type,
+                                                        const std::string &user_name) const;
 };
 
 template <>
-policy_check_status
+[[nodiscard]] policy_check_status
 acl_policies::policies_check<policy_check_type::kAllow>(access_type ac_type,
                                                         const std::string &user_name) const;
 
 template <>
-policy_check_status
+[[nodiscard]] policy_check_status
 acl_policies::policies_check<policy_check_type::kDeny>(access_type ac_type,
                                                        const std::string &user_name) const;
 
 template <>
-policy_check_status
+[[nodiscard]] policy_check_status
 acl_policies::do_policies_check<policy_check_type::kAllow, policy_check_status::kAllowed>(
     access_type ac_type, const std::string &user_name) const;
 
 template <>
-policy_check_status
+[[nodiscard]] policy_check_status
 acl_policies::do_policies_check<policy_check_type::kDeny, policy_check_status::kDenied>(
     access_type ac_type, const std::string &user_name) const;
 
@@ -271,5 +272,4 @@ access_control_result do_check_ranger_database_table_policy<policy_check_type::k
     access_type ac_type,
     const std::string &user_name);
 
-} // namespace ranger
-} // namespace dsn
+} // namespace dsn::ranger

--- a/src/ranger/ranger_resource_policy_manager.cpp
+++ b/src/ranger/ranger_resource_policy_manager.cpp
@@ -165,7 +165,7 @@ ranger_resource_policy_manager::ranger_resource_policy_manager(
                               "RPC_CLI_CLI_CALL_ACK"},
                              _ac_type_of_global_rpcs);
     // DATABASE - kList
-    register_rpc_access_type(access_type::kList, {"RPC_CM_LIST_APPS"}, _ac_type_of_database_rpcs);
+    register_rpc_access_type(access_type::kList, {"RPC_CM_LIST_APPS", "RPC_CM_DDD_DIAGNOSE"}, _ac_type_of_database_rpcs);
     // DATABASE - kCreate
     register_rpc_access_type(
         access_type::kCreate, {"RPC_CM_CREATE_APP"}, _ac_type_of_database_rpcs);
@@ -191,7 +191,6 @@ ranger_resource_policy_manager::ranger_resource_policy_manager(
                               "RPC_CM_ADD_DUPLICATION",
                               "RPC_CM_MODIFY_DUPLICATION",
                               "RPC_CM_UPDATE_APP_ENV",
-                              "RPC_CM_DDD_DIAGNOSE",
                               "RPC_CM_START_PARTITION_SPLIT",
                               "RPC_CM_CONTROL_PARTITION_SPLIT",
                               "RPC_CM_START_BULK_LOAD",

--- a/src/ranger/ranger_resource_policy_manager.cpp
+++ b/src/ranger/ranger_resource_policy_manager.cpp
@@ -205,7 +205,12 @@ ranger_resource_policy_manager::ranger_resource_policy_manager(
 
 void ranger_resource_policy_manager::start()
 {
-    CHECK_NOTNULL(_meta_svc, "");
+    if (_meta_svc == nullptr) {
+        // `_meta_svc` being null implies that the policies will be updated manually,
+        // which is often used for testing purposes.
+        return;
+    }
+
     _ranger_policy_meta_root = dsn::utils::filesystem::concat_path_unix_style(
         _meta_svc->cluster_root(), "ranger_policy_meta_root");
     tasking::enqueue_timer(

--- a/src/ranger/ranger_resource_policy_manager.cpp
+++ b/src/ranger/ranger_resource_policy_manager.cpp
@@ -208,11 +208,15 @@ ranger_resource_policy_manager::ranger_resource_policy_manager(
 
 void ranger_resource_policy_manager::start()
 {
+#ifdef MOCK_TEST
     if (_meta_svc == nullptr) {
         // `_meta_svc` being null implies that the policies will be updated manually,
-        // which is often used for testing purposes.
+        // which is only used for testing purposes.
         return;
     }
+#else
+    CHECK_NOTNULL(_meta_svc, "");
+#endif
 
     _ranger_policy_meta_root = dsn::utils::filesystem::concat_path_unix_style(
         _meta_svc->cluster_root(), "ranger_policy_meta_root");

--- a/src/ranger/ranger_resource_policy_manager.cpp
+++ b/src/ranger/ranger_resource_policy_manager.cpp
@@ -645,7 +645,7 @@ dsn::error_code ranger_resource_policy_manager::sync_policies_to_app_envs()
 
 std::string get_database_name_from_app_name(const std::string &app_name)
 {
-    std::string prefix = utils::find_string_prefix(app_name, '.');
+    const auto &prefix = utils::find_string_prefix(app_name, '.');
     if (prefix.empty() || prefix == app_name) {
         return std::string();
     }

--- a/src/ranger/ranger_resource_policy_manager.cpp
+++ b/src/ranger/ranger_resource_policy_manager.cpp
@@ -165,7 +165,8 @@ ranger_resource_policy_manager::ranger_resource_policy_manager(
                               "RPC_CLI_CLI_CALL_ACK"},
                              _ac_type_of_global_rpcs);
     // DATABASE - kList
-    register_rpc_access_type(access_type::kList, {"RPC_CM_LIST_APPS", "RPC_CM_DDD_DIAGNOSE"}, _ac_type_of_database_rpcs);
+    register_rpc_access_type(
+        access_type::kList, {"RPC_CM_LIST_APPS", "RPC_CM_DDD_DIAGNOSE"}, _ac_type_of_database_rpcs);
     // DATABASE - kCreate
     register_rpc_access_type(
         access_type::kCreate, {"RPC_CM_CREATE_APP"}, _ac_type_of_database_rpcs);

--- a/src/ranger/ranger_resource_policy_manager.cpp
+++ b/src/ranger/ranger_resource_policy_manager.cpp
@@ -74,8 +74,7 @@ DSN_DEFINE_string(ranger,
                   "The name of the Ranger database policy matched by the legacy table(The table "
                   "name does not follow the naming rules of {database_name}.{table_name})");
 
-namespace dsn {
-namespace ranger {
+namespace dsn::ranger {
 
 #define RETURN_ERR_IF_MISSING_MEMBER(obj, member)                                                  \
     do {                                                                                           \
@@ -645,18 +644,15 @@ dsn::error_code ranger_resource_policy_manager::sync_policies_to_app_envs()
 
 std::string get_database_name_from_app_name(const std::string &app_name)
 {
-    const auto &prefix = utils::find_string_prefix(app_name, '.');
-    if (prefix.empty() || prefix == app_name) {
-        return std::string();
-    }
-
-    return prefix;
+    return utils::find_string_prefix(app_name, '.');
 }
 
 std::string get_table_name_from_app_name(const std::string &app_name)
 {
-    std::string database_name = get_database_name_from_app_name(app_name);
+    // TODO(wangdan): optimize getting table name by finding the separator without initializing
+    // an extra string object.
+    const auto &database_name = get_database_name_from_app_name(app_name);
     return database_name.empty() ? app_name : app_name.substr(database_name.size() + 1);
 }
-} // namespace ranger
-} // namespace dsn
+
+} // namespace dsn::ranger

--- a/src/ranger/ranger_resource_policy_manager.cpp
+++ b/src/ranger/ranger_resource_policy_manager.cpp
@@ -164,6 +164,9 @@ ranger_resource_policy_manager::ranger_resource_policy_manager(
                               "RPC_CLI_CLI_CALL_ACK"},
                              _ac_type_of_global_rpcs);
     // DATABASE - kList
+    // The `RPC_CM_DDD_DIAGNOSE` request is only used to retrieve information about DDD
+    // partitions and does not modify any data or metadata, so it is more appropriate to
+    // classify it as `kList` rather than `kControl`.
     register_rpc_access_type(
         access_type::kList, {"RPC_CM_LIST_APPS", "RPC_CM_DDD_DIAGNOSE"}, _ac_type_of_database_rpcs);
     // DATABASE - kCreate

--- a/src/ranger/ranger_resource_policy_manager.h
+++ b/src/ranger/ranger_resource_policy_manager.h
@@ -80,6 +80,13 @@ public:
                                   const std::string &user_name,
                                   const std::string &database_name) const;
 
+protected:
+    // The cache of the global resources policies, it's a subset of '_all_resource_policies'.
+    resource_policies _global_policies_cache;
+
+    // The cache of the database resources policies, it's a subset of '_all_resource_policies'.
+    resource_policies _database_policies_cache;
+
 private:
     // Parse Ranger ACL policies from 'data' in JSON format into 'policies'.
     static void parse_policies_from_json(const rapidjson::Value &data,
@@ -106,14 +113,6 @@ private:
     // Sync policies to app_envs(REPLICA_ACCESS_CONTROLLER_RANGER_POLICIES).
     dsn::error_code sync_policies_to_app_envs();
 
-protected:
-    // The cache of the global resources policies, it's a subset of '_all_resource_policies'.
-    resource_policies _global_policies_cache;
-
-    // The cache of the database resources policies, it's a subset of '_all_resource_policies'.
-    resource_policies _database_policies_cache;
-
-private:
     dsn::task_tracker _tracker;
 
     // The path where policies to be saved in remote storage.
@@ -149,5 +148,6 @@ std::string get_database_name_from_app_name(const std::string &app_name);
 // Try to get the table_name of 'app_name'.
 // Return 'app_name' if 'app_name' is not a valid Ranger rule table name.
 std::string get_table_name_from_app_name(const std::string &app_name);
+
 } // namespace ranger
 } // namespace dsn

--- a/src/ranger/test/ranger_resource_policy_manager_test.cpp
+++ b/src/ranger/test/ranger_resource_policy_manager_test.cpp
@@ -479,8 +479,11 @@ TEST_F(ranger_resource_policy_manager_function_test, allowed)
         {"TASK_CODE_INVALID", "user1", "database1", access_control_result::kDenied},
         {"RPC_CM_CREATE_APP", "user1", "database1", access_control_result::kDenied},
         {"RPC_CM_CREATE_APP", "user2", "database1", access_control_result::kDenied},
+        // Both RPC_CM_LIST_APPS and RPC_CM_DDD_DIAGNOSE belong to access_type::kList.
         {"RPC_CM_LIST_APPS", "user1", "database1", access_control_result::kAllowed},
         {"RPC_CM_LIST_APPS", "user2", "database1", access_control_result::kAllowed},
+        {"RPC_CM_DDD_DIAGNOSE", "user1", "database1", access_control_result::kAllowed},
+        {"RPC_CM_DDD_DIAGNOSE", "user2", "database1", access_control_result::kAllowed},
         {"RPC_CM_GET_MAX_REPLICA_COUNT", "user1", "database1", access_control_result::kAllowed},
         {"RPC_CM_GET_MAX_REPLICA_COUNT", "user2", "database1", access_control_result::kDenied},
         {"TASK_CODE_INVALID", "user3", "database2", access_control_result::kDenied},
@@ -502,11 +505,15 @@ TEST_F(ranger_resource_policy_manager_function_test, allowed)
         // RPC_CM_LIST_APPS has been removed from global resources.
         {"RPC_CM_LIST_APPS", "user7", "database3", access_control_result::kDenied},
         {"RPC_CM_LIST_APPS", "user8", "database3", access_control_result::kDenied},
+        {"RPC_CM_DDD_DIAGNOSE", "user7", "database3", access_control_result::kDenied},
+        {"RPC_CM_DDD_DIAGNOSE", "user8", "database3", access_control_result::kDenied},
         {"TASK_CODE_INVALID", "user9", "database4", access_control_result::kDenied},
         {"RPC_CM_LIST_NODES", "user9", "database4", access_control_result::kDenied},
         {"RPC_CM_LIST_NODES", "user10", "database4", access_control_result::kDenied},
         {"RPC_CM_LIST_APPS", "user9", "database4", access_control_result::kDenied},
         {"RPC_CM_LIST_APPS", "user10", "database4", access_control_result::kDenied},
+        {"RPC_CM_DDD_DIAGNOSE", "user9", "database4", access_control_result::kDenied},
+        {"RPC_CM_DDD_DIAGNOSE", "user10", "database4", access_control_result::kDenied},
         {"RPC_CM_CONTROL_META", "user9", "database4", access_control_result::kAllowed},
         {"RPC_CM_CONTROL_META", "user10", "database4", access_control_result::kDenied}};
     for (const auto &test : tests) {

--- a/src/replica/replica.cpp
+++ b/src/replica/replica.cpp
@@ -747,7 +747,8 @@ error_code replica::load_app_info(app_info &info) const { return load_app_info(_
 
 bool replica::access_controller_allowed(message_ex *msg, const ranger::access_type &ac_type) const
 {
-    return !_access_controller->is_enable_ranger_acl() || _access_controller->allowed(msg, ac_type);
+    return !_access_controller->is_ranger_acl_enabled() ||
+           _access_controller->allowed(msg, ac_type);
 }
 
 int64_t replica::get_backup_request_count() const { return METRIC_VAR_VALUE(backup_requests); }

--- a/src/replica/replica_stub.h
+++ b/src/replica/replica_stub.h
@@ -297,7 +297,7 @@ public:
                                            ::dsn::rpc_replier<TRespType> &reply,
                                            const ::dsn::ranger::access_type &ac_type) const
     {
-        if (!_access_controller->is_enable_ranger_acl()) {
+        if (!_access_controller->is_ranger_acl_enabled()) {
             return true;
         }
         const auto &pid = request.pid;

--- a/src/runtime/serverlet.h
+++ b/src/runtime/serverlet.h
@@ -123,11 +123,13 @@ protected:
                               const char *extra_name,
                               void (T::*handler)(const TRequest &, TResponse &));
 
+    // Register non-const member function of class T as handler.
     template <typename TRpcHolder>
     bool register_rpc_handler_with_rpc_holder(dsn::task_code rpc_code,
                                               const char *extra_name,
                                               void (T::*handler)(TRpcHolder));
 
+    // Register const member function of class T as handler.
     template <typename TRpcHolder>
     bool register_rpc_handler_with_rpc_holder(dsn::task_code rpc_code,
                                               const char *extra_name,

--- a/src/runtime/serverlet.h
+++ b/src/runtime/serverlet.h
@@ -110,7 +110,7 @@ public:
     explicit serverlet(const char *nm);
     virtual ~serverlet() = default;
 
-    const std::string &name() const { return _name; }
+    [[nodiscard]] const std::string &name() const { return _name; }
 
 protected:
     template <typename TRequest>
@@ -197,7 +197,7 @@ inline bool serverlet<T>::register_rpc_handler_with_rpc_holder(dsn::task_code rp
                                                                void (T::*handler)(TRpcHolder))
 {
     const rpc_request_handler cb = [this, handler](dsn::message_ex *request) {
-        (((T *)this)->*(handler))(TRpcHolder::auto_reply(request));
+        (static_cast<T *>(this)->*handler)(TRpcHolder::auto_reply(request));
     };
 
     return dsn_rpc_register_handler(rpc_code, extra_name, cb);
@@ -210,7 +210,7 @@ inline bool serverlet<T>::register_rpc_handler_with_rpc_holder(dsn::task_code rp
                                                                void (T::*handler)(TRpcHolder) const)
 {
     const rpc_request_handler cb = [this, handler](dsn::message_ex *request) {
-        (((const T *)this)->*(handler))(TRpcHolder::auto_reply(request));
+        (static_cast<const T *>(this)->*handler)(TRpcHolder::auto_reply(request));
     };
 
     return dsn_rpc_register_handler(rpc_code, extra_name, cb);

--- a/src/runtime/serverlet.h
+++ b/src/runtime/serverlet.h
@@ -145,7 +145,7 @@ protected:
     bool unregister_rpc_handler(task_code rpc_code);
 
     template <typename TResponse>
-    void reply(dsn::message_ex *request, const TResponse &resp);
+    static void reply(dsn::message_ex *request, const TResponse &resp);
 
 private:
     std::string _name;

--- a/src/security/access_controller.cpp
+++ b/src/security/access_controller.cpp
@@ -50,7 +50,12 @@ access_controller::access_controller()
     utils::split_args(FLAGS_super_users, _super_users, ',');
 }
 
-/* static */ bool access_controller::is_enable_ranger_acl() { return FLAGS_enable_ranger_acl; }
+/* static */ bool access_controller::is_ranger_acl_enabled() { return FLAGS_enable_ranger_acl; }
+
+/* static */ bool access_controller::is_acl_enabled()
+{
+    return FLAGS_enable_ranger_acl || FLAGS_enable_acl;
+}
 
 bool access_controller::is_super_user(const std::string &user_name) const
 {

--- a/src/security/access_controller.cpp
+++ b/src/security/access_controller.cpp
@@ -39,8 +39,7 @@ DSN_DEFINE_string(security,
                   "Name of the cluster key that is used to encrypt server encryption keys as"
                   "stored in Ranger KMS.");
 
-namespace dsn {
-namespace security {
+namespace dsn::security {
 
 access_controller::access_controller()
 {
@@ -50,8 +49,6 @@ access_controller::access_controller()
           "when FLAGS_enable_ranger_acl is true, FLAGS_enable_acl must be true too");
     utils::split_args(FLAGS_super_users, _super_users, ',');
 }
-
-access_controller::~access_controller() {}
 
 bool access_controller::is_enable_ranger_acl() const { return FLAGS_enable_ranger_acl; }
 
@@ -70,5 +67,5 @@ std::unique_ptr<access_controller> create_replica_access_controller(const std::s
 {
     return std::make_unique<replica_access_controller>(replica_name);
 }
-} // namespace security
-} // namespace dsn
+
+} // namespace dsn::security

--- a/src/security/access_controller.cpp
+++ b/src/security/access_controller.cpp
@@ -17,6 +17,7 @@
 
 #include "access_controller.h"
 
+#include "gutil/map_util.h"
 #include "meta_access_controller.h"
 #include "replica_access_controller.h"
 #include "utils/flags.h"
@@ -56,7 +57,7 @@ bool access_controller::is_enable_ranger_acl() const { return FLAGS_enable_range
 
 bool access_controller::is_super_user(const std::string &user_name) const
 {
-    return _super_users.find(user_name) != _super_users.end();
+    return gutil::ContainsKey(_super_users, user_name);
 }
 
 std::shared_ptr<access_controller> create_meta_access_controller(

--- a/src/security/access_controller.cpp
+++ b/src/security/access_controller.cpp
@@ -50,7 +50,7 @@ access_controller::access_controller()
     utils::split_args(FLAGS_super_users, _super_users, ',');
 }
 
-bool access_controller::is_enable_ranger_acl() const { return FLAGS_enable_ranger_acl; }
+/* static */ bool access_controller::is_enable_ranger_acl() { return FLAGS_enable_ranger_acl; }
 
 bool access_controller::is_super_user(const std::string &user_name) const
 {

--- a/src/security/access_controller.h
+++ b/src/security/access_controller.h
@@ -41,10 +41,10 @@ public:
     // Return true if Ranger ACL is enabled, otherwise false.
     static bool is_ranger_acl_enabled();
 
-    // Return true if either Ranger ACL or old ACL is enabled, otherwise false.
+    // Return true if either Ranger ACL or legacy ACL is enabled, otherwise false.
     static bool is_acl_enabled();
 
-    // Update allowed users for old ACL.
+    // Update allowed users for legacy ACL.
     //
     // Parameters:
     // - users: the new allowed users used to update.

--- a/src/security/access_controller.h
+++ b/src/security/access_controller.h
@@ -56,7 +56,8 @@ public:
     // - policies: the new policies used to update.
     virtual void update_ranger_policies(const std::string &policies) {}
 
-    // Return true if the received request is allowd to access the system with specified type.
+    // Return true if the received request is allowd to access the system with specified
+    // type, otherwise false.
     //
     // Parameters:
     // - msg: the received request, should never be null.

--- a/src/security/access_controller.h
+++ b/src/security/access_controller.h
@@ -36,7 +36,7 @@ class access_controller
 {
 public:
     access_controller();
-    virtual ~access_controller();
+    virtual ~access_controller() = default;
 
     // Update the access controller.
     // users - the new allowed users to update
@@ -68,7 +68,7 @@ protected:
 
     std::unordered_set<std::string> _super_users;
 
-    friend class meta_access_controller_test;
+    friend class SuperUserTest;
 };
 
 std::shared_ptr<access_controller> create_meta_access_controller(
@@ -76,5 +76,6 @@ std::shared_ptr<access_controller> create_meta_access_controller(
 
 std::unique_ptr<access_controller>
 create_replica_access_controller(const std::string &replica_name);
+
 } // namespace security
 } // namespace dsn

--- a/src/security/access_controller.h
+++ b/src/security/access_controller.h
@@ -56,11 +56,12 @@ public:
     // Check if the received request is allowd to access the table.
     //
     // Parameters:
-    // - msg: the received request, should never be NULL.
+    // - msg: the received request, should never be null.
     // - app_name: the name of the table on which the ACL check is performed.
     virtual bool allowed(message_ex *msg, const std::string &app_name) const { return false; }
 
-    bool allowed(message_ex *msg) const { return allowed(msg, std::string()); }
+    // The same as the above function, except that `app_name` is set empty.
+    bool allowed(message_ex *msg) const { return allowed(msg, ""); }
 
 protected:
     // Check if 'user_name' is the super user.

--- a/src/security/access_controller.h
+++ b/src/security/access_controller.h
@@ -53,9 +53,11 @@ public:
     // msg - the message received
     virtual bool allowed(message_ex *msg, dsn::ranger::access_type req_type) const { return false; }
 
-    // Check if the message received is allowd to access the table.
-    // msg - the message received
-    // app_name - tables involved in ACL
+    // Check if the received message is allowd to access the table.
+    //
+    // Parameters:
+    // - msg: the message received
+    // - app_name: tables involved in ACL
     virtual bool allowed(message_ex *msg, const std::string &app_name) const { return false; }
 
     bool allowed(message_ex *msg) const { return allowed(msg, std::string()); }

--- a/src/security/access_controller.h
+++ b/src/security/access_controller.h
@@ -56,7 +56,7 @@ public:
     // Check if the received message is allowd to access the table.
     //
     // Parameters:
-    // - msg: the message received
+    // - msg: the message received, should never be NULL.
     // - app_name: tables involved in ACL
     virtual bool allowed(message_ex *msg, const std::string &app_name) const { return false; }
 

--- a/src/security/access_controller.h
+++ b/src/security/access_controller.h
@@ -53,11 +53,11 @@ public:
     // msg - the message received
     virtual bool allowed(message_ex *msg, dsn::ranger::access_type req_type) const { return false; }
 
-    // Check if the received message is allowd to access the table.
+    // Check if the received request is allowd to access the table.
     //
     // Parameters:
-    // - msg: the message received, should never be NULL.
-    // - app_name: tables involved in ACL
+    // - msg: the received request, should never be NULL.
+    // - app_name: the name of the table on which the ACL check is performed.
     virtual bool allowed(message_ex *msg, const std::string &app_name) const { return false; }
 
     bool allowed(message_ex *msg) const { return allowed(msg, std::string()); }

--- a/src/security/access_controller.h
+++ b/src/security/access_controller.h
@@ -43,7 +43,7 @@ public:
     virtual void update_allowed_users(const std::string &users) {}
 
     // Check whether the Ranger ACL is enabled or not.
-    bool is_enable_ranger_acl() const;
+    static bool is_enable_ranger_acl();
 
     // Update the access controller policy
     // policies -  the new Ranger policies to update

--- a/src/security/access_controller.h
+++ b/src/security/access_controller.h
@@ -56,7 +56,9 @@ public:
     // Check if the message received is allowd to access the table.
     // msg - the message received
     // app_name - tables involved in ACL
-    virtual bool allowed(message_ex *msg, const std::string &app_name = "") const { return false; }
+    virtual bool allowed(message_ex *msg, const std::string &app_name) const { return false; }
+
+    bool allowed(message_ex *msg) const { return allowed(msg, std::string()); }
 
 protected:
     // Check if 'user_name' is the super user.

--- a/src/security/access_controller.h
+++ b/src/security/access_controller.h
@@ -38,22 +38,32 @@ public:
     access_controller();
     virtual ~access_controller() = default;
 
-    // Update the access controller.
-    // users - the new allowed users to update
+    // Return true if Ranger ACL is enabled, otherwise false.
+    static bool is_ranger_acl_enabled();
+
+    // Return true if either Ranger ACL or old ACL is enabled, otherwise false.
+    static bool is_acl_enabled();
+
+    // Update allowed users for old ACL.
+    //
+    // Parameters:
+    // - users: the new allowed users used to update.
     virtual void update_allowed_users(const std::string &users) {}
 
-    // Check whether the Ranger ACL is enabled or not.
-    static bool is_enable_ranger_acl();
-
-    // Update the access controller policy
-    // policies -  the new Ranger policies to update
+    // Update policies for Ranger ACL.
+    //
+    // Parameters:
+    // - policies: the new policies used to update.
     virtual void update_ranger_policies(const std::string &policies) {}
 
-    // Check if the message received is allowd to access the system.
-    // msg - the message received
+    // Return true if the received request is allowd to access the system with specified type.
+    //
+    // Parameters:
+    // - msg: the received request, should never be null.
+    // - req_type: the access type.
     virtual bool allowed(message_ex *msg, dsn::ranger::access_type req_type) const { return false; }
 
-    // Check if the received request is allowd to access the table.
+    // Return true if the received request is allowd to access the table, otherwise false.
     //
     // Parameters:
     // - msg: the received request, should never be null.

--- a/src/security/meta_access_controller.cpp
+++ b/src/security/meta_access_controller.cpp
@@ -50,6 +50,7 @@ meta_access_controller::meta_access_controller(
     if (utils::is_empty(FLAGS_meta_acl_rpc_allow_list)) {
         register_allowed_rpc_code_list({"RPC_CM_CLUSTER_INFO",
                                         "RPC_CM_LIST_APPS",
+                                        "RPC_CM_DDD_DIAGNOSE",
                                         "RPC_CM_LIST_NODES",
                                         "RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX"});
     } else {

--- a/src/security/meta_access_controller.cpp
+++ b/src/security/meta_access_controller.cpp
@@ -19,6 +19,7 @@
 
 #include <vector>
 
+#include "gutil/map_util.h"
 #include "ranger/ranger_resource_policy.h"
 #include "ranger/ranger_resource_policy_manager.h"
 #include "rpc/network.h"

--- a/src/security/meta_access_controller.cpp
+++ b/src/security/meta_access_controller.cpp
@@ -17,6 +17,7 @@
 
 #include "meta_access_controller.h"
 
+#include <utility>
 #include <vector>
 
 #include "gutil/map_util.h"
@@ -42,13 +43,13 @@ namespace dsn {
 namespace security {
 
 meta_access_controller::meta_access_controller(
-    const std::shared_ptr<ranger::ranger_resource_policy_manager> &policy_manager)
-    : _ranger_resource_policy_manager(policy_manager)
+    std::shared_ptr<ranger::ranger_resource_policy_manager> policy_manager)
+    : _ranger_resource_policy_manager(std::move(policy_manager))
 {
     // For the old ACL:
     // 1. the meta server accepts and processes any RPC requests in the allow list from
     // all users;
-    // 2. for the RPC requests not in the allow list, only those sent by the superuser
+    // 2. for the RPC requests not in the allow list, only those issued by the superuser
     // are accepted.
     if (utils::is_empty(FLAGS_meta_acl_rpc_allow_list)) {
         register_allowed_rpc_code_list({"RPC_CM_CLUSTER_INFO",

--- a/src/security/meta_access_controller.cpp
+++ b/src/security/meta_access_controller.cpp
@@ -93,19 +93,21 @@ meta_access_controller::meta_access_controller(
 
 bool meta_access_controller::allowed(message_ex *msg, const std::string &app_name) const
 {
-    // when the Ranger ACL is not enabled, the old ACL will be used in these three cases, the ACL
-    // will be allowed:
-    // 1. enable_acl is false
-    // 2. the client user is a super user
-    // 3. the rpc_code is allowed
+    // Once the Ranger ACL is not enabled, the old ACL check will pass as long as any one of
+    // these three conditions is met:
+    // 1. the old ACL is disabled, or
+    // 2. the client user is a super user, or
+    // 3. the RPC code is in the allow list.
     if (!FLAGS_enable_ranger_acl) {
         return !FLAGS_enable_acl || is_super_user(msg->io_session->get_client_username()) ||
                rpc_allowed(msg->rpc_code().code());
     }
 
-    // in this case, the Ranger ACL is enabled. In both cases, the ACL will be allowed:
-    // 1. the rpc_code is in _allowed_rpc_code_list.(usually internal rpc)
-    // 2. the user_name and resource have passed the validation of Ranger policy
+    // Once the Ranger ACL is enabled, the ACL check will pass as long as any one of these
+    // two conditions is met:
+    // 1. the RPC code is in the allow list (usually internal RPCs), or
+    // 2. the username and the target database have both been verified through the Ranger
+    // policy.
     const auto rpc_code = msg->rpc_code().code();
     if (rpc_allowed(rpc_code)) {
         return true;

--- a/src/security/meta_access_controller.cpp
+++ b/src/security/meta_access_controller.cpp
@@ -45,8 +45,11 @@ meta_access_controller::meta_access_controller(
     const std::shared_ptr<ranger::ranger_resource_policy_manager> &policy_manager)
     : _ranger_resource_policy_manager(policy_manager)
 {
-    // MetaServer serves the allow-list RPC from all users. RPCs unincluded are accessible to only
-    // superusers.
+    // For the old ACL:
+    // 1. the meta server accepts and processes any RPC requests in the allow list from
+    // all users;
+    // 2. for the RPC requests not in the allow list, only those sent by the superuser
+    // are accepted.
     if (utils::is_empty(FLAGS_meta_acl_rpc_allow_list)) {
         register_allowed_rpc_code_list({"RPC_CM_CLUSTER_INFO",
                                         "RPC_CM_LIST_APPS",
@@ -59,7 +62,8 @@ meta_access_controller::meta_access_controller(
         register_allowed_rpc_code_list(rpc_code_white_list);
     }
 
-    // use Ranger policy
+    // Once Ranger ACL is enabled, the allow list registered by the old ACL will be cleared
+    // and replaced by the allow list from the Ranger ACL.
     if (FLAGS_enable_ranger_acl) {
         register_allowed_rpc_code_list({"RPC_BULK_LOAD",
                                         "RPC_CALL_RAW_MESSAGE",

--- a/src/security/meta_access_controller.cpp
+++ b/src/security/meta_access_controller.cpp
@@ -46,7 +46,7 @@ meta_access_controller::meta_access_controller(
     std::shared_ptr<ranger::ranger_resource_policy_manager> policy_manager)
     : _ranger_resource_policy_manager(std::move(policy_manager))
 {
-    // For the old ACL:
+    // For the legacy ACL:
     // 1. the meta server accepts and processes any RPC requests in the allow list from
     // all users;
     // 2. for the RPC requests not in the allow list, only those issued by the superuser
@@ -63,8 +63,8 @@ meta_access_controller::meta_access_controller(
         register_allowed_rpc_code_list(rpc_code_white_list);
     }
 
-    // Once Ranger ACL is enabled, the allow list registered by the old ACL will be cleared
-    // and replaced by the allow list from the Ranger ACL.
+    // Once Ranger ACL is enabled, the allow list registered by the legacy ACL will be
+    // cleared and replaced by the allow list from the Ranger ACL.
     if (FLAGS_enable_ranger_acl) {
         register_allowed_rpc_code_list({"RPC_BULK_LOAD",
                                         "RPC_CALL_RAW_MESSAGE",
@@ -98,9 +98,9 @@ meta_access_controller::meta_access_controller(
 
 bool meta_access_controller::allowed(message_ex *msg, const std::string &app_name) const
 {
-    // Once the Ranger ACL is not enabled, the old ACL check will pass as long as any one of
-    // these three conditions is met:
-    // 1. the old ACL is disabled, or
+    // Once the Ranger ACL is not enabled, the legacy ACL check will pass as long as any one
+    // of these three conditions is met:
+    // 1. the legacy ACL is disabled, or
     // 2. the client user is a super user, or
     // 3. the RPC code is in the allow list.
     if (!FLAGS_enable_ranger_acl) {

--- a/src/security/meta_access_controller.h
+++ b/src/security/meta_access_controller.h
@@ -36,7 +36,7 @@ namespace security {
 class meta_access_controller : public access_controller
 {
 public:
-    meta_access_controller(
+    explicit meta_access_controller(
         const std::shared_ptr<ranger::ranger_resource_policy_manager> &policy_manager);
 
     bool allowed(message_ex *msg, const std::string &app_name) const override;

--- a/src/security/meta_access_controller.h
+++ b/src/security/meta_access_controller.h
@@ -39,7 +39,7 @@ public:
     meta_access_controller(
         const std::shared_ptr<ranger::ranger_resource_policy_manager> &policy_manager);
 
-    bool allowed(message_ex *msg, const std::string &app_name = "") const override;
+    bool allowed(message_ex *msg, const std::string &app_name) const override;
 
 private:
     void register_allowed_rpc_code_list(const std::vector<std::string> &rpc_list);

--- a/src/security/meta_access_controller.h
+++ b/src/security/meta_access_controller.h
@@ -44,6 +44,8 @@ public:
 private:
     void register_allowed_rpc_code_list(const std::vector<std::string> &rpc_list);
 
+    bool rpc_allowed(int rpc_code) const;
+
     std::unordered_set<int> _allowed_rpc_code_list;
 
     std::shared_ptr<ranger::ranger_resource_policy_manager> _ranger_resource_policy_manager;

--- a/src/security/meta_access_controller.h
+++ b/src/security/meta_access_controller.h
@@ -44,6 +44,7 @@ public:
 private:
     void register_allowed_rpc_code_list(const std::vector<std::string> &rpc_list);
 
+    // Return true if the RPC code is in the allow list, otherwise false.
     bool rpc_allowed(int rpc_code) const;
 
     std::unordered_set<int> _allowed_rpc_code_list;

--- a/src/security/meta_access_controller.h
+++ b/src/security/meta_access_controller.h
@@ -37,7 +37,7 @@ class meta_access_controller : public access_controller
 {
 public:
     explicit meta_access_controller(
-        const std::shared_ptr<ranger::ranger_resource_policy_manager> &policy_manager);
+        std::shared_ptr<ranger::ranger_resource_policy_manager> policy_manager);
 
     bool allowed(message_ex *msg, const std::string &app_name) const override;
 

--- a/src/security/replica_access_controller.h
+++ b/src/security/replica_access_controller.h
@@ -57,9 +57,8 @@ private:
     // Security check to avoid allowed_users is not empty in special scenarios.
     void check_allowed_users_valid() const;
 
-private:
     mutable utils::rw_lock_nr _lock;
-    // Users will pass the access control in the old ACL.
+    // Users will pass the access control in the legacy ACL.
     std::unordered_set<std::string> _allowed_users;
 
     // App_env(REPLICA_ACCESS_CONTROLLER_ALLOWED_USERS) to facilitate whether to update

--- a/src/security/test/meta_access_controller_test.cpp
+++ b/src/security/test/meta_access_controller_test.cpp
@@ -44,7 +44,7 @@ struct super_user_case
     bool is_super_user;
 };
 
-// The super user tests are only for old ACL.
+// The super user tests are only for legacy ACL.
 class SuperUserTest : public testing::TestWithParam<super_user_case>
 {
 protected:
@@ -103,8 +103,8 @@ protected:
         PRESERVE_FLAG(enable_ranger_acl);
         PRESERVE_FLAG(super_users);
 
-        // Always make old ACL enabled, since once Ranger ACL is enabled old ACL is also required
-        // to be enabled.
+        // Always make legacy ACL enabled, since once Ranger ACL is enabled legacy ACL is also
+        // required to be enabled.
         FLAGS_enable_acl = true;
 
         const auto &test_case = GetParam();
@@ -129,8 +129,8 @@ TEST_P(RpcAclTest, RpcAllowed)
     PRESERVE_FLAG(enable_acl);
     PRESERVE_FLAG(enable_ranger_acl);
 
-    // Always make old ACL enabled, since once Ranger ACL is enabled old ACL is also required
-    // to be enabled.
+    // Always make legacy ACL enabled, since once Ranger ACL is enabled legacy ACL is also
+    // required to be enabled.
     FLAGS_enable_acl = true;
 
     const auto &test_case = GetParam();
@@ -151,7 +151,7 @@ TEST_P(RpcAclTest, RpcAllowed)
 }
 
 const std::vector<rpc_acl_case> rpc_acl_tests = {
-    // Whether an RPC request is allowed depends on the allow list for old ACL once Ranger
+    // Whether an RPC request is allowed depends on the allow list for legacy ACL once Ranger
     // ACL is disabled and the client user is a non-super user.
     {false, "non_super_user", RPC_CM_CLUSTER_INFO, true},
     {false, "non_super_user", RPC_CM_LIST_APPS, true},
@@ -160,7 +160,7 @@ const std::vector<rpc_acl_case> rpc_acl_tests = {
     {false, "non_super_user", RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX, true},
     {false, "non_super_user", RPC_CM_START_RECOVERY, false},
 
-    // Any RPC request will be allowed for old ACL once Ranger ACL is disabled and the
+    // Any RPC request will be allowed for legacy ACL once Ranger ACL is disabled and the
     // client user is a super user.
     {false, "super_user_1", RPC_CM_CLUSTER_INFO, true},
     {false, "super_user_2", RPC_CM_LIST_APPS, true},
@@ -179,7 +179,7 @@ const std::vector<rpc_acl_case> rpc_acl_tests = {
     {true, "non_super_user", RPC_CM_START_RECOVERY, false},
 
     // Whether an RPC request is allowed depends on the allow list for Ranger ACL once it
-    // is enabled even if the client user is a super user for old ACL.
+    // is enabled even if the client user is a super user for legacy ACL.
     {true, "super_user_1", RPC_CM_CLUSTER_INFO, false},
     {true, "super_user_2", RPC_CM_LIST_APPS, false},
     {true, "super_user_1", RPC_CM_DDD_DIAGNOSE, false},

--- a/src/security/test/meta_access_controller_test.cpp
+++ b/src/security/test/meta_access_controller_test.cpp
@@ -21,93 +21,149 @@
 
 #include "common/replication.codes.h"
 #include "gtest/gtest.h"
+#include "ranger/ranger_resource_policy_manager.h"
 #include "rpc/network.h"
 #include "rpc/network.sim.h"
 #include "rpc/rpc_address.h"
 #include "rpc/rpc_message.h"
 #include "security/access_controller.h"
 #include "task/task_code.h"
+#include "test_util/test_util.h"
 #include "utils/autoref_ptr.h"
 #include "utils/flags.h"
 
 DSN_DECLARE_bool(enable_acl);
+DSN_DECLARE_bool(enable_ranger_acl);
+DSN_DECLARE_string(super_users);
 
-namespace dsn {
-namespace security {
+namespace dsn::security {
 
-class meta_access_controller_test : public testing::Test
+struct super_user_case
 {
-public:
-    meta_access_controller_test()
+    std::string super_users;
+    std::string user_name;
+    bool is_super_user;
+};
+
+class SuperUserTest : public testing::TestWithParam<super_user_case>
+{
+protected:
+    SuperUserTest()
     {
+        PRESERVE_FLAG(super_users);
+
+        const auto &test_case = GetParam();
+        FLAGS_super_users = test_case.super_users.c_str();
+
+        // `_meta_access_controller` should be initialized after `FLAGS_super_users`
+        // is assigned, since it parses its own super users from `FLAGS_super_users`.
         _meta_access_controller = create_meta_access_controller(nullptr);
     }
 
-    void set_super_user(const std::string &super_user)
+    bool is_super_user(const std::string &user_name) const
     {
-        _meta_access_controller->_super_users.insert(super_user);
+        return _meta_access_controller->is_super_user(user_name);
     }
 
-    bool is_super_user_or_disable_acl(const std::string &user_name)
-    {
-        return !FLAGS_enable_acl || _meta_access_controller->is_super_user(user_name);
-    }
-
-    bool allowed(dsn::message_ex *msg) { return _meta_access_controller->allowed(msg); }
-
+private:
     std::shared_ptr<access_controller> _meta_access_controller;
 };
 
-TEST_F(meta_access_controller_test, is_super_user_or_disable_acl)
+TEST_P(SuperUserTest, IsSuperUser)
 {
-    const std::string SUPER_USER_NAME = "super_user";
-    struct
-    {
-        bool enable_acl;
-        std::string user_name;
-        bool result;
-    } tests[] = {{true, "not_super_user", false},
-                 {false, "not_super_user", true},
-                 {true, SUPER_USER_NAME, true}};
-
-    bool origin_enable_acl = FLAGS_enable_acl;
-    set_super_user(SUPER_USER_NAME);
-
-    for (const auto &test : tests) {
-        FLAGS_enable_acl = test.enable_acl;
-        ASSERT_EQ(is_super_user_or_disable_acl(test.user_name), test.result);
-    }
-
-    FLAGS_enable_acl = origin_enable_acl;
+    const auto &test_case = GetParam();
+    EXPECT_EQ(test_case.is_super_user, is_super_user(test_case.user_name));
 }
 
-TEST_F(meta_access_controller_test, allowed)
-{
-    struct
-    {
-        task_code rpc_code;
-        bool result;
-    } tests[] = {{RPC_CM_LIST_APPS, true},
-                 {RPC_CM_LIST_NODES, true},
-                 {RPC_CM_CLUSTER_INFO, true},
-                 {RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX, true},
-                 {RPC_CM_START_RECOVERY, false}};
+const std::vector<super_user_case> super_user_tests = {
+    {"super_user_1, super_user_2", "", false},
+    {"super_user_1, super_user_2", "non_super_user", false},
+    {"super_user_1, super_user_2", "super_user_1", true},
+    {"super_user_1, super_user_2", "super_user_2", true},
+};
 
-    bool origin_enable_acl = FLAGS_enable_acl;
+INSTANTIATE_TEST_SUITE_P(MetaAccessControllerTest,
+                         SuperUserTest,
+                         testing::ValuesIn(super_user_tests));
+
+struct rpc_acl_case
+{
+    bool enable_ranger_acl;
+    task_code rpc_code;
+    bool is_allowed;
+};
+
+class RpcAclTest : public testing::TestWithParam<rpc_acl_case>
+{
+protected:
+    RpcAclTest()
+    {
+        PRESERVE_FLAG(enable_acl);
+        PRESERVE_FLAG(enable_ranger_acl);
+        PRESERVE_FLAG(super_users);
+
+        FLAGS_enable_acl = true;
+
+        const auto &test_case = GetParam();
+        FLAGS_enable_ranger_acl = test_case.enable_ranger_acl;
+
+        FLAGS_super_users = "super_user_1";
+
+        // `_meta_access_controller` should be initialized after `FLAGS_super_users`
+        // is assigned, since it parses its own super users from `FLAGS_super_users`.
+        _meta_access_controller = create_meta_access_controller(
+            std::make_shared<ranger::ranger_resource_policy_manager>(nullptr));
+    }
+
+    bool allowed(dsn::message_ex *msg) const { return _meta_access_controller->allowed(msg); }
+
+private:
+    std::shared_ptr<access_controller> _meta_access_controller;
+};
+
+TEST_P(RpcAclTest, RpcAllowed)
+{
+    PRESERVE_FLAG(enable_acl);
+    PRESERVE_FLAG(enable_ranger_acl);
+
     FLAGS_enable_acl = true;
 
-    std::unique_ptr<tools::sim_network_provider> sim_net(
+    const auto &test_case = GetParam();
+    FLAGS_enable_ranger_acl = test_case.enable_ranger_acl;
+
+    const std::unique_ptr<tools::sim_network_provider> sim_net(
         new tools::sim_network_provider(nullptr, nullptr));
-    auto sim_session =
+    const auto sim_session =
         sim_net->create_client_session(rpc_address::from_host_port("localhost", 10086));
-    for (const auto &test : tests) {
-        dsn::message_ptr msg = message_ex::create_request(test.rpc_code);
-        msg->io_session = sim_session;
 
-        ASSERT_EQ(allowed(msg), test.result);
-    }
+    // Make sure that a non-super user is specified as the client user.
+    sim_session->set_client_username("non_super_user");
 
-    FLAGS_enable_acl = origin_enable_acl;
+    const dsn::message_ptr msg = message_ex::create_request(test_case.rpc_code);
+    msg->io_session = sim_session;
+
+    std::cout << "ready to test" << std::endl;
+    ASSERT_EQ(test_case.is_allowed, allowed(msg));
 }
-} // namespace security
-} // namespace dsn
+
+const std::vector<rpc_acl_case> rpc_acl_tests = {
+    // Whether RPC is allowed depends on ranger policy once it is enabled.
+    {false, RPC_CM_CLUSTER_INFO, true},
+    {false, RPC_CM_LIST_APPS, true},
+    {false, RPC_CM_DDD_DIAGNOSE, true},
+    {false, RPC_CM_LIST_NODES, true},
+    {false, RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX, true},
+    {false, RPC_CM_START_RECOVERY, false},
+
+    // Whether RPC is allowed depends on ranger policy once it is enabled.
+    {true, RPC_CM_CLUSTER_INFO, false},
+    {true, RPC_CM_LIST_APPS, false},
+    {true, RPC_CM_DDD_DIAGNOSE, false},
+    {true, RPC_CM_LIST_NODES, false},
+    {true, RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX, true},
+    {true, RPC_CM_START_RECOVERY, false},
+};
+
+INSTANTIATE_TEST_SUITE_P(MetaAccessControllerTest, RpcAclTest, testing::ValuesIn(rpc_acl_tests));
+
+} // namespace dsn::security

--- a/src/security/test/meta_access_controller_test.cpp
+++ b/src/security/test/meta_access_controller_test.cpp
@@ -160,7 +160,7 @@ const std::vector<rpc_acl_case> rpc_acl_tests = {
     {false, "non_super_user", RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX, true},
     {false, "non_super_user", RPC_CM_START_RECOVERY, false},
 
-    // All RPC requests will be allowed for old ACL once Ranger ACL is disabled and the
+    // Any RPC request will be allowed for old ACL once Ranger ACL is disabled and the
     // client user is a super user.
     {false, "super_user_1", RPC_CM_CLUSTER_INFO, true},
     {false, "super_user_2", RPC_CM_LIST_APPS, true},

--- a/src/security/test/meta_access_controller_test.cpp
+++ b/src/security/test/meta_access_controller_test.cpp
@@ -17,7 +17,7 @@
 
 #include <memory>
 #include <string>
-#include <unordered_set>
+#include <vector>
 
 #include "common/replication.codes.h"
 #include "gtest/gtest.h"
@@ -60,7 +60,7 @@ protected:
         _meta_access_controller = create_meta_access_controller(nullptr);
     }
 
-    bool is_super_user(const std::string &user_name) const
+    [[nodiscard]] bool is_super_user(const std::string &user_name) const
     {
         return _meta_access_controller->is_super_user(user_name);
     }
@@ -142,7 +142,6 @@ TEST_P(RpcAclTest, RpcAllowed)
     const dsn::message_ptr msg = message_ex::create_request(test_case.rpc_code);
     msg->io_session = sim_session;
 
-    std::cout << "ready to test" << std::endl;
     ASSERT_EQ(test_case.is_allowed, allowed(msg));
 }
 

--- a/src/utils/distributed_lock_service.h
+++ b/src/utils/distributed_lock_service.h
@@ -63,7 +63,7 @@ public:
         return new T();
     }
 
-    using factory = distributed_lock_service *(*)();
+    using factory = std::function<distributed_lock_service *()>;
 
     struct lock_options
     {

--- a/src/utils/distributed_lock_service.h
+++ b/src/utils/distributed_lock_service.h
@@ -43,6 +43,7 @@
 #include "task/future_types.h"
 #include "utils/api_utilities.h"
 #include "utils/error_code.h"
+#include "utils/ports.h"
 #include "utils/threadpool_code.h"
 
 namespace dsn::dist {
@@ -64,7 +65,6 @@ public:
 
     typedef distributed_lock_service *(*factory)();
 
-public:
     struct lock_options
     {
         bool create_if_not_exist;
@@ -72,6 +72,7 @@ public:
     };
 
     virtual ~distributed_lock_service() = default;
+
     /*
      * initialization routine
      */
@@ -171,6 +172,13 @@ public:
     virtual error_code query_cache(const std::string &lock_id,
                                    /*out*/ std::string &owner,
                                    /*out*/ uint64_t &version) const = 0;
+
+protected:
+    distributed_lock_service() = default;
+
+private:
+    DISALLOW_COPY_AND_ASSIGN(distributed_lock_service);
+    DISALLOW_MOVE_AND_ASSIGN(distributed_lock_service);
 };
 
 } // namespace dsn::dist

--- a/src/utils/distributed_lock_service.h
+++ b/src/utils/distributed_lock_service.h
@@ -47,10 +47,10 @@
 
 namespace dsn::dist {
 
-typedef std::function<void(error_code ec, const std::string &owner_id, uint64_t version)>
-    lock_callback;
-typedef future_task<error_code, std::string, uint64_t> lock_future;
-typedef dsn::ref_ptr<lock_future> lock_future_ptr;
+using lock_callback =
+    std::function<void(error_code ec, const std::string &owner_id, uint64_t version)>;
+using lock_future = future_task<error_code, std::string, uint64_t>;
+using lock_future_ptr = dsn::ref_ptr<lock_future>;
 
 // The interface of the reliable distributed lock service.
 class distributed_lock_service

--- a/src/utils/distributed_lock_service.h
+++ b/src/utils/distributed_lock_service.h
@@ -45,8 +45,7 @@
 #include "utils/error_code.h"
 #include "utils/threadpool_code.h"
 
-namespace dsn {
-namespace dist {
+namespace dsn::dist {
 
 typedef std::function<void(error_code ec, const std::string &owner_id, uint64_t version)>
     lock_callback;
@@ -173,5 +172,5 @@ public:
                                    /*out*/ std::string &owner,
                                    /*out*/ uint64_t &version) const = 0;
 };
-} // namespace dist
-} // namespace dsn
+
+} // namespace dsn::dist

--- a/src/utils/distributed_lock_service.h
+++ b/src/utils/distributed_lock_service.h
@@ -51,7 +51,7 @@ namespace dsn::dist {
 using lock_callback =
     std::function<void(error_code ec, const std::string &owner_id, uint64_t version)>;
 using lock_future = future_task<error_code, std::string, uint64_t>;
-using lock_future_ptr = dsn::ref_ptr<lock_future>;
+using lock_future_ptr = ref_ptr<lock_future>;
 
 // The interface of the reliable distributed lock service.
 class distributed_lock_service

--- a/src/utils/distributed_lock_service.h
+++ b/src/utils/distributed_lock_service.h
@@ -72,7 +72,7 @@ public:
         bool create_enable_cache;
     };
 
-    virtual ~distributed_lock_service() {}
+    virtual ~distributed_lock_service() = default;
     /*
      * initialization routine
      */
@@ -171,7 +171,7 @@ public:
      */
     virtual error_code query_cache(const std::string &lock_id,
                                    /*out*/ std::string &owner,
-                                   /*out*/ uint64_t &version) = 0;
+                                   /*out*/ uint64_t &version) const = 0;
 };
 } // namespace dist
 } // namespace dsn

--- a/src/utils/distributed_lock_service.h
+++ b/src/utils/distributed_lock_service.h
@@ -63,7 +63,7 @@ public:
         return new T();
     }
 
-    typedef distributed_lock_service *(*factory)();
+    using factory = distributed_lock_service *(*)();
 
     struct lock_options
     {

--- a/src/utils/strings.cpp
+++ b/src/utils/strings.cpp
@@ -467,7 +467,7 @@ std::string find_string_prefix(const std::string &input, char separator)
 {
     const auto pos = input.find(separator);
     if (pos == 0 || pos == std::string::npos) {
-        return std::string();
+        return {};
     }
 
     return input.substr(0, pos);

--- a/src/utils/strings.cpp
+++ b/src/utils/strings.cpp
@@ -465,11 +465,12 @@ std::string string_md5(const char *buffer, unsigned length)
 
 std::string find_string_prefix(const std::string &input, char separator)
 {
-    auto current = input.find(separator);
-    if (current == 0 || current == std::string::npos) {
+    const auto pos = input.find(separator);
+    if (pos == 0 || pos == std::string::npos) {
         return std::string();
     }
-    return input.substr(0, current);
+
+    return input.substr(0, pos);
 }
 
 bool has_space(const std::string &str)

--- a/src/zookeeper/distributed_lock_service_zookeeper.cpp
+++ b/src/zookeeper/distributed_lock_service_zookeeper.cpp
@@ -55,8 +55,11 @@ distributed_lock_service_zookeeper::~distributed_lock_service_zookeeper()
     std::vector<lock_struct_ptr> handle_vec;
     {
         utils::auto_write_lock l(_service_lock);
-        for (auto &kv : _zookeeper_locks)
+
+        for (auto &kv : _zookeeper_locks) {
             handle_vec.push_back(kv.second);
+        }
+
         _zookeeper_locks.clear();
     }
 

--- a/src/zookeeper/distributed_lock_service_zookeeper.cpp
+++ b/src/zookeeper/distributed_lock_service_zookeeper.cpp
@@ -36,6 +36,8 @@
 #include "utils/flags.h"
 #include "utils/fmt_logging.h"
 #include "utils/strings.h"
+#include "zookeeper/lock_struct.h"
+#include "zookeeper/lock_types.h"
 #include "zookeeper/zookeeper_session_mgr.h"
 #include "zookeeper_error.h"
 #include "zookeeper_session.h"

--- a/src/zookeeper/distributed_lock_service_zookeeper.cpp
+++ b/src/zookeeper/distributed_lock_service_zookeeper.cpp
@@ -54,19 +54,19 @@ distributed_lock_service_zookeeper::~distributed_lock_service_zookeeper()
         return;
     }
 
-    std::vector<lock_struct_ptr> handle_vec;
+    std::vector<lock_struct_ptr> owners;
     {
         utils::auto_write_lock l(_service_lock);
 
-        for (const auto &zk_lock : _zookeeper_locks) {
-            handle_vec.push_back(zk_lock.second);
+        for (const auto &[_, lock] : _zookeeper_locks) {
+            owners.push_back(lock);
         }
 
         _zookeeper_locks.clear();
     }
 
-    for (const lock_struct_ptr &ptr : handle_vec) {
-        _session->detach(ptr.get());
+    for (const auto &owner : owners) {
+        _session->detach(owner.get());
     }
 
     _session->detach(this);

--- a/src/zookeeper/distributed_lock_service_zookeeper.cpp
+++ b/src/zookeeper/distributed_lock_service_zookeeper.cpp
@@ -230,17 +230,18 @@ task_ptr distributed_lock_service_zookeeper::query_lock(const std::string &lock_
 
 error_code distributed_lock_service_zookeeper::query_cache(const std::string &lock_id,
                                                            /*out*/ std::string &owner,
-                                                           /*out*/ uint64_t &version)
+                                                           /*out*/ uint64_t &version) const
 {
     utils::auto_read_lock l(_service_lock);
-    auto iter = _lock_cache.find(lock_id);
-    if (_lock_cache.end() == iter)
+
+    const auto iter = std::as_const(_lock_cache).find(lock_id);
+    if (iter == _lock_cache.end()) {
         return ERR_OBJECT_NOT_FOUND;
-    else {
-        owner = iter->second.first;
-        version = iter->second.second;
-        return ERR_OK;
     }
+
+    owner = iter->second.first;
+    version = iter->second.second;
+    return ERR_OK;
 }
 
 void distributed_lock_service_zookeeper::refresh_lock_cache(const std::string &lock_id,

--- a/src/zookeeper/distributed_lock_service_zookeeper.cpp
+++ b/src/zookeeper/distributed_lock_service_zookeeper.cpp
@@ -44,8 +44,7 @@
 
 DSN_DECLARE_int32(timeout_ms);
 
-namespace dsn {
-namespace dist {
+namespace dsn::dist {
 
 std::string distributed_lock_service_zookeeper::LOCK_NODE_PREFIX = "LOCKNODE";
 
@@ -283,5 +282,5 @@ void distributed_lock_service_zookeeper::on_zoo_session_evt(lock_srv_ptr _this, 
         LOG_WARNING("get zoo state: {}, ignore it", zookeeper_session::string_zoo_state(zoo_state));
     }
 }
-} // namespace dist
-} // namespace dsn
+
+} // namespace dsn::dist

--- a/src/zookeeper/distributed_lock_service_zookeeper.cpp
+++ b/src/zookeeper/distributed_lock_service_zookeeper.cpp
@@ -58,14 +58,14 @@ distributed_lock_service_zookeeper::~distributed_lock_service_zookeeper()
     {
         utils::auto_write_lock l(_service_lock);
 
-        for (auto &kv : _zookeeper_locks) {
-            handle_vec.push_back(kv.second);
+        for (const auto &zk_lock : _zookeeper_locks) {
+            handle_vec.push_back(zk_lock.second);
         }
 
         _zookeeper_locks.clear();
     }
 
-    for (lock_struct_ptr &ptr : handle_vec) {
+    for (const lock_struct_ptr &ptr : handle_vec) {
         _session->detach(ptr.get());
     }
 

--- a/src/zookeeper/distributed_lock_service_zookeeper.h
+++ b/src/zookeeper/distributed_lock_service_zookeeper.h
@@ -106,8 +106,8 @@ private:
 
     std::string _lock_root; // lock path: ${lock_root}/${lock_id}/${LOCK_NODE_PREFIX}${i}
 
-    typedef std::unordered_map<lock_key, lock_struct_ptr, pair_hash> lock_map;
-    typedef std::map<std::string, std::pair<std::string, uint64_t>> cache_map;
+    using lock_map = std::unordered_map<lock_key, lock_struct_ptr, pair_hash>;
+    using cache_map = std::map<std::string, std::pair<std::string, uint64_t>>;
 
     mutable utils::rw_lock_nr _service_lock;
     lock_map _zookeeper_locks;

--- a/src/zookeeper/distributed_lock_service_zookeeper.h
+++ b/src/zookeeper/distributed_lock_service_zookeeper.h
@@ -53,11 +53,11 @@ class distributed_lock_service_zookeeper : public distributed_lock_service, publ
 {
 public:
     explicit distributed_lock_service_zookeeper();
-    virtual ~distributed_lock_service_zookeeper() override;
+    ~distributed_lock_service_zookeeper() override;
 
     // lock_root = argv[0]
-    virtual error_code initialize(const std::vector<std::string> &args) override;
-    virtual error_code finalize() override;
+    error_code initialize(const std::vector<std::string> &args) override;
+    error_code finalize() override;
 
     //
     // distributed lock service implemented by zk.
@@ -66,7 +66,7 @@ public:
     // lease_expire_callback is called when the session-expire's zk-event is encountered
     // use should exist the process when lease expires
     //
-    virtual std::pair<task_ptr, task_ptr> lock(const std::string &lock_id,
+    std::pair<task_ptr, task_ptr> lock(const std::string &lock_id,
                                                const std::string &myself_id,
                                                task_code lock_cb_code,
                                                const lock_callback &lock_cb,
@@ -74,20 +74,20 @@ public:
                                                const lock_callback &lease_expire_callback,
                                                const lock_options &opt) override;
 
-    virtual task_ptr cancel_pending_lock(const std::string &lock_id,
+    task_ptr cancel_pending_lock(const std::string &lock_id,
                                          const std::string &myself_id,
                                          task_code cb_code,
                                          const lock_callback &cb) override;
-    virtual task_ptr unlock(const std::string &lock_id,
+    task_ptr unlock(const std::string &lock_id,
                             const std::string &myself_id,
                             bool destroy,
                             task_code cb_code,
                             const err_callback &cb) override;
-    virtual task_ptr
+    task_ptr
     query_lock(const std::string &lock_id, task_code cb_code, const lock_callback &cb) override;
-    virtual error_code query_cache(const std::string &lock_id,
+    error_code query_cache(const std::string &lock_id,
                                    /*out*/ std::string &owner,
-                                   /*out*/ uint64_t &version);
+                                   /*out*/ uint64_t &version) const override;
 
     void refresh_lock_cache(const std::string &lock_id, const std::string &owner, uint64_t version);
 
@@ -109,7 +109,7 @@ private:
     typedef std::unordered_map<lock_key, lock_struct_ptr, pair_hash> lock_map;
     typedef std::map<std::string, std::pair<std::string, uint64_t>> cache_map;
 
-    utils::rw_lock_nr _service_lock;
+    mutable utils::rw_lock_nr _service_lock;
     lock_map _zookeeper_locks;
     cache_map _lock_cache;
 

--- a/src/zookeeper/distributed_lock_service_zookeeper.h
+++ b/src/zookeeper/distributed_lock_service_zookeeper.h
@@ -43,6 +43,7 @@
 #include "utils/autoref_ptr.h"
 #include "utils/distributed_lock_service.h"
 #include "utils/error_code.h"
+#include "utils/ports.h"
 #include "utils/synchronize.h"
 
 namespace dsn::dist {
@@ -125,6 +126,9 @@ private:
     static void on_zoo_session_evt(lock_srv_ptr _this, int zoo_state);
 
     friend class lock_struct;
+
+    DISALLOW_COPY_AND_ASSIGN(distributed_lock_service_zookeeper);
+    DISALLOW_MOVE_AND_ASSIGN(distributed_lock_service_zookeeper);
 };
 
 } // namespace dsn::dist

--- a/src/zookeeper/distributed_lock_service_zookeeper.h
+++ b/src/zookeeper/distributed_lock_service_zookeeper.h
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include "boost/container/detail/std_fwd.hpp"
+#include "lock_struct.h"
 #include "lock_types.h"
 #include "task/future_types.h"
 #include "task/task.h"
@@ -51,7 +52,7 @@ class zookeeper_session;
 class distributed_lock_service_zookeeper : public distributed_lock_service, public ref_counter
 {
 public:
-    explicit distributed_lock_service_zookeeper();
+    distributed_lock_service_zookeeper() = default;
     ~distributed_lock_service_zookeeper() override;
 
     // lock_root = argv[0]
@@ -112,9 +113,9 @@ private:
     lock_map _zookeeper_locks;
     cache_map _lock_cache;
 
-    zookeeper_session *_session;
-    int _zoo_state;
-    bool _first_call;
+    zookeeper_session *_session{nullptr};
+    int _zoo_state{0};
+    bool _first_call{true};
     utils::notify_event _waiting_attach;
 
     void erase(const lock_key &key);

--- a/src/zookeeper/distributed_lock_service_zookeeper.h
+++ b/src/zookeeper/distributed_lock_service_zookeeper.h
@@ -67,27 +67,27 @@ public:
     // use should exist the process when lease expires
     //
     std::pair<task_ptr, task_ptr> lock(const std::string &lock_id,
-                                               const std::string &myself_id,
-                                               task_code lock_cb_code,
-                                               const lock_callback &lock_cb,
-                                               task_code lease_expire_code,
-                                               const lock_callback &lease_expire_callback,
-                                               const lock_options &opt) override;
+                                       const std::string &myself_id,
+                                       task_code lock_cb_code,
+                                       const lock_callback &lock_cb,
+                                       task_code lease_expire_code,
+                                       const lock_callback &lease_expire_callback,
+                                       const lock_options &opt) override;
 
     task_ptr cancel_pending_lock(const std::string &lock_id,
-                                         const std::string &myself_id,
-                                         task_code cb_code,
-                                         const lock_callback &cb) override;
+                                 const std::string &myself_id,
+                                 task_code cb_code,
+                                 const lock_callback &cb) override;
     task_ptr unlock(const std::string &lock_id,
-                            const std::string &myself_id,
-                            bool destroy,
-                            task_code cb_code,
-                            const err_callback &cb) override;
+                    const std::string &myself_id,
+                    bool destroy,
+                    task_code cb_code,
+                    const err_callback &cb) override;
     task_ptr
     query_lock(const std::string &lock_id, task_code cb_code, const lock_callback &cb) override;
     error_code query_cache(const std::string &lock_id,
-                                   /*out*/ std::string &owner,
-                                   /*out*/ uint64_t &version) const override;
+                           /*out*/ std::string &owner,
+                           /*out*/ uint64_t &version) const override;
 
     void refresh_lock_cache(const std::string &lock_id, const std::string &owner, uint64_t version);
 

--- a/src/zookeeper/distributed_lock_service_zookeeper.h
+++ b/src/zookeeper/distributed_lock_service_zookeeper.h
@@ -44,8 +44,7 @@
 #include "utils/error_code.h"
 #include "utils/synchronize.h"
 
-namespace dsn {
-namespace dist {
+namespace dsn::dist {
 
 class zookeeper_session;
 
@@ -126,5 +125,5 @@ private:
 
     friend class lock_struct;
 };
-} // namespace dist
-} // namespace dsn
+
+} // namespace dsn::dist

--- a/src/zookeeper/lock_struct.cpp
+++ b/src/zookeeper/lock_struct.cpp
@@ -47,22 +47,25 @@
 #include "zookeeper/zookeeper.jute.h"
 #include "zookeeper_session.h"
 
-namespace dsn {
-namespace dist {
+namespace dsn::dist {
 
-static const char *states[] = {
-    "uninitialized", "pending", "locked", "expired", "cancelled", "unlocking"};
+namespace {
 
-static inline const char *string_state(lock_state state)
+constexpr const char *string_state(lock_state state)
 {
-    CHECK_LT(state, lock_state::state_count);
-    return states[state];
+    constexpr std::array kStates = {
+        "uninitialized", "pending", "locked", "expired", "cancelled", "unlocking"};
+    static_assert(kStates.size() == lock_state::state_count, "States do not match messages");
+
+    return kStates.at(state);
 }
 
-static bool is_zookeeper_timeout(int zookeeper_error)
+bool is_zookeeper_timeout(int zookeeper_error)
 {
     return zookeeper_error == ZCONNECTIONLOSS || zookeeper_error == ZOPERATIONTIMEOUT;
 }
+
+} // anonymous namespace
 
 #define __check_code(code, allow_list, allow_list_size, code_str)                                  \
     do {                                                                                           \
@@ -799,5 +802,5 @@ void lock_struct::lock_expired(lock_struct_ptr _this)
     _this->_checker.only_one_thread_access();
     _this->on_expire();
 }
-} // namespace dist
-} // namespace dsn
+
+} // namespace dsn::dist

--- a/src/zookeeper/lock_struct.cpp
+++ b/src/zookeeper/lock_struct.cpp
@@ -715,8 +715,9 @@ void lock_struct::after_remove_my_locknode(lock_struct_ptr _this, int ec, bool r
             dsn_ec = ERR_OK;
     }
 
-    if (dsn_ec == ERR_OK)
+    if (dsn_ec == ERR_OK) {
         _this->remove_lock();
+    }
 
     if (remove_for_unlock) {
         _this->_unlock_callback->enqueue_with(dsn_ec);

--- a/src/zookeeper/lock_struct.h
+++ b/src/zookeeper/lock_struct.h
@@ -118,10 +118,10 @@ private:
     static void owner_change(lock_struct_ptr _this, int zoo_event);
     static void my_lock_removed(lock_struct_ptr _this, int zoo_event);
 
-    lock_future_ptr _lock_callback{nullptr};
-    lock_future_ptr _lease_expire_callback{nullptr};
-    lock_future_ptr _cancel_callback{nullptr};
-    error_code_future_ptr _unlock_callback{nullptr};
+    lock_future_ptr _lock_callback;
+    lock_future_ptr _lease_expire_callback;
+    lock_future_ptr _cancel_callback;
+    error_code_future_ptr _unlock_callback;
 
     std::string _lock_id;
     std::string _lock_dir; // ${lock_root}/${lock_id}

--- a/src/zookeeper/lock_struct.h
+++ b/src/zookeeper/lock_struct.h
@@ -111,7 +111,7 @@ private:
     static void after_self_check(lock_struct_ptr _this, int ec, std::shared_ptr<std::string> value);
     static void after_remove_duplicated_locknode(lock_struct_ptr _this,
                                                  int ec,
-                                                 std::shared_ptr<std::string> value);
+                                                 std::shared_ptr<std::string> path);
     static void after_remove_my_locknode(lock_struct_ptr _this, int ec, bool remove_for_unlock);
 
     /*lock owner watch callback*/

--- a/src/zookeeper/lock_struct.h
+++ b/src/zookeeper/lock_struct.h
@@ -109,7 +109,6 @@ private:
     static void owner_change(lock_struct_ptr _this, int zoo_event);
     static void my_lock_removed(lock_struct_ptr _this, int zoo_event);
 
-private:
     lock_future_ptr _lock_callback;
     lock_future_ptr _lease_expire_callback;
     lock_future_ptr _cancel_callback;

--- a/src/zookeeper/lock_struct.h
+++ b/src/zookeeper/lock_struct.h
@@ -38,8 +38,7 @@
 #include "utils/fmt_utils.h"
 #include "utils/thread_access_checker.h"
 
-namespace dsn {
-namespace dist {
+namespace dsn::dist {
 
 enum lock_state
 {
@@ -59,6 +58,10 @@ struct zoolock_pair
     std::string _node_seq_name;
     int64_t _sequence_id;
 };
+
+class lock_struct;
+
+using lock_struct_ptr = ref_ptr<lock_struct>;
 
 class lock_struct : public ref_counter
 {
@@ -122,5 +125,5 @@ private:
 
     thread_access_checker _checker;
 };
-} // namespace dist
-} // namespace dsn
+
+} // namespace dsn::dist

--- a/src/zookeeper/lock_struct.h
+++ b/src/zookeeper/lock_struct.h
@@ -42,7 +42,7 @@ namespace dsn::dist {
 
 enum lock_state
 {
-    uninitialized,
+    uninitialized = 0,
     pending,
     locked,
     expired,
@@ -66,7 +66,7 @@ using lock_struct_ptr = ref_ptr<lock_struct>;
 class lock_struct : public ref_counter
 {
 public:
-    lock_struct(lock_srv_ptr srv);
+    explicit lock_struct(lock_srv_ptr srv);
     void initialize(std::string lock_id, std::string myself_id);
     const int hash() const { return _hash; }
 

--- a/src/zookeeper/lock_struct.h
+++ b/src/zookeeper/lock_struct.h
@@ -112,7 +112,7 @@ private:
     static void after_remove_duplicated_locknode(lock_struct_ptr _this,
                                                  int ec,
                                                  std::shared_ptr<std::string> value);
-    static void after_remove_my_locknode(lock_struct_ptr _this, int ec, bool need_to_notify);
+    static void after_remove_my_locknode(lock_struct_ptr _this, int ec, bool remove_for_unlock);
 
     /*lock owner watch callback*/
     static void owner_change(lock_struct_ptr _this, int zoo_event);

--- a/src/zookeeper/lock_types.h
+++ b/src/zookeeper/lock_types.h
@@ -33,15 +33,12 @@
 #include "common/gpid.h"
 #include "utils/distributed_lock_service.h"
 
-namespace dsn {
-namespace dist {
+namespace dsn::dist {
 
 DEFINE_THREAD_POOL_CODE(THREAD_POOL_DLOCK)
 DEFINE_TASK_CODE(TASK_CODE_DLOCK, TASK_PRIORITY_HIGH, THREAD_POOL_DLOCK)
 
 class distributed_lock_service_zookeeper;
-class lock_struct;
-typedef ref_ptr<distributed_lock_service_zookeeper> lock_srv_ptr;
-typedef ref_ptr<lock_struct> lock_struct_ptr;
-} // namespace dist
-} // namespace dsn
+using lock_srv_ptr = ref_ptr<distributed_lock_service_zookeeper>;
+
+} // namespace dsn::dist


### PR DESCRIPTION
Fix https://github.com/apache/incubator-pegasus/issues/2258.

When the client (via shell) decides to diagnose all DDD partitions, it sets
`app_id = -1` and sends the request to the meta server. Upon receiving the
request, the meta server attempts to look up the table name based on `app_id`
and then performs ACL checks to verify whether the user has permission to
access the table. However, since `app_id = -1` represents **all** tables rather
than a specific one, there is no corresponding table name to look up. As a result,
the lookup fails and the meta server returns an `ERR_INVALID_PARAMETERS`
error to the client.

To fix this issue, the meta server must first check whether `app_id == -1` when it
receives a DDD diagnose request:
- If `app_id == -1`, the ACL check is deferred: the server first retrieves all DDD
partitions and then performs ACL checks on each one individually, returning only
those partitions that the client user is authorized to access.
- If `app_id != -1`, the `app_id` must correspond to a real table, so the existing logic
remains unchanged: the server resolves the table name by `app_id` and performs a
single and standard ACL check.

In addition to this root cause, several related issues were discovered and fixed as part
of this change:
- Changed the access type for `RPC_CM_DDD_DIAGNOSE` from `access_type::kControl`
to `access_type::kList`, since the request only retrieves partition information and does
not modify any data or metadata.
- The meta server previously handled only Ranger ACLs for the `RPC_CM_LIST_APPS`
request, ignoring the legacy ACLs; this has now been fixed, where legacy ACLs are also
respected.
- Refactored some ACL-related code for clarity and maintainability.