### PR TITLE
fix(shell): Fix the issue where the scanner index in async_get_unordered_scanners does not correctly correspond to the table's partition_id

### DIFF
--- a/src/client_lib/pegasus_client_impl.cpp
+++ b/src/client_lib/pegasus_client_impl.cpp
@@ -1219,18 +1219,20 @@ void pegasus_client_impl::async_get_unordered_scanners(
         if (err == ERR_OK) {
             ::dsn::unmarshall(resp, response);
             if (response.err == ERR_OK) {
-                unsigned int count = response.partition_count;
+                auto count = response.partition_count;
                 int split = count < max_split_count ? count : max_split_count;
                 scanners.resize(split);
 
                 int size = count / split;
                 int more = count - size * split;
+                int partition_index = 0;
 
                 for (int i = 0; i < split; i++) {
-                    int s = size + (i < more);
+                    int s = size + static_cast<int>(i < more);
                     std::vector<uint64_t> hash(s);
-                    for (int j = 0; j < s; j++)
-                        hash[j] = --count;
+                    for (int j = 0; j < s; j++) {
+                        hash[j] = partition_index++;
+                    }
                     scanners[i] =
                         new pegasus_scanner_impl(_client, std::move(hash), options, true, true);
                 }


### PR DESCRIPTION
[#2309](
This pull request updates the logic for assigning partition indices in the `async_get_unordered_scanners` method of `pegasus_client_impl.cpp`. The change ensures that each scanner receives a unique and sequential partition index, rather than decrementing from the total count, when the variable max_split_count is greater than the number of partitions in the table.

Partition assignment logic update:
* Changed the assignment of partition indices in the scanner creation loop to use an incrementing `partition_index` variable, ensuring unique and sequential indices for each partition instead of using a decrementing `count` value. 