### PR TITLE
ci(github): bump OpenSSL from 1 to 3 on Ubuntu 20.04 to fix missing `openssl/types.h` issue

### DIFF
--- a/docker/pegasus-build-env/ubuntu2004/Dockerfile
+++ b/docker/pegasus-build-env/ubuntu2004/Dockerfile
@@ -67,6 +67,20 @@ RUN wget --progress=dot:giga https://archive.apache.org/dist/thrift/0.11.0/thrif
     make -j$(($(nproc)/2+1)) && make install && cd - && \
     rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz
 
+ENV OPENSSL_VERSION="3.0.12"
+ENV OPENSSL_INSTALL_DIR="/usr/local/ssl"
+
+RUN wget https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz -P /opt/openssl\
+    && cd /opt/openssl \ && tar -xzvf openssl-$OPENSSL_VERSION.tar.gz \
+    && cd openssl-$OPENSSL_VERSION \
+    && ./config shared --prefix=$OPENSSL_INSTALL_DIR \
+    && make -j$(nproc) \
+    && make install \
+    && ln -sf $OPENSSL_INSTALL_DIR/bin/openssl /usr/bin/openssl \
+    && ln -sf $OPENSSL_INSTALL_DIR/include/openssl /usr/local/include/openssl \
+    && echo "$OPENSSL_INSTALL_DIR/lib64" | tee /etc/ld.so.conf.d/openssl-3.0.conf \
+    && ldconfig -v
+
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV CLASSPATH=$JAVA_HOME/lib/
 ENV PATH=$JAVA_HOME/bin:$PATH


### PR DESCRIPTION
Fix https://github.com/apache/incubator-pegasus/issues/2325.

The reason is that in https://github.com/apache/incubator-pegasus/pull/2293
openssl/types.h was included, while the default version of OpenSSL on Ubuntu
20.04 is 1.1.1 which does not have this header file. To solve this problem, we
install OpenSSL 3.0.12 instead on Ubuntu 20.04.