### PR TITLE
fix(java-client): guard against NPE in FutureGroup.waitAllComplete when future cause is null

### DIFF
--- a/java-client/src/main/java/org/apache/pegasus/client/FutureGroup.java
+++ b/java-client/src/main/java/org/apache/pegasus/client/FutureGroup.java
@@ -112,10 +112,15 @@ public class FutureGroup<Result> {
       if (fu.isSuccess()) {
         results.add(Pair.of(null, fu.getNow()));
       } else {
+        // fu.cause() is null when the future never completed (e.g. await timed out),
+        // in which case dereferencing it throws a NullPointerException. Guard against
+        // that so a failing-but-incomplete task is reported instead of crashing the
+        // caller. See https://github.com/apache/incubator-pegasus/issues/2152.
+        Throwable cause = fu.cause();
+        String causeMsg =
+            cause != null ? cause.getMessage() : "unknown cause (future not completed)";
         results.add(
-            Pair.of(
-                new PException("async task #[" + i + "] await failed: " + fu.cause().getMessage()),
-                null));
+            Pair.of(new PException("async task #[" + i + "] await failed: " + causeMsg), null));
       }
     }
   }

--- a/java-client/src/test/java/org/apache/pegasus/client/TestFutureGroup.java
+++ b/java-client/src/test/java/org/apache/pegasus/client/TestFutureGroup.java
@@ -18,13 +18,23 @@
  */
 package org.apache.pegasus.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -99,5 +109,29 @@ public class TestFutureGroup {
       return;
     }
     fail();
+  }
+
+  @Test
+  public void testWaitAllCompleteHandlesNullCause(TestInfo testInfo) throws Exception {
+    // Reproduces #2152: a Future that is neither completed nor successful (e.g. its
+    // await timed out before it ever resolved) reports isSuccess()==false and
+    // cause()==null. waitAllComplete must not dereference the null cause.
+    @SuppressWarnings("unchecked")
+    Future<String> unfinished = mock(Future.class);
+    when(unfinished.await(anyLong())).thenReturn(false); // timed out, still not done
+    when(unfinished.isSuccess()).thenReturn(false);
+    when(unfinished.cause()).thenReturn(null);
+
+    FutureGroup<String> group = new FutureGroup<>(1);
+    group.add(unfinished);
+
+    List<Pair<PException, String>> results = new ArrayList<>();
+    // Before the fix this threw NullPointerException inside waitAllComplete.
+    group.waitAllComplete(results, 5000);
+
+    assertEquals(1, results.size());
+    assertNotNull(results.get(0).getLeft()); // a PException is reported
+    assertNull(results.get(0).getRight()); // no result
+    System.err.println(testInfo.getDisplayName() + ": " + results.get(0).getLeft().toString());
   }
 }


### PR DESCRIPTION
## Background

Closes #2152. When using batch APIs (`Batch.asyncCommit` → `FutureGroup.waitAllComplete`, a.k.a. `commitWaitAllComplete`), a `NullPointerException` can occur intermittently.

## Root cause

`FutureGroup.waitAllComplete` builds the failure message by dereferencing `fu.cause()`:

```java
} else {
    results.add(Pair.of(
        new PException("async task #[" + i + "] await failed: " + fu.cause().getMessage()),
        null));
}
```

A netty `Future.cause()` returns `null` **not only on success**, but also **while the future is still incomplete**. If `await` times out before the future ever resolves, `isSuccess()` is `false` (so we enter the `else` branch) but `cause()` is still `null` — thus `cause().getMessage()` throws NPE, crashing the entire batch commit instead of reporting just the single failed task.

The sibling method `waitAllCompleteOrOneFail` is unaffected because it passes `fu.cause()` directly to the `PException` constructor, which tolerates `null`.

## Fix

Guard the dereference and fall back to a placeholder message when `cause()` is `null`:

```java
Throwable cause = fu.cause();
String causeMsg = cause != null ? cause.getMessage() : "unknown cause (future not completed)";
results.add(Pair.of(new PException("async task #[" + i + "] await failed: " + causeMsg), null));
```

This matches the fix suggested by the issue reporter.

## Test

Added `TestFutureGroup.testWaitAllCompleteHandlesNullCause`, which uses Mockito to mock an incomplete Future (`await`→false, `isSuccess`→false, `cause`→null) to reproduce the scenario deterministically, without relying on timing.

Verified both directions:
- **With the fix**: all 3 tests in `TestFutureGroup` pass.
- **Without the fix** (temporarily reverted): the new test fails with the exact NPE reported in the issue:
  ```
  NullPointerException: Cannot invoke "Throwable.getMessage()" because the return value of "io.netty.util.concurrent.Future.cause()" is null
      at FutureGroup.waitAllComplete(FutureGroup.java:117)
  ```
