### PR TITLE
fix(server): handle incomplete RocksDB with missing column families gracefully

### DIFF
--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1667,48 +1667,71 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
             LOG_ERROR_PREFIX("check column families failed");
             return ec;
         }
-        CHECK_PREFIX_MSG(!missing_meta_cf, "You must upgrade Pegasus server from 2.0");
-        CHECK_PREFIX_MSG(!missing_data_cf, "Missing data column family");
 
-        // Load latest options from option file stored in the db directory.
-        rocksdb::DBOptions loaded_db_opt;
-        std::vector<rocksdb::ColumnFamilyDescriptor> loaded_cf_descs;
-        rocksdb::ColumnFamilyOptions loaded_data_cf_opts;
-        rocksdb::ConfigOptions config_options;
-        // Set `ignore_unknown_options` true for forward compatibility.
-        config_options.ignore_unknown_options = true;
-        config_options.env = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive);
-        auto status =
-            rocksdb::LoadLatestOptions(config_options, rdb_path, &loaded_db_opt, &loaded_cf_descs);
-        if (!status.ok()) {
-            // Here we ignore an invalid argument error related to `pegasus_data_version` and
-            // `pegasus_data` options, which were used in old version rocksdbs (before 2.1.0).
-            if (status.code() != rocksdb::Status::kInvalidArgument ||
-                status.ToString().find("pegasus_data") == std::string::npos) {
-                LOG_ERROR_PREFIX("load latest option file failed: {}.", status.ToString());
-                return dsn::ERR_LOCAL_APP_FAILURE;
-            }
-            has_incompatible_db_options = true;
+        if (missing_meta_cf || missing_data_cf) {
+            // The DB is incomplete/corrupted (e.g., process crashed during DB::Open,
+            // leaving a partial MANIFEST with only some column families). An incomplete
+            // DB is unusable since we cannot read decree, data version, etc. from it.
+            // Delete the corrupted rdb directory and fall through to create a new DB.
+            // The replica will re-sync data from the primary.
             LOG_WARNING_PREFIX(
-                "The latest option file has incompatible db options: {}, use default "
-                "options to open db.",
-                status.ToString());
+                "rdb is incomplete (missing_meta_cf={}, missing_data_cf={}), removing corrupted "
+                "rdb directory '{}' and will create a new DB. This may be caused by a previous "
+                "process crash during DB initialization.",
+                missing_meta_cf,
+                missing_data_cf,
+                rdb_path);
+
+            if (!dsn::utils::filesystem::remove_path(rdb_path)) {
+                LOG_ERROR_PREFIX("failed to remove corrupted rdb directory '{}'", rdb_path);
+                return dsn::ERR_FILE_OPERATION_FAILED;
+            }
+            LOG_INFO_PREFIX("successfully removed corrupted rdb directory '{}'", rdb_path);
+            db_exist = false;
         }
 
-        if (!has_incompatible_db_options) {
-            for (int i = 0; i < loaded_cf_descs.size(); ++i) {
-                if (loaded_cf_descs[i].name == meta_store::DATA_COLUMN_FAMILY_NAME) {
-                    loaded_data_cf_opts = loaded_cf_descs[i].options;
+        if (db_exist) {
+            // Load latest options from option file stored in the db directory.
+            rocksdb::DBOptions loaded_db_opt;
+            std::vector<rocksdb::ColumnFamilyDescriptor> loaded_cf_descs;
+            rocksdb::ColumnFamilyOptions loaded_data_cf_opts;
+            rocksdb::ConfigOptions config_options;
+            // Set `ignore_unknown_options` true for forward compatibility.
+            config_options.ignore_unknown_options = true;
+            config_options.env = dsn::utils::PegasusEnv(dsn::utils::FileDataType::kSensitive);
+            auto status = rocksdb::LoadLatestOptions(
+                config_options, rdb_path, &loaded_db_opt, &loaded_cf_descs);
+            if (!status.ok()) {
+                // Here we ignore an invalid argument error related to `pegasus_data_version` and
+                // `pegasus_data` options, which were used in old version rocksdbs (before 2.1.0).
+                if (status.code() != rocksdb::Status::kInvalidArgument ||
+                    status.ToString().find("pegasus_data") == std::string::npos) {
+                    LOG_ERROR_PREFIX("load latest option file failed: {}.", status.ToString());
+                    return dsn::ERR_LOCAL_APP_FAILURE;
                 }
+                has_incompatible_db_options = true;
+                LOG_WARNING_PREFIX(
+                    "The latest option file has incompatible db options: {}, use default "
+                    "options to open db.",
+                    status.ToString());
             }
-            // Reset usage scenario related options according to loaded_data_cf_opts.
-            // We don't use `loaded_data_cf_opts` directly because pointer-typed options will
-            // only be initialized with default values when calling 'LoadLatestOptions', see
-            // 'rocksdb/utilities/options_util.h'.
-            reset_rocksdb_options(
-                loaded_data_cf_opts, loaded_db_opt, envs, &_table_data_cf_opts, &_db_opts);
+
+            if (!has_incompatible_db_options) {
+                for (int i = 0; i < loaded_cf_descs.size(); ++i) {
+                    if (loaded_cf_descs[i].name == meta_store::DATA_COLUMN_FAMILY_NAME) {
+                        loaded_data_cf_opts = loaded_cf_descs[i].options;
+                    }
+                }
+                // Reset usage scenario related options according to loaded_data_cf_opts.
+                // We don't use `loaded_data_cf_opts` directly because pointer-typed options will
+                // only be initialized with default values when calling 'LoadLatestOptions', see
+                // 'rocksdb/utilities/options_util.h'.
+                reset_rocksdb_options(
+                    loaded_data_cf_opts, loaded_db_opt, envs, &_table_data_cf_opts, &_db_opts);
+            }
         }
-    } else {
+    }
+    if (!db_exist) {
         // When create new DB, we have to create a new column family to store meta data (meta column
         // family).
         _db_opts.create_missing_column_families = true;


### PR DESCRIPTION
## Problem

When a replica server crashes during `DB::Open` (e.g. OOM, `kill -9`), it may leave an incomplete rdb directory — the MANIFEST contains only partial column families (e.g. only `pegasus_data` without `pegasus_meta`). On restart, the server hits:

```
CHECK_PREFIX_MSG(!missing_meta_cf, "You must upgrade Pegasus server from 2.0");
```

and aborts immediately, making the replica unrecoverable.

## Root Cause

- The crash leaves a partially created RocksDB directory (`rdb_path` exists but is incomplete)
- On restart, `db_exist = true` and the code enters the "open existing DB" path
- `check_column_families()` detects `missing_meta_cf = true` or `missing_data_cf = true`
- The `CHECK_PREFIX_MSG` causes a hard abort

An incomplete DB is unusable anyway (cannot read decree, data version, etc. from it), so crashing is unnecessary.

## Fix

When `missing_meta_cf || missing_data_cf` is detected:
1. Log a WARNING with details about the incomplete state
2. Remove the corrupted `rdb` directory
3. Set `db_exist = false`
4. Fall through to create a fresh DB — the replica will re-sync data from the primary

The existing `db_exist` branch (LoadLatestOptions etc.) is wrapped in `if (db_exist)` to avoid operating on the deleted directory.

## Testing

- Verified that the fix resolves the crash in Docker development environment (Docker for Mac ARM64)
- The replica successfully creates a new DB and re-syncs from primary after the corrupted directory is removed
- Ran `./run.sh test -m base_api_test`: `integration_test.write_corrupt_db` and `integration_test.read_corrupt_db` now pass. This also resolves #2283, where the replica dropped on a corrupted DB (`get_alive_replica_server_count()` returned 2) and cascaded into 49 failures across the whole suite.

## Related

Closes #2215
Closes #2283
