### PR TITLE
refactor(FQDN): feather refactor on meta server side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,17 @@ thirdparty/output/
 
 #collector
 collector/collector
+
+# aider
+.aider.chat.history.md
+.aider.input.history
+.aider.tags.cache.v4/
+
+# codex
+.codex
+
+# local config
+config-server.ini
+
+# hadoop
+hadoop-bin/

--- a/src/client/partition_resolver_simple.cpp
+++ b/src/client/partition_resolver_simple.cpp
@@ -413,14 +413,18 @@ void partition_resolver_simple::handle_pending_requests(std::deque<request_conte
 host_port partition_resolver_simple::get_host_port(const partition_configuration &pc) const
 {
     if (_app_is_stateful) {
-        return pc.hp_primary;
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        return primary;
     }
 
-    if (pc.hp_last_drops.empty()) {
+    std::vector<host_port> last_drops;
+    GET_HOST_PORTS(pc, last_drops, last_drops);
+    if (last_drops.empty()) {
         return host_port();
     }
 
-    return pc.hp_last_drops[rand::next_u32(0, pc.last_drops.size() - 1)];
+    return last_drops[rand::next_u32(0, last_drops.size() - 1)];
 }
 
 error_code partition_resolver_simple::get_host_port(int partition_index, /*out*/ host_port &hp)

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -168,9 +168,19 @@ dsn::error_code replication_ddl_client::wait_app_ready(const std::string &app_na
         int ready_count = 0;
         for (int i = 0; i < partition_count; i++) {
             const auto &pc = query_resp.partitions[i];
-            if (pc.hp_primary && (pc.hp_secondaries.size() + 1 >= max_replica_count)) {
-                ready_count++;
+            host_port primary;
+            GET_HOST_PORT(pc, primary, primary);
+            if (!primary) {
+                continue;
             }
+
+            std::vector<host_port> secondaries;
+            GET_HOST_PORTS(pc, secondaries, secondaries);
+            if (secondaries.size() + 1 < max_replica_count) {
+                continue;
+            }
+
+            ready_count++;
         }
         if (ready_count == partition_count) {
             std::cout << app_name << " is ready now: (" << ready_count << "/" << partition_count
@@ -429,11 +439,16 @@ error_s replication_ddl_client::list_apps(bool detailed,
             int read_unhealthy = 0;
             for (const auto &pc : pcs) {
                 int replica_count = 0;
-                if (pc.hp_primary) {
+                host_port primary;
+                GET_HOST_PORT(pc, primary, primary);
+                if (primary) {
                     replica_count++;
                 }
-                replica_count += pc.hp_secondaries.size();
-                if (pc.hp_primary) {
+
+                std::vector<host_port> secondaries;
+                GET_HOST_PORTS(pc, secondaries, secondaries);
+                replica_count += static_cast<int>(secondaries.size());
+                if (primary) {
                     if (replica_count >= pc.max_replica_count) {
                         fully_healthy++;
                     } else if (replica_count < 2) {

--- a/src/meta/cluster_balance_policy.cpp
+++ b/src/meta/cluster_balance_policy.cpp
@@ -229,12 +229,17 @@ bool cluster_balance_policy::get_app_migration_info(std::shared_ptr<app_state> a
     info.partitions.reserve(app->pcs.size());
     for (const auto &pc : app->pcs) {
         std::map<host_port, partition_status::type> pstatus_map;
-        pstatus_map[pc.hp_primary] = partition_status::PS_PRIMARY;
-        if (pc.hp_secondaries.size() != pc.max_replica_count - 1) {
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        pstatus_map[primary] = partition_status::PS_PRIMARY;
+
+        std::vector<host_port> secondaries;
+        GET_HOST_PORTS(pc, secondaries, secondaries);
+        if (secondaries.size() != pc.max_replica_count - 1) {
             // partition is unhealthy
             return false;
         }
-        for (const auto &secondary : pc.hp_secondaries) {
+        for (const auto &secondary : secondaries) {
             pstatus_map[secondary] = partition_status::PS_SECONDARY;
         }
         info.partitions.push_back(std::move(pstatus_map));

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -35,6 +35,7 @@
 #include "meta_admin_types.h"
 #include "rpc/dns_resolver.h" // IWYU pragma: keep
 #include "rpc/rpc_address.h"
+#include "rpc/rpc_host_port.h"
 #include "utils/command_manager.h"
 #include "utils/fail_point.h"
 #include "utils/flags.h"
@@ -172,14 +173,16 @@ generate_balancer_request(const app_mapper &apps,
             new_proposal_action(to, to, config_type::CT_UPGRADE_TO_PRIMARY));
         result.action_list.emplace_back(new_proposal_action(to, from, config_type::CT_REMOVE));
         break;
-    case balance_type::COPY_SECONDARY:
+    case balance_type::COPY_SECONDARY: {
         ans = "copy_secondary";
         result.balance_type = balancer_request_type::copy_secondary;
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
         result.action_list.emplace_back(
-            new_proposal_action(pc.hp_primary, to, config_type::CT_ADD_SECONDARY_FOR_LB));
-        result.action_list.emplace_back(
-            new_proposal_action(pc.hp_primary, from, config_type::CT_REMOVE));
+            new_proposal_action(primary, to, config_type::CT_ADD_SECONDARY_FOR_LB));
+        result.action_list.emplace_back(new_proposal_action(primary, from, config_type::CT_REMOVE));
         break;
+    }
     default:
         CHECK(false, "");
     }
@@ -566,7 +569,9 @@ void ford_fulkerson::update_decree(int node_id, const node_state &ns)
 {
     ns.for_each_primary(_app->app_id, [&, this](const gpid &pid) {
         const auto &pc = _app->pcs[pid.get_partition_index()];
-        for (const auto &secondary : pc.hp_secondaries) {
+        std::vector<host_port> secondaries;
+        GET_HOST_PORTS(pc, secondaries, secondaries);
+        for (const auto &secondary : secondaries) {
             auto i = _host_port_id.find(secondary);
             CHECK(i != _host_port_id.end(), "invalid secondary: {}", secondary);
             _network[node_id][i->second]++;

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -138,7 +138,7 @@ bool construct_replica(meta_view view, const gpid &pid, int max_replica_count)
     GET_HOST_PORTS(pc, last_drops, last_drops);
     CHECK(last_drops.empty(), "last_drops of partition({}) must be empty", pid);
     for (auto iter = drop_list.rbegin(); iter != drop_list.rend(); ++iter) {
-        // hp_last_drops is added in the steps bellow.
+        // hp_last_drops is added in the steps below.
         if (last_drops.size() + 1 >= max_replica_count) {
             break;
         }
@@ -540,11 +540,6 @@ app_state::app_state(const app_info &info) : app_info(info), helpers(new app_sta
     RESET_IP_AND_HOST_PORT(pc, primary);
     CLEAR_IP_AND_HOST_PORT(pc, secondaries);
     CLEAR_IP_AND_HOST_PORT(pc, last_drops);
-
-    // TODO(yujingwei): use marco simplify the code, and the logical may should
-    // change
-    pc.__set_hp_secondaries({});
-    pc.__set_hp_last_drops({});
 
     pcs.assign(app_info::partition_count, pc);
     for (int i = 0; i != app_info::partition_count; ++i) {

--- a/src/meta/meta_data.h
+++ b/src/meta/meta_data.h
@@ -266,24 +266,14 @@ struct partition_configuration_stateless
 {
     partition_configuration &pc;
     explicit partition_configuration_stateless(partition_configuration &_pc) : pc(_pc) {}
-    std::vector<dsn::host_port> &workers()
-    {
-        DCHECK(pc.__isset.hp_last_drops, "");
-        return pc.hp_last_drops;
-    }
-    std::vector<dsn::host_port> &hosts()
-    {
-        DCHECK(pc.__isset.hp_secondaries, "");
-        return pc.hp_secondaries;
-    }
+    std::vector<dsn::host_port> &workers() { return pc.hp_last_drops; }
+    std::vector<dsn::host_port> &hosts() { return pc.hp_secondaries; }
     [[nodiscard]] bool is_host(const host_port &node) const
     {
-        DCHECK(pc.__isset.hp_secondaries, "");
         return utils::contains(pc.hp_secondaries, node);
     }
     [[nodiscard]] bool is_worker(const host_port &node) const
     {
-        DCHECK(pc.__isset.hp_last_drops, "");
         return utils::contains(pc.hp_last_drops, node);
     }
     [[nodiscard]] bool is_member(const host_port &node) const

--- a/src/meta/meta_http_service.cpp
+++ b/src/meta/meta_http_service.cpp
@@ -15,12 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <fmt/core.h>
-#include <rapidjson/ostreamwrapper.h>
 #include <algorithm>
 #include <cstddef>
+#include <fmt/core.h>
 #include <map>
 #include <memory>
+#include <rapidjson/ostreamwrapper.h>
 #include <set>
 #include <sstream>
 #include <string>
@@ -251,11 +251,15 @@ void meta_http_service::list_app_handler(const http_request &req, http_response 
             int read_unhealthy = 0;
             for (const auto &pc : response.partitions) {
                 int replica_count = 0;
-                if (pc.hp_primary) {
+                host_port primary;
+                GET_HOST_PORT(pc, primary, primary);
+                if (primary) {
                     replica_count++;
                 }
-                replica_count += pc.hp_secondaries.size();
-                if (pc.hp_primary) {
+                std::vector<host_port> secondaries;
+                GET_HOST_PORTS(pc, secondaries, secondaries);
+                replica_count += static_cast<int>(secondaries.size());
+                if (primary) {
                     if (replica_count >= pc.max_replica_count) {
                         fully_healthy++;
                     } else if (replica_count < 2) {

--- a/src/meta/meta_split_service.cpp
+++ b/src/meta/meta_split_service.cpp
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <fmt/core.h>
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <fmt/core.h>
 #include <functional>
 #include <map>
 #include <utility>
@@ -311,10 +311,12 @@ void meta_split_service::on_add_child_on_remote_storage_reply(error_code ec,
     // TODO(yingchun): should use conference?
     auto child_pc = app->pcs[child_gpid.get_partition_index()];
     child_pc.secondaries = request.child_config.secondaries;
-    child_pc.__set_hp_secondaries(request.child_config.hp_secondaries);
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(request.child_config, secondaries, secondaries);
+    child_pc.__set_hp_secondaries(secondaries);
     _state->update_configuration_locally(*app, update_child_request);
 
-    if (parent_context.msg) {
+    if (parent_context.msg != nullptr) {
         response.err = ERR_OK;
         response.app = *app;
         response.parent_config = app->pcs[parent_gpid.get_partition_index()];

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -19,14 +19,15 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
-// IWYU pragma: no_include <ext/alloc_traits.h>
-#include <inttypes.h>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
-#include <stdio.h>
+// IWYU pragma: no_include <ext/alloc_traits.h>
 #include <algorithm>
+#include <cinttypes>
 #include <cstdint>
+#include <cstdio>
 #include <ostream>
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
 
@@ -85,12 +86,16 @@ pc_status partition_guardian::cure(meta_view view,
     CHECK(app->is_stateful, "");
     CHECK(acts.empty(), "");
 
-    pc_status status;
-    if (!pc.hp_primary) {
+    pc_status status{0};
+    host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    if (!primary) {
         status = on_missing_primary(view, gpid);
-    } else if (static_cast<int>(pc.hp_secondaries.size()) + 1 < pc.max_replica_count) {
+    } else if (static_cast<int>(secondaries.size()) + 1 < pc.max_replica_count) {
         status = on_missing_secondary(view, gpid);
-    } else if (static_cast<int>(pc.hp_secondaries.size()) >= pc.max_replica_count) {
+    } else if (static_cast<int>(secondaries.size()) >= pc.max_replica_count) {
         status = on_redundant_secondary(view, gpid);
     } else {
         status = pc_status::healthy;
@@ -125,8 +130,8 @@ void partition_guardian::reconfig(meta_view view, const configuration_update_req
     // handle the dropped out servers
     if (request.type == config_type::CT_DROP_PARTITION) {
         cc->serving.clear();
-
-        const auto &last_drops = request.config.hp_last_drops;
+        std::vector<host_port> last_drops;
+        GET_HOST_PORTS(request.config, last_drops, last_drops);
         for (const auto &last_drop : last_drops) {
             cc->record_drop_history(last_drop);
         }
@@ -153,46 +158,62 @@ bool partition_guardian::from_proposals(meta_view &view,
 {
     const partition_configuration &pc = *get_config(*(view.apps), gpid);
     config_context &cc = *get_config_context(*(view.apps), gpid);
-    bool is_action_valid;
+    bool is_action_valid{false};
+
+    auto handle_invalid_action = [&](std::string_view reason) {
+        LOG_INFO("proposal action({}) for gpid({}) is invalid, clear all proposal actions: {}",
+                 action,
+                 gpid,
+                 reason);
+        action.type = config_type::CT_INVALID;
+
+        while (!cc.lb_actions.empty()) {
+            configuration_proposal_action cpa = *cc.lb_actions.front();
+            if (!cc.lb_actions.is_from_balancer()) {
+                finish_cure_proposal(view, gpid, cpa);
+            }
+            cc.lb_actions.pop_front();
+        }
+        return false;
+    };
 
     if (cc.lb_actions.empty()) {
         action.type = config_type::CT_INVALID;
         return false;
     }
+
     action = *(cc.lb_actions.front());
     host_port target;
     host_port node;
     GET_HOST_PORT(action, target, target);
     std::string reason;
+    host_port primary;
+    GET_HOST_PORT(pc, primary, primary);
+
     if (!target) {
-        reason = "action target is invalid";
-        goto invalid_action;
+        return handle_invalid_action("action target is invalid");
     }
     if (!is_node_alive(*(view.nodes), target)) {
-        reason = fmt::format("action target({}) is not alive", target);
-        goto invalid_action;
+        return handle_invalid_action(fmt::format("action target({}) is not alive", target));
     }
     GET_HOST_PORT(action, node, node);
     if (!node) {
-        reason = "action node is invalid";
-        goto invalid_action;
+        return handle_invalid_action("action node is invalid");
     }
     if (!is_node_alive(*(view.nodes), node)) {
-        reason = fmt::format("action node({}) is not alive", node);
-        goto invalid_action;
+        return handle_invalid_action(fmt::format("action node({}) is not alive", node));
     }
 
     if (cc.lb_actions.is_abnormal_learning_proposal()) {
-        reason = "learning process abnormal";
-        goto invalid_action;
+        return handle_invalid_action("learning process abnormal");
     }
 
     switch (action.type) {
     case config_type::CT_ASSIGN_PRIMARY:
-        is_action_valid = (node == target && !pc.primary && !is_secondary(pc, node));
+        is_action_valid = (node == target && !primary && !is_secondary(pc, node));
         break;
     case config_type::CT_UPGRADE_TO_PRIMARY:
-        is_action_valid = (node == target && !pc.primary && is_secondary(pc, node));
+        is_action_valid = (node == target && !primary && is_secondary(pc, node));
         break;
     case config_type::CT_ADD_SECONDARY:
     case config_type::CT_ADD_SECONDARY_FOR_LB:
@@ -213,25 +234,9 @@ bool partition_guardian::from_proposals(meta_view &view,
 
     if (is_action_valid) {
         return true;
-    } else {
-        reason = "action is invalid";
     }
 
-invalid_action:
-    LOG_INFO("proposal action({}) for gpid({}) is invalid, clear all proposal actions: {}",
-             action,
-             gpid,
-             reason);
-    action.type = config_type::CT_INVALID;
-
-    while (!cc.lb_actions.empty()) {
-        configuration_proposal_action cpa = *cc.lb_actions.front();
-        if (!cc.lb_actions.is_from_balancer()) {
-            finish_cure_proposal(view, gpid, cpa);
-        }
-        cc.lb_actions.pop_front();
-    }
-    return false;
+    return handle_invalid_action("action is invalid");
 }
 
 pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpid &gpid)
@@ -247,10 +252,14 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
 
     action.type = config_type::CT_INVALID;
     // try to upgrade a secondary to primary if the primary is missing
-    if (!pc.hp_secondaries.empty()) {
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    std::vector<host_port> last_drops;
+    GET_HOST_PORTS(pc, last_drops, last_drops);
+    if (!secondaries.empty()) {
         RESET_IP_AND_HOST_PORT(action, node);
-        for (const auto &secondary : pc.hp_secondaries) {
-            const auto ns = get_node_state(*(view.nodes), secondary, false);
+        for (const auto &secondary : secondaries) {
+            auto *const ns = get_node_state(*(view.nodes), secondary, false);
             CHECK_NOTNULL(ns, "invalid secondary: {}", secondary);
             if (dsn_unlikely(!ns->alive())) {
                 continue;
@@ -284,7 +293,7 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
     }
     // if nothing in the last_drops, it means that this is a newly created partition, so let's
     // just find a node and assign primary for it.
-    else if (pc.hp_last_drops.empty()) {
+    else if (last_drops.empty()) {
         dsn::host_port min_primary_server;
         newly_partitions *min_primary_server_np = nullptr;
 
@@ -338,10 +347,10 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                      dr.last_prepared_decree);
         }
 
-        for (int i = 0; i < pc.hp_last_drops.size(); ++i) {
+        for (int i = 0; i < last_drops.size(); ++i) {
             int dropped_index = -1;
             for (int k = 0; k < cc.dropped.size(); k++) {
-                if (cc.dropped[k].node == pc.hp_last_drops[i]) {
+                if (cc.dropped[k].node == last_drops[i]) {
                     dropped_index = k;
                     break;
                 }
@@ -353,13 +362,13 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                      dropped_index);
         }
 
-        if (pc.hp_last_drops.size() == 1) {
+        if (last_drops.size() == 1) {
             LOG_WARNING("{}: the only node({}) is dead, waiting it to come back",
                         gpid_name,
                         FMT_HOST_PORT_AND_IP(pc, last_drops.back()));
             SET_OBJ_IP_AND_HOST_PORT(action, node, pc, last_drops.back());
         } else {
-            std::vector<dsn::host_port> nodes(pc.hp_last_drops.end() - 2, pc.hp_last_drops.end());
+            std::vector<dsn::host_port> nodes(last_drops.end() - 2, last_drops.end());
             std::vector<dropped_replica> collected_info(2);
             bool ready = true;
 
@@ -559,7 +568,7 @@ pc_status partition_guardian::on_missing_secondary(meta_view &view, const dsn::g
             gpid,
             oss.str(),
             cc.prefered_dropped);
-        if (cc.prefered_dropped < 0 || cc.prefered_dropped >= (int)cc.dropped.size()) {
+        if (cc.prefered_dropped < 0 || cc.prefered_dropped >= static_cast<int>(cc.dropped.size())) {
             LOG_INFO("gpid({}): prefered_dropped({}) is invalid according to drop_list(size {}), "
                      "reset it to {} (drop_list.size - 1)",
                      gpid,
@@ -668,9 +677,11 @@ pc_status partition_guardian::on_redundant_secondary(meta_view &view, const dsn:
     const node_mapper &nodes = *(view.nodes);
     const partition_configuration &pc = *get_config(*(view.apps), gpid);
     int target = 0;
-    int load = nodes.find(pc.hp_secondaries.front())->second.partition_count();
-    for (int i = 0; i != pc.hp_secondaries.size(); ++i) {
-        int l = nodes.find(pc.hp_secondaries[i])->second.partition_count();
+    std::vector<host_port> secondaries;
+    GET_HOST_PORTS(pc, secondaries, secondaries);
+    int load = static_cast<int>(nodes.find(secondaries.front())->second.partition_count());
+    for (int i = 0; i != secondaries.size(); ++i) {
+        int l = static_cast<int>(nodes.find(secondaries[i])->second.partition_count());
         if (l > load) {
             load = l;
             target = i;

--- a/src/meta/server_load_balancer.cpp
+++ b/src/meta/server_load_balancer.cpp
@@ -178,8 +178,9 @@ void server_load_balancer::register_proposals(meta_view view,
         if (act.target) {
             continue;
         }
-
-        if (!pc.hp_primary) {
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        if (!primary) {
             resp.err = ERR_INVALID_PARAMETERS;
             return;
         }

--- a/src/meta/test/meta_data.cpp
+++ b/src/meta/test/meta_data.cpp
@@ -28,7 +28,6 @@
 #include <string>
 #include <vector>
 
-#include "client/partition_resolver.h"
 #include "common/gpid.h"
 #include "dsn.layer2_types.h"
 #include "gtest/gtest.h"
@@ -39,13 +38,14 @@
 #include "rpc/rpc_address.h"
 #include "rpc/rpc_host_port.h"
 
-using namespace dsn::replication;
+namespace dsn::replication {
 
 TEST(meta_data, dropped_cmp)
 {
-    dsn::host_port n;
+    host_port n;
 
-    dropped_replica d1, d2;
+    dropped_replica d1;
+    dropped_replica d2;
     // time not equal
     {
         d1 = {n, 10, 5, 5, 5};
@@ -112,10 +112,10 @@ TEST(meta_data, collect_replica)
     app_mapper apps;
     node_mapper nodes;
 
-    dsn::app_info info;
+    app_info info;
     info.app_id = 1;
     info.is_stateful = true;
-    info.status = dsn::app_status::AS_AVAILABLE;
+    info.status = app_status::AS_AVAILABLE;
     info.app_name = "test";
     info.app_type = "test";
     info.max_replica_count = 3;
@@ -126,12 +126,12 @@ TEST(meta_data, collect_replica)
 
     replica_info rep;
     rep.app_type = "test";
-    rep.pid = dsn::gpid(1, 0);
+    rep.pid = gpid(1, 0);
 
     auto &pc = *get_config(apps, rep.pid);
     auto &cc = *get_config_context(apps, rep.pid);
 
-    std::vector<dsn::host_port> node_list;
+    std::vector<host_port> node_list;
     generate_node_list(node_list, 10, 10);
 
 #define CLEAR_REPLICA                                                                              \
@@ -355,10 +355,10 @@ TEST(meta_data, construct_replica)
     app_mapper apps;
     node_mapper nodes;
 
-    dsn::app_info info;
+    app_info info;
     info.app_id = 1;
     info.is_stateful = true;
-    info.status = dsn::app_status::AS_AVAILABLE;
+    info.status = app_status::AS_AVAILABLE;
     info.app_name = "test";
     info.app_type = "test";
     info.max_replica_count = 3;
@@ -369,12 +369,12 @@ TEST(meta_data, construct_replica)
 
     replica_info rep;
     rep.app_type = "test";
-    rep.pid = dsn::gpid(1, 0);
+    rep.pid = gpid(1, 0);
 
-    dsn::partition_configuration &pc = *get_config(apps, rep.pid);
+    partition_configuration &pc = *get_config(apps, rep.pid);
     config_context &cc = *get_config_context(apps, rep.pid);
 
-    std::vector<dsn::host_port> node_list;
+    std::vector<host_port> node_list;
     generate_node_list(node_list, 10, 10);
 
 #define CLEAR_REPLICA                                                                              \
@@ -405,8 +405,15 @@ TEST(meta_data, construct_replica)
         CLEAR_ALL;
         cc.dropped = {dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 5, 10, 12}};
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-        ASSERT_EQ(node_list[0], pc.hp_primary);
-        ASSERT_TRUE(pc.hp_secondaries.empty());
+
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        ASSERT_EQ(node_list[0], primary);
+
+        std::vector<host_port> secondaries;
+        GET_HOST_PORTS(pc, secondaries, secondaries);
+        ASSERT_TRUE(secondaries.empty());
+
         ASSERT_TRUE(cc.dropped.empty());
         ASSERT_EQ(-1, cc.prefered_dropped);
     }
@@ -419,11 +426,20 @@ TEST(meta_data, construct_replica)
                       dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 8, 10, 12},
                       dropped_replica{node_list[4], dropped_replica::INVALID_TIMESTAMP, 9, 11, 12}};
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-        ASSERT_EQ(node_list[4], pc.hp_primary);
-        ASSERT_TRUE(pc.hp_secondaries.empty());
 
-        std::vector<dsn::host_port> nodes = {node_list[2], node_list[3]};
-        ASSERT_EQ(nodes, pc.hp_last_drops);
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        ASSERT_EQ(node_list[4], primary);
+
+        std::vector<host_port> secondaries;
+        GET_HOST_PORTS(pc, secondaries, secondaries);
+        ASSERT_TRUE(secondaries.empty());
+
+        std::vector<host_port> nodes = {node_list[2], node_list[3]};
+        std::vector<host_port> last_drops;
+        GET_HOST_PORTS(pc, last_drops, last_drops);
+        ASSERT_EQ(nodes, last_drops);
+
         ASSERT_EQ(3, cc.dropped.size());
         ASSERT_EQ(2, cc.prefered_dropped);
     }
@@ -436,11 +452,20 @@ TEST(meta_data, construct_replica)
                       dropped_replica{node_list[2], dropped_replica::INVALID_TIMESTAMP, 7, 12, 12}};
 
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-        ASSERT_EQ(node_list[2], pc.hp_primary);
-        ASSERT_TRUE(pc.hp_secondaries.empty());
 
-        std::vector<dsn::host_port> nodes = {node_list[0], node_list[1]};
-        ASSERT_EQ(nodes, pc.hp_last_drops);
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        ASSERT_EQ(node_list[2], primary);
+
+        std::vector<host_port> secondaries;
+        GET_HOST_PORTS(pc, secondaries, secondaries);
+        ASSERT_TRUE(secondaries.empty());
+
+        std::vector<host_port> nodes = {node_list[0], node_list[1]};
+        std::vector<host_port> last_drops;
+        GET_HOST_PORTS(pc, last_drops, last_drops);
+        ASSERT_EQ(nodes, last_drops);
+
         ASSERT_EQ(2, cc.dropped.size());
         ASSERT_EQ(1, cc.prefered_dropped);
     }
@@ -454,13 +479,22 @@ TEST(meta_data, construct_replica)
                       dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 7, 14, 14}};
 
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-        ASSERT_EQ(node_list[3], pc.hp_primary);
-        ASSERT_TRUE(pc.hp_secondaries.empty());
+        host_port primary;
+        GET_HOST_PORT(pc, primary, primary);
+        ASSERT_EQ(node_list[3], primary);
 
-        std::vector<dsn::host_port> nodes = {node_list[1], node_list[2]};
-        ASSERT_EQ(nodes, pc.hp_last_drops);
+        std::vector<host_port> secondaries;
+        GET_HOST_PORTS(pc, secondaries, secondaries);
+        ASSERT_TRUE(secondaries.empty());
+
+        std::vector<host_port> nodes = {node_list[1], node_list[2]};
+        std::vector<host_port> last_drops;
+        GET_HOST_PORTS(pc, last_drops, last_drops);
+        ASSERT_EQ(nodes, last_drops);
 
         ASSERT_EQ(3, cc.dropped.size());
         ASSERT_EQ(2, cc.prefered_dropped);
     }
 }
+
+} // namespace dsn::replication

--- a/src/meta/test/meta_data.cpp
+++ b/src/meta/test/meta_data.cpp
@@ -405,15 +405,8 @@ TEST(meta_data, construct_replica)
         CLEAR_ALL;
         cc.dropped = {dropped_replica{node_list[0], dropped_replica::INVALID_TIMESTAMP, 5, 10, 12}};
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-
-        host_port primary;
-        GET_HOST_PORT(pc, primary, primary);
-        ASSERT_EQ(node_list[0], primary);
-
-        std::vector<host_port> secondaries;
-        GET_HOST_PORTS(pc, secondaries, secondaries);
-        ASSERT_TRUE(secondaries.empty());
-
+        ASSERT_EQ(node_list[0], pc.hp_primary);
+        ASSERT_TRUE(pc.hp_secondaries.empty());
         ASSERT_TRUE(cc.dropped.empty());
         ASSERT_EQ(-1, cc.prefered_dropped);
     }
@@ -426,20 +419,11 @@ TEST(meta_data, construct_replica)
                       dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 8, 10, 12},
                       dropped_replica{node_list[4], dropped_replica::INVALID_TIMESTAMP, 9, 11, 12}};
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-
-        host_port primary;
-        GET_HOST_PORT(pc, primary, primary);
-        ASSERT_EQ(node_list[4], primary);
-
-        std::vector<host_port> secondaries;
-        GET_HOST_PORTS(pc, secondaries, secondaries);
-        ASSERT_TRUE(secondaries.empty());
+        ASSERT_EQ(node_list[4], pc.hp_primary);
+        ASSERT_TRUE(pc.hp_secondaries.empty());
 
         std::vector<host_port> nodes = {node_list[2], node_list[3]};
-        std::vector<host_port> last_drops;
-        GET_HOST_PORTS(pc, last_drops, last_drops);
-        ASSERT_EQ(nodes, last_drops);
-
+        ASSERT_EQ(nodes, pc.hp_last_drops);
         ASSERT_EQ(3, cc.dropped.size());
         ASSERT_EQ(2, cc.prefered_dropped);
     }
@@ -452,20 +436,11 @@ TEST(meta_data, construct_replica)
                       dropped_replica{node_list[2], dropped_replica::INVALID_TIMESTAMP, 7, 12, 12}};
 
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-
-        host_port primary;
-        GET_HOST_PORT(pc, primary, primary);
-        ASSERT_EQ(node_list[2], primary);
-
-        std::vector<host_port> secondaries;
-        GET_HOST_PORTS(pc, secondaries, secondaries);
-        ASSERT_TRUE(secondaries.empty());
+        ASSERT_EQ(node_list[2], pc.hp_primary);
+        ASSERT_TRUE(pc.hp_secondaries.empty());
 
         std::vector<host_port> nodes = {node_list[0], node_list[1]};
-        std::vector<host_port> last_drops;
-        GET_HOST_PORTS(pc, last_drops, last_drops);
-        ASSERT_EQ(nodes, last_drops);
-
+        ASSERT_EQ(nodes, pc.hp_last_drops);
         ASSERT_EQ(2, cc.dropped.size());
         ASSERT_EQ(1, cc.prefered_dropped);
     }
@@ -479,19 +454,11 @@ TEST(meta_data, construct_replica)
                       dropped_replica{node_list[3], dropped_replica::INVALID_TIMESTAMP, 7, 14, 14}};
 
         ASSERT_TRUE(construct_replica(view, rep.pid, 3));
-        host_port primary;
-        GET_HOST_PORT(pc, primary, primary);
-        ASSERT_EQ(node_list[3], primary);
-
-        std::vector<host_port> secondaries;
-        GET_HOST_PORTS(pc, secondaries, secondaries);
-        ASSERT_TRUE(secondaries.empty());
+        ASSERT_EQ(node_list[3], pc.hp_primary);
+        ASSERT_TRUE(pc.hp_secondaries.empty());
 
         std::vector<host_port> nodes = {node_list[1], node_list[2]};
-        std::vector<host_port> last_drops;
-        GET_HOST_PORTS(pc, last_drops, last_drops);
-        ASSERT_EQ(nodes, last_drops);
-
+        ASSERT_EQ(nodes, pc.hp_last_drops);
         ASSERT_EQ(3, cc.dropped.size());
         ASSERT_EQ(2, cc.prefered_dropped);
     }

--- a/src/rpc/rpc_host_port.h
+++ b/src/rpc/rpc_host_port.h
@@ -73,7 +73,7 @@ class TProtocol;
         } else {                                                                                   \
             _target.reserve(_obj.field.size());                                                    \
             for (const auto &addr : _obj.field) {                                                  \
-                _target.emplace_back(host_port::from_address(addr));                               \
+                _target.emplace_back(dsn::host_port::from_address(addr));                          \
             }                                                                                      \
         }                                                                                          \
     } while (0)
@@ -215,15 +215,18 @@ class TProtocol;
 // Head insert 'hp' and its DNS resolved rpc_address to the optional vector 'hp_<field>' and vector
 // '<field>' of 'obj'. The types of the fields are std::vector<rpc_address> and
 // std::vector<host_port>, respectively.
-#define HEAD_INSERT_IP_AND_HOST_PORT_BY_DNS(obj, field, hp)                                        \
+#define HEAD_INSERT_IP_AND_HOST_PORT_BY_DNS(obj, field, hp, target)                                \
     do {                                                                                           \
         auto &_obj = (obj);                                                                        \
         const auto &_hp = (hp);                                                                    \
+        auto &_target = (target);                                                                  \
         _obj.field.insert(_obj.field.begin(), _hp.resolve());                                      \
         if (!_obj.__isset.hp_##field) {                                                            \
             _obj.__set_hp_##field({_hp});                                                          \
+            _target.emplace_back(_hp);                                                             \
         } else {                                                                                   \
             _obj.hp_##field.insert(_obj.hp_##field.begin(), _hp);                                  \
+            _target = _obj.hp_##field;                                                             \
         }                                                                                          \
         DCHECK_EQ(_obj.field.size(), _obj.hp_##field.size());                                      \
     } while (0)

--- a/src/rpc/rpc_host_port.h
+++ b/src/rpc/rpc_host_port.h
@@ -223,11 +223,10 @@ class TProtocol;
         _obj.field.insert(_obj.field.begin(), _hp.resolve());                                      \
         if (!_obj.__isset.hp_##field) {                                                            \
             _obj.__set_hp_##field({_hp});                                                          \
-            _target.emplace_back(_hp);                                                             \
         } else {                                                                                   \
             _obj.hp_##field.insert(_obj.hp_##field.begin(), _hp);                                  \
-            _target = _obj.hp_##field;                                                             \
         }                                                                                          \
+        _target = _obj.hp_##field;                                                                 \
         DCHECK_EQ(_obj.field.size(), _obj.hp_##field.size());                                      \
     } while (0)
 


### PR DESCRIPTION
#2351 

This pr is mainly refactor the fqdn on meta server side.
1. Use marcos like `GET_HOST_PORT` and `GET_HOST_PORTS` to replace where partition_configuration objects apprea.
2. Refactor marco `HEAD_INSERT_IP_AND_HOST_PORT_BY_DNS` to process the `last_drops` objects in right way. 
3. Fix the clang-tidy errors.


