### PR TITLE
[backport] ci(github): fix branch glob to actually match release branches

### DIFF
--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -21,7 +21,7 @@ on:
   push:
     branches:
       - master
-      - 'v[0-9]+.*' # release branch
+      - 'v[0-9]*' # release branch
       - ci-test # testing branch for github action
       - '*dev' # developing branch
     paths:

--- a/.github/workflows/lint_and_test_admin-cli.yml
+++ b/.github/workflows/lint_and_test_admin-cli.yml
@@ -25,7 +25,7 @@ on:
     types: [ synchronize, opened, reopened ]
     branches:
       - master
-      - 'v[0-9]+.*' # release branch
+      - 'v[0-9]*' # release branch
       - ci-test # testing branch for github action
       - '*dev'
     paths:

--- a/.github/workflows/lint_and_test_admin-cli_always_pass.yml
+++ b/.github/workflows/lint_and_test_admin-cli_always_pass.yml
@@ -25,7 +25,7 @@ on:
     types: [ synchronize, opened, reopened ]
     branches:
       - master
-      - 'v[0-9]+.*' # release branch
+      - 'v[0-9]*' # release branch
       - ci-test # testing branch for github action
       - '*dev'
     paths-ignore:

--- a/.github/workflows/lint_and_test_cpp.yaml
+++ b/.github/workflows/lint_and_test_cpp.yaml
@@ -29,7 +29,7 @@ on:
     types: [ synchronize, opened, reopened ]
     branches:
       - master
-      - 'v[0-9]+.*' # release branch
+      - 'v[0-9]*' # release branch
       - ci-test # testing branch for github action
       - '*dev'
     paths:

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -25,7 +25,7 @@ on:
     types: [ synchronize, reopened, opened ]
     branches:
       - master
-      - 'v[0-9]+.*' # release branch
+      - 'v[0-9]*' # release branch
       - ci-test # testing branch for github action
       - '*dev'
     paths:

--- a/.github/workflows/lint_and_test_pegic.yml
+++ b/.github/workflows/lint_and_test_pegic.yml
@@ -25,7 +25,7 @@ on:
     types: [ synchronize, reopened, opened ]
     branches:
       - master
-      - 'v[0-9]+.*' # release branch
+      - 'v[0-9]*' # release branch
       - ci-test # testing branch for github action
       - '*dev'
     paths:

--- a/.github/workflows/lint_and_test_pegic_always_pass.yml
+++ b/.github/workflows/lint_and_test_pegic_always_pass.yml
@@ -25,7 +25,7 @@ on:
     types: [ synchronize, opened, reopened ]
     branches:
       - master
-      - 'v[0-9]+.*' # release branch
+      - 'v[0-9]*' # release branch
       - ci-test # testing branch for github action
       - '*dev'
     paths-ignore:

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -23,7 +23,7 @@ on:
       - '.github/workflows/regular-build.yml'
     branches:
       - master
-      - 'v[0-9]+.*' # release branch
+      - 'v[0-9]*' # release branch
       - ci-test # testing branch for github action
       - '*dev' # developing branch
 

--- a/.github/workflows/standardization_lint.yaml
+++ b/.github/workflows/standardization_lint.yaml
@@ -24,7 +24,7 @@ on:
     types: [ synchronize, opened, reopened, edited ]
     branches:
       - master
-      - 'v[0-9]+.*' # release branch
+      - 'v[0-9]*' # release branch
       - ci-test # testing branch for github action
       - '*dev'
   # for manually triggering workflow

--- a/.github/workflows/test_java-client.yml
+++ b/.github/workflows/test_java-client.yml
@@ -22,7 +22,7 @@ on:
   pull_request:
     branches:
         - master
-        - 'v[0-9]+.*' # release branch
+        - 'v[0-9]*' # release branch
         - ci-test # testing branch for github action
         - '*dev'      # developing branch
     paths:

--- a/.github/workflows/test_nodejs-client.yml
+++ b/.github/workflows/test_nodejs-client.yml
@@ -22,7 +22,7 @@ on:
   pull_request:
     branches:
         - master
-        - 'v[0-9]+.*' # release branch
+        - 'v[0-9]*' # release branch
         - ci-test # testing branch for github action
         - '*dev'      # developing branch
     paths:

--- a/.github/workflows/test_python-client.yml
+++ b/.github/workflows/test_python-client.yml
@@ -22,7 +22,7 @@ on:
   pull_request:
     branches:
         - master
-        - 'v[0-9]+.*' # release branch
+        - 'v[0-9]*' # release branch
         - ci-test # testing branch for github action
         - '*dev'      # developing branch
     paths:

--- a/.github/workflows/test_scala-client.yml
+++ b/.github/workflows/test_scala-client.yml
@@ -22,7 +22,7 @@ on:
   pull_request:
     branches:
         - master
-        - 'v[0-9]+.*' # release branch
+        - 'v[0-9]*' # release branch
     paths:
         - scala-client/**
 

--- a/.github/workflows/thirdparty-regular-push.yml
+++ b/.github/workflows/thirdparty-regular-push.yml
@@ -21,7 +21,7 @@ on:
   push:
     branches:
       - master
-      - 'v[0-9]+.*' # release branch
+      - 'v[0-9]*' # release branch
       - ci-test # testing branch for github action
       - '*dev' # developing branch
     paths:


### PR DESCRIPTION
## Summary

Backport of #2401 to `v2.5`.

The branch filter `'v[0-9]+.*'` used in workflow files **never matches the `v2.5` branch**, because GitHub Actions branch filters use glob syntax (not regex):

- `+` is a **literal character**, not a quantifier
- `[0-9]` matches **exactly one** digit, not "one or more"

As a result, PRs targeting `v2.5` silently skip every workflow that has this filter, while only those without `branches:` filters (e.g., the Golang/Labeler ones) actually run.

## Evidence

**PR #2394** targets `v2.5` and modifies `src/replica/duplication/**` (C++ code):

- ✅ Triggered: `Golang Lint and Unit Test - admin-cli/pegic`, `Module Labeler` (no `branches` filter)
- ❌ Did NOT trigger: `Cpp CI`, `Lint and Test - admin-cli` (cli proper), `Lint and Test - go-client`, etc.

Confirmed historically:
```
$ gh run list --repo apache/incubator-pegasus \
    --workflow lint_and_test_cpp.yaml --branch v2.5 --limit 5
(empty — never run)
```

`Cpp CI` has **never run on the `v2.5` branch** since the workflow was added.

## Fix

Replace `'v[0-9]+.*'` with `'v[0-9]*'`, which is valid GitHub Actions glob syntax and matches `v2.5`, `v2.5.1`, `v10.20`, etc. Applied uniformly to all 14 affected workflows on `v2.5` (mechanical sed replacement, one-line change per file).

## Self-validating

This PR modifies `.github/workflows/lint_and_test_cpp.yaml`, which matches `Cpp CI`'s own `paths:` filter. Combined with the branch glob fix on `v2.5`, **this PR itself should be the first time `Cpp CI` ever runs on a `v2.5` PR** — providing direct, in-band proof that the fix works.

## Verification

- [x] All workflow YAMLs parse successfully (`yaml.safe_load`)
- [x] Diff is minimal: 14 files changed, +14/-14
- [ ] After this PR is opened: confirm `Cpp CI` actually appears in the checks list (proof the fix works)