### PR TITLE
fix(shell): make the returned scanners sorted in ascending order by partition index to support fetching specified partition in shell

### DIFF
--- a/src/client_lib/pegasus_client_impl.cpp
+++ b/src/client_lib/pegasus_client_impl.cpp
@@ -1219,22 +1219,22 @@ void pegasus_client_impl::async_get_unordered_scanners(
         if (err == ERR_OK) {
             ::dsn::unmarshall(resp, response);
             if (response.err == ERR_OK) {
-                auto count = response.partition_count;
-                int split = count < max_split_count ? count : max_split_count;
-                scanners.resize(split);
+                const int split_count = std::min(response.partition_count, max_split_count);
+                scanners.reserve(split_count);
 
-                int size = count / split;
-                int more = count - size * split;
+                const int split_size = response.partition_count / split_count;
+                const int remain = response.partition_count % split_count;
                 int partition_index = 0;
 
-                for (int i = 0; i < split; i++) {
-                    int s = size + static_cast<int>(i < more);
-                    std::vector<uint64_t> hash(s);
-                    for (int j = 0; j < s; j++) {
-                        hash[j] = partition_index++;
+                for (int i = 0; i < split_count; ++i) {
+                    const int real_split_size = split_size + (i < remain ? 1 : 0);
+                    std::vector<uint64_t> partition_hashes;
+                    partition_hashes.reserve(real_split_size);
+                    for (int j = 0; j < real_split_size; ++j) {
+                        partition_hashes.push_back(partition_index++);
                     }
-                    scanners[i] =
-                        new pegasus_scanner_impl(_client, std::move(hash), options, true, true);
+                    scanners.push_back(new pegasus_scanner_impl(
+                        _client, std::move(partition_hashes), options, true, true));
                 }
             }
         }


### PR DESCRIPTION
Fix https://github.com/apache/incubator-pegasus/issues/2309.

This pull request updates the logic for assigning partition indices in the
`async_get_unordered_scanners` method of `pegasus_client_impl.cpp`.
The change ensures that each scanner receives a unique and sequential
partition index, rather than decrementing from the total count, when the
variable max_split_count is greater than the number of partitions in the
table.

Partition assignment logic update:
* Changed the assignment of partition indices in the scanner creation loop
to use an incrementing `partition_index` variable, ensuring unique and
sequential indices for each partition instead of using a decrementing `count`
value.