### PR TITLE
test: fix heap-use-after-free issue in `test_disable_backup_policy` caused by unfinished task

### DIFF
--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -51,6 +51,7 @@
 #include "task/async_calls.h"
 #include "task/task.h"
 #include "task/task_code.h"
+#include "task/task_tracker.h"
 #include "utils/autoref_ptr.h"
 #include "utils/chrono_literals.h"
 #include "utils/error_code.h"


### PR DESCRIPTION
Fix https://github.com/apache/incubator-pegasus/issues/2281.

In `test_disable_backup_policy`, `continue_current_backup_unlocked()`
is invoked, which in turn calls `issue_new_backup_unlocked()` onto `_mp`
as the callback function where if `_policy.is_disable` is set to `true`, the
callback will recursively reschedule itself through the thread pool. After the
test has finished and `_mp` has been destructed, however, the background
thread may be still executing the callback, where accessing members inside
`_mp` will lead to a heap-use-after-free error. The solution is to stop all
running tasks on `_mp` before the unit test exits.

