### PR TITLE
fix(test): fix GCC 13 -Warray-bounds build failure in pegasus_server_test_base

### DIFF
--- a/src/server/test/pegasus_server_test_base.h
+++ b/src/server/test/pegasus_server_test_base.h
@@ -23,6 +23,8 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+
+#include <vector>
 #include "common/fs_manager.h"
 #include "replica/replica_stub.h"
 #include "test_util/test_util.h"
@@ -89,17 +91,15 @@ public:
 
     dsn::error_code start(const std::map<std::string, std::string> &envs)
     {
-        std::unique_ptr<char *[]> argvs = std::make_unique<char *[]>(1 + envs.size() * 2);
-        char **argv = argvs.get();
-        int idx = 0;
-        argv[idx++] = const_cast<char *>("unit_test_app");
-        if (!envs.empty()) {
-            for (auto &kv : envs) {
-                argv[idx++] = const_cast<char *>(kv.first.c_str());
-                argv[idx++] = const_cast<char *>(kv.second.c_str());
-            }
+        std::vector<char *> argv;
+        argv.reserve(2 + envs.size() * 2);
+        argv.push_back(const_cast<char *>("unit_test_app"));
+        for (const auto &kv : envs) {
+            argv.push_back(const_cast<char *>(kv.first.c_str()));
+            argv.push_back(const_cast<char *>(kv.second.c_str()));
         }
-        return _server->start(idx, argv);
+        argv.push_back(nullptr);
+        return _server->start(argv.size() - 1, argv.data());
     }
 
     dsn::error_code start() { return start({}); }


### PR DESCRIPTION
## Problem

Building tests (`-DBUILD_TEST=ON`) with **GCC 13** fails with:

```
src/server/test/pegasus_server_test_base.h:98:29: error: array subscript 1 is outside array bounds of 'void [8]' [-Werror=array-bounds=]
   98 |                 argv[idx++] = const_cast<char *>(kv.first.c_str());
```

This affects every test file that includes `pegasus_server_test_base.h` (12+ test files).

## Root Cause

GCC 13 introduced stricter `-Warray-bounds` static analysis with aggressive inlining. The chain of events:

1. `start()` calls `start({})` — passing an empty `std::map`
2. GCC inlines `start(const map&)` into `start()`
3. With an empty map: `make_unique<char*[]>(1 + 0 * 2)` allocates space for **1** pointer
4. The compiler sees the loop body `argv[idx++] = ...` and determines that accessing `argv[1]` (or beyond) would be out-of-bounds for the allocated array
5. Even though the loop body never executes (empty map), GCC 13's static analysis flags the potential out-of-bounds access
6. Since Pegasus builds with `-Werror`, this becomes a **hard build failure**

Note: older GCC versions (and possibly Clang) don't trigger this warning, which is why community CI passes.

## Fix

Replace `std::make_unique<char*[]>` with `std::vector<char*>`:

- `vector::push_back` doesn't trigger the same static analysis false positive
- Also adds a `nullptr` sentinel at the end of argv (good practice for C-style argv arrays)
- Adds `#include <vector>`

## Testing

- Full build with `-DBUILD_TEST=ON` passes on GCC 13.3 (Ubuntu 24.04 ARM64)
- `base_api_test` runs successfully