### PR TITLE
ci(github): update markdown lint check

### DIFF
--- a/.github/workflows/standardization_lint.yaml
+++ b/.github/workflows/standardization_lint.yaml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
+      - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225
 
   dockerfile_linter:
     name: Lint Dockerfile


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Use tcort/github-action-markdown-link-check instead of gaurav-nelson/github-action-markdown-link-check
since the latter is deprecated.

See https://github.com/apache/infrastructure-actions/issues/371.

### What is changed and how does it work?


### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

##### Code changes

- Has exported function/method change
- Has exported variable/fields change
- Has interface methods change
- Has persistent data change

##### Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

##### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
