### PR TITLE
fix(admin-cli): change default value of checkpoint flag to false in duplication

### DIFF
--- a/admin-cli/cmd/duplication.go
+++ b/admin-cli/cmd/duplication.go
@@ -53,7 +53,7 @@ func init() {
 		}),
 		Flags: func(f *grumble.Flags) {
 			f.String("c", "cluster", "", "the destination where the source data is duplicated")
-			f.Bool("p", "checkpoint", true, "whether to duplicate checkpoint when duplication created")
+			f.Bool("p", "checkpoint", false, "whether to duplicate checkpoint when duplication created")
 		},
 	})
 	rootCmd.AddCommand(&grumble.Command{


### PR DESCRIPTION
When the -p flag is not explicitly specified, checkpoint synchronization
should be disabled by default.