### PR TITLE
build(thirdparty): make RocksDB depend on Hadoop before building HDFS plugin

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -514,7 +514,7 @@ ExternalProject_Add(rocksdb
         COMMAND rm -rf ${TP_DIR}/build/Source/rocksdb/plugin/hdfs
         COMMAND git clone -b master --depth=1 https://github.com/riversand963/rocksdb-hdfs-env.git ${TP_DIR}/build/Source/rocksdb/plugin/hdfs
         COMMAND cd ${TP_DIR}/build/Source/rocksdb/plugin/hdfs && patch -p1 < ${TP_DIR}/fix_rocksdb-plugin-hdfs.patch
-        DEPENDS googletest jemalloc lz4 snappy zstd
+        DEPENDS googletest jemalloc lz4 snappy zstd hadoop
         CMAKE_ARGS ${ROCKSDB_OPTIONS}
         DOWNLOAD_EXTRACT_TIMESTAMP true
         DOWNLOAD_NO_PROGRESS true


### PR DESCRIPTION
Add an explicit thirdparty build dependency from RocksDB to Hadoop.

RocksDB builds the HDFS plugin on Linux, and that plugin includes hdfs.h from the
Hadoop native client output. Without a CMake ExternalProject dependency, RocksDB
and Hadoop can build in parallel, causing RocksDB to compile before Hadoop has copied
hdfs.h into thirdparty/output/include/hdfs.

This fixes intermittent thirdparty Docker build failures such as:
  fatal error: hdfs.h: No such file or directory

Validation:
- Verified the failure is caused by RocksDB HDFS plugin compiling before Hadoop native client output is available.
- The change serializes RocksDB after Hadoop while preserving existing thirdparty build behavior.