### PR TITLE
build(images): install pluggable authentication modules for Cyrus SASL on Ubuntu to provide auth mechanisms required for tests

### DIFF
--- a/docker/pegasus-build-env/ubuntu1804/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu1804/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update -y; \
                        bison \
                        libkrb5-dev \
                        libsasl2-dev \
+                       libsasl2-modules \
                        maven \
                        flex \
                        python3-setuptools; \

--- a/docker/pegasus-build-env/ubuntu2004/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2004/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update -y; \
                        bison \
                        libkrb5-dev \
                        libsasl2-dev \
+                       libsasl2-modules \
                        maven \
                        flex; \
     rm -rf /var/lib/apt/lists/*

--- a/docker/pegasus-build-env/ubuntu2204/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2204/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update -y; \
                        bison \
                        libkrb5-dev \
                        libsasl2-dev \
+                       libsasl2-modules \
                        maven \
                        flex; \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2292

To support tests that connect to ZooKeeper via SASL, auth modules should be
introduced. Otherwise, those tests would fail due to missing necessary mechanisms.

