### PR TITLE
fix(server): avoid retro-triggering periodic manual compaction for never-compacted apps

### DIFF
--- a/src/server/pegasus_manual_compact_service.cpp
+++ b/src/server/pegasus_manual_compact_service.cpp
@@ -70,6 +70,7 @@ pegasus_manual_compact_service::pegasus_manual_compact_service(pegasus_server_im
       _manual_compact_start_running_time_ms(0),
       _manual_compact_last_finish_time_ms(0),
       _manual_compact_last_time_used_ms(0),
+      _app_start_time_ms(dsn_now_ms()),
       METRIC_VAR_INIT_replica(rdb_manual_compact_queued_tasks),
       METRIC_VAR_INIT_replica(rdb_manual_compact_running_tasks)
 {
@@ -208,9 +209,18 @@ bool pegasus_manual_compact_service::check_periodic_compact(
     }
 
     auto now = static_cast<int64_t>(now_timestamp());
+    // For an app that has never been compacted (last_finish == 0) the lower bound
+    // would be 0, causing every trigger time that already passed today to
+    // retro-fire -- dangerous for a freshly-started duplication backup whose
+    // RocksDB is not fully initialized. Use the app start time as the floor in
+    // that case, so only triggers strictly after startup are honored. Apps that
+    // have already been compacted keep using last_finish and thus still catch up
+    // on a missed daily trigger after a restart. See #1564.
+    uint64_t last_finish = _manual_compact_last_finish_time_ms.load();
+    uint64_t lower_bound = last_finish == 0 ? _app_start_time_ms.load() : last_finish;
     for (auto t : trigger_time) {
         auto t_ms = t * 1000;
-        if (_manual_compact_last_finish_time_ms.load() < t_ms && t_ms < now) {
+        if (lower_bound < t_ms && t_ms < now) {
             return true;
         }
     }

--- a/src/server/pegasus_manual_compact_service.h
+++ b/src/server/pegasus_manual_compact_service.h
@@ -100,6 +100,11 @@ private:
     std::atomic<uint64_t> _manual_compact_last_finish_time_ms;
     std::atomic<uint64_t> _manual_compact_last_time_used_ms;
 
+    // Time the service was constructed. Used as a floor for the trigger-time
+    // checks so a never-compacted app (last_finish == 0) does not retro-fire on a
+    // trigger whose time already passed before startup. See #1564.
+    std::atomic<uint64_t> _app_start_time_ms;
+
     METRIC_VAR_DECLARE_gauge_int64(rdb_manual_compact_queued_tasks);
     METRIC_VAR_DECLARE_gauge_int64(rdb_manual_compact_running_tasks);
 };

--- a/src/server/test/manual_compact_service_test.cpp
+++ b/src/server/test/manual_compact_service_test.cpp
@@ -49,6 +49,10 @@ public:
     {
         start();
         manual_compact_svc = std::make_unique<pegasus_manual_compact_service>(_server);
+        // _app_start_time_ms defaults to construction time; reset to 0 so existing
+        // tests (which set last_finish to fixed timestamps) are unaffected by the
+        // start-time floor. Tests that exercise the floor set it explicitly.
+        manual_compact_svc->_app_start_time_ms.store(0);
     }
 
     void set_compact_time(int64_t ts) const
@@ -60,6 +64,11 @@ public:
     void set_mock_now(uint64_t mock_now_sec) const
     {
         manual_compact_svc->_mock_now_timestamp = mock_now_sec * 1000;
+    }
+
+    void set_app_start_time(uint64_t app_start_sec) const
+    {
+        manual_compact_svc->_app_start_time_ms.store(app_start_sec * 1000);
     }
 
     void check_compact_disabled(const std::map<std::string, std::string> &envs, bool ok)
@@ -243,6 +252,33 @@ TEST_P(manual_compact_service_test, check_periodic_compact)
 
     set_mock_now((uint64_t)dsn::utils::hh_mm_today_to_unix_sec("22:00"));
     check_periodic_compact(envs, false);
+}
+
+TEST_P(manual_compact_service_test, check_periodic_compact_never_compacted)
+{
+    // #1564: an app that has never been compacted (last_finish == 0) must not
+    // immediately fire periodic compaction just because today's trigger time
+    // already passed. The app start time is used as a floor, so only triggers
+    // strictly after startup are honored -- a freshly-started duplication backup
+    // whose RocksDB isn't fully initialized won't be crashed by a retro-trigger.
+    std::map<std::string, std::string> envs;
+
+    // app started at 14:00 today, never compacted (last_finish stays 0)
+    uint64_t start_14h = (uint64_t)dsn::utils::hh_mm_today_to_unix_sec("14:00");
+    set_app_start_time(start_14h);
+    set_mock_now(start_14h);
+
+    // trigger 01:00 already passed before startup -> must NOT trigger
+    envs[dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME] = "1:00";
+    check_periodic_compact(envs, false);
+
+    // trigger 18:00 not reached yet (now=14:00) -> must NOT trigger
+    envs[dsn::replica_envs::MANUAL_COMPACT_PERIODIC_TRIGGER_TIME] = "18:00";
+    check_periodic_compact(envs, false);
+
+    // advance now to 19:00: trigger 18:00 lies in (start=14:00, now=19:00) -> trigger
+    set_mock_now((uint64_t)dsn::utils::hh_mm_today_to_unix_sec("19:00"));
+    check_periodic_compact(envs, true);
 }
 
 TEST_P(manual_compact_service_test, extract_manual_compact_opts)


### PR DESCRIPTION
## Problem (#1564)

When `manual_compact.periodic.trigger_time` is set to a time of day that has
already passed (e.g. `1:00` while it is now `14:00`), periodic manual
compaction fires **immediately**. This is catastrophic for **duplication
full-app duplicate**: the backup cluster creates a brand-new app and copies
the primary's manual-compact envs, so the backup's RocksDB performs
compaction before it is fully initialized → undefined behavior → **all nodes
in the backup cluster crash**.

Closes #1564.

## Root cause

Each partition uses `_manual_compact_last_finish_time_ms`, initialized to `0`,
as the **"never compacted"** sentinel. But `check_periodic_compact()` treats
that `0` as a distant-past lower bound:

```cpp
// before
if (_manual_compact_last_finish_time_ms.load() < t_ms && t_ms < now)
    return true;
//     ^ 0 < t_ms is always true  =>  reduces to "trigger time already passed"
```

The new-DB path (which is exactly what a duplication backup app is — a freshly
created app) never calls `init_last_finish_time_ms`, so `last_finish` stays `0`.
`check_manual_compact_state()` also sees `== 0` and lets it through. So an
already-passed trigger retro-fires at the very start of the backup app's life
(the check even runs from `update_app_envs_before_open_db`, i.e. before the DB
is fully open), before RocksDB is ready.

## Fix

Keep the `last_finish == 0` "never compacted" sentinel intact, and use the
**service start time** as the trigger-time lower bound only when
`last_finish == 0`:

```cpp
// after
uint64_t last_finish = _manual_compact_last_finish_time_ms.load();
uint64_t lower_bound = last_finish == 0 ? _app_start_time_ms.load() : last_finish;
for (auto t : trigger_time) {
    auto t_ms = t * 1000;
    if (lower_bound < t_ms && t_ms < now)
        return true;
}
```

`_app_start_time_ms` is a new member fixed at construction time (`dsn_now_ms()`).

Why this design:

- **Preserves the `0` sentinel.** `check_manual_compact_state()`'s min-interval
  branch and `query_compact_state()`'s display both rely on `last_finish == 0`
  meaning "never compacted". We do not touch `_manual_compact_last_finish_time_ms`.
- **One mechanism, both DB paths.** The floor keys off `last_finish == 0` at
  check time, so it covers both the new-DB path (no `init` call) and the
  existing-but-never-compacted path (`init(0)`). No change to
  `init_last_finish_time_ms` is needed.
- **No deadlock.** The floor is the fixed start time, not a dynamic `now`, so
  the first periodic trigger after startup (e.g. start 14:00, trigger 18:00)
  still fires normally once `now` passes it.
- **Timing-safe.** The periodic check only runs after the app is open, so a
  trigger within `(start, now)` fires on an already-initialized RocksDB; only
  triggers that already passed *before* startup (the retro-fire) are suppressed.

Apps that have already been compacted keep using `last_finish`, so the
existing "catch up on a missed daily trigger after a restart" behavior is
unchanged.

## Test

New regression test `check_periodic_compact_never_compacted` mocks the
never-compacted state (`last_finish == 0`, app start `14:00`):

- trigger `1:00` (already passed before startup) → must **not** fire
- trigger `18:00` not yet reached (`now == 14:00`) → must **not** fire
- advance `now` to `19:00` → `18:00` now lies in `(start, now)` → **fires**
  (proves no deadlock)

Forward run: all `manual_compact_service_test.*` pass (14 cases).
Reverse check (temporarily neutering the floor): the new case fails as
expected, confirming the test actually catches the bug.

## Scope / notes

- `check_once_compact()` has analogous behavior when `last_finish == 0`, but
  #1564 is specifically about `periodic.trigger_time`; the once-trigger is out
  of scope here.
- Residual narrow window: if a backup app starts *before* a trigger time and
  the check runs after that time passes but before duplication is ready, it
  could still fire. Fully closing that requires duplication-readiness
  awareness, which lives in the replica layer (out of scope for this fix).
  This PR fixes the primary scenario — crash on startup.
