### PR TITLE
ci(github): pin all actions to exact commit SHAs instead of tags or branch references

### DIFF
--- a/.github/actions/build_pegasus/action.yaml
+++ b/.github/actions/build_pegasus/action.yaml
@@ -20,7 +20,8 @@ runs:
   using: composite
   steps:
     - name: Setup cache
-      uses: actions/cache@v3
+      # actions/cache@v3.5.0
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
       with:
         path: |
           /github/home/.ccache

--- a/.github/actions/download_artifact/action.yaml
+++ b/.github/actions/download_artifact/action.yaml
@@ -22,7 +22,8 @@ runs:
     - name: Unpack prebuilt third-parties
       uses: "./.github/actions/unpack_prebuilt_thirdparties"
     - name: Download tarball
-      uses: actions/download-artifact@v4
+      # actions/download-artifact@v4.3.0
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         name: ${{ env.ARTIFACT_NAME }}_artifact_${{ github.sha }}
         path: .

--- a/.github/actions/upload_artifact/action.yaml
+++ b/.github/actions/upload_artifact/action.yaml
@@ -30,7 +30,8 @@ runs:
         tar -zcvhf ${ARTIFACT_NAME}_builder.tar build/latest/output build/latest/bin build/latest/src/server/test/config.ini hadoop-bin zookeeper-bin
       shell: bash
     - name: Upload tarball
-      uses: actions/upload-artifact@v4
+      # actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: ${{ env.ARTIFACT_NAME }}_artifact_${{ github.sha }}
         path: ${{ env.ARTIFACT_NAME }}_builder.tar

--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -52,18 +52,23 @@ jobs:
       - name: Checkout
         # The glibc version on ubuntu1804 is lower than the actions/checkout@v4 required, so
         # we need to force to use actions/checkout@v3.
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        # docker/setup-qemu-action@v3.7.0
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        # docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        # docker/login-action@3.7.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        # docker/build-push-action@v6.19.2
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           platforms: linux/amd64
           context: .
@@ -83,18 +88,23 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        # docker/setup-qemu-action@v3.7.0
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        # docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        # docker/login-action@3.7.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        # docker/build-push-action@v6.19.2
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           platforms: linux/amd64
           context: .

--- a/.github/workflows/build-push-thirdparty.yml
+++ b/.github/workflows/build-push-thirdparty.yml
@@ -28,18 +28,23 @@ jobs:
   build_push_src_docker_images:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        # docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        # docker/setup-buildx-action@v1.7.0
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        # docker/login-action@1.14.1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v2.10.0
+        # docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
           file: ./docker/thirdparties-src/Dockerfile
@@ -64,18 +69,23 @@ jobs:
     steps:
       # The glibc version on ubuntu1804 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
-      - uses: actions/checkout@v3
+      # actions/checkout@v3.6.0
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        # docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        # docker/setup-buildx-action@v1.7.0
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        # docker/login-action@1.14.1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for production
-        uses: docker/build-push-action@v2.10.0
+        # docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
           file: ./docker/thirdparties-bin/Dockerfile
@@ -100,18 +110,23 @@ jobs:
     steps:
       # The glibc version on ubuntu1804 is lower than the actions/checkout@v4 required, so
       # we need to force to use actions/checkout@v3.
-      - uses: actions/checkout@v3
+      # actions/checkout@v3.6.0
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        # docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        # docker/setup-buildx-action@v1.7.0
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        # docker/login-action@1.14.1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for production with jemalloc
-        uses: docker/build-push-action@v2.10.0
+        # docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
           file: ./docker/thirdparties-bin/Dockerfile
@@ -129,18 +144,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_push_src_docker_images
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        # docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        # docker/setup-buildx-action@v1.7.0
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        # docker/login-action@1.14.1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for test
-        uses: docker/build-push-action@v2.10.0
+        # docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
           file: ./docker/thirdparties-bin/Dockerfile
@@ -158,18 +178,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_push_src_docker_images
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        # docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        # docker/setup-buildx-action@v1.7.0
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        # docker/login-action@1.14.1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for test asan
-        uses: docker/build-push-action@v2.10.0
+        # docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
           file: ./docker/thirdparties-bin/Dockerfile
@@ -188,18 +213,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_push_src_docker_images
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        # docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        # docker/setup-buildx-action@v1.7.0
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        # docker/login-action@1.14.1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for test with jemalloc
-        uses: docker/build-push-action@v2.10.0
+        # docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
           file: ./docker/thirdparties-bin/Dockerfile

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -30,9 +30,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Assign GitHub labels
-        uses: actions/labeler@v5
+        # uses: actions/labeler@v5.0.0
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/workflows/module_labeler_conf.yml

--- a/.github/workflows/lint_and_test_admin-cli.yml
+++ b/.github/workflows/lint_and_test_admin-cli.yml
@@ -43,13 +43,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        # golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           version: v1.56.2
           working-directory: ./admin-cli
@@ -59,9 +62,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
       - name: Compile

--- a/.github/workflows/lint_and_test_collector.yml
+++ b/.github/workflows/lint_and_test_collector.yml
@@ -44,9 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
       - name: Format
@@ -63,16 +65,19 @@ jobs:
       image: apache/pegasus:build-env-ubuntu2204-${{ github.base_ref }}-go
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 1
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
           cache: false
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        # golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           version: v1.56.2
           working-directory: ./collector
@@ -85,11 +90,13 @@ jobs:
       image: apache/pegasus:build-env-ubuntu2204-${{ github.base_ref }}-go
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 1
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
       - name: Build

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -53,7 +53,8 @@ jobs:
     name: Format
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: clang-format
         run: ./build_tools/run-clang-format.py --clang-format-executable clang-format-14 -e ./src/shell/linenoise -e ./src/shell/sds -e ./thirdparty -r .
 
@@ -70,7 +71,8 @@ jobs:
         run: |
           apt-get update
           apt-get install clang-tidy -y
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
       - name: Rebuild thirdparty if needed
@@ -93,7 +95,8 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Free Disk Space (Ubuntu)
         run: |
           .github/workflows/free_disk_space.sh
@@ -126,7 +129,8 @@ jobs:
       image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
       - name: Clone code
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Rebuild thirdparty if needed
         uses: "./.github/actions/rebuild_thirdparty_if_needed"
       - name: Build Pegasus
@@ -196,7 +200,8 @@ jobs:
       image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Download artifact
         uses: "./.github/actions/download_artifact"
       - name: Run server tests
@@ -215,7 +220,8 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-asan-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Rebuild thirdparty if needed
         uses: "./.github/actions/rebuild_thirdparty_if_needed"
       - name: Build Pegasus
@@ -287,7 +293,8 @@ jobs:
       image: apache/pegasus:thirdparties-bin-test-asan-ubuntu2204-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Download artifact
         uses: "./.github/actions/download_artifact"
       - name: Run server tests
@@ -309,7 +316,8 @@ jobs:
 #    container:
 #      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
 #    steps:
-#      - uses: actions/checkout@v4
+#      # actions/checkout@v4.3.1
+#      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 #      - name: Rebuild thirdparty if needed
 #        uses: "./.github/actions/rebuild_thirdparty_if_needed"
 #      - name: Build Pegasus
@@ -377,7 +385,8 @@ jobs:
 #      image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
 #      options: --cap-add=SYS_PTRACE
 #    steps:
-#      - uses: actions/checkout@v4
+#      # actions/checkout@v4.3.1
+#      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 #      - name: Download artifact
 #        uses: "./.github/actions/download_artifact"
 #      - name: Run server tests
@@ -396,7 +405,8 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-jemallc-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Rebuild thirdparty if needed
         uses: "./.github/actions/rebuild_thirdparty_if_needed"
       # TODO(yingchun): Append "-m dsn_utils_tests" to the command if not needed to pack server or tools, for example, the dependencies are static linked.
@@ -420,7 +430,8 @@ jobs:
       image: apache/pegasus:thirdparties-bin-test-jemallc-ubuntu2204-${{ github.base_ref }}
       options: --cap-add=SYS_PTRACE
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Download artifact
         uses: "./.github/actions/download_artifact"
       - name: Run server tests
@@ -437,9 +448,11 @@ jobs:
           # Preinstalled softwares: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-15-Readme.md
           brew install ccache
           brew install openssl@1.1
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup cache
-        uses: actions/cache@v3
+        # actions/cache@v3.5.0
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: |
             /Users/runner/Library/Caches/ccache
@@ -475,7 +488,8 @@ jobs:
       image: apache/pegasus:thirdparties-bin-rockylinux9-${{ github.base_ref }}
     steps:
       - name: Clone code
-        uses: actions/checkout@v3
+        # actions/checkout@v3.6.0
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Rebuild thirdparty if needed
         uses: "./.github/actions/rebuild_thirdparty_if_needed"
       - name: Build Pegasus

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -46,9 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
       - name: Format
@@ -65,9 +67,11 @@ jobs:
       image: apache/pegasus:build-env-ubuntu2204-${{ github.base_ref }}-go
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
       - name: Build
@@ -75,7 +79,8 @@ jobs:
         run: make build
       # because some files are generated after building, so lint after the build step
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        # golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           version: v1.56.2
           working-directory: ./go-client
@@ -91,7 +96,8 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: "./.github/actions/rebuild_thirdparty_if_needed"
       - uses: "./.github/actions/build_pegasus"
       - uses: "./.github/actions/upload_artifact"
@@ -118,9 +124,11 @@ jobs:
           make install
           cd - && rm -rf thrift-${THRIFT_VERSION} v${THRIFT_VERSION}.tar.gz
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
       - uses: "./.github/actions/download_artifact"

--- a/.github/workflows/lint_and_test_java-client.yml
+++ b/.github/workflows/lint_and_test_java-client.yml
@@ -40,8 +40,10 @@ jobs:
     name: Spotless
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/setup-java@v4.8.0
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           java-version: 8
           distribution: temurin
@@ -61,7 +63,8 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Rebuild thirdparty if needed
         uses: "./.github/actions/rebuild_thirdparty_if_needed"
       - name: Build Pegasus
@@ -82,14 +85,17 @@ jobs:
       matrix:
         java: [ '8', '11', '17' ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/cache@v3.5.0
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: actions/setup-java@v4
+      # actions/setup-java@v4.8.0
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin

--- a/.github/workflows/lint_and_test_pegic.yml
+++ b/.github/workflows/lint_and_test_pegic.yml
@@ -43,13 +43,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        # golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           version: v1.56.2
           working-directory: ./pegic
@@ -59,9 +62,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
       - name: Compile 

--- a/.github/workflows/lint_and_test_scala-client.yml
+++ b/.github/workflows/lint_and_test_scala-client.yml
@@ -40,8 +40,10 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/setup-java@v4.8.0
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           java-version: 8
           distribution: temurin
@@ -68,7 +70,8 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: "./.github/actions/rebuild_thirdparty_if_needed"
       - uses: "./.github/actions/build_pegasus"
       - uses: "./.github/actions/upload_artifact"
@@ -84,14 +87,17 @@ jobs:
       matrix:
         java: [ '8', '11', '17' ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/cache@v3.5.0
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: actions/setup-java@v4
+      # actions/setup-java@v4.8.0
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -39,7 +39,8 @@ jobs:
     name: Lint Cpp
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: clang-format
         run: ./build_tools/run-clang-format.py --clang-format-executable clang-format-14 -e ./src/shell/linenoise -e ./src/shell/sds -e ./thirdparty -r .
 
@@ -78,7 +79,8 @@ jobs:
       - name: Clone Apache Pegasus Source
         # The glibc version on ubuntu1804 is lower than the actions/checkout@v4 required, so
         # we need to force to use actions/checkout@v3.
-        uses: actions/checkout@v3
+        # actions/checkout@v3.6.0
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Unpack prebuilt third-parties
         uses: "./.github/actions/unpack_prebuilt_thirdparties"
       - name: Build Pegasus
@@ -91,16 +93,19 @@ jobs:
       image: apache/pegasus:build-env-ubuntu2204-${{ github.ref_name }}-go
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Go
-        uses: actions/setup-go@v4
+        # actions/setup-go@v4.3.0
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: 1.18
       - name: Build go-client
         run: make
         working-directory: ./go-client
       - name: Lint go-client
-        uses: golangci/golangci-lint-action@v3
+        # golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           version: v1.56.2
           working-directory: ./go-client
@@ -108,7 +113,8 @@ jobs:
         run: make
         working-directory: ./collector
       - name: Lint collector
-        uses: golangci/golangci-lint-action@v3
+        # golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           version: v1.56.2
           working-directory: ./collector
@@ -116,7 +122,8 @@ jobs:
         run: make
         working-directory: ./admin-cli
       - name: Lint admin-cli
-        uses: golangci/golangci-lint-action@v3
+        # golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           version: v1.56.2
           working-directory: ./admin-cli
@@ -124,7 +131,8 @@ jobs:
         run: make
         working-directory: ./pegic
       - name: Lint pegic
-        uses: golangci/golangci-lint-action@v3
+        # golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           version: v1.56.2
           working-directory: ./pegic
@@ -136,14 +144,17 @@ jobs:
       matrix:
         java: [ '8', '11', '17' ]
     steps:
-      - uses: actions/cache@v3
+      # actions/cache@v3.5.0
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/setup-java@v4.8.0
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin

--- a/.github/workflows/standardization_lint.yaml
+++ b/.github/workflows/standardization_lint.yaml
@@ -39,7 +39,8 @@ jobs:
     name: Lint PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4.3.0
+      # amannn/action-semantic-pull-request@v4.3.0
+      - uses: amannn/action-semantic-pull-request@b4011711b945563fe63ffa9654c38d1782532528
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -47,14 +48,16 @@ jobs:
     name: Check Markdown links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225
 
   dockerfile_linter:
     name: Lint Dockerfile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
         with:
           recursive: true
@@ -65,7 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v4
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Check License Header
         uses: apache/skywalking-eyes@main
         env:

--- a/.github/workflows/test_nodejs-client.yml
+++ b/.github/workflows/test_nodejs-client.yml
@@ -48,7 +48,8 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: "./.github/actions/rebuild_thirdparty_if_needed"
       - uses: "./.github/actions/build_pegasus"
       - uses: "./.github/actions/upload_artifact"
@@ -60,9 +61,11 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install nodejs
-        uses: actions/setup-node@v3
+        # actions/setup-node@v3.9.1
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: 16
       - name: Download artifact

--- a/.github/workflows/test_python-client.yml
+++ b/.github/workflows/test_python-client.yml
@@ -48,7 +48,8 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: "./.github/actions/rebuild_thirdparty_if_needed"
       - uses: "./.github/actions/build_pegasus"
       - uses: "./.github/actions/upload_artifact"
@@ -60,8 +61,10 @@ jobs:
     container:
       image: apache/pegasus:thirdparties-bin-test-ubuntu2204-${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/setup-python@v5.6.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11.12'
       # python-client imports thrift package of 0.13.0, so we must use thrift-compiler 0.13.0


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/2397

According to the the reply from INFRA team[1] and the doc of infrastructure
actions[2], the actions in allow list must be pinned to a SHA rather than a tag
as of August 1st, 2025.

1. https://issues.apache.org/jira/browse/INFRA-27084
2. https://github.com/apache/infrastructure-actions/?tab=readme-ov-file#adding-a-new-action-to-the-allow-list