### PR TITLE
ci(github): use Apache allowed SHA-pinned GitHub Actions

### DIFF
--- a/.github/actions/rebuild_thirdparty_if_needed/action.yaml
+++ b/.github/actions/rebuild_thirdparty_if_needed/action.yaml
@@ -19,7 +19,8 @@ name: Rebuild thirdparty if needed
 runs:
   using: composite
   steps:
-    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+    # dorny/paths-filter@v4.0.1
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
       id: changes
       with:
         filters: |

--- a/.github/workflows/build-push-env-docker.yml
+++ b/.github/workflows/build-push-env-docker.yml
@@ -55,20 +55,20 @@ jobs:
         # actions/checkout@v4.3.1
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        # docker/setup-qemu-action@v3.7.0
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+        # docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        # docker/setup-buildx-action@v3.12.0
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        # docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to DockerHub
-        # docker/login-action@3.7.0
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        # docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        # docker/build-push-action@v6.19.2
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        # docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           platforms: linux/amd64
           context: .
@@ -91,20 +91,20 @@ jobs:
         # actions/checkout@v4.3.1
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        # docker/setup-qemu-action@v3.7.0
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+        # docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        # docker/setup-buildx-action@v3.12.0
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        # docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to DockerHub
-        # docker/login-action@3.7.0
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        # docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        # docker/build-push-action@v6.19.2
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        # docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           platforms: linux/amd64
           context: .

--- a/.github/workflows/build-push-thirdparty.yml
+++ b/.github/workflows/build-push-thirdparty.yml
@@ -31,20 +31,20 @@ jobs:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        # docker/setup-qemu-action@v1.2.0
-        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+        # docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        # docker/setup-buildx-action@v1.7.0
-        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
+        # docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to DockerHub
-        # docker/login-action@1.14.1
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+        # docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        # docker/build-push-action@v2.10.0
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        # docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: ./docker/thirdparties-src/Dockerfile
@@ -72,20 +72,20 @@ jobs:
       # actions/checkout@v3.6.0
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Set up QEMU
-        # docker/setup-qemu-action@v1.2.0
-        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+        # docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        # docker/setup-buildx-action@v1.7.0
-        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
+        # docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to DockerHub
-        # docker/login-action@1.14.1
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+        # docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for production
-        # docker/build-push-action@v2.10.0
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        # docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: ./docker/thirdparties-bin/Dockerfile
@@ -113,20 +113,20 @@ jobs:
       # actions/checkout@v3.6.0
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Set up QEMU
-        # docker/setup-qemu-action@v1.2.0
-        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+        # docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        # docker/setup-buildx-action@v1.7.0
-        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
+        # docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to DockerHub
-        # docker/login-action@1.14.1
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+        # docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for production with jemalloc
-        # docker/build-push-action@v2.10.0
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        # docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: ./docker/thirdparties-bin/Dockerfile
@@ -147,20 +147,20 @@ jobs:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        # docker/setup-qemu-action@v1.2.0
-        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+        # docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        # docker/setup-buildx-action@v1.7.0
-        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
+        # docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to DockerHub
-        # docker/login-action@1.14.1
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+        # docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for test
-        # docker/build-push-action@v2.10.0
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        # docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: ./docker/thirdparties-bin/Dockerfile
@@ -181,20 +181,20 @@ jobs:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        # docker/setup-qemu-action@v1.2.0
-        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+        # docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        # docker/setup-buildx-action@v1.7.0
-        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
+        # docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to DockerHub
-        # docker/login-action@1.14.1
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+        # docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for test asan
-        # docker/build-push-action@v2.10.0
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        # docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: ./docker/thirdparties-bin/Dockerfile
@@ -216,20 +216,20 @@ jobs:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up QEMU
-        # docker/setup-qemu-action@v1.2.0
-        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+        # docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        # docker/setup-buildx-action@v1.7.0
-        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
+        # docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to DockerHub
-        # docker/login-action@1.14.1
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+        # docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push for test with jemalloc
-        # docker/build-push-action@v2.10.0
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        # docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: ./docker/thirdparties-bin/Dockerfile

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -33,7 +33,7 @@ jobs:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Assign GitHub labels
-        # uses: actions/labeler@v5.0.0
+        # actions/labeler@v5.0.0
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint_and_test_admin-cli.yml
+++ b/.github/workflows/lint_and_test_admin-cli.yml
@@ -51,8 +51,8 @@ jobs:
         with:
           go-version: 1.18
       - name: Lint
-        # golangci/golangci-lint-action@v3.7.0
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
+        # golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: v1.56.2
           working-directory: ./admin-cli

--- a/.github/workflows/lint_and_test_collector.yml
+++ b/.github/workflows/lint_and_test_collector.yml
@@ -76,8 +76,8 @@ jobs:
           go-version: 1.18
           cache: false
       - name: Lint
-        # golangci/golangci-lint-action@v3.7.0
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
+        # golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: v1.56.2
           working-directory: ./collector

--- a/.github/workflows/lint_and_test_go-client.yml
+++ b/.github/workflows/lint_and_test_go-client.yml
@@ -79,8 +79,8 @@ jobs:
         run: make build
       # because some files are generated after building, so lint after the build step
       - name: Lint
-        # golangci/golangci-lint-action@v3.7.0
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
+        # golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: v1.56.2
           working-directory: ./go-client

--- a/.github/workflows/lint_and_test_pegic.yml
+++ b/.github/workflows/lint_and_test_pegic.yml
@@ -51,8 +51,8 @@ jobs:
         with:
           go-version: 1.18
       - name: Lint
-        # golangci/golangci-lint-action@v3.7.0
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
+        # golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: v1.56.2
           working-directory: ./pegic

--- a/.github/workflows/regular-build.yml
+++ b/.github/workflows/regular-build.yml
@@ -104,8 +104,8 @@ jobs:
         run: make
         working-directory: ./go-client
       - name: Lint go-client
-        # golangci/golangci-lint-action@v3.7.0
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
+        # golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: v1.56.2
           working-directory: ./go-client
@@ -113,8 +113,8 @@ jobs:
         run: make
         working-directory: ./collector
       - name: Lint collector
-        # golangci/golangci-lint-action@v3.7.0
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
+        # golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: v1.56.2
           working-directory: ./collector
@@ -122,8 +122,8 @@ jobs:
         run: make
         working-directory: ./admin-cli
       - name: Lint admin-cli
-        # golangci/golangci-lint-action@v3.7.0
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
+        # golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: v1.56.2
           working-directory: ./admin-cli
@@ -131,8 +131,8 @@ jobs:
         run: make
         working-directory: ./pegic
       - name: Lint pegic
-        # golangci/golangci-lint-action@v3.7.0
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
+        # golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: v1.56.2
           working-directory: ./pegic

--- a/.github/workflows/standardization_lint.yaml
+++ b/.github/workflows/standardization_lint.yaml
@@ -50,6 +50,7 @@ jobs:
     steps:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # tcort/github-action-markdown-link-check@v1.1.2
       - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225
 
   dockerfile_linter:
@@ -58,6 +59,7 @@ jobs:
     steps:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # hadolint/hadolint-action@v3.3.0
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
         with:
           recursive: true
@@ -71,7 +73,8 @@ jobs:
         # actions/checkout@v4.3.1
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Check License Header
-        uses: apache/skywalking-eyes@main
+        # apache/skywalking-eyes@v0.8.0
+        uses: apache/skywalking-eyes@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # needed only when you want License-Eye to comment on the pull request.
         with:


### PR DESCRIPTION
 Update GitHub Actions references to use SHA-pinned versions allowed by Apache infrastructure.

Changes:
- Replace Docker-related actions with Apache allowlist SHA versions.
- Replace dorny/paths-filter with the Apache allowlist SHA version.
- Replace golangci/golangci-lint-action with the Apache allowlist SHA version.
- Pin apache/skywalking-eyes to a concrete SHA instead of main.
- Add or normalize version comments above action SHA references.

Validation:
- Confirmed all active uses entries are pinned to 40-character SHA values.
- Confirmed all active uses entries have version comments.