### PR TITLE
fix(utils): handle clock regression in chronograph::duration_ns

### DIFF
--- a/src/utils/time_utils.h
+++ b/src/utils/time_utils.h
@@ -150,8 +150,20 @@ public:
     [[nodiscard]] inline uint64_t duration_ns() const
     {
         auto now = dsn_now_ns();
-        CHECK_GE(now, _start_time_ns);
-
+        if (dsn_unlikely(now < _start_time_ns)) {
+            // In virtualized environments (e.g. Docker for Mac ARM64), high_resolution_clock
+            // may exhibit minor time regression. Return 0 instead of crashing when this occurs.
+            // Rate-limit the warning to avoid log flooding on hot paths.
+            static thread_local uint64_t last_warn_ns = 0;
+            if (now - last_warn_ns > 1'000'000'000ULL) { // 1s
+                last_warn_ns = now;
+                LOG_WARNING("clock regression detected: now={}, start={}, diff={}ns",
+                            now,
+                            _start_time_ns,
+                            _start_time_ns - now);
+            }
+            return 0;
+        }
         return now - _start_time_ns;
     }
 


### PR DESCRIPTION
## Problem

In virtualized environments (e.g. Docker for Mac ARM64), `high_resolution_clock` may exhibit minor time regression, causing `chronograph::duration_ns()` to hit:

```cpp
CHECK_GE(now, _start_time_ns);
```

and abort the process with a FATAL error.

## Root Cause

Virtualized environments (especially Docker for Mac with ARM64) can have non-monotonic `high_resolution_clock` behavior, where `now < _start_time_ns` occurs briefly. This is a known issue with time virtualization in these environments.

## Fix

Replace the hard `CHECK_GE` with graceful degradation:
- If `now < _start_time_ns`, return 0 instead of crashing
- Add rate-limited warning (1 per second per thread) to avoid log flooding on hot paths
- Use `dsn_unlikely` hint since this is an exceptional case

## Testing

Verified in Docker for Mac ARM64 development environment — the process no longer aborts and continues normal operation.