### PR TITLE
ci: fix the failure in Python client tests caused by "version `GLIBC_2.38' not found"

### DIFF
--- a/.github/workflows/test_python-client.yml
+++ b/.github/workflows/test_python-client.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11.11'
+          python-version: '3.11.12'
       # python-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0
       # to generate code as well. The thrift-compiler version on ubuntu-22.04 is 0.16.0, so
       # build and install thrift-compiler 0.13.0 manually.


### PR DESCRIPTION
Resolve https://github.com/apache/incubator-pegasus/issues/2278.

The Python client tests run on the Ubuntu 22.04 image, which uses glibc 2.35.
In the YAML configuration for the workflow, these tests depend on a precompiled
Python 3.11 downloaded via `setup-python`, which began to use 3.11.13 after it
had been released.

However, starting from version 3.11.13, Python was built against glibc 2.38, leading
to the error "version `GLIBC_2.38' not found" during test execution.

To fix this issue, the `setup-python` version is pinned to **3.11.12**, which is the
latest 3.11.x release still built against glibc 2.35.
