### PR TITLE
fix(build): replace variable-length arrays with proper structures to fix compilation errors on macOS

### DIFF
--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -109,11 +109,11 @@ TEST_P(aio_test, basic)
             pegasus::stop_watch sw;
             uint64_t offset = 0;
             std::list<aio_task_ptr> tasks;
-            for (int i = 0; i < kTotalBufferCount; i++) {
-                char read_buffer[kUnitBufferLength + 1];
-                read_buffer[kUnitBufferLength] = 0;
+            for (int i = 0; i < kTotalBufferCount; ++i) {
+                auto read_buffer = std::make_unique<char[]>(kUnitBufferLength + 1);
+                read_buffer[kUnitBufferLength] = '\0';
                 auto t = ::dsn::file::read(rfile,
-                                           read_buffer,
+                                           read_buffer.get(),
                                            kUnitBufferLength,
                                            offset,
                                            LPC_AIO_TEST,
@@ -123,7 +123,7 @@ TEST_P(aio_test, basic)
 
                 t->wait();
                 ASSERT_EQ(kUnitBufferLength, t->get_transferred_size());
-                ASSERT_STREQ(kUnitBuffer.c_str(), read_buffer);
+                ASSERT_STREQ(kUnitBuffer.c_str(), read_buffer.get());
             }
             sw.stop_and_output(fmt::format("sequential read"));
         }
@@ -133,11 +133,12 @@ TEST_P(aio_test, basic)
             pegasus::stop_watch sw;
             uint64_t offset = 0;
             std::list<aio_task_ptr> tasks;
-            char read_buffers[kTotalBufferCount][kUnitBufferLength + 1];
-            for (int i = 0; i < kTotalBufferCount; i++) {
-                read_buffers[i][kUnitBufferLength] = 0;
+            std::vector<std::unique_ptr<char[]>> read_buffers(kTotalBufferCount);
+            for (int i = 0; i < kTotalBufferCount; ++i) {
+                read_buffers[i] = std::make_unique<char[]>(kUnitBufferLength + 1);
+                read_buffers[i][kUnitBufferLength] = '\0';
                 auto t = ::dsn::file::read(rfile,
-                                           read_buffers[i],
+                                           read_buffers[i].get(),
                                            kUnitBufferLength,
                                            offset,
                                            LPC_AIO_TEST,

--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+// IWYU pragma: no_include <ext/alloc_traits.h>
 #include <fmt/core.h>
 #include <rocksdb/status.h>
 #include <string.h>
@@ -38,8 +39,8 @@
 #include "aio/aio_task.h"
 #include "aio/file_io.h"
 #include "gtest/gtest.h"
-#include "task/task_code.h"
 #include "runtime/tool_api.h"
+#include "task/task_code.h"
 #include "test_util/test_util.h"
 #include "utils/autoref_ptr.h"
 #include "utils/env.h"

--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -27,9 +27,9 @@
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include <fmt/core.h>
 #include <rocksdb/status.h>
-#include <string.h>
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <list>
 #include <memory>
 #include <random>

--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -114,7 +114,7 @@ TEST_P(aio_test, basic)
                 read_buffer[kUnitBufferLength] = '\0';
                 auto t = ::dsn::file::read(rfile,
                                            read_buffer.get(),
-                                           kUnitBufferLength,
+                                           static_cast<int>(kUnitBufferLength),
                                            offset,
                                            LPC_AIO_TEST,
                                            nullptr,
@@ -139,7 +139,7 @@ TEST_P(aio_test, basic)
                 read_buffers[i][kUnitBufferLength] = '\0';
                 auto t = ::dsn::file::read(rfile,
                                            read_buffers[i].get(),
-                                           kUnitBufferLength,
+                                           static_cast<int>(kUnitBufferLength),
                                            offset,
                                            LPC_AIO_TEST,
                                            nullptr,
@@ -152,7 +152,7 @@ TEST_P(aio_test, basic)
                 ASSERT_EQ(kUnitBufferLength, t->get_transferred_size());
             }
             for (int i = 0; i < kTotalBufferCount; i++) {
-                ASSERT_STREQ(kUnitBuffer.c_str(), read_buffers[i]);
+                ASSERT_STREQ(kUnitBuffer.c_str(), read_buffers[i].get());
             }
             sw.stop_and_output(fmt::format("concurrent read"));
         }

--- a/src/server/test/pegasus_server_write_test.cpp
+++ b/src/server/test/pegasus_server_write_test.cpp
@@ -83,16 +83,16 @@ public:
                  * rpc_holders, which created in on_batched_write_requests. So we don't need to
                  * release them here
                  **/
-                dsn::message_ex *writes[total_rpc_cnt];
-                for (uint32_t i = 0; i < put_rpc_cnt; i++) {
+                auto writes = std::make_unique<dsn::message_ex *[]>(total_rpc_cnt);
+                for (uint32_t i = 0; i < put_rpc_cnt; ++i) {
                     writes[i] = pegasus::create_put_request(req);
                 }
-                for (uint32_t i = put_rpc_cnt; i < total_rpc_cnt; i++) {
+                for (uint32_t i = put_rpc_cnt; i < total_rpc_cnt; ++i) {
                     writes[i] = pegasus::create_remove_request(key);
                 }
 
                 const int err = _server_write->on_batched_write_requests(
-                    writes, total_rpc_cnt, decree, 0, nullptr);
+                    writes.get(), total_rpc_cnt, decree, 0, nullptr);
                 switch (err) {
                 case FAIL_DB_WRITE_BATCH_PUT:
                 case FAIL_DB_WRITE_BATCH_DELETE:

--- a/src/shell/commands/local_partition_split.cpp
+++ b/src/shell/commands/local_partition_split.cpp
@@ -233,7 +233,7 @@ bool split_file(const LocalPartitionSplitContext &lpsc,
 
     // 4. Iterate the sst file though sst reader, then split it to multiple sst files
     // though sst writers.
-    std::shared_ptr<rocksdb::SstFileWriter> writers[lpsc.split_count];
+    std::vector<std::shared_ptr<rocksdb::SstFileWriter>> writers(lpsc.split_count);
     std::unique_ptr<rocksdb::Iterator> iter(reader->NewIterator({}));
     for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
         const auto &skey = iter->key();


### PR DESCRIPTION
Fix https://github.com/apache/incubator-pegasus/issues/2291.

Variable-length arrays are used somewhere in our codes.  However, as a Clang
extension, currently they are considered as errors while building on macOS.
Therefore, we will replace them with some structures such as `std::vector` or
`std::unique_ptr` to eliminate the compilation errors.