### PR TITLE
ci(github): pin the action `dorny/paths-filter` to the commit SHA pointing to `v3.0.2`

### DIFF
--- a/.github/actions/rebuild_thirdparty_if_needed/action.yaml
+++ b/.github/actions/rebuild_thirdparty_if_needed/action.yaml
@@ -19,7 +19,7 @@ name: Rebuild thirdparty if needed
 runs:
   using: composite
   steps:
-    - uses: dorny/paths-filter@v3.0.2
+    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
       id: changes
       with:
         filters: |

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -29,6 +29,7 @@ on:
       - ci-test # testing branch for github action
       - '*dev'
     paths:
+      - .github/actions/**
       - .github/workflows/lint_and_test_go-client.yml
       - go-client/**
 

--- a/.github/workflows/lint_and_test_java-client.yml
+++ b/.github/workflows/lint_and_test_java-client.yml
@@ -25,6 +25,7 @@ on:
         - ci-test # testing branch for github action
         - '*dev'      # developing branch
     paths:
+      - .github/actions/**
       - .github/workflows/lint_and_test_java-client.yml
       - java-client/**
 

--- a/.github/workflows/lint_and_test_scala-client.yml
+++ b/.github/workflows/lint_and_test_scala-client.yml
@@ -22,6 +22,7 @@ on:
       - master
       - 'v[0-9]+.*' # release branch
     paths:
+      - .github/actions/**
       - .github/workflows/lint_and_test_scala-client.yml
       - scala-client/**
 

--- a/.github/workflows/test_nodejs-client.yml
+++ b/.github/workflows/test_nodejs-client.yml
@@ -24,6 +24,7 @@ on:
         - ci-test # testing branch for github action
         - '*dev'      # developing branch
     paths:
+      - .github/actions/**
       - .github/workflows/test_nodejs-client.yml
       - nodejs-client/**
 

--- a/.github/workflows/test_python-client.yml
+++ b/.github/workflows/test_python-client.yml
@@ -24,6 +24,7 @@ on:
         - ci-test # testing branch for github action
         - '*dev'      # developing branch
     paths:
+      - .github/actions/**
       - .github/workflows/test_python-client.yml
       - python-client/**
 


### PR DESCRIPTION
Resolve https://github.com/apache/incubator-pegasus/issues/2276.

According to the the reply from INFRA team[1] and the doc of infrastructure
actions[2], the actions in allow list must be pinned to a SHA rather than a tag
as of August 1st.

Only the action `rebuild_thirdparty_if_needed`[3] uses `dorny/paths-filter`.
Events are also added to the workflows depending on it so that they could be
triggered once it is changed.

1. https://issues.apache.org/jira/browse/INFRA-27084
2. https://github.com/apache/infrastructure-actions/?tab=readme-ov-file#adding-a-new-action-to-the-allow-list
3. https://github.com/apache/incubator-pegasus/blob/master/.github/actions/rebuild_thirdparty_if_needed/action.yaml#L22