### PR TITLE
fix(ci): use master Docker image for v2.5 branch only

### DIFF
--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# NOTE: Docker images use 'master' branch tag for release branches (e.g., v2.5)
+# that may not have prebuilt Docker images. Other branches use their own images.
+
 name: Cpp CI
 
 on:
@@ -64,7 +67,8 @@ jobs:
       USE_JEMALLOC: OFF
       ENABLE_ASAN: OFF
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu2204-${{ github.base_ref }}
+      # Use master image for v2.5 branch (which lacks prebuilt images), others use their own
+      image: apache/pegasus:thirdparties-bin-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' || github.base_ref }}
     steps:
       - name: Install Softwares
         run: |
@@ -91,7 +95,8 @@ jobs:
       USE_JEMALLOC: OFF
       ENABLE_ASAN: OFF
     container:
-      image: apache/pegasus:thirdparties-bin-ubuntu2204-${{ github.base_ref }}
+      # Use master image for v2.5 branch (which lacks prebuilt images), others use their own
+      image: apache/pegasus:thirdparties-bin-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' || github.base_ref }}
     steps:
       - uses: actions/checkout@v4
       - name: Free Disk Space (Ubuntu)
@@ -123,7 +128,8 @@ jobs:
       ARTIFACT_NAME: release
       BUILD_OPTIONS: -t release --test
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
+      # Use master image for v2.5 branch (which lacks prebuilt images), others use their own
+      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' || github.base_ref }}
     steps:
       - name: Clone code
         uses: actions/checkout@v4
@@ -193,7 +199,8 @@ jobs:
     env:
       ARTIFACT_NAME: release
     container:
-      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
+      # Use master image for v2.5 branch (which lacks prebuilt images), others use their own
+      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' || github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v4
@@ -213,7 +220,8 @@ jobs:
       ARTIFACT_NAME: release_address
       BUILD_OPTIONS: --sanitizer address --disable_gperf --test
     container:
-      image: apache/pegasus:thirdparties-bin-test-asan-ubuntu2204-${{ github.base_ref }}
+      # Use master image for v2.5 branch (which lacks prebuilt images), others use their own
+      image: apache/pegasus:thirdparties-bin-test-asan-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' || github.base_ref }}
     steps:
       - uses: actions/checkout@v4
       - name: Rebuild thirdparty if needed
@@ -284,7 +292,8 @@ jobs:
     env:
       ARTIFACT_NAME: release_address
     container:
-      image: apache/pegasus:thirdparties-bin-test-asan-ubuntu2204-${{ github.base_ref }}
+      # Use master image for v2.5 branch (which lacks prebuilt images), others use their own
+      image: apache/pegasus:thirdparties-bin-test-asan-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' || github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v4
@@ -394,7 +403,8 @@ jobs:
       ARTIFACT_NAME: release_jemalloc
       BUILD_OPTIONS: -t release --use_jemalloc --test
     container:
-      image: apache/pegasus:thirdparties-bin-test-jemallc-ubuntu2204-${{ github.base_ref }}
+      # Use master image for v2.5 branch (which lacks prebuilt images), others use their own
+      image: apache/pegasus:thirdparties-bin-test-jemallc-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' || github.base_ref }}
     steps:
       - uses: actions/checkout@v4
       - name: Rebuild thirdparty if needed
@@ -417,7 +427,8 @@ jobs:
     env:
       ARTIFACT_NAME: release_jemalloc
     container:
-      image: apache/pegasus:thirdparties-bin-test-jemallc-ubuntu2204-${{ github.base_ref }}
+      # Use master image for v2.5 branch (which lacks prebuilt images), others use their own
+      image: apache/pegasus:thirdparties-bin-test-jemallc-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' || github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
       - uses: actions/checkout@v4
@@ -472,7 +483,8 @@ jobs:
       BUILD_OPTIONS: -t debug --test --separate_servers
       PACK_OPTIONS: --separate_servers
     container:
-      image: apache/pegasus:thirdparties-bin-rockylinux9-${{ github.base_ref }}
+      # Use master image for v2.5 branch (which lacks prebuilt images), others use their own
+      image: apache/pegasus:thirdparties-bin-rockylinux9-${{ github.base_ref == 'v2.5' && 'master' || github.base_ref }}
     steps:
       - name: Clone code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

Fix CI startup failures for v2.5 branch PRs that dont have prebuilt Docker images.

## Problem

The workflow lint_and_test_cpp.yaml used `${{ github.base_ref }}` to construct Docker image tags:
- `apache/pegasus:thirdparties-bin-test-ubuntu2204-v2.5` (doesnt exist!)

This caused `startup_failure` for PRs targeting v2.5 branch.

## Solution

Use GitHub Actions conditional expressions to use master branch images **only for v2.5 PRs**:

| Branch | Image Used |
|--------|------------|
| v2.5 | master (fallback) |
| master, ci-test, *dev | their own branch images |

Image tag format: `${{ github.base_ref == 'v2.5' && 'master' || github.base_ref }}`

## Changes

| Job | Image Tag |
|-----|-----------|
| Tidy | `ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' \|\| github.base_ref }}` |
| IWYU | same |
| Build/Test Release | `test-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' \|\| github.base_ref }}` |
| ASAN | `test-asan-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' \|\| github.base_ref }}` |
| jemalloc | `test-jemallc-ubuntu2204-${{ github.base_ref == 'v2.5' && 'master' \|\| github.base_ref }}` |
| Rockylinux9 | `rockylinux9-${{ github.base_ref == 'v2.5' && 'master' \|\| github.base_ref }}` |

Also restored clang-tidy to compare against `origin/base_ref`.

## Testing

The change only affects CI configuration. No code changes to C++ source.

## Related

This fix enables CI for cherry-pick PRs targeting v2.5 branch.