### PR TITLE
build(thirdparty): bump zookeeper-client-c from 3.7.0 to 3.9.4

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -227,7 +227,7 @@ endif ()
 
 ExternalProject_Add(zookeeper
         URL ${OSS_URL_PREFIX}/apache-zookeeper-3.9.4.tar.gz
-        https://downloads.apache.org/zookeeper/zookeeper-3.9.4/apache-zookeeper-3.9.4.tar.gz
+        https://archive.apache.org/dist/zookeeper/zookeeper-3.9.4/apache-zookeeper-3.9.4.tar.gz
         URL_MD5 f3bc1e774792e3dc4f979be410b61d97
         PATCH_COMMAND ""
         COMMAND cd zookeeper-jute && mvn compile && cd ../zookeeper-client/zookeeper-client-c && cmake -DCMAKE_BUILD_TYPE=release -DWANT_CPPUNIT=OFF -DWITH_OPENSSL=OFF -DWITH_CYRUS_SASL=${ZOOKEEPER_WITH_CYRUS_SASL} -DCMAKE_INSTALL_PREFIX=${TP_OUTPUT}


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2292

To support encryption of the password file used for SASL authentication with
ZooKeeper, we need to introduce a new feature from the ZooKeeper C client:
https://github.com/apache/zookeeper/pull/2223.

Since this feature is only available starting from [ZooKeeper 3.9.4 which was
just released](https://zookeeper.apache.org/doc/r3.9.4/releasenotes.html), we
need to upgrade the ZooKeeper version from 3.7.0 to 3.9.4.